### PR TITLE
docs: explain how to work around MacOS Catalina extra security prompts.

### DIFF
--- a/content/v2.0/get-started.md
+++ b/content/v2.0/get-started.md
@@ -66,12 +66,18 @@ Start InfluxDB by running the `influxd` daemon:
 influxd
 ```
 {{% warn %}}
-#### Influxd cannot be opened because the developer cannot be verified.
-With the latest release of macOS Catalina some binaries cannot be run without first
-being authorized.  To allow these files to run open Spotlight search (⌘ + space) and
-type "Security".  Open the Security & Privacy panel and click "Allow Anyway".  
-Next time you run influxd you will be prompted to click "Open" and Influxd will run.
-This will be resolved soon.
+#### Run InfluxDB on macOS Catalina
+macOS Catalina requires downloaded binaries to be signed by registered Apple developers.
+Currently, when you first attempt to run `influxd` or `influx`, macOS will prevent it from running.
+To manually authorize the InfluxDB binaries:
+
+1. Attempt to run the `influx` or `influxd` commands.
+2. Open **System Preferences** and click **Security & Privacy**. 
+3. Under the **General** tab, there is a message about `influxd` or `influx` being blocked.
+   Click **Open Anyway**.
+4. Repeat this process for both binaries.
+
+We are in the process of updating our build process to ensure released binaries are signed by InfluxData.
 {{% /warn %}}
 
 _See the [`influxd` documentation](/v2.0/reference/cli/influxd) for information about

--- a/content/v2.0/get-started.md
+++ b/content/v2.0/get-started.md
@@ -67,7 +67,7 @@ influxd
 ```
 {{% warn %}}
 #### Influxd cannot be opened because the developer cannot be verified.
-With the latest release of MacOS Catalina some binaries cannot be run without first
+With the latest release of macOS Catalina some binaries cannot be run without first
 being authorized.  To allow these files to run open Spotlight search (⌘ + space) and
 type "Security".  Open the Security & Privacy panel and click "Allow Anyway".  
 Next time you run influxd you will be prompted to click "Open" and Influxd will run.

--- a/content/v2.0/get-started.md
+++ b/content/v2.0/get-started.md
@@ -65,6 +65,14 @@ Start InfluxDB by running the `influxd` daemon:
 ```bash
 influxd
 ```
+{{% warn %}}
+#### Influxd cannot be opened because the developer cannot be verified.
+With the latest release of MacOS Catalina some binaries cannot be run without first
+being authorized.  To allow these files to run open Spotlight search (⌘ + space) and
+type "Security".  Open the Security & Privacy panel and click "Allow Anyway".  
+Next time you run influxd you will be prompted to click "Open" and Influxd will run.
+This will be resolved soon.
+{{% /warn %}}
 
 _See the [`influxd` documentation](/v2.0/reference/cli/influxd) for information about
 available flags and options._


### PR DESCRIPTION
Closes #603 

This commit adds a warn section to the docs to explain how to work
around the additional security added in Catalina which prevents
execution of downloaded binaries which are not signed by Apple.

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
