### PR TITLE
add Billing doc

### DIFF
--- a/content/v2.0/cloud/account-management/billing.md
+++ b/content/v2.0/cloud/account-management/billing.md
@@ -53,7 +53,7 @@ menu:
 
 ### View Free plan information
 
-If you're on the Free plan, the Billing page monitors rate limits and lets you know how much data or options you have left to use.
+- On the Billing page, view the total limits available for the Free plan.
 
 ### Exceeded rate limits
 


### PR DESCRIPTION
Thoughts on the following:

- For information about what to do (and what happens) when folks exceed their Free Plan rate limits. Should it be in the Billing doc or Usage doc (with ref link to other)? 
- What if they don't see past invoices, contact Support?
- Cancel service. Separate topic? Seems important enough not to sub under "billing," but not sure how we want to advertise.