### PR TITLE
Various Flux updates

### DIFF
--- a/content/v2.0/reference/flux/stdlib/built-in/misc/now.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/misc/now.md
@@ -8,6 +8,8 @@ menu:
     name: now
     parent: built-in-misc
 weight: 401
+related:
+  - /v2.0/reference/flux/stdlib/system/time/
 ---
 
 The `now()` function returns the current time (UTC).

--- a/content/v2.0/reference/flux/stdlib/built-in/misc/now.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/misc/now.md
@@ -30,6 +30,11 @@ data
 {{% note %}}
 #### now() vs system.time()
 `now()` returns the current UTC time.
+`now()` is cached at runtime, so all instances of `now()` in a Flux script
+return the same value.
+
 [`system.time()`](/v2.0/reference/flux/stdlib/system/time/) returns the current
 system time of the host machine, which typically accounts for the local time zone.
+This time represents the time at which `system.time()` it is executed, so each
+instance of `system.time()` in a Flux script returns a unique value.
 {{% /note %}}

--- a/content/v2.0/reference/flux/stdlib/built-in/misc/now.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/misc/now.md
@@ -26,3 +26,10 @@ now()
 data
   |> range(start: -10h, stop: now())
 ```
+
+{{% note %}}
+#### now() vs system.time()
+`now()` returns the current UTC time.
+[`system.time()`](/v2.0/reference/flux/stdlib/system/time/) returns the current
+system time of the host machine, which typically accounts for the local time zone.
+{{% /note %}}

--- a/content/v2.0/reference/flux/stdlib/csv/from.md
+++ b/content/v2.0/reference/flux/stdlib/csv/from.md
@@ -29,10 +29,6 @@ csv.from(file: "/path/to/data-file.csv")
 csv.from(csv: csvData)
 ```
 
-{{% cloud-msg %}}
-`csv.from()` is not available in {{< cloud-name "short" >}}.
-{{% /cloud-msg %}}
-
 ## Parameters
 
 ### file
@@ -40,6 +36,10 @@ The file path of the CSV file to query.
 The path can be absolute or relative.
 If relative, it is relative to the working directory of the `influxd` process.
 _The CSV file must exist in the same file system running the `influxd` process._
+
+{{% cloud-msg %}}
+{{< cloud-name "short" >}} does not support the `file` parameter.
+{{% /cloud-msg %}}
 
 _**Data type:** String_
 

--- a/content/v2.0/reference/flux/stdlib/monitor/check.md
+++ b/content/v2.0/reference/flux/stdlib/monitor/check.md
@@ -83,6 +83,7 @@ from(bucket: "telegraf")
       r._measurement == "disk" and
       r._field = "used_percent"
   )
+  |> group(columns: ["_measurement"])
   |> monitor.check(
     crit: (r) => r._value > 90.0,
     warn: (r) => r._value > 80.0,

--- a/content/v2.0/reference/flux/stdlib/system/time.md
+++ b/content/v2.0/reference/flux/stdlib/system/time.md
@@ -32,3 +32,10 @@ import "system"
 data
   |> set(key: "processed_at", value: string(v: system.time() ))
 ```
+
+{{% note %}}
+#### system.time() vs now()
+`system.time()` returns the current system time of the host machine, which
+typically accounts for the local time zone.
+[`now()`](/v2.0/reference/flux/stdlib/built-in/misc/now/) returns the current UTC time.
+{{% /note %}}

--- a/content/v2.0/reference/flux/stdlib/system/time.md
+++ b/content/v2.0/reference/flux/stdlib/system/time.md
@@ -10,6 +10,8 @@ menu:
     name: system.time
     parent: System
 weight: 401
+related:
+  - /v2.0/reference/flux/stdlib/built-in/misc/now/
 ---
 
 The `system.time()` function returns the current system time.

--- a/content/v2.0/reference/flux/stdlib/system/time.md
+++ b/content/v2.0/reference/flux/stdlib/system/time.md
@@ -37,5 +37,10 @@ data
 #### system.time() vs now()
 `system.time()` returns the current system time of the host machine, which
 typically accounts for the local time zone.
+This time represents the time at which `system.time()` it is executed, so each
+instance of `system.time()` in a Flux script returns a unique value.
+
 [`now()`](/v2.0/reference/flux/stdlib/built-in/misc/now/) returns the current UTC time.
+`now()` is cached at runtime, so all instances of `now()` in a Flux script
+return the same value.
 {{% /note %}}


### PR DESCRIPTION
Closes #405, #545, #546

Various updates to the Flux docs that include explaining the difference between `system.time()` and `now()` with cross-references between the two, updated `monitor.check()` example, and a clarification about the availability of `csv.from()` in InfluxDB Cloud 2.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
