### PR TITLE
Use shortcode for cli "Global Flags" docs

### DIFF
--- a/content/v2.0/reference/cli/influx/_index.md
+++ b/content/v2.0/reference/cli/influx/_index.md
@@ -59,3 +59,8 @@ retrieving authentication tokens._
 | [write](/v2.0/reference/cli/influx/write)   | Write points to InfluxDB                             |
 
 {{% influx-cli-global-flags %}}
+
+## Flags
+| Flag           | Description                   |
+|:---------------|:------------------------------|
+| `-h`, `--help` | Help for the `influx` command |

--- a/content/v2.0/reference/cli/influx/_index.md
+++ b/content/v2.0/reference/cli/influx/_index.md
@@ -58,10 +58,4 @@ retrieving authentication tokens._
 | [user](/v2.0/reference/cli/influx/user)     | User management commands                             |
 | [write](/v2.0/reference/cli/influx/write)   | Write points to InfluxDB                             |
 
-## Flags
-| Flag            | Description                                                | Input type |
-|:----            |:-----------                                                |:----------:|
-| `-h`, `--help`  | Help for the influx command                                |            |
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/_index.md
+++ b/content/v2.0/reference/cli/influx/auth/_index.md
@@ -34,9 +34,4 @@ influx auth [command]
 |:----           |:-----------                 |
 | `-h`, `--help` | Help for the `auth` command |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/active.md
+++ b/content/v2.0/reference/cli/influx/auth/active.md
@@ -21,9 +21,4 @@ influx auth active [flags]
 | `-h`, `--help` | Help for the `active` command       |            |
 | `-i`, `--id`   | The authorization ID **(Required)** | string     |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/create.md
+++ b/content/v2.0/reference/cli/influx/auth/create.md
@@ -36,9 +36,4 @@ influx auth create [flags]
 | `--write-telegrafs`  | Grants the permission to create telegraf configs                               |             |
 | `--write-user`       | Grants the permission to perform mutative actions against organization users   |             |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/delete.md
+++ b/content/v2.0/reference/cli/influx/auth/delete.md
@@ -21,9 +21,4 @@ influx auth delete [flags]
 | `-h`, `--help` | Help for the `delete` command       |             |
 | `-i`, `--id`   | The authorization ID **(Required)** | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/find.md
+++ b/content/v2.0/reference/cli/influx/auth/find.md
@@ -25,9 +25,4 @@ influx auth find [flags]
 | `-u`, `--user` | The user                    | string      |
 | `--user-id`    | The user ID                 | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/inactive.md
+++ b/content/v2.0/reference/cli/influx/auth/inactive.md
@@ -21,9 +21,4 @@ influx auth inactive [flags]
 | `-h`, `--help` | Help for the `inactive` command     |             |
 | `-i`, `--id`   | The authorization ID **(Required)** | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/_index.md
+++ b/content/v2.0/reference/cli/influx/bucket/_index.md
@@ -30,9 +30,4 @@ influx bucket [command]
 |:----           |:-----------                   |
 | `-h`, `--help` | Help for the `bucket` command |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/create.md
+++ b/content/v2.0/reference/cli/influx/bucket/create.md
@@ -23,9 +23,4 @@ influx bucket create [flags]
 | `--org-id`          | The ID of the organization that owns the bucket  | string      |
 | `-r`, `--retention` | Duration in nanoseconds data will live in bucket | duration    |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/delete.md
+++ b/content/v2.0/reference/cli/influx/bucket/delete.md
@@ -21,9 +21,4 @@ influx bucket delete [flags]
 | `-h`, `--help` | Help for the `delete` command |             |
 | `-i`, `--id`   | The bucket ID **(Required)**  | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/find.md
+++ b/content/v2.0/reference/cli/influx/bucket/find.md
@@ -24,9 +24,4 @@ influx bucket find [flags]
 | `-o`, `--org`  | The bucket organization name | string      |
 | `--org-id`     | The bucket organization ID   | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/update.md
+++ b/content/v2.0/reference/cli/influx/bucket/update.md
@@ -23,9 +23,4 @@ influx bucket update [flags]
 | `-n`, `--name`      | New bucket name                       | string      |
 | `-r`, `--retention` | New duration data will live in bucket | duration    |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/delete/_index.md
+++ b/content/v2.0/reference/cli/influx/delete/_index.md
@@ -34,9 +34,4 @@ timestamps between the specified `--start` and `--stop` times in the specified b
 | `--start`           | The start time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                   | string     |
 | `--stop`            | The stop time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                    | string     |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/help/_index.md
+++ b/content/v2.0/reference/cli/influx/help/_index.md
@@ -20,9 +20,4 @@ influx help [command] [flags]
 |:----           |:-----------   |
 | `-h`, `--help` | Help for help |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/_index.md
