### PR TITLE
Commented out unavailable join methods

### DIFF
--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/join.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/join.md
@@ -67,10 +67,10 @@ _**Data type:** String_
 
 ###### Possible Values:
 - `inner`
-- `cross`
+<!-- - `cross`
 - `left`
 - `right`
-- `full`
+- `full` -->
 
 {{% note %}}
 The `on` parameter and the `cross` method are mutually exclusive.


### PR DESCRIPTION
Closes #613

Just commented out unavailable `join()` methods. `join()` is undergoing a refactor that will introduce these soon, so I didn't remove them completely.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
