### PR TITLE
Reference/syntax

### DIFF
--- a/content/v2.0/query-data/execute-queries.md
+++ b/content/v2.0/query-data/execute-queries.md
@@ -64,7 +64,7 @@ In your request, set the following:
 - `Content-type` header to `application/vnd.flux`.
 - Your plain text query as the request's raw data.
 
-InfluxDB returns the query results in [annotated CSV](/v2.0/reference/annotated-csv/).
+InfluxDB returns the query results in [annotated CSV](/v2.0/reference/syntax/annotated-csv/).
 
 {{% note %}}
 #### Use gzip to compress the query response

--- a/content/v2.0/reference/cli/influx/delete/_index.md
+++ b/content/v2.0/reference/cli/influx/delete/_index.md
@@ -23,16 +23,16 @@ timestamps between the specified `--start` and `--stop` times in the specified b
 {{% /warn %}}
 
 ## Flags
-| Flag                | Description                                                                                 | Input type |
-|:----                |:-----------                                                                                 |:----------:|
-| `-b`, `--bucket`    | The name of bucket to remove data from                                                      | string     |
-| `--bucket-id`       | The ID of the bucket to remove data from                                                    | string     |
-| `-h`, `--help`      | Help for the `delete` command                                                               |            |
-| `-o`, `--org`       | The name of the organization that owns the bucket                                           | string     |
-| `--org-id`          | The ID of the organization that owns the bucket                                             | string     |
-| `-p`, `--predicate` | SQL-like predicate string (see [Delete predicate](/v2.0/reference/syntax/delete-predicate)) | string     |
-| `--start`           | The start time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                              | string     |
-| `--stop`            | The stop time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                               | string     |
+| Flag                | Description                                                                                      | Input type |
+|:----                |:-----------                                                                                      |:----------:|
+| `-b`, `--bucket`    | The name of bucket to remove data from                                                           | string     |
+| `--bucket-id`       | The ID of the bucket to remove data from                                                         | string     |
+| `-h`, `--help`      | Help for the `delete` command                                                                    |            |
+| `-o`, `--org`       | The name of the organization that owns the bucket                                                | string     |
+| `--org-id`          | The ID of the organization that owns the bucket                                                  | string     |
+| `-p`, `--predicate` | InfluxQL-like predicate string (see [Delete predicate](/v2.0/reference/syntax/delete-predicate)) | string     |
+| `--start`           | The start time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                   | string     |
+| `--stop`            | The stop time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                    | string     |
 
 ## Global flags
 | Global flag     | Description                                                | Input type |

--- a/content/v2.0/reference/cli/influx/delete/_index.md
+++ b/content/v2.0/reference/cli/influx/delete/_index.md
@@ -23,16 +23,16 @@ timestamps between the specified `--start` and `--stop` times in the specified b
 {{% /warn %}}
 
 ## Flags