+++ b/content/v2.0/reference/cli/influx/org/_index.md
@@ -34,9 +34,4 @@ influx org [command]
 |:----           |:-----------                |
 | `-h`, `--help` | Help for the `org` command |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/create.md
+++ b/content/v2.0/reference/cli/influx/org/create.md
@@ -21,9 +21,4 @@ influx org create [flags]
 | `-h`, `--help` | Help for `create`                             |             |
 | `-n`, `--name` | The name of organization that will be created | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/delete.md
+++ b/content/v2.0/reference/cli/influx/org/delete.md
@@ -21,9 +21,4 @@ influx org delete [flags]
 | `-h`, `--help` | Help for `delete`                  |             |
 | `-i`, `--id`   | The organization ID **(Required)** | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/find.md
+++ b/content/v2.0/reference/cli/influx/org/find.md
@@ -22,9 +22,4 @@ influx org find [flags]
 | `-i`, `--id`   | The organization ID   | string      |
 | `-n`, `--name` | The organization name | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/_index.md
+++ b/content/v2.0/reference/cli/influx/org/members/_index.md
@@ -29,9 +29,4 @@ influx org members [command]
 |:----           |:-----------        |
 | `-h`, `--help` | Help for `members` |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/add.md
+++ b/content/v2.0/reference/cli/influx/org/members/add.md
@@ -23,9 +23,4 @@ influx org members add [flags]
 | `-o`, `--member` | The member ID         | string      |
 | `-n`, `--name`   | The organization name | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/list.md
+++ b/content/v2.0/reference/cli/influx/org/members/list.md
@@ -22,9 +22,4 @@ influx org members list [flags]
 | `-i`, `--id`   | The organization ID   | string      |
 | `-n`, `--name` | The organization name | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/remove.md
+++ b/content/v2.0/reference/cli/influx/org/members/remove.md
@@ -23,9 +23,4 @@ influx org members remove [flags]
 | `-o`, `--member` | The member ID         | string      |
 | `-n`, `--name`   | The organization name | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/update.md
+++ b/content/v2.0/reference/cli/influx/org/update.md
@@ -22,9 +22,4 @@ influx org update [flags]
 | `-i`, `--id`   | The organization ID **(Required)** | string      |
 | `-n`, `--name` | The organization name              | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/ping/_index.md
+++ b/content/v2.0/reference/cli/influx/ping/_index.md
@@ -25,9 +25,4 @@ influx ping [flags]
 |:----           |:-----------                 |
 | `-h`, `--help` | Help for the `ping` command |
 
-## Global Flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/query/_index.md
+++ b/content/v2.0/reference/cli/influx/query/_index.md
@@ -25,9 +25,4 @@ influx query [query literal or @/path/to/query.flux] [flags]
 | `-h`, `--help` | Help for the query command |            |
 | `--org-id`     | The organization ID        | string     |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/repl/_index.md
