### PR TITLE
docs(influxd): add description for 3 new flags

### DIFF
--- a/content/v2.0/reference/cli/influxd.md
+++ b/content/v2.0/reference/cli/influxd.md
@@ -21,8 +21,10 @@ influxd [flags]
 
 | Flag                   | Description                                                                            | Input type |
 | :--------------------- | :------------------------------------------------------------------------------------- | :--------: |
+| `--assets-path`        | Override default assets by serving from a specific directory (default `memory`)        |   string   |
 | `--bolt-path`          | Path to boltdb database (default `~/.influxdbv2/influxd.bolt`)                         |   string   |
 | `--developer-mode`     | Serve assets from the local filesystem in developer mode                               |            |
+| `--e2e-testing`        | Add /debug/flush endpoint to clear stores; used for end-to-end tests (default `false`) |  boolean   |
 | `--engine-path`        | Path to persistent engine files (default `~/.influxdbv2/engine`)                       |   string   |
 | `-h`, `--help`         | Help for `influxd`                                                                     |            |
 | `--http-bind-address`  | Bind address for the REST HTTP API (default `:9999`)                                   |   string   |
@@ -30,6 +32,4 @@ influxd [flags]
 | `--reporting-disabled` | Disable sending telemetry data to https://telemetry.influxdata.com                     |            |
 | `--protos-path`        | Path to protos on the filesystem (default `~/.influxdbv2/protos`)                      |   string   |
 | `--secret-store`       | Data store for secrets (bolt or vault) (default `bolt`)                                |   string   |
-| `--assets-path`        | Override default assets by serving from a specific directory (default `memory`)        |   string   |
 | `--store`              | Data store for REST resources (bolt or memory) (default `bolt`)                        |   string   |
-| `--e2e-testing`        | Add /debug/flush endpoint to clear stores; used for end-to-end tests (default `false`) |  boolean   |


### PR DESCRIPTION
With the addition of [this](https://github.com/influxdata/influxdb/pull/11686) pull request to 2.0 there will be three new influxd daemon flags:

- assets-path
- store
- e2e-testing

This pr is an attempt to document these changes.  The implementation of these flags can be found [here](https://github.com/influxdata/influxdb/pull/11686/files#diff-48d231e253565ba9e9d3c88d51cec1deR215)
