### PR TITLE
docs(reference/cli): nats-path was removed

### DIFF
--- a/content/v2.0/reference/cli/influxd.md
+++ b/content/v2.0/reference/cli/influxd.md
@@ -25,7 +25,6 @@ influxd [flags]
 | `-h`, `--help`         | Help for `influxd`                                                   |            |
 | `--http-bind-address`  | Bind address for the REST HTTP API (default `:9999`)                 | string     |
 | `--log-level`          | Supported log levels are debug, info, and error (default `info`)     | string     |
-| `--nats-path`          | Path to NATS queue for scraping tasks (default `~/.influxdbv2/nats`) | string     |
 | `--reporting-disabled` | Disable sending telemetry data to https://telemetry.influxdata.com   |            |
 | `--protos-path`        | Path to protos on the filesystem (default `~/.influxdbv2/protos`)    | string     |
 | `--secret-store`       | Data store for secrets (bolt or vault) (default `bolt`)              | string     |


### PR DESCRIPTION
nats-path was removed because scraper uses in-memory queue

Originally, we had been using persistent NATS to store data that would be sent to the storage engine.  Because we not longer need those guarantees, I removed the file durability and thus the need for `nats-path.`

Hope everything is great!