### PR TITLE
'http.get' timeout parameter

### DIFF
--- a/content/v2.0/reference/flux/stdlib/experimental/http/get.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/http/get.md
@@ -25,7 +25,8 @@ import "experimental/http"
 
 http.get(
   url: "http://localhost:9999/",
-  headers: {x:"a", y:"b", z:"c"}
+  headers: {x:"a", y:"b", z:"c"},
+  timeout: 30s
 )
 ```
 
@@ -40,6 +41,12 @@ _**Data type:** String_
 Headers to include with the GET request.
 
 _**Data type:** Object_
+
+### timeout
+Timeout for the GET request.
+Default is `30s`.
+
+_**Data type:** Duration_
 
 ## Examples
 


### PR DESCRIPTION
Closes #648 

Add the new `timeout` parameter on the experimental `http.get()` function.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
