### PR TITLE
Update glossary

### DIFF
--- a/content/v2.0/reference/glossary.md
+++ b/content/v2.0/reference/glossary.md
@@ -760,6 +760,19 @@ The series cardinality would remain unchanged at 6, as `firstname` is already sc
 
 Related entries: [field key](#field-key),[measurement](#measurement), [tag key](#tag-key), [tag set](#tag-set)
 
+## series key
+
+A series key identifies a particular series by measurement, tag set, and field key.
+
+For example:
+
+```
+# measurement, tag set, field key
+h2o_level, location=santa_monica, h2o_feet
+```
+
+Related entries: [series](/influxdb/v1.7/concepts/glossary/#series)
+
 ### server
 
 A computer, virtual or physical, running InfluxDB. <!--is this still valid for 2.0: There should only be one InfluxDB process per server. -->

--- a/content/v2.0/reference/glossary.md
+++ b/content/v2.0/reference/glossary.md
@@ -620,9 +620,11 @@ An operator (`|>`) used in Flux to chain operations together. Specifies the outp
 
 In InfluxDB, a point represents a single data record, similar to a row in a SQL database table. Each point:
 
-- Has four components: a measurement, a tag set, a field set, and a timestamp.
-- Is represented by one row in [line protocol](/v2.0/reference/line-protocol/).
-- Is uniquely identified by its series and timestamp. In a series, each point has a unique timestamp. If you write a point to a series with a timestamp that matches an existing point, the field set becomes a union of the old and new field set, where any ties go to the new field set.
+- has a measurement, a tag set, a field key, a field value, and a timestamp;
+- is uniquely identified by its series and timestamp.
+
+In a series, each point has a unique timestamp.
+If you write a point to a series with a timestamp that matches an existing point, the field set becomes a union of the old and new field set, where any ties go to the new field set.
 
 Related entries: [measurement](#measurement), [tag set](#tag-set), [field set](#field-set), [timestamp](#timestamp)
 


### PR DESCRIPTION
Updates/adds definitions for "point" and "series key".

Uses a fully formatted table for the alphabetical links.