### PR TITLE
Add kubernetes instructions to "Get started"

### DIFF
--- a/content/v2.0/get-started.md
+++ b/content/v2.0/get-started.md
@@ -200,7 +200,9 @@ docker exec -it influxdb /bin/bash
 
 ### Install InfluxDB in a Kubernetes cluster
 
+{{% note %}}
 The instructions below use Minikube, but the steps should be similar in any Kubernetes cluster.
+{{% /note %}}
 
 1. [Install Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/).
 

--- a/content/v2.0/get-started.md
+++ b/content/v2.0/get-started.md
@@ -212,87 +212,27 @@ The instructions below use Minikube, but the steps should be similar in any Kube
     minikube start
     ```
 
-3. Save the following YAML configuration file on your local machine:
-
-    ```yaml
-    ---
-    apiVersion: v1
-    kind: Namespace
-    metadata:
-        name: influxdb
-    ---
-    apiVersion: apps/v1
-    kind: StatefulSet
-    metadata:
-        labels:
-            app: influxdb
-        name: influxdb
-        namespace: influxdb
-    spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app: influxdb
-        serviceName: influxdb
-        template:
-            metadata:
-                labels:
-                    app: influxdb
-            spec:
-                containers:
-                  - image: quay.io/influxdb/influxdb:2.0.0-alpha
-                    name: influxdb
-                    ports:
-                      - containerPort: 9999
-                        name: influxdb
-                    volumeMounts:
-                      - mountPath: /root/.influxdbv2
-                        name: data
-        volumeClaimTemplates:
-          - metadata:
-                name: data
-                namespace: influxdb
-            spec:
-                accessModes:
-                  - ReadWriteOnce
-                resources:
-                    requests:
-                        storage: 10G
-    ---
-    apiVersion: v1
-    kind: Service
-    metadata:
-        name: influxdb
-        namespace: influxdb
-    spec:
-        ports:
-          - name: influxdb
-            port: 9999
-            targetPort: 9999
-        selector:
-            app: influxdb
-        type: ClusterIP
-    ```
-
-4. Apply the configuration by running:
+3. Apply the [sample InfluxDB configuration](https://github.com/influxdata/docs-v2/blob/master/static/downloads/influxdb-k8-minikube.yaml) by running:
 
     ```
-    kubectl apply -f <path-to-config>.yaml
+    kubectl apply -f https://raw.githubusercontent.com/influxdata/docs-v2/master/static/downloads/influxdb-k8-minikube.yaml
     ```
 
-5. Ensure the pod is running:
+    (**Note:** Always inspect yaml manifests before running `kubectl apply -f <url>`!)
+
+4. Ensure the pod is running:
 
     ```
     kubectl get pods -n influxdb
     ```
     
-6. Ensure the service is running:
+5. Ensure the service is running:
 
     ```
     kubectl get service -n influxdb
     ```
 
-7. Forward port 9999 from inside the cluster:
+6. Forward port 9999 from inside the cluster to localhost:
 
     ```
     kubectl port-forward -n influxdb svc/influxdb 9999:9999 &

--- a/content/v2.0/get-started.md
+++ b/content/v2.0/get-started.md
@@ -198,15 +198,11 @@ docker exec -it influxdb /bin/bash
 <!-------------------------------- BEGIN kubernetes---------------------------->
 {{% tab-content %}}
 
-You can install InfluxDB in a local kubernetes environment with Minikube.
+### Install InfluxDB in a Kubernetes Cluster
 
-1. Install minikube.
+Below you will find instructions for using Minikube, but the steps should be similar in any Kubernetes cluster.
 
-    On macOS, run:
-
-    ```
-    brew install minikube
-    ```
+1. [Install minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/).
 
 2. Start minikube:
 
@@ -214,7 +210,9 @@ You can install InfluxDB in a local kubernetes environment with Minikube.
     minikube start
     ```
 
-3. Save the following YAML configuration file somewhere on your machine:
+3. Save the following YAML configuration file on your local machine.
+   This file will set up a namespace in your cluster named "influxdb",
+   and create a Deployment and Service for running and connecting to InfluxDB.
 
     ```yaml
     kind: Namespace
@@ -263,29 +261,18 @@ You can install InfluxDB in a local kubernetes environment with Minikube.
     kubectl apply -f <path-to-config>.yaml
     ```
 
-    You should see an output like this:
-
-    ```
-    namespace/influxdb configured
-    deployment.apps/influxdb configured
-    service/influxdb configured
-    ```
-
 5. Ensure the service is running:
 
     ```
     $ kubectl get service -n influxdb