-| Flag                | Description                                                    | Input type |
-|:----                |:-----------                                                    |:----------:|
-| `-b`, `--bucket`    | The name of bucket to remove data from                         | string     |
-| `--bucket-id`       | The ID of the bucket to remove data from                       | string     |
-| `-h`, `--help`      | Help for the `delete` command                                  |            |
-| `-o`, `--org`       | The name of the organization that owns the bucket              | string     |
-| `--org-id`          | The ID of the organization that owns the bucket                | string     |
-| `-p`, `--predicate` | SQL-like predicate string (i.e. `tag1="v1" and tag2=123`)      | string     |
-| `--start`           | The start time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`) | string     |
-| `--stop`            | The stop time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)  | string     |
+| Flag                | Description                                                                                 | Input type |
+|:----                |:-----------                                                                                 |:----------:|
+| `-b`, `--bucket`    | The name of bucket to remove data from                                                      | string     |
+| `--bucket-id`       | The ID of the bucket to remove data from                                                    | string     |
+| `-h`, `--help`      | Help for the `delete` command                                                               |            |
+| `-o`, `--org`       | The name of the organization that owns the bucket                                           | string     |
+| `--org-id`          | The ID of the organization that owns the bucket                                             | string     |
+| `-p`, `--predicate` | SQL-like predicate string (see [Delete predicate](/v2.0/reference/syntax/delete-predicate)) | string     |
+| `--start`           | The start time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                              | string     |
+| `--stop`            | The stop time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                               | string     |
 
 ## Global flags
 | Global flag     | Description                                                | Input type |

--- a/content/v2.0/reference/flux/_index.md
+++ b/content/v2.0/reference/flux/_index.md
@@ -1,10 +1,10 @@
 ---
-title: Flux query language
+title: Flux data scripting language
 description: Reference articles for Flux functions and the Flux language specification.
 v2.0/tags: [flux]
 menu:
   v2_0_ref:
-    name: Flux query language
+    name: Flux language
 weight: 4
 ---
 

--- a/content/v2.0/reference/flux/language/_index.md
+++ b/content/v2.0/reference/flux/language/_index.md
@@ -6,7 +6,7 @@ description: >
 menu:
   v2_0_ref:
     name: Flux specification
-    parent: Flux query language
+    parent: Flux language
 weight: 103
 v2.0/tags: [flux]
 ---

--- a/content/v2.0/reference/flux/stdlib/_index.md
+++ b/content/v2.0/reference/flux/stdlib/_index.md
@@ -8,7 +8,7 @@ aliases:
 v2.0/tags: [flux, functions, package]
 menu:
   v2_0_ref:
-    parent: Flux query language
+    parent: Flux language
 weight: 102
 ---
 

--- a/content/v2.0/reference/glossary.md
+++ b/content/v2.0/reference/glossary.md
@@ -50,7 +50,7 @@ Submitting a batch of points using a single HTTP request to the write endpoints 
 InfluxData typically recommends batch sizes of 5,000-10,000 points.
 In some use cases, performance may improve with significantly smaller or larger batches.
 
-Related entries: [line protocol](/v2.0/reference/line-protocol/), [point](#point)
+Related entries: [line protocol](/v2.0/reference/syntax/line-protocol/), [point](#point)
 
 ### batch size
 
@@ -136,7 +136,7 @@ Each record consists of one or more fields, separated by commas.
 CSV file format is not fully standardized.
 
 InfluxData uses annotated CSV (comma-separated values) format to encode HTTP responses and results returned to the Flux csv.from() function.
-For more detail, see [Annotated CSV](/v2.0/reference/annotated-csv/).
+For more detail, see [Annotated CSV](/v2.0/reference/syntax/annotated-csv/).
 
 <!-- enterprise
 ### cardinality
@@ -521,7 +521,7 @@ The InfluxDB 2.0 user interface (UI) can be used to view log history and data.
 ### Line protocol (LP)
 
 The text based format for writing points to InfluxDB.
-See [line protocol](/v2.0/reference/line-protocol/).
+See [line protocol](/v2.0/reference/syntax/line-protocol/).
 
 ## M
 
@@ -993,7 +993,7 @@ Irregular time series data changes at non-constant intervals.
 The date and time associated with a point.
 Time in InfluxDB is in UTC.
 
-To specify time when writing data, see [Elements of line protocol](/v2.0/reference/line-protocol/#elements-of-line-protocol).
+To specify time when writing data, see [Elements of line protocol](/v2.0/reference/syntax/line-protocol/#elements-of-line-protocol).
 To specify time when querying data, see [Query InfluxDB with Flux](/v2.0/query-data/get-started/query-influxdb/#2-specify-a-time-range).
 
 Related entries: [point](#point)

--- a/content/v2.0/reference/key-concepts/table-structure.md
+++ b/content/v2.0/reference/key-concepts/table-structure.md
@@ -18,7 +18,7 @@ InfluxDB 2.0 uses the following columnar table structure to store data:
 - **Data rows:** all rows that contain time series data. For details about the type of data stored in InfluxDB, see [InfluxDB data elements](/v2.0/reference/key-concepts/data-elements/).
 - **Group keys** determine the contents of output tables in Flux by grouping records that share common values in specified columns. Learn more about [grouping your data with Flux](/v2.0/query-data/guides/group-data/).
 
-For specifications on the InfluxDB 2.0 table structure, see [Tables](/v2.0/reference/annotated-csv/#tables).
+For specifications on the InfluxDB 2.0 table structure, see [Tables](/v2.0/reference/syntax/annotated-csv/#tables).
 
 **_Tip:_** To visualize your table structure in the InfluxDB user interface, click the **Data Explorer** icon
 in the sidebar, create a query, click **Submit**, and then select **View Raw Data**.

--- a/content/v2.0/reference/syntax/_index.md
+++ b/content/v2.0/reference/syntax/_index.md
@@ -1,0 +1,18 @@
+---
+title: InfluxDB syntaxes
+description: >
+  InfluxDB uses a handful of languages and syntaxes to perform tasks such as
+  writing, querying, processing, and deleting data.
+weight: 5
+menu:
+  v2_0_ref:
+    name: Syntax
+v2.0/tags: [syntax]
+---
+
+InfluxDB uses a handful of languages and syntaxes to perform tasks such as
+writing, querying, processing, and deleting data.
+The following articles provide information about the different syntaxes used with
+InfluxDB and the contexts in which they're used:
+
+{{< children >}}

--- a/content/v2.0/reference/syntax/annotated-csv.md
+++ b/content/v2.0/reference/syntax/annotated-csv.md
@@ -1,16 +1,25 @@
 ---
 title: Annotated CSV syntax
+list_title: Annotated CSV
 description: >
-  Annotated CSV format is used to encode HTTP responses and results returned to the Flux `csv.from()` function.
-weight: 6
+  Flux returns raw results in Annotated CSV format and also reads Annotated CSV
+  using the `csv.from()` function.
+weight: 106
 menu:
   v2_0_ref:
+    parent: Syntax
     name: Annotated CSV
+v2.0/tags: [csv, syntax]
+aliases:
+  - /v2.0/reference/syntax/annotated-csv/
 ---
 
-Annotated CSV (comma-separated values) format is used to encode HTTP responses and results returned to the Flux [`csv.from()` function](https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/csv/from/).
+Flux returns raw results in Annotated CSV format and also reads Annotated CSV
+using the [`csv.from()` function](/v2.0/reference/flux/stdlib/csv/from/).
 
-CSV tables must be encoded in UTF-8 and Unicode Normal Form C as defined in [UAX15](http://www.unicode.org/reports/tr15/). Line endings must be CRLF (Carriage Return Line Feed) as defined by the `text/csv` MIME type in [RFC 4180](https://tools.ietf.org/html/rfc4180).
+CSV tables must be encoded in UTF-8 and Unicode Normal Form C as defined in [UAX15](http://www.unicode.org/reports/tr15/).
+Line endings must be CRLF (Carriage Return Line Feed) as defined by the `text/csv`
+MIME type in [RFC 4180](https://tools.ietf.org/html/rfc4180).
 
 ## Examples
 
@@ -71,7 +80,10 @@ my-result,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,east,
 
 In addition to the data columns, a table may include the following columns:
 
-- **Annotation column**: Only used in annotation rows. Always the first column. Displays the name of an annotation. Value can be empty or a supported [annotation](#annotations). You'll notice a space for this column for the entire length of the table, so rows appear to start with `,`.
+- **Annotation column**: Only used in annotation rows. Always the first column.
+  Displays the name of an annotation. Value can be empty or a supported [annotation](#annotations).
+  You'll notice a space for this column for the entire length of the table,
+  so rows appear to start with `,`.
 
 - **Result column**: Contains the name of the result specified by the query.
 
@@ -130,23 +142,25 @@ my-result,1,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,west,
 
 Flux supports the following dialect options for `text/csv` format.
 
-| Option    | Description| Default |
-| :-------- | :--------- | :-------|
-| **header**    | If true, the header row is included.| `true`|   
-| **delimiter** | Character used to delimit columns. | `,`|
-| **quoteChar** | Character used to quote values containing the delimiter. |`"`|   
-| **annotations** | List of annotations to encode (datatype, group, or default). |`empty`|
-| **commentPrefix** | String prefix to identify a comment. Always added to annotations. |`#`|
+| Option            | Description                                                       | Default |
+| :--------         | :---------                                                        |:------- |
+| **header**        | If true, the header row is included.                              | `true`  |
+| **delimiter**     | Character used to delimit columns.                                | `,`     |
+| **quoteChar**     | Character used to quote values containing the delimiter.          | `"`     |
+| **annotations**   | List of annotations to encode (datatype, group, or default).      | `empty` |
+| **commentPrefix** | String prefix to identify a comment. Always added to annotations. | `#`     |
 
 ### Annotations
 
