### PR TITLE
Flux experimental HTTP package and 'http.get()' function

### DIFF
--- a/content/v2.0/reference/flux/stdlib/experimental/http/_index.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/http/_index.md
@@ -10,7 +10,7 @@ menu:
     name: HTTP
     identifier: HTTP-exp
     parent: Experimental
-weight: 202
+weight: 201
 v2.0/tags: [functions, http, package]
 ---
 

--- a/content/v2.0/reference/flux/stdlib/experimental/http/_index.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/http/_index.md
@@ -1,0 +1,31 @@
+---
+title: Flux HTTP package
+list_title: HTTP package
+description: >
+  The Flux Experimental HTTP package provides experimental functions for transferring
+  data using the HTTP protocol.
+  Import the `experimental/http` package.
+menu:
+  v2_0_ref:
+    name: HTTP
+    identifier: HTTP-exp
+    parent: Experimental
+weight: 202
+v2.0/tags: [functions, http, package]
+---
+
+The Flux Experimental HTTP package provides experimental functions for transferring
+data using the HTTP protocol.
+
+{{% warn %}}
+The experimental HTTP package is subject to change at any time.
+By using this package, you accept the [risks of experimental functions](/v2.0/reference/flux/stdlib/experimental/#use-experimental-functions-at-your-own-risk).
+{{% /warn %}}
+
+Import the `experimental/http` package:
+
+```js
+import "experimental/http"
+```
+
+{{< children type="functions" show="pages" >}}

--- a/content/v2.0/reference/flux/stdlib/experimental/http/_index.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/http/_index.md
@@ -2,8 +2,8 @@
 title: Flux HTTP package
 list_title: HTTP package
 description: >
-  The Flux Experimental HTTP package provides experimental functions for transferring
-  data using the HTTP protocol.
+  The Flux Experimental HTTP package provides functions for transferring data
+  using HTTP protocol.
   Import the `experimental/http` package.
 menu:
   v2_0_ref:
@@ -14,8 +14,8 @@ weight: 201
 v2.0/tags: [functions, http, package]
 ---
 
-The Flux Experimental HTTP package provides experimental functions for transferring
-data using the HTTP protocol.
+The Flux Experimental HTTP package provides functions for transferring data
+using HTTP protocol.
 
 {{% warn %}}
 The experimental HTTP package is subject to change at any time.

--- a/content/v2.0/reference/flux/stdlib/experimental/http/get.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/http/get.md
@@ -2,7 +2,7 @@
 title: http.get() function
 description: >
   The `http.get()` function submits an HTTP GET request to the specified URL with headers
-  and returns the HTTP status code and body as a byte array.
+  and returns the HTTP status code as an integer and the response body as a byte array.
 menu:
   v2_0_ref:
     name: http.get
@@ -11,7 +11,7 @@ weight: 301
 ---
 
 The `http.get()` function submits an HTTP GET request to the specified URL with headers
-and returns the HTTP status code and body as a byte array.
+and returns the HTTP status code as an integer and the response body as a byte array.
 
 _**Function type:** Miscellaneous_
 
@@ -56,6 +56,6 @@ response = http.get(
     headers: {Authorization: "Token ${token}"}
   )
 
-status = string(v: response.statusCode)
+status = response.statusCode
 body = string(v: response.body)
 ```

--- a/content/v2.0/reference/flux/stdlib/experimental/http/get.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/http/get.md
@@ -1,0 +1,56 @@
+---
+title: http.get() function
+description: >
+  The `http.get()` function submits an HTTP GET request to the specified URL with headers
+  and returns the HTTP status code and body as a byte array.
+menu:
+  v2_0_ref:
+    name: http.get
+    parent: HTTP-exp
+weight: 202
+---
+
+The `http.get()` function submits an HTTP GET request to the specified URL with headers
+and returns the HTTP status code and body as a byte array.
+
+_**Function type:** Miscellaneous_
+
+{{% warn %}}
+The `http.get()` function is currently experimental and subject to change at any time.
+By using this function, you accept the [risks of experimental functions](/v2.0/reference/flux/stdlib/experimental/#use-experimental-functions-at-your-own-risk).
+{{% /warn %}}
+
+```js
+import "experimental/http"
+
+http.get(
+  url: "http://localhost:9999/",
+  headers: {x:"a", y:"b", z:"c"}
+)
+```
+
+## Parameters
+
+### url
+The URL to send the GET request to.
+
+_**Data type:** String_
+
+### headers
+Headers to include with the GET request.
+
+_**Data type:** Object_
+
+## Examples
+
+##### Get the status of InfluxDB
+```js
+import "experimental/http"
+
+response = http.get(
+    url: "http://localhost.com:9999/health",
+    headers: {}
+  )
+
+status = string(v: response.body)
+```

--- a/content/v2.0/reference/flux/stdlib/experimental/http/get.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/http/get.md
@@ -52,5 +52,6 @@ response = http.get(
     headers: {}
   )
 
-status = string(v: response.body)
+status = string(v: response.statusCode)
+body = string(v: response.body)
 ```

--- a/content/v2.0/reference/flux/stdlib/experimental/http/get.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/http/get.md
@@ -38,6 +38,7 @@ _**Data type:** String_
 
 ### headers
 Headers to include with the GET request.
+Headers are represented by key-value pairs.
 
 _**Data type:** Object_
 
@@ -45,11 +46,14 @@ _**Data type:** Object_
 
 ##### Get the status of InfluxDB
 ```js
+import "influxdata/influxdb/secrets"
 import "experimental/http"
+
+token = secrets.get(key: "READONLY_TOKEN")
 
 response = http.get(
     url: "http://localhost.com:9999/health",
-    headers: {}
+    headers: {Authorization: "Token ${token}"}
   )
 
 status = string(v: response.statusCode)

--- a/content/v2.0/reference/flux/stdlib/experimental/http/get.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/http/get.md
@@ -7,7 +7,7 @@ menu:
   v2_0_ref:
     name: http.get
     parent: HTTP-exp
-weight: 202
+weight: 301
 ---
 
 The `http.get()` function submits an HTTP GET request to the specified URL with headers

--- a/content/v2.0/reference/flux/stdlib/experimental/http/get.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/http/get.md
@@ -38,7 +38,6 @@ _**Data type:** String_
 
 ### headers
 Headers to include with the GET request.
-Headers are represented by key-value pairs.
 
 _**Data type:** Object_
 

--- a/content/v2.0/reference/flux/stdlib/experimental/http/get.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/http/get.md
@@ -1,8 +1,8 @@
 ---
 title: http.get() function
 description: >
-  The `http.get()` function submits an HTTP GET request to the specified URL with headers
-  and returns the HTTP status code as an integer and the response body as a byte array.
+  The `http.get()` function submits an HTTP GET request to the specified URL and
+  returns the HTTP status code as an integer and the response body as a byte array.
 menu:
   v2_0_ref:
     name: http.get
@@ -10,8 +10,8 @@ menu:
 weight: 301
 ---
 
-The `http.get()` function submits an HTTP GET request to the specified URL with headers
-and returns the HTTP status code as an integer and the response body as a byte array.
+The `http.get()` function submits an HTTP GET request to the specified URL and
+returns the HTTP status code as an integer and the response body as a byte array.
 
 _**Function type:** Miscellaneous_
 


### PR DESCRIPTION
Closes # 601

Adds the `experimental/http` package with the `http.get()` function.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