-    NAME       TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
-    influxdb   NodePort   10.100.164.55   <none>        9999:31111/TCP   26m
     ```
 
-6. Forward the port:
+6. Forward the port from inside the cluster:
 
     ```
     kubectl port-forward -n influxdb svc/influxdb 9999:9999 &
     ```
-    
-Vist localhost:9999 in your browser and follow the on-screen instructions to start using InfluxDB!
+
 {{% /tab-content %}}
 <!--------------------------------- END kubernetes ---------------------------->
 

--- a/content/v2.0/get-started.md
+++ b/content/v2.0/get-started.md
@@ -220,13 +220,13 @@ You can install InfluxDB in a local kubernetes environment with Minikube.
     kind: Namespace
     apiVersion: v1
     metadata:
-      name: monitoring
+      name: influxdb
     ---
     apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: influxdb
-      namespace: monitoring
+      namespace: influxdb
     spec:
       selector:
         matchLabels:
@@ -239,10 +239,6 @@ You can install InfluxDB in a local kubernetes environment with Minikube.
           containers:
             - name: influxdb
               image: quay.io/influxdb/influxdb:2.0.0-alpha
-              resources:
-                limits:
-                  memory: "128Mi"
-                  cpu: "1000m"
               ports:
                 - containerPort: 9999
     ---
@@ -250,9 +246,9 @@ You can install InfluxDB in a local kubernetes environment with Minikube.
     kind: Service
     metadata:
       name: influxdb
-      namespace: monitoring
+      namespace: influxdb
     spec:
-      type: NodePort
+      type: ClusterIP
       ports:
         - port: 9999
           protocol: TCP
@@ -270,7 +266,7 @@ You can install InfluxDB in a local kubernetes environment with Minikube.
     You should see an output like this:
 
     ```
-    namespace/monitoring configured
+    namespace/influxdb configured
     deployment.apps/influxdb configured
     service/influxdb configured
     ```
@@ -278,21 +274,18 @@ You can install InfluxDB in a local kubernetes environment with Minikube.
 5. Ensure the service is running:
 
     ```
-    $ kubectl get service -n monitoring
+    $ kubectl get service -n influxdb
     NAME       TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
     influxdb   NodePort   10.100.164.55   <none>        9999:31111/TCP   26m
     ```
 
-6. Get the cluster IP address:
+6. Forward the port:
 
-   ```
-   minikube ip
-   ```
-
-7. In your browser, visit the minikube IP address and port number listed for the service
-   (something like `192.168.64.6:31111`).
-
-Follow the on-screen instructions start using InfluxDB!
+    ```
+    kubectl port-forward -n influxdb svc/influxdb 9999:9999 &
+    ```
+    
+Vist localhost:9999 in your browser and follow the on-screen instructions to start using InfluxDB!
 {{% /tab-content %}}
 <!--------------------------------- END kubernetes ---------------------------->
 

--- a/content/v2.0/get-started.md
+++ b/content/v2.0/get-started.md
@@ -210,50 +210,67 @@ The instructions below use Minikube, but the steps should be similar in any Kube
     minikube start
     ```
 
-3. Save the following YAML configuration file on your local machine.
-   This file will create an `influxdb` namespace in your clusterand a deployment and service for running and connecting to InfluxDB.
+3. Save the following YAML configuration file on your local machine:
 
-    {{% truncate %}}
-    kind: Namespace
+    ```yaml
+    ---
     apiVersion: v1
+    kind: Namespace
     metadata:
-      name: influxdb
+        name: influxdb
     ---
     apiVersion: apps/v1
-    kind: Deployment
+    kind: StatefulSet
     metadata:
-      name: influxdb
-      namespace: influxdb
-    spec:
-      selector:
-        matchLabels:
-          app: influxdb
-      template:
-        metadata:
-          labels:
+        labels:
             app: influxdb
-        spec:
-          containers:
-            - name: influxdb
-              image: quay.io/influxdb/influxdb:2.0.0-alpha
-              ports:
-                - containerPort: 9999
+        name: influxdb
+        namespace: influxdb
+    spec:
+        replicas: 1
+        selector:
+            matchLabels:
+                app: influxdb
+        serviceName: influxdb
+        template:
+            metadata:
+                labels:
+                    app: influxdb
+            spec:
+                containers:
+                  - image: quay.io/influxdb/influxdb:2.0.0-alpha
+                    name: influxdb
+                    ports:
+                      - containerPort: 9999
+                        name: influxdb
+                    volumeMounts:
+                      - mountPath: /root/.influxdbv2
+                        name: data
+        volumeClaimTemplates:
+          - metadata:
+                name: data
+                namespace: influxdb
+            spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                    requests:
+                        storage: 10G
     ---
     apiVersion: v1
     kind: Service
     metadata:
-      name: influxdb
-      namespace: influxdb
+        name: influxdb
+        namespace: influxdb
     spec:
-      type: ClusterIP
-      ports:
-        - port: 9999
-          protocol: TCP
-          name: http
-      selector:
-        app: influxdb
-    {{% /truncate %}}
-
+        ports:
+          - name: influxdb
+            port: 9999
+            targetPort: 9999
+        selector:
+            app: influxdb
+        type: ClusterIP
+    ```
 
 4. Apply the configuration by running:
 