+++ b/content/v2.0/reference/cli/influx/repl/_index.md
@@ -32,9 +32,4 @@ To use the Flux REPL, you must first authenticate with a [token](/v2.0/security/
 | `-o`, `--org`  | The name of the organization    | string     |
 | `--org-id`     | The ID of organization to query | string     |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/setup/_index.md
+++ b/content/v2.0/reference/cli/influx/setup/_index.md
@@ -24,9 +24,4 @@ influx setup [flags]
 |:----           |:-----------                  |
 | `-h`, `--help` | Help for the `setup` command |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/_index.md
+++ b/content/v2.0/reference/cli/influx/task/_index.md
@@ -33,9 +33,4 @@ influx task [command]
 |:----           |:-----------                 |
 | `-h`, `--help` | Help for the `task` command |
 
-### Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/create.md
+++ b/content/v2.0/reference/cli/influx/task/create.md
@@ -22,9 +22,4 @@ influx task create [query literal or @/path/to/query.flux] [flags]
 | `--org`        | Organization name                         | string      |
 | `--org-id`     | ID of the organization that owns the task | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/delete.md
+++ b/content/v2.0/reference/cli/influx/task/delete.md
@@ -21,9 +21,4 @@ influx task delete [flags]
 | `-h`, `--help` | Help for `delete`      |             |
 | `-i`, `--id`   | Task id **(Required)** | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/find.md
+++ b/content/v2.0/reference/cli/influx/task/find.md
@@ -25,9 +25,4 @@ influx task find [flags]
 | `--org-id`        | Task organization ID                        | string      |
 | `-n`, `--user-id` | Task owner ID                               | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/log/_index.md
+++ b/content/v2.0/reference/cli/influx/task/log/_index.md
@@ -27,9 +27,4 @@ influx task log [command]
 |:----           |:-----------    |
 | `-h`, `--help` | Help for `log` |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/log/find.md
+++ b/content/v2.0/reference/cli/influx/task/log/find.md
@@ -23,9 +23,4 @@ influx task log find [flags]
 | `--run-id`     | Run ID                 | string      |
 | `--task-id`    | Task ID **(Required)** | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/retry.md
+++ b/content/v2.0/reference/cli/influx/task/retry.md
@@ -22,9 +22,4 @@ influx task retry [flags]
 | `-r`, `--run-id`  | Run id **(Required)**  | string      |
 | `-i`, `--task-id` | Task id **(Required)** | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/run/_index.md
+++ b/content/v2.0/reference/cli/influx/task/run/_index.md
@@ -28,9 +28,4 @@ influx task run [command]
 |:----           |:-----------    |
 | `-h`, `--help` | Help for `run` |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/run/find.md
+++ b/content/v2.0/reference/cli/influx/task/run/find.md
@@ -26,9 +26,4 @@ influx task run find [flags]
 | `--run-id`    | Run ID                      | string      |
 | `--task-id`   | Task ID **(Required)**      | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/update.md
+++ b/content/v2.0/reference/cli/influx/task/update.md
@@ -22,9 +22,4 @@ influx task update [flags]
 | `-i`, `--id`   | Task ID **(Required)** | string      |
 | `--status`     | Update task status     | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/_index.md
+++ b/content/v2.0/reference/cli/influx/user/_index.md
@@ -30,9 +30,4 @@ influx user [command]
 |:----           |:-----------                 |
 | `-h`, `--help` | Help for the `user` command |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/create.md
+++ b/content/v2.0/reference/cli/influx/user/create.md
@@ -21,9 +21,4 @@ influx user create [flags]
 | `-h`, `--help` | Help for `create`            |             |
 | `-n`, `--name` | The user name **(Required)** | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/delete.md
+++ b/content/v2.0/reference/cli/influx/user/delete.md
@@ -21,9 +21,4 @@ influx user delete [flags]
 | `-h`, `--help` | Help for `delete`          |             |
 | `-i`, `--id`   | The user ID **(Required)** | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/find.md
+++ b/content/v2.0/reference/cli/influx/user/find.md
@@ -22,9 +22,4 @@ influx user find [flags]
 | `-i`, `--id`   | The user ID     | string      |
 | `-n`, `--name` | The user name   | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/update.md
+++ b/content/v2.0/reference/cli/influx/user/update.md
@@ -23,9 +23,4 @@ influx user update [flags]
 | `-i`, `--id`   | The user ID **(Required)** | string      |
 | `-n`, `--name` | The user name              | string      |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influx/write/_index.md
+++ b/content/v2.0/reference/cli/influx/write/_index.md
@@ -29,9 +29,4 @@ influx write [line protocol or @/path/to/points.txt] [flags]
 | `--org-id`          | The ID of the organization that owns the bucket         | string     |
 | `-p`, `--precision` | Precision of the timestamps of the lines (default `ns`) | string     |
 
-## Global flags
-| Global flag     | Description                                                | Input type |
-|:-----------     |:-----------                                                |:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string     |
-| `--local`       | Run commands against the local filesystem                  |            |
-| `-t`, `--token` | API token to use in client calls                           | string     |
+{{% influx-cli-global-flags %}}

--- a/layouts/shortcodes/influx-cli-global-flags.md
+++ b/layouts/shortcodes/influx-cli-global-flags.md
@@ -1,0 +1,8 @@
+## Global Flags
+
+| Flag            | Description                                                                                 | Input type |
+|:----------------|:--------------------------------------------------------------------------------------------|:----------:|
+| `-h`, `--help`  | Help for the influx command                                                                 |            |
+| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`)                                  | string     |
+| `--local`       | Run commands against the local filesystem                                                   |            |
+| `-t`, `--token` | API token to use in client calls                                                            | string     |

--- a/layouts/shortcodes/influx-cli-global-flags.md
+++ b/layouts/shortcodes/influx-cli-global-flags.md
@@ -6,3 +6,4 @@
 | `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`)                                  | string     |
 | `--local`       | Run commands against the local filesystem                                                   |            |
 | `-t`, `--token` | API token to use in client calls                                                            | string     |
+| `--skip-verify` | Skip certificate verification (use when connecting over TLS with a self-signed certificate) |            |

--- a/layouts/shortcodes/influx-cli-global-flags.md
+++ b/layouts/shortcodes/influx-cli-global-flags.md
@@ -2,7 +2,6 @@
 
 | Flag            | Description                                                                                 | Input type |
 |:----------------|:--------------------------------------------------------------------------------------------|:----------:|
-| `-h`, `--help`  | Help for the influx command                                                                 |            |
 | `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`)                                  | string     |
 | `--local`       | Run commands against the local filesystem                                                   |            |
 | `-t`, `--token` | API token to use in client calls                                                            | string     |


### PR DESCRIPTION
*Trying again...*

Use shortcode for the "Global Flags" sections of each cli command page.

Adds the --skip-verify flag to this list (addressing #608).