-Annotation rows describe column properties, and start with `#` (or commentPrefix value). The first column in an annotation row always contains the annotation name. Subsequent columns contain annotation values as shown in the table below.
+Annotation rows describe column properties, and start with `#` (or commentPrefix value).
+The first column in an annotation row always contains the annotation name.
+Subsequent columns contain annotation values as shown in the table below.
 
-|Annotation name | Values| Description |
-| :-------- | :--------- | :-------|
-| **datatype**    | a [valid data type](#valid-data-types) | Describes the type of data. |   
-| **group** | boolean flag `true` or `false` | Indicates the column is part of the group key.|
-| **default** | a [valid data type](#valid-data-types) |Value to use for rows with an empty string value.|   
+| Annotation name | Values                                 | Description                                       |
+|:--------        |:---------                              | :-------                                          |
+| **datatype**    | a [valid data type](#valid-data-types) | Describes the type of data.                       |
+| **group**       | boolean flag `true` or `false`         | Indicates the column is part of the group key.    |
+| **default**     | a [valid data type](#valid-data-types) | Value to use for rows with an empty string value. |
 
 {{% note %}}
 To encode a table with its group key, the `datatype`, `group`, and `default` annotations must be included. If a table has no rows, the `default` annotation provides the group key values.
@@ -174,16 +188,16 @@ csv.from(csv:a) |> yield()
 
 ### Valid data types
 
-| Datatype     | Flux type     | Description                                                                        |
-| :--------    | :---------    | :-----------------------------------------------------------------------------|
-| boolean      | bool          | a truth value, one of "true" or "false"                                            |
-| unsignedLong | uint          | an unsigned 64-bit integer                                                         |
-| long         | int           | a signed 64-bit integer                                                            |
-| double       | float         | an IEEE-754 64-bit floating-point number                                           |
-| string       | string        | a UTF-8 encoded string                                                             |
-| base64Binary | bytes         | a base64 encoded sequence of bytes as defined in RFC 4648                          |
-| dateTime     | time          | an instant in time, may be followed with a colon : and a description of the format |
-| duration     | duration      | a length of time represented as an unsigned 64-bit integer number of nanoseconds   |
+| Datatype     | Flux type  | Description                                                                        |
+| :--------    | :--------- | :----------                                                                        |
+| boolean      | bool       | a truth value, one of "true" or "false"                                            |
+| unsignedLong | uint       | an unsigned 64-bit integer                                                         |
+| long         | int        | a signed 64-bit integer                                                            |
+| double       | float      | an IEEE-754 64-bit floating-point number                                           |
+| string       | string     | a UTF-8 encoded string                                                             |
+| base64Binary | bytes      | a base64 encoded sequence of bytes as defined in RFC 4648                          |
+| dateTime     | time       | an instant in time, may be followed with a colon : and a description of the format |
+| duration     | duration   | a length of time represented as an unsigned 64-bit integer number of nanoseconds   |
 
 ## Errors
 

--- a/content/v2.0/reference/syntax/annotated-csv.md
+++ b/content/v2.0/reference/syntax/annotated-csv.md
@@ -4,7 +4,7 @@ list_title: Annotated CSV
 description: >
   Flux returns raw results in Annotated CSV format and also reads Annotated CSV
   using the `csv.from()` function.
-weight: 106
+weight: 103
 menu:
   v2_0_ref:
     parent: Syntax

--- a/content/v2.0/reference/syntax/annotated-csv.md
+++ b/content/v2.0/reference/syntax/annotated-csv.md
@@ -11,7 +11,7 @@ menu:
     name: Annotated CSV
 v2.0/tags: [csv, syntax]
 aliases:
-  - /v2.0/reference/syntax/annotated-csv/
+  - /v2.0/reference/annotated-csv/
 ---
 
 Flux returns raw results in Annotated CSV format and also reads Annotated CSV

--- a/content/v2.0/reference/syntax/delete-predicate.md
+++ b/content/v2.0/reference/syntax/delete-predicate.md
@@ -1,0 +1,82 @@
+---
+title: Delete predicate syntax
+list_title: Delete predicate
+description: >
+  The InfluxDB `/delete` endpoint uses a SQL-like predicate syntax to determine
+  what data points to delete.
+menu:
+  v2_0_ref:
+    parent: Syntax
+    name: Delete predicate
+weight: 104
+v2.0/tags: [syntax, delete]
+related:
+  - /v2.0/reference/cli/influx/delete/
+---
+
+The InfluxDB `/delete` endpoint uses a SQL-like predicate syntax to determine
+what data [points](/v2.0/reference/glossary/#point) to delete.
+InfluxDB uses the delete predicate to evaluate each point in the time range
+specified in the delete request.
+Points that evaluate to `true` are deleted.
+Points that evaluate to `false` are preserved.
+
+A delete predicate is comprised of one or more [predicate expressions](/v2.0/reference/glossary/#predicate-expression).
+The left operand of the predicate expression is the column name.
+The right operand is the column value.
+Operands are compared using [comparison operators](#comparison-operators).
+Use [logical operators](#logical-operators) to combine two or more predicate expressions.
+
+##### Example delete predicate
+```sql
+key1="value1" AND key2="value"
+```
+{{% note %}}
+Predicate expressions can use any column or tag except `_time` or `_value`.
+{{% /note %}}
+
+## Logical operators
+Logical operators join two or more predicate expressions.
+
+| Operator | Description                                                                  |
+|:-------- |:-----------                                                                  |
+| `AND`    | Both left and right operands must be `true` for the expression to be `true`. |
+
+## Comparison operators
+Comparison operators compare left and right operands and return `true` or `false`.
+
+| Operator | Description  | Example        | Result |
+|:-------- |:-----------  |:-------:       |:------:|
+| `=`      | Equal to     | `"abc"="abc"`  | `true` |
+| `!=`     | Not equal to | `"abc"!="def"` | `true` |
+
+
+## Delete predicate examples
+
+### Delete a measurement
+The following will delete points in the `sensorData` measurement:
+
+```sql
+_measurement="sensorData"
+```
+
+### Delete a field
+The following will delete points with the `temperature` field:
+
+```sql
+_field="temperature"
+```
+
+### Delete points with a specific tag set
+The following will delete points from the `prod-1.4` host in the `us-west` region:
+
+```sql
+host="prod-1.4" AND region="us-west"
+```
+
+## Limitations
+The delete predicate syntax has the following limitations.
+
+- Delete predicates do not support regular expressions.
+- Delete predicates do not support the `OR` logical operator.
+- Delete predicates can use any column or tag except `_time` or `_value`.

--- a/content/v2.0/reference/syntax/delete-predicate.md
+++ b/content/v2.0/reference/syntax/delete-predicate.md
@@ -2,7 +2,7 @@
 title: Delete predicate syntax
 list_title: Delete predicate
 description: >
-  The InfluxDB `/delete` endpoint uses a InfluxQL-like predicate syntax to determine
+  The InfluxDB `/delete` endpoint uses an InfluxQL-like predicate syntax to determine
   what data points to delete.
 menu:
   v2_0_ref:
@@ -14,7 +14,7 @@ related:
   - /v2.0/reference/cli/influx/delete/
 ---
 
-The InfluxDB `/delete` endpoint uses a InfluxQL-like predicate syntax to determine
+The InfluxDB `/delete` endpoint uses an InfluxQL-like predicate syntax to determine
 what data [points](/v2.0/reference/glossary/#point) to delete.
 InfluxDB uses the delete predicate to evaluate the [series keys](/v2.0/reference/glossary/#series-key)
 of points in the time range specified in the delete request.

--- a/content/v2.0/reference/syntax/delete-predicate.md
+++ b/content/v2.0/reference/syntax/delete-predicate.md
@@ -2,7 +2,7 @@
 title: Delete predicate syntax
 list_title: Delete predicate
 description: >
-  The InfluxDB `/delete` endpoint uses a SQL-like predicate syntax to determine
+  The InfluxDB `/delete` endpoint uses a InfluxQL-like predicate syntax to determine
   what data points to delete.
 menu:
   v2_0_ref:
@@ -14,12 +14,12 @@ related:
   - /v2.0/reference/cli/influx/delete/
 ---
 
-The InfluxDB `/delete` endpoint uses a SQL-like predicate syntax to determine
+The InfluxDB `/delete` endpoint uses a InfluxQL-like predicate syntax to determine
 what data [points](/v2.0/reference/glossary/#point) to delete.
-InfluxDB uses the delete predicate to evaluate each point in the time range
-specified in the delete request.
-Points that evaluate to `true` are deleted.
-Points that evaluate to `false` are preserved.
+InfluxDB uses the delete predicate to evaluate the [series keys](/v2.0/reference/glossary/#series-key)
+of points in the time range specified in the delete request.
+Points with series keys that evaluate to `true` for the given predicate are deleted.
+Points with series keys that evaluate to `false` are preserved.
 
 A delete predicate is comprised of one or more [predicate expressions](/v2.0/reference/glossary/#predicate-expression).
 The left operand of the predicate expression is the column name.
@@ -48,19 +48,17 @@ Comparison operators compare left and right operands and return `true` or `false
 | Operator | Description  | Example        | Result |
 |:-------- |:-----------  |:-------:       |:------:|
 | `=`      | Equal to     | `"abc"="abc"`  | `true` |
-| `!=`     | Not equal to | `"abc"!="def"` | `true` |
-
 
 ## Delete predicate examples
 
-### Delete a measurement
+### Delete points with a specific measurement
 The following will delete points in the `sensorData` measurement:
 
 ```sql
 _measurement="sensorData"
 ```
 
-### Delete a field
+### Delete points with a specific field
 The following will delete points with the `temperature` field:
 
 ```sql
@@ -79,4 +77,5 @@ The delete predicate syntax has the following limitations.
 
 - Delete predicates do not support regular expressions.
 - Delete predicates do not support the `OR` logical operator.
+- Delete predicates only support equality (`=`), not inequality (`!=`).
 - Delete predicates can use any column or tag except `_time` or `_value`.

--- a/content/v2.0/reference/syntax/flux.md
+++ b/content/v2.0/reference/syntax/flux.md
@@ -1,0 +1,36 @@
+---
+title: Flux syntax
+list_title: Flux
+description: >
+  Flux is a functional data scripting language designed for querying, analyzing, and acting on data.
+menu:
+  v2_0_ref:
+    parent: Syntax
+    name: Flux
+    identifier: flux-syntax
+weight: 101
+v2.0/tags: [syntax, flux]
+---
+
+Flux is a functional data scripting language designed for querying, analyzing, and acting on data.
+
+## Flux design principles
+Flux takes a functional approach to data exploration and processing, but is designed
+to be usable, readable, flexible, composable, testable, contributable, and shareable.
+
+```js
+from(bucket:"example-bucket")
+  |> range(start:-1h)
+  |> filter(fn:(r) =>
+    r._measurement == "cpu" and
+    r.cpu == "cpu-total"
+  )
+  |> aggregateWindow(every: 1m, fn: mean)
+```
+
+## Flux documentation
+For more information about Flux syntax, packages, and functions, see:
+
+- [Get started with Flux](/v2.0/reference/flux/)
+- [Flux standard library](/v2.0/reference/flux/stdlib/)
+- [Flux language specification](/v2.0/reference/flux/language/)

--- a/content/v2.0/reference/syntax/flux.md
+++ b/content/v2.0/reference/syntax/flux.md
@@ -18,6 +18,8 @@ Flux is a functional data scripting language designed for querying, analyzing, a
 Flux takes a functional approach to data exploration and processing, but is designed
 to be usable, readable, flexible, composable, testable, contributable, and shareable.
 
+The following example returns the the average CPU usage per minute over the last hour.
+
 ```js
 from(bucket:"example-bucket")
   |> range(start:-1h)

--- a/content/v2.0/reference/syntax/line-protocol.md
+++ b/content/v2.0/reference/syntax/line-protocol.md
@@ -1,13 +1,17 @@
 ---
 title: Line protocol reference
+list_title: Line protocol
 description: >
   InfluxDB uses line protocol to write data points.
   It is a text-based format that provides the measurement, tag set, field set, and timestamp of a data point.
 menu:
   v2_0_ref:
+    parent: Syntax
     name: Line protocol
-weight: 6
-v2.0/tags: [write, line protocol]
+weight: 102
+v2.0/tags: [write, line protocol, syntax]
+aliases:
+  - /v2.0/reference/syntax/line-protocol
 ---
 
 InfluxDB uses line protocol to write data points.

--- a/content/v2.0/reference/syntax/line-protocol.md
+++ b/content/v2.0/reference/syntax/line-protocol.md
@@ -11,7 +11,7 @@ menu:
 weight: 102
 v2.0/tags: [write, line protocol, syntax]
 aliases:
-  - /v2.0/reference/syntax/line-protocol
+  - /v2.0/reference/line-protocol
 ---
 
 InfluxDB uses line protocol to write data points.

--- a/content/v2.0/write-data/_index.md
+++ b/content/v2.0/write-data/_index.md
@@ -11,7 +11,7 @@ menu:
 v2.0/tags: [write, line protocol]
 ---
 
-Collect and write time series data to InfluxDB using [line protocol](/v2.0/reference/line-protocol),
+Collect and write time series data to InfluxDB using [line protocol](/v2.0/reference/syntax/line-protocol),
 Telegraf, data scrapers, the InfluxDB v2 API, `influx` command line interface (CLI),
 the InfluxDB user interface (UI), and client libraries.
 
@@ -40,9 +40,9 @@ The [InfluxDB setup process](/v2.0/get-started/#set-up-influxdb) creates each of
 
 Use _line protocol_ format to write data into InfluxDB.
 Each line represents a data point.
-Each point requires a [*measurement*](/v2.0/reference/line-protocol/#measurement)
-and [*field set*](/v2.0/reference/line-protocol/#field-set) and may also include
-a [*tag set*](/v2.0/reference/line-protocol/#tag-set) and a [*timestamp*](/v2.0/reference/line-protocol/#timestamp).
+Each point requires a [*measurement*](/v2.0/reference/syntax/line-protocol/#measurement)
+and [*field set*](/v2.0/reference/syntax/line-protocol/#field-set) and may also include
+a [*tag set*](/v2.0/reference/syntax/line-protocol/#tag-set) and a [*timestamp*](/v2.0/reference/syntax/line-protocol/#timestamp).
 
 Line protocol data looks like this:
 
@@ -67,7 +67,7 @@ InfluxDB accepts the following precisions:
 - `ms` - Milliseconds
 - `s` - Seconds
 
-_For more details about line protocol, see the [Line protocol reference](/v2.0/reference/line-protocol) and [Best practices for writing data](/v2.0/write-data/best-practices/)._
+_For more details about line protocol, see the [Line protocol reference](/v2.0/reference/syntax/line-protocol) and [Best practices for writing data](/v2.0/write-data/best-practices/)._
 
 ## Ways to write data into InfluxDB
 

--- a/content/v2.0/write-data/best-practices/duplicate-points.md
+++ b/content/v2.0/write-data/best-practices/duplicate-points.md
@@ -14,7 +14,7 @@ v2.0/tags: [best practices, write]
 ---
 
 InfluxDB identifies unique data points by their measurement, tag set, and timestamp
-(each a part of [Line protocol](/v2.0/reference/line-protocol) used to write data to InfluxDB).
+(each a part of [Line protocol](/v2.0/reference/syntax/line-protocol) used to write data to InfluxDB).
 
 ```txt
 web,host=host2,region=us_west firstByte=15.0 1559260800000000000


### PR DESCRIPTION
Closes #566 and #565

Created a new "Syntax" reference section and moved the Annotated CSV and Line protocol docs there. Added a Flux summary doc and a new Delete predicate syntax doc.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