@@ -261,13 +278,19 @@ The instructions below use Minikube, but the steps should be similar in any Kube
     kubectl apply -f <path-to-config>.yaml
     ```
 
-5. Ensure the service is running:
+5. Ensure the pod is running:
+
+    ```
+    kubectl get pods -n influxdb
+    ```
+    
+6. Ensure the service is running:
 
     ```
     kubectl get service -n influxdb
     ```
 
-6. Forward the port from inside the cluster:
+7. Forward port 9999 from inside the cluster:
 
     ```
     kubectl port-forward -n influxdb svc/influxdb 9999:9999 &

--- a/content/v2.0/get-started.md
+++ b/content/v2.0/get-started.md
@@ -20,6 +20,7 @@ This article describes how to get started with InfluxDB OSS. To get started with
 [macOS](#)
 [Linux](#)
 [Docker](#)
+[Kubernetes](#)
 {{% /tabs %}}
 
 <!-------------------------------- BEGIN macOS -------------------------------->
@@ -193,6 +194,107 @@ docker exec -it influxdb /bin/bash
 
 {{% /tab-content %}}
 <!--------------------------------- END Docker -------------------------------->
+
+<!-------------------------------- BEGIN kubernetes---------------------------->
+{{% tab-content %}}
+
+You can install InfluxDB in a local kubernetes environment with Minikube.
+
+1. Install minikube.
+
+    On macOS, run:
+
+    ```
+    brew install minikube
+    ```
+
+2. Start minikube:
+
+    ```
+    minikube start
+    ```
+
+3. Save the following YAML configuration file somewhere on your machine:
+
+    ```yaml
+    kind: Namespace
+    apiVersion: v1
+    metadata:
+      name: monitoring
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: influxdb
+      namespace: monitoring
+    spec:
+      selector:
+        matchLabels:
+          app: influxdb
+      template:
+        metadata:
+          labels:
+            app: influxdb
+        spec:
+          containers:
+            - name: influxdb
+              image: quay.io/influxdb/influxdb:2.0.0-alpha
+              resources:
+                limits:
+                  memory: "128Mi"
+                  cpu: "1000m"
+              ports:
+                - containerPort: 9999
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: influxdb
+      namespace: monitoring
+    spec:
+      type: NodePort
+      ports:
+        - port: 9999
+          protocol: TCP
+          name: http
+      selector:
+        app: influxdb
+    ```
+
+4. Apply the configuration by running:
+
+    ```
+    kubectl apply -f <path-to-config>.yaml
+    ```
+
+    You should see an output like this:
+
+    ```
+    namespace/monitoring configured
+    deployment.apps/influxdb configured
+    service/influxdb configured
+    ```
+
+5. Ensure the service is running:
+
+    ```
+    $ kubectl get service -n monitoring
+    NAME       TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
+    influxdb   NodePort   10.100.164.55   <none>        9999:31111/TCP   26m
+    ```
+
+6. Get the cluster IP address:
+
+   ```
+   minikube ip
+   ```
+
+7. In your browser, visit the minikube IP address and port number listed for the service
+   (something like `192.168.64.6:31111`).
+
+Follow the on-screen instructions start using InfluxDB!
+{{% /tab-content %}}
+<!--------------------------------- END kubernetes ---------------------------->
 
 {{< /tabs-wrapper >}}
 

--- a/content/v2.0/get-started.md
+++ b/content/v2.0/get-started.md
@@ -198,23 +198,22 @@ docker exec -it influxdb /bin/bash
 <!-------------------------------- BEGIN kubernetes---------------------------->
 {{% tab-content %}}
 
-### Install InfluxDB in a Kubernetes Cluster
+### Install InfluxDB in a Kubernetes cluster
 
-Below you will find instructions for using Minikube, but the steps should be similar in any Kubernetes cluster.
+The instructions below use Minikube, but the steps should be similar in any Kubernetes cluster.
 
-1. [Install minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/).
+1. [Install Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/).
 
-2. Start minikube:
+2. Start Minikube:
 
     ```
     minikube start
     ```
 
 3. Save the following YAML configuration file on your local machine.
-   This file will set up a namespace in your cluster named "influxdb",
-   and create a Deployment and Service for running and connecting to InfluxDB.
+   This file will create an `influxdb` namespace in your clusterand a deployment and service for running and connecting to InfluxDB.
 
-    ```yaml
+    {{% truncate %}}
     kind: Namespace
     apiVersion: v1
     metadata:
@@ -253,7 +252,8 @@ Below you will find instructions for using Minikube, but the steps should be sim
           name: http
       selector:
         app: influxdb
-    ```
+    {{% /truncate %}}
+
 
 4. Apply the configuration by running:
 
@@ -264,7 +264,7 @@ Below you will find instructions for using Minikube, but the steps should be sim
 5. Ensure the service is running:
 
     ```
-    $ kubectl get service -n influxdb
+    kubectl get service -n influxdb
     ```
 
 6. Forward the port from inside the cluster:


### PR DESCRIPTION
Documents a quick-start workflow for getting influxdb running locally in Kubernetes using minikube.

Closes #630.