### PR TITLE
updated reference nav order, nested client libraries under api

### DIFF
--- a/content/v2.0/reference/api/_index.md
+++ b/content/v2.0/reference/api/_index.md
@@ -48,4 +48,4 @@ and visit the `/docs` endpoint in a browser ([localhost:9999/docs](http://localh
 
 ## InfluxDB client libraries
 InfluxDB client libraries are language-specific packages that integrate with the InfluxDB v2 API.
-For information about supported client libraries, see [InfluxDB client libraries](/v2.0/reference/client-libraries/).
+For information about supported client libraries, see [InfluxDB client libraries](/v2.0/reference/api/client-libraries/).

--- a/content/v2.0/reference/api/client-libraries.md
+++ b/content/v2.0/reference/api/client-libraries.md
@@ -3,10 +3,13 @@ title: InfluxDB client libraries
 description: >
   InfluxDB client libraries are language-specific tools that integrate with the InfluxDB v2 API.
   View the list of available client libraries.
-weight: 4
+weight: 103
+aliases:
+  - /v2.0/reference/client-libraries/
 menu:
   v2_0_ref:
     name: Client libraries
+    parent: InfluxDB v2 API
 v2.0/tags: [client libraries]
 ---
 

--- a/content/v2.0/reference/flux/_index.md
+++ b/content/v2.0/reference/flux/_index.md
@@ -5,7 +5,7 @@ v2.0/tags: [flux]
 menu:
   v2_0_ref:
     name: Flux language
-weight: 4
+weight: 3
 ---
 
 The following articles are meant as a reference for the Flux standard library and

--- a/content/v2.0/write-data/_index.md
+++ b/content/v2.0/write-data/_index.md
@@ -184,4 +184,4 @@ curl -XPOST "http://localhost:9999/api/v2/write?org=YOUR_ORG&bucket=YOUR_BUCKET&
 ### InfluxDB client libraries
 
 Use language-specific client libraries to integrate with the InfluxDB v2 API.
-See [Client libraries reference](/v2.0/reference/client-libraries/) for more information.
+See [Client libraries reference](/v2.0/reference/api/client-libraries/) for more information.

--- a/content/v2.0/write-data/best-practices/optimize-writes.md
+++ b/content/v2.0/write-data/best-practices/optimize-writes.md
@@ -16,7 +16,7 @@ The following tools write to InfluxDB and employ write optimizations by default:
 
 - [Telegraf](/v2.0/write-data/use-telegraf/)
 - [InfluxDB scrapers](/v2.0/write-data/scrape-data/)
-- [InfluxDB client libraries](/v2.0/reference/client-libraries/)
+- [InfluxDB client libraries](/v2.0/reference/api/client-libraries/)
 {{% /note %}}
 
 ---


### PR DESCRIPTION
This nests the Client Libraries doc under the API reference section to help keep the top level left nav from getting too long. It also adjusts the order in which the top level reference items appear.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
