### PR TITLE
Telegraf 1.13

### DIFF
--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -11,7 +11,6 @@ input:
       The AMQP Consumer input plugin provides a consumer for use with AMQP 0-9-1,
       a prominent implementation of this protocol
       being RabbitMQ.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/amqp_consumer/README.md
     introduced: 1.3.0
     tags: [linux, macos, windows, messaging]
 
@@ -20,7 +19,6 @@ input:
     description: |
       The ActiveMQ input plugin gathers queues, topics, and subscriber metrics
       using the ActiveMQ Console API.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/activemq/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows, messaging]
 
@@ -29,7 +27,6 @@ input:
     description: |
       The Aerospike input plugin queries Aerospike servers and gets node statistics
       and  statistics for all configured namespaces.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/aerospike/README.md
     introduced: 0.2.0
     tags: [linux, macos, windows, data-stores]
 
@@ -37,7 +34,6 @@ input:
     id: cloudwatch
     description: |
       The Amazon CloudWatch Statistics input plugin pulls metric statistics from Amazon CloudWatch.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/cloudwatch/README.md
     introduced: 0.12.1
     tags: [linux, macos, windows, cloud]
 
@@ -47,7 +43,6 @@ input:
       Amazon ECS input plugin (AWS Fargate compatible) uses the Amazon ECS v2 metadata and stats API endpoints to gather stats on running containers in a task.
       The Telegraf container and the workload that Telegraf is inspecting must be run in the same task. This is similar to (and reuses pieces of) the
       Docker input plugin, with some ECS-specific modifications for AWS metadata and stats formats.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/ecs/README.md
     introduced: 1.11.0
     tags: [linux, macos, windows, cloud, containers]
 
@@ -56,7 +51,6 @@ input:
     description: |
       The Amazon Kinesis Consumer input plugin reads from a Kinesis data stream and creates
       metrics using one of the supported [input data formats](https://docs.influxdata.com/telegraf/latest/data_formats/input).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/kinesis_consumer/README.md
     introduced: 1.10.0
     tags: [linux, macos, windows, cloud, messaging]
 
@@ -65,7 +59,6 @@ input:
     description: |
       The Aurora input plugin gathers metrics from [Apache Aurora](https://aurora.apache.org/) schedulers.
       For monitoring recommendations, see [Monitoring your Aurora cluster](https://aurora.apache.org/documentation/latest/operations/monitoring/).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/aurora/README.md
     introduced: 1.7.0
     tags: [linux, macos, windows, applications, containers]
 
@@ -81,7 +74,6 @@ input:
         option must be enabled in order to collect all available fields.
         For information about how to configure your server reference, see the
         [module documentation](https://httpd.apache.org/docs/2.4/mod/mod_status.html#enable).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/apache/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows, servers, web]
 
@@ -93,7 +85,6 @@ input:
       [Consumer Group](http://godoc.org/github.com/wvanbergen/kafka/consumergroup)
       is used to talk to the Kafka cluster so multiple instances of Telegraf can read
       from the same topic in parallel.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/kafka_consumer/README.md
     introduced: 0.2.3
     tags: [linux, macos, windows, messaging]
 
@@ -102,7 +93,6 @@ input:
     description: |
       The Apache Mesos input plugin gathers metrics from Mesos. For more information, please check the
       [Mesos Observability Metrics](http://mesos.apache.org/documentation/latest/monitoring/) page.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/mesos/README.md
     introduced: 0.10.3
     tags: [linux, macos, windows, containers]
 
@@ -111,7 +101,6 @@ input:
     id: solr
     description: |
       The Apache Solr input plugin collects stats using the MBean Request Handler.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/solr/README.md
     introduced: 1.5.0
     tags: [linux, macos, windows, data-stores]
 
@@ -123,7 +112,6 @@ input:
       Using `XML=true` returns XML data.
       See the [Apache Tomcat documentation](https://tomcat.apache.org/tomcat-9.0-doc/manager-howto.html#Server_Status)
       for details on these statistics.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/tomcat/README.md
     introduced: 1.4.0
     tags: [linux, macos, windows, servers, web]
 
@@ -135,7 +123,6 @@ input:
 
       > This plugin is experimental. Its data schema may be subject to change based on
       > its main usage cases and the evolution of the OpenTracing standard.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/zipkin/README.md
     introduced: 1.4.0
     tags: [linux, macos, windows, networking]
 
@@ -144,7 +131,6 @@ input:
     description: |
       The Apache Zookeeper input plugin collects variables output from the `mntr`
       command [Zookeeper Admin](https://zookeeper.apache.org/doc/current/zookeeperAdmin.html).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/zookeeper/README.md
     introduced: 0.2.0
     tags: [linux, macos, windows, build-deploy]
 
@@ -152,7 +138,6 @@ input:
     id: apcupsd
     description: |
       The Apcupsd input plugin reads data from an apcupsd daemon over its NIS network protocol.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/apcupsd/README.md
     introduced: 1.12.0
     tags: [linux, macos, windows, systems]
 
@@ -160,15 +145,13 @@ input:
     id: azure_storage_queue
     description: |
       The Azure Storage Queue plugin gathers sizes of Azure Storage Queues.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/azure_storage_queue/README.md
-    introduces: 1.13.0
+    introduced: 1.13.0
     tags: [linux, macos, windows, systems, cloud]
 
   - name: Bcache
     id: bcache
     description: |
       The Bcache input plugin gets bcache statistics from the `stats_total` directory and `dirty_data` file.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/bcache/README.md
     introduced: 0.2.0
     tags: [linux, macos, windows, systems]
 
@@ -177,7 +160,6 @@ input:
     description: |
       The Beanstalkd input plugin collects server stats as well as tube stats
       (reported by `stats` and `stats-tube` commands respectively).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/beanstalkd/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows, messaging]
 
@@ -185,7 +167,6 @@ input:
     id: bind
     description: |
       plugin decodes the JSON or XML statistics provided by BIND 9 nameservers.
-    links: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/bind/README.md
     introduced: 1.11.0
     tags: [linux, macos, windows, netoworking]
 
@@ -195,7 +176,6 @@ input:
       The Bond input plugin collects network bond interface status, bond's slaves
       interfaces status and failures count of bond's slaves interfaces.
       The plugin collects these metrics from `/proc/net/bonding/*` files.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/bond/README.md
     introduced: 1.5.0
     tags: [linux, macos, windows, networking]
 
@@ -205,7 +185,6 @@ input:
       The Burrow input plugin collects Apache Kafka topic, consumer, and partition
       status using the [Burrow](https://github.com/linkedin/Burrow)
       [HTTP Endpoint](https://github.com/linkedin/Burrow/wiki/HTTP-Endpoint).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/burrow/README.md
     introduced: 1.7.0
     tags: [linux, macos, windows, messaging]
 
@@ -218,7 +197,6 @@ input:
       The Cassandra input plugin collects Cassandra 3 / JVM metrics exposed as MBean
       attributes through the jolokia REST endpoint.
       All metrics are collected for each server configured.
-    link: https://github.com/influxdata/telegraf/tree/release-1.6/plugins/inputs/cassandra
     introduced: 0.12.1
     deprecated: 1.7.0
     tags: [linux, macos, windows, data-stores]
@@ -227,7 +205,6 @@ input:
     id: ceph
     description: |
       The Ceph Storage input plugin collects performance metrics from the MON and OSD nodes in a Ceph storage cluster.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/ceph/README.md
     introduced: 0.13.1
     tags: [linux, macos, windows, data-stores]
 
@@ -235,7 +212,6 @@ input:
     id: cgroup
     description: |
       The CGroup input plugin captures specific statistics per cgroup.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/cgroup/README.md
     introduced: 1.0.0
     tags: [linux, macos, windows, systems]
 
@@ -243,7 +219,6 @@ input:
     id: chrony
     description: |
       The Chrony input plugin gets standard chrony metrics, requires chronyc executable.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/chrony/README.md
     introduced: 0.13.1
     tags: [linux, macos, windows, networking, systems]
 
@@ -253,7 +228,6 @@ input:
       Cisco GNMI Telemetry is an input plugin that consumes telemetry data similar to the GNMI specification.
       This GRPC-based protocol can utilize TLS for authentication and encryption.
       This plugin has been developed to support GNMI telemetry as produced by Cisco IOS XR (64-bit) version 6.5.1 and later.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/cisco_telemetry_gnmi/README.md
     introduced: 1.11.0
     tags: [linux, macos, windows, applications]
 
@@ -263,7 +237,6 @@ input:
       Cisco model-driven telemetry (MDT) is an input plugin that consumes telemetry data from Cisco IOS XR, IOS XE and NX-OS platforms.
       It supports TCP & GRPC dialout transports. GRPC-based transport can utilize TLS for authentication and encryption.
       Telemetry data is expected to be GPB-KV (self-describing-gpb) encoded.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/cisco_telemetry_mdt/README.md
     introduced: 1.11.0
     tags: [linux, macos, windows, applications]
 
@@ -279,7 +252,6 @@ input:
       or `/proc/sys/net/netfilter` and will be prefixed with either `ip_` or `nf_`.
       This plugin reads the files specified in its configuration and publishes each one as a field,
       with the prefix normalized to `ip_`.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/conntrack/README.md
     introduced: 1.0.0
     tags: [linux, macos, windows, networking]
 
@@ -289,7 +261,6 @@ input:
       The Consul input plugin will collect statistics about all health checks registered in the Consul.
       It uses Consul API to query the data.
       It will not report the telemetry but Consul can report those stats already using StatsD protocol, if needed.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/consul/README.md
     introduced: 1.0.0
     tags: [linux, macos, windows, build-deploy, containers]
 
@@ -297,7 +268,6 @@ input:
     id: couchbase
     description: |
       The Couchbase input plugin reads per-node and per-bucket metrics from Couchbase.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/couchbase/README.md
     introduced: 0.12.0
     tags: [linux, macos, windows, data-stores]
 
@@ -305,7 +275,6 @@ input:
     id: couchdb
     description: |
       The CouchDB input plugin gathers metrics of CouchDB using `_stats` endpoint.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/couchdb/README.md
     introduced: 0.10.3
     tags: [linux, macos, windows, data-stores]
 
@@ -313,7 +282,6 @@ input:
     id: cpu
     description: |
       The CPU input plugin gathers metrics about cpu usage.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/cpu/README.md
     introduced: 0.1.5
     tags: [linux, macos, windows, systems]
 
@@ -321,7 +289,6 @@ input:
     id: disk
     description: |
       The Disk input plugin gathers metrics about disk usage by mount point.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/disk/README.md
     introduced: 0.1.1
     tags: [linux, macos, windows, systems]
 
@@ -329,7 +296,6 @@ input:
     id: diskio
     description: |
       The DiskIO input plugin gathers metrics about disk IO by device.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/diskio/README.md
     introduced: 0.10.0
     tags: [linux, macos, windows, systems]
 
@@ -337,7 +303,6 @@ input:
     id: disque
     description: |
       The Disque input plugin gathers metrics from one or more [Disque](https://github.com/antirez/disque) servers.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/disque
     introduced: 0.10.0
     tags: [linux, macos, windows, messaging]
 
@@ -345,7 +310,6 @@ input:
     id: dmcache
     description: |
       The DMCache input plugin provides a native collection for dmsetup-based statistics for dm-cache.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/dmcache/README.md
     introduced: 1.3.0
     tags: [linux, macos, windows, systems]
 
@@ -354,7 +318,6 @@ input:
     description: |
       The DNS Query input plugin gathers DNS query times in milliseconds -
       like [Dig](https://en.wikipedia.org/wiki/Dig_(command)).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/dns_query/README.md
     introduced: 1.4.0
     tags: [linux, macos, windows, networking]
 
@@ -364,7 +327,6 @@ input:
       The Docker input plugin uses the Docker Engine API to gather metrics on running Docker containers.
       The Docker plugin uses the [Official Docker Client](https://github.com/moby/moby/tree/master/client)
       to gather stats from the [Engine API](https://docs.docker.com/engine/api/v1.20/) library documentation.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/docker/README.md
     introduced: 0.1.9
     tags: [linux, macos, windows, build-deploy, containers]
 
@@ -376,7 +338,6 @@ input:
       to gather logs from the [Engine API](https://docs.docker.com/engine/api/v1.24/).
 
       > This plugin works only for containers with the local or `json-file` or `journald` logging driver.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/docker_log/README.md
     introduced: 1.12.0
     tags: [linux, macos, windows, build-deploy, containers, logging]
 
@@ -385,7 +346,6 @@ input:
     description: |
       The Dovecot input plugin uses the dovecot Stats protocol to gather metrics on configured domains.
       For more information, see the [Dovecot documentation](http://wiki2.dovecot.org/Statistics).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/dovecot/README.md
     introduced: 0.10.3
     tags: [linux, macos, windows, applications, web]
 
@@ -395,7 +355,6 @@ input:
       The Elasticsearch input plugin queries endpoints to obtain [node](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html)
       and optionally [cluster-health](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html)
       or [cluster-stats](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-stats.html) metrics.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/elasticsearch/README.md
     introduced: 0.1.5
     tags: [linux, macos, windows, data-stores]
 
@@ -404,7 +363,6 @@ input:
     description: |
       The Ethtool plugin gathers ethernet device statistics.
       The network device and driver determine what fields are gathered.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/ethtool/README.md
     introduced: 1.13.0
     tags: [linux, macos, windows, networking, servers]
 
@@ -414,7 +372,6 @@ input:
       The Exec input plugin parses supported [Telegraf input data formats](https://docs.influxdata.com/telegraf/latest/data_formats/input/)
       (line protocol, JSON, Graphite, Value, Nagios, Collectd, and Dropwizard) into metrics.
       Each Telegraf metric includes the measurement name, tags, fields, and timestamp.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/exec/README.md
     introduced: 0.1.5
     tags: [linux, macos, windows]
 
@@ -423,7 +380,6 @@ input:
     description: |
       The Fail2ban input plugin gathers the count of failed and banned IP addresses
       using [fail2ban](https://www.fail2ban.org/).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/fail2ban/README.md
     introduced: 1.4.0
     tags: [linux, macos, windows, networking, security]
 
@@ -432,7 +388,6 @@ input:
     description: |
       The Fibaro input plugin makes HTTP calls to the Fibaro controller API to gather values of hooked devices.
       Those values could be true (`1`) or false (`0`) for switches, percentage for dimmers, temperature, etc.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/fibaro/README.md
     introduced: 1.7.0
     tags: [linux, macos, windows, iot]
 
@@ -448,7 +403,6 @@ input:
       > To parse metrics from multiple files that are formatted in one of the supported
       > [input data formats](https://docs.influxdata.com/telegraf/latest/data_formats/input),
       > use the [Multifile input plugin](#multifile).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/file/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows, systems]
 
@@ -456,7 +410,6 @@ input:
     id: filecount
     description: |
       The Filecount input plugin reports the number and total size of files in directories that match certain criteria.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/filecount/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows, systems]
 
@@ -464,7 +417,6 @@ input:
     id: filestat
     description: |
       The Filestat input plugin gathers metrics about file existence, size, and other stats.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/filestat/README.md
     introduced: 0.13.0
     tags: [linux, macos, windows, systems]
 
@@ -473,7 +425,6 @@ input:
     description: |
       The Fireboard input plugin gathers real time temperature data from Fireboard thermometers.
       To use this input plugin, sign up to use the [Fireboard REST API](https://docs.fireboard.io/reference/restapi.html).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/fireboard/README.md
     introduced: 1.12.0
     tags: [linux, macos, windows, cloud, iot]
 
@@ -482,7 +433,6 @@ input:
     description: |
       The Fluentd input plugin gathers Fluentd server metrics from plugin endpoint provided by in_monitor plugin.
       This plugin understands data provided by `/api/plugin.json` resource (`/api/config.json` is not covered).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/fluentd/README.md
     introduced: 1.4.0
     tags: [linux, macos, windows, servers]
 
@@ -490,7 +440,6 @@ input:
     id: github
     description: |
       Gathers repository information from GitHub-hosted repositories.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/github/README.md
     introduced: 1.11.0
     tags: [linux, macos, windows, applications]
 
@@ -500,7 +449,6 @@ input:
       The Google Cloud PubSub input plugin ingests metrics from
       [Google Cloud PubSub](https://cloud.google.com/pubsub) and creates metrics
       using one of the supported [input data formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/cloud_pubsub/README.md
     introduced: 1.10.0
     tags: [linux, macos, windows, cloud, messaging]
 
@@ -513,7 +461,6 @@ input:
       The intent of the plugin is to allow Telegraf to serve as an endpoint of the
       Google Pub/Sub 'Push' service. Google's PubSub service will only send over
       HTTPS/TLS so this plugin must be behind a valid proxy or must be configured to use TLS.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/cloud_pubsub_push/README.md
     introduced: 1.10.0
     tags: [linux, macos, windows, cloud, messaging]
 
@@ -525,7 +472,6 @@ input:
 
       - multiple (e.g., `http://[graylog-server-ip]:12900/system/metrics/multiple`)
       - namespace (e.g., `http://[graylog-server-ip]:12900/system/metrics/namespace/{namespace}`)
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/graylog/README.md
     introduced: 1.0.0
     tags: [linux, macos, windows, logging]
 
@@ -534,7 +480,6 @@ input:
     description: |
       The HAproxy input plugin gathers metrics directly from any running HAproxy instance.
       It can do so by using CSV generated by HAproxy status page or from admin sockets.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/haproxy/README.md
     introduced: 0.1.5
     tags: [linux, macos, windows, networking, web]
 
@@ -542,7 +487,6 @@ input:
     id: hddtemp
     description: |
       The Hddtemp input plugin reads data from `hddtemp` daemons.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/hddtemp/README.md
     introduced: 1.0.0
     tags: [linux, macos, windows, systems]
 
@@ -552,7 +496,6 @@ input:
       The HTTP input plugin collects metrics from one or more HTTP (or HTTPS) endpoints.
       The endpoint should have metrics formatted in one of the [supported input data formats](https://docs.influxdata.com/telegraf/latest/data_formats/input/).
       Each data format has its own unique set of configuration options which can be added to the input configuration.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/http/README.md
     introduced: 1.6.0
     tags: [linux, macos, windows, servers, web]
 
@@ -563,7 +506,6 @@ input:
 
       The HTTP JSON input plugin collects data from HTTP URLs which respond with JSON.
       It flattens the JSON and finds all numeric values, treating them as floats.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/httpjson/README.md
     introduced: 0.1.6
     deprecated: 1.6.0
     tags: [linux, macos, windows, servers, web]
@@ -574,7 +516,7 @@ input:
       The `http_listener` input plugin was renamed to [`influxdb_listener`](#influxdb_listener).
       The new name better describes the intended use of the plugin as a InfluxDB relay.
       For general purpose transfer of metrics in any format via HTTP, use [`http_listener_v2`](#http_listener_v2)instead.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/influxdb_listener/README.md
+    link: https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_listener/README.md
     introduced: 1.1.0
     deprecated: 1.9.0
     tags: [linux, macos, windows, servers, web]
@@ -586,7 +528,6 @@ input:
       Messages are expected in [line protocol format](https://docs.influxdata.com/telegraf/latest/data_formats/input/influx)
       ONLY (other [Telegraf input data formats](https://docs.influxdata.com/telegraf/latest//data_formats/input/) are not supported).
       This plugin allows Telegraf to serve as a proxy or router for the `/write` endpoint of the InfluxDB v2110 HTTP API.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/http_listener_v2/README.md
     introduced: 1.9.0
     tags: [linux, macos, windows, servers, web]
 
@@ -596,7 +537,6 @@ input:
       The HTTP Response input plugin gathers metrics for HTTP responses.
       The measurements and fields include `response_time`, `http_response_code`,
       and `result_type`. Tags for measurements include `server` and `method`.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/http_response/README.md
     introduced: 0.12.1
     tags: [linux, macos, windows, servers, web]
 
@@ -605,7 +545,6 @@ input:
     description: |
       The Icinga 2 input plugin gather status on running services and hosts using
       the [Icinga 2 API](https://docs.icinga.com/icinga2/latest/doc/module/icinga2/chapter/icinga2-api).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/icinga2
     introduced: 1.8.0
     tags: [linux, macos, windows, networking, servers, systems]
 
@@ -617,7 +556,6 @@ input:
       best practice and allows you to reduce the overhead associated with capturing
       and storing these metrics locally within the `_internal` database for production deployments.
       [Read more about this approach here](https://www.influxdata.com/blog/influxdb-debugvars-endpoint/).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/influxdb/README.md
     introduced: 0.2.5
     tags: [linux, macos, windows, data-stores]
 
@@ -657,7 +595,6 @@ input:
       receive a `200 OK` response with message body `{"results":[]}` but they are not
       relayed. The output configuration of the Telegraf instance which ultimately
       submits data to InfluxDB determines the destination database.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/influxdb_listener/README.md
     introduced: 1.9.0
     tags: [linux, macos, windows, data-stores]
 
@@ -666,7 +603,6 @@ input:
     description: |
       The Interrupts input plugin gathers metrics about IRQs, including `interrupts`
       (from `/proc/interrupts`) and `soft_interrupts` (from `/proc/softirqs`).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/interrupts/README.md
     introduced: 1.3.0
     tags: [linux, macos, windows, systems]
 
@@ -675,7 +611,6 @@ input:
     description: |
       The IPMI Sensor input plugin queries the local machine or remote host
       sensor statistics using the `ipmitool` utility.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/ipmi_sensor/README.md
     introduced: 0.12.0
     tags: [linux, macos, windows, iot]
 
@@ -684,7 +619,6 @@ input:
     description: |
       The Ipset input plugin gathers packets and bytes counters from Linux `ipset`.
       It uses the output of the command `ipset save`. Ipsets created without the `counters` option are ignored.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/ipset/README.md
     introduced: 1.6.0
     tags: [linux, macos, windows, networking, security, systems]
 
@@ -693,7 +627,6 @@ input:
     description: |
       The IPtables input plugin gathers packets and bytes counters for rules within
       a set of table and chain from the Linux iptables firewall.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/iptables/README.md
     introduced: 1.1.0
     tags: [linux, macos, windows, systems]
 
@@ -702,7 +635,6 @@ input:
     description: |
       The IPVS input plugin uses the Linux kernel netlink socket interface to
       gather metrics about IPVS virtual and real servers.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/ipvs/README.md
     introduced: 1.9.0
     tags: [linux, macos, windows, systems]
 
@@ -714,7 +646,6 @@ input:
 
       This plugin does not require a plugin on Jenkins and it makes use of Jenkins
       API to retrieve all the information needed.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/jenkins/README.md
     introduced: 1.9.0
     tags: [linux, macos, windows, build-deploy]
 
@@ -722,7 +653,6 @@ input:
     id: jolokia
     description: |
       *Deprecated in Telegraf 1.5.0. Use the [Jolokia2 input plugin](#jolokia2_agent).*
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/jolokia/README.md
     introduced: 0.2.1
     deprecated: 1.5.0
     tags: [linux, macos, windows, networking]
@@ -754,7 +684,6 @@ input:
       of OpenConfig telemetry data from listed sensors using the Junos Telemetry Interface.
       Refer to [openconfig.net](http://openconfig.net/) for more details about OpenConfig
       and [Junos Telemetry Interface (JTI)](https://www.juniper.net/documentation/en_US/junos/topics/concept/junos-telemetry-interface-oveview.html).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/jti_openconfig_telemetry/README.md
     introduced: 1.7.0
     tags: [linux, macos, windows, iot]
 
@@ -762,7 +691,6 @@ input:
     id: kapacitor
     description: |
       The Kapacitor input plugin will collect metrics from the given Kapacitor instances.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/kapacitor/README.md
     introduced: 1.3.0
     tags: [linux, macos, windows, applications]
 
@@ -770,7 +698,6 @@ input:
     id: kernel
     description: |
       The Kernel input plugin gathers kernel statistics from `/proc/stat`.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/kernel/README.md
     introduced: 0.11.0
     tags: [linux, macos, windows, systems]
 
@@ -778,7 +705,6 @@ input:
     id: kernel_vmstat
     description: |
       The Kernel VMStat input plugin gathers kernel statistics from `/proc/vmstat`.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/kernel_vmstat/README.md
     introduced: 1.0.0
     tags: [linux, macos, windows, systems]
 
@@ -787,7 +713,6 @@ input:
     description: |
       The Kibana input plugin queries the Kibana status API to obtain the health
       status of Kibana and some useful metrics.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/kibana/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows, applications]
 
@@ -802,7 +727,6 @@ input:
       It is assumed that this plugin is running as part of a daemonset within a
       Kubernetes installation. This means that Telegraf is running on every node within the cluster.
       Therefore, you should configure this plugin to talk to its locally running kubelet.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/kubernetes/README.md
     introduced: 1.1.0
     tags: [linux, macos, windows, build-deploy, containers]
 
@@ -820,7 +744,6 @@ input:
       - pods (containers)
       - statefulsets
 
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/kube_inventory/README.md
     introduced: 1.10.0
     tags: [linux, macos, windows, build-deploy, containers]
 
@@ -830,7 +753,6 @@ input:
       The LeoFS input plugin gathers metrics of LeoGateway, LeoManager, and LeoStorage using SNMP.
       See [System monitoring](https://leo-project.net/leofs/docs/admin/system_admin/monitoring/)
       in the [LeoFS documentation](https://leo-project.net/leofs/docs/) for more information.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/leofs/README.md
     introduced: 0.1.5
     tags: [linux, macos, windows, systems, data-stores]
 
@@ -839,7 +761,6 @@ input:
     description: |
       The Linux Sysctl FS input plugin provides Linux system level file (`sysctl fs`) metrics.
       The documentation on these fields can be found [here](https://www.kernel.org/doc/Documentation/sysctl/fs.txt).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/linux_sysctl_fs/README.md
     introduced: 1.3.0
     tags: [linux, macos, windows, systems]
 
@@ -849,7 +770,6 @@ input:
       The Logparser input plugin streams and parses the given log files.
       Currently, it has the capability of parsing "grok" patterns
       from log files, which also supports regular expression (regex) patterns.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/logparser/README.md
     introduced: 1.0.0
     tags: [linux, macos, windows, logging]
 
@@ -858,7 +778,6 @@ input:
     description: |
       The Logstash input plugin reads metrics exposed by the [Logstash Monitoring API](https://www.elastic.co/guide/en/logstash/current/monitoring-logstash.html).
       The plugin supports Logstash 5 and later.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/logstash/README.md
     introduced: 1.12.0
     tags: [linux, macos, windows, logging]
 
@@ -868,7 +787,6 @@ input:
       Lustre Jobstats allows for RPCs to be tagged with a value, such as a job's ID.
       This allows for per job statistics.
       The Lustre2 input plugin collects statistics and tags the data with the `jobid`.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/lustre2
     introduced: 0.1.5
     tags: [linux, macos, windows, systems]
 
@@ -876,7 +794,6 @@ input:
     id: mailchimp
     description: |
       The Mailchimp input plugin gathers metrics from the `/3.0/reports` MailChimp API.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/mailchimp
     introduced: 0.2.4
     tags: [linux, macos, windows, cloud, web]
 
@@ -884,7 +801,6 @@ input:
     id: marklogic
     description: |
       The MarkLogic input plugin gathers health status metrics from one or more MarkLogic hosts.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/marklogic/README.md
     introduced: 1.12.0
     tags: [linux, macos, windows, data-stores]
 
@@ -896,7 +812,6 @@ input:
       developed and maintained by Facebook, for scaling memcached (http://memcached.org/) deployments.
       It's a core component of cache infrastructure at Facebook and Instagram where mcrouter
       handles almost 5 billion requests per second at peak.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/mcrouter/README.md
     introduced: 1.7.0
     tags: [linux, macos, windows, networking]
 
@@ -906,7 +821,6 @@ input:
       The Mem input plugin collects system memory metrics.
       For a more complete explanation of the difference between used and actual_used RAM,
       see [Linux ate my ram](https://www.linuxatemyram.com/).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/mem/README.md
     introduced: 0.1.5
     tags: [linux, macos, windows, systems]
 
@@ -914,7 +828,6 @@ input:
     id: memcached
     description: |
       The Memcached input plugin gathers statistics data from a Memcached server.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/memcached/README.md
     introduced: 0.1.2
     tags: [linux, macos, windows, data-stores]
 
@@ -923,7 +836,6 @@ input:
     description: |
       The Mesosphere DC/OS input plugin gathers metrics from a DC/OS cluster's
       [metrics component](https://docs.mesosphere.com/1.10/metrics/).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/dcos/README.md
     introduced: 1.5.0
     tags: [linux, macos, windows, containers]
 
@@ -933,7 +845,6 @@ input:
       The Microsoft SQL Server input plugin provides metrics for your Microsoft SQL Server instance.
       It currently works with SQL Server versions 2008+.
       Recorded metrics are lightweight and use Dynamic Management Views supplied by SQL Server.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/sqlserver/README.md
     introduced: 0.10.1
     tags: [linux, macos, windows, data-stores]
 
@@ -942,7 +853,6 @@ input:
     description: |
       The Minecraft input plugin uses the RCON protocol to collect statistics from
       a scoreboard on a Minecraft server.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/minecraft/README.md
     introduced: 1.4.0
     tags: [linux, macos, windows, gaming]
 
@@ -951,7 +861,6 @@ input:
     description: |
       The MongoDB input plugin collects MongoDB stats exposed by `serverStatus` and
       few more and create a single measurement containing values.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/mongodb/README.md
     introduced: 0.1.5
     tags: [linux, macos, windows, data-stores]
 
@@ -960,7 +869,6 @@ input:
     description: |
       The MQTT Consumer input plugin reads from specified MQTT topics and adds messages to InfluxDB.
       Messages are in the [Telegraf input data formats](https://docs.influxdata.com/telegraf/latest/data_formats/input/).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/mqtt_consumer/README.md
     introduced: 0.10.3
     tags: [linux, macos, windows, messaging]
 
@@ -974,7 +882,6 @@ input:
       > To parse metrics from a single file formatted in one of the supported
       > [input data formats](https://docs.influxdata.com/telegraf/latest/data_formats/input),
       > use the [file input plugin](#file).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/multifile/README.md
     introduced: 1.10.0
     tags: [linux, macos, windows]
 
@@ -982,7 +889,6 @@ input:
     id: mysql
     description: |
       The MySQL input plugin gathers the statistics data from MySQL servers.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/mysql/README.md
     introduced: 0.1.1
     tags: [linux, macos, windows, data-stores]
 
@@ -993,7 +899,6 @@ input:
       Messages are expected in the [Telegraf input data formats](https://docs.influxdata.com/telegraf/latest/data_formats/input/).
       A Queue Group is used when subscribing to subjects so multiple instances of Telegraf
       can read from a NATS cluster in parallel.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nats_consumer/README.md
     introduced: 0.10.3
     tags: [linux, macos, windows, messaging]
 
@@ -1002,7 +907,6 @@ input:
     description: |
       The NATS Server Monitoring input plugin gathers metrics when using the
       [NATS Server monitoring server](https://www.nats.io/documentation/server/gnatsd-monitoring/).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nats/README.md
     introduced: 1.6.0
     tags: [linux, macos, windows, messaging]
 
@@ -1014,7 +918,6 @@ input:
       control their tanks based on various probes.
       The data is taken directly from the `/cgi-bin/status.xml` at the interval specified
       in the `telegraf.conf` configuration file.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/neptune_apex/README.md
     introduced: 1.10.0
     tags: [linux, macos, windows, iot]
 
@@ -1040,7 +943,6 @@ input:
     description: |
       The Network Response input plugin tests UDP and TCP connection response time.
       It can also check response text.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/net_response/README.md
     introduced: 0.10.3
     tags: [linux, macos, windows, networking]
 
@@ -1048,7 +950,6 @@ input:
     id: nginx
     description: |
       The NGINX input plugin reads NGINX basic status information (`ngx_http_stub_status_module`).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nginx/README.md
     introduced: 0.1.5
     tags: [linux, macos, windows, servers, web]
 
@@ -1062,7 +963,6 @@ input:
       This is similar to the live activity monitoring of NGINX Plus.
       For module configuration details, see the
       [NGINX VTS module documentation](https://github.com/vozlt/nginx-module-vts#synopsis).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nginx_vts/README.md
     introduced: 1.9.0
     tags: [linux, macos, windows, servers, web]
 
@@ -1075,7 +975,6 @@ input:
 
       Structures for NGINX Plus have been built based on history of
       [status module documentation](http://nginx.org/en/docs/http/ngx_http_status_module.html).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nginx_plus/README.md
     introduced: 1.5.0
     tags: [linux, macos, windows, servers, web]
 
@@ -1083,7 +982,6 @@ input:
     id: nginx_plus_api
     description: |
       The NGINX Plus API input plugin gathers advanced status information for NGINX Plus servers.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nginx_plus_api/README.md
     introduced: 1.9.0
     tags: [linux, macos, windows, servers, web]
 
@@ -1100,7 +998,6 @@ input:
       The status page displays the current status of all upstreams and servers as well
       as number of the failed and successful checks. This information can be exported
       in JSON format and parsed by this input.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nginx_plus_api/README.md
     introduced: 1.10.0
     tags: [linux, macos, windows, servers, web]
 
@@ -1108,7 +1005,6 @@ input:
     id: nsq
     description: |
       The NSQ input plugin collects metrics from NSQD API endpoints.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nsq
     introduced: 1.0.0
     tags: [linux, macos, windows, messaging]
 
@@ -1117,7 +1013,6 @@ input:
     description: |
       The NSQ Consumer input plugin polls a specified NSQD topic and adds messages to InfluxDB.
       This plugin allows a message to be in any of the supported data_format types.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nsq_consumer/README.md
     introduced: 0.10.1
     tags: [linux, macos, windows, messaging]
 
@@ -1126,7 +1021,6 @@ input:
     description: |
       The Nstat input plugin collects network metrics from `/proc/net/netstat`,
       `/proc/net/snmp`, and `/proc/net/snmp6` files.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nstat/README.md
     introduced: 0.13.1
     tags: [linux, macos, windows, networking, systems]
 
@@ -1134,7 +1028,6 @@ input:
     id: ntpq
     description: |
       The NTPq input plugin gets standard NTP query metrics, requires ntpq executable.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/ntpq/README.md
     introduced: 0.11.0
     tags: [linux, macos, windows, networking, systems]
 
@@ -1144,7 +1037,6 @@ input:
       The NVIDIA SMI input plugin uses a query on the [NVIDIA System Management Interface
       (`nvidia-smi`)](https://developer.nvidia.com/nvidia-system-management-interface)
       binary to pull GPU stats including memory and GPU usage, temp and other.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nvidia_smi/README.md
     introduced: 1.7.0
     tags: [linux, macos, windows, systems]
 
@@ -1152,7 +1044,6 @@ input:
     id: openldap
     description: |
       The OpenLDAP input plugin gathers metrics from OpenLDAP's `cn=Monitor` backend.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/openldap/README.md
     introduced: 1.4.0
     tags: [linux, macos, windows, data-stores]
 
@@ -1161,7 +1052,6 @@ input:
     description: |
       The OpenNTPD input plugin gathers standard Network Time Protocol (NTP) query
       metrics from OpenNTPD using the `ntpctl` command.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/openntpd/README.md
     introduced: 1.12.0
     tags: [linux, macos, windows, networking]
 
@@ -1170,7 +1060,6 @@ input:
     description: |
       The OpenSMTPD input plugin gathers stats from [OpenSMTPD](https://www.opensmtpd.org/),
       a free implementation of the server-side SMTP protocol.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/opensmtpd/README.md
     introduced: 1.5.0
     tags: [linux, macos, windows, applications]
 
@@ -1178,7 +1067,6 @@ input:
     id: openweathermap
     description: |
       Collect current weather and forecast data from OpenWeatherMap.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/openweathermap/README.md
     introduced: 1.11.0
     tags: [linux, macos, windows, applications]
 
@@ -1189,7 +1077,6 @@ input:
       Currently it can retrive information about the state table: the number of current
       entries in the table, and counters for the number of searches, inserts, and removals
       to the table. The pf plugin retrieves this information by invoking the `pfstat` command.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/pf/README.md
     introduced: 1.5.0
     tags: [linux, macos, windows, networking, security]
 
@@ -1198,7 +1085,6 @@ input:
     description: |
       The PgBouncer input plugin provides metrics for your PgBouncer load balancer.
       For information about the metrics, see the [PgBouncer documentation](https://pgbouncer.github.io/usage.html).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/pgbouncer/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows, data-stores]
 
@@ -1207,15 +1093,13 @@ input:
     description: |
       The Phfusion 0Passenger input plugin gets Phusion Passenger statistics using
       their command line utility `passenger-status`.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/passenger/README.md
     introduced: 0.10.1
     tags: [linux, macos, windows, web]
 
-  - name: PHP FPM
+  - name: PHP-FPM
     id: phpfpm
     description: |
-      The PHP FPM input plugin gets phpfpm statistics using either HTTP status page or fpm socket.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/phpfpm/README.md
+      The PHP-FPM input plugin gets phpfpm statistics using either HTTP status page or fpm socket.
     introduced: 0.1.10
     tags: [linux, macos, windows, servers, web]
 
@@ -1224,7 +1108,6 @@ input:
     description: |
       The Ping input plugin measures the round-trip for ping commands, response time,
       and other packet statistics.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/ping/README.md
     introduced: 0.1.8
     tags: [linux, macos, windows, networking]
 
@@ -1236,7 +1119,6 @@ input:
       [queues](http://www.postfix.org/QSHAPE_README.html#queues),
       it will report the queue length (number of items),
       size (bytes used by items), and age (age of oldest item in seconds).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/postfix/README.md
     introduced: 1.5.0
     tags: [linux, macos, windows, services, web]
 
@@ -1247,7 +1129,6 @@ input:
       It currently works with PostgreSQL versions 8.1+.
       It uses data from the built-in `pg_stat_database` and `pg_stat_bgwriter` views.
       The metrics recorded depend on your version of PostgreSQL.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/postgresql/README.md
     introduced: 0.10.3
     tags: [linux, macos, windows, data-stores]
 
@@ -1256,7 +1137,6 @@ input:
     description: |
       This PostgreSQL Extensible input plugin provides metrics for your Postgres database.
       It has been designed to parse SQL queries in the plugin section of `telegraf.conf` files.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/postgresql_extensible
     introduced: 0.12.0
     tags: [linux, macos, windows, data-stores]
 
@@ -1264,7 +1144,6 @@ input:
     id: powerdns
     description: |
       The PowerDNS input plugin gathers metrics about PowerDNS using UNIX sockets.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/powerdns/README.md
     introduced: 0.10.2
     tags: [linux, macos, windows, networking, web]
 
@@ -1272,7 +1151,6 @@ input:
     id: powerdns_recursor
     description: |
       The PowerDNS Recursor input plugin gathers metrics about PowerDNS Recursor using UNIX sockets.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/powerdns_recursor/README.md
     introduced: 1.11.0
     tags: [linux, macos, windows, networking, web]
 
@@ -1283,7 +1161,6 @@ input:
       and groups them by status (zombie, sleeping, running, etc.). On Linux, this
       plugin requires access to `procfs` (`/proc`); on other operating systems,
       it requires access to execute `ps`.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/processes/README.md
     introduced: 0.11.0
     tags: [linux, macos, windows, systems]
 
@@ -1303,7 +1180,6 @@ input:
       The Procstat input plugin will tag processes according to how they are specified
       in the configuration. If a pid file is used, a "pidfile" tag will be generated.
       On the other hand, if an executable is used an "exe" tag will be generated.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/procstat/README.md
     introduced: 0.2.0
     tags: [linux, macos, windows, systems]
 
@@ -1312,7 +1188,6 @@ input:
     description: |
       The Prometheus Format input plugin input plugin gathers metrics from HTTP
       servers exposing metrics in Prometheus format.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/prometheus/README.md
     introduced: 0.2.1
     tags: [linux, macos, windows, applications]
 
@@ -1322,7 +1197,6 @@ input:
       The Puppet Agent input plugin collects variables outputted from the `last_run_summary.yaml`
       file usually located in `/var/lib/puppet/state/` Puppet Agent Runs. For more information, see
       [Puppet Monitoring: How to Monitor the Success or Failure of Puppet Runs](https://puppet.com/blog/puppet-monitoring-how-to-monitor-success-or-failure-of-puppet-runs)
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/puppetagent
     introduced: 0.2.0
     tags: [linux, macos, windows, build-deploy]
 
@@ -1331,7 +1205,6 @@ input:
     description: |
       The RabbitMQ input plugin reads metrics from RabbitMQ servers via the
       [Management Plugin](https://www.rabbitmq.com/management.html).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/rabbitmq/README.md
     introduced: 0.1.5
     tags: [linux, macos, windows, messaging]
 
@@ -1341,7 +1214,6 @@ input:
       The Raindrops Middleware input plugin reads from the specified
       [Raindrops middleware](http://raindrops.bogomips.org/Raindrops/Middleware.html)
       URI and adds the statistics to InfluxDB.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/raindrops/README.md
     introduced: 0.10.3
     tags: [linux, macos, windows, servers, web]
 
@@ -1354,7 +1226,6 @@ input:
 
       Additionally the plugin also calculates the hit/miss ratio (`keyspace_hitrate`)
       and the elapsed time since the last RDB save (`rdb_last_save_time_elapsed`).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/redis/README.md
     introduced: 0.1.1
     tags: [linux, macos, windows, data-stores]
 
@@ -1363,7 +1234,6 @@ input:
     description: |
       The RethinkDB input plugin works with RethinkDB 2.3.5+ databases that requires
       username, password authorization, and Handshake protocol v1.0.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/rethinkdb
     introduced: 0.1.3
     tags: [linux, macos, windows, data-stores]
 
@@ -1371,7 +1241,6 @@ input:
     id: riak
     description: |
       The Riak input plugin gathers metrics from one or more Riak instances.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/riak/README.md
     introduced: 0.10.4
     tags: [linux, macos, windows, data-stores]
 
@@ -1381,7 +1250,6 @@ input:
       The Salesforce input plugin gathers metrics about the limits in your Salesforce
       organization and the remaining usage.
       It fetches its data from the limits endpoint of the Salesforce REST API.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/salesforce/README.md
     introduced: 1.4.0
     tags: [linux, macos, windows, applications, cloud]
 
@@ -1390,11 +1258,10 @@ input:
     description: |
       The Sensors input plugin collects collects sensor metrics with the sensors
       executable from the `lm-sensor` package.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/sensors/README.md
     introduced: 0.10.1
     tags: [linux, macos, windows, iot]
 
-  - name: SMART
+  - name: S.M.A.R.T.
     id: smart
     description: |
       The SMART input plugin gets metrics using the command line utility `smartctl`
@@ -1404,7 +1271,6 @@ input:
       The plugin detects and reports on various indicators of drive reliability,
       with the intent of enabling the anticipation of hardware failures.
       See [smartmontools](https://www.smartmontools.org/).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/smart/README.md
     introduced: 1.5.0
     tags: [linux, macos, windows, systems]
 
@@ -1412,7 +1278,6 @@ input:
     id: snmp
     description: |
       The SNMP input plugin gathers metrics from SNMP agents.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/snmp/README.md
     introduced: 0.10.1
     tags: [linux, macos, windows, networking]
 
@@ -1421,7 +1286,6 @@ input:
     description: |
       The SNMP Legacy input plugin gathers metrics from SNMP agents.
       *Deprecated in Telegraf 1.0.0. Use the [SNMP input plugin](#snmp).*
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/snmp_legacy/README.md
     introduced: 0.10.1
     deprecated: 1.0.0
     tags: [linux, macos, windows, networking]
@@ -1432,7 +1296,6 @@ input:
       The SNMP Trap plugin receives SNMP notifications (traps and inform requests).
       Notifications are received over UDP on a configurable port.
       Resolve OIDs to strings using system MIB files (just like with the [SNMP input plugin](#snmp)).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/snmp_trap/README.md
     introduced: 1.13.0
     tags: [linux, macos, windows, networking]
 
@@ -1442,7 +1305,6 @@ input:
       The Socket Listener input plugin listens for messages from streaming (TCP, UNIX)
       or datagram (UDP, unixgram) protocols. Messages are expected in the
       [Telegraf Input Data Formats](https://docs.influxdata.com/telegraf/latest/data_formats/input/).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/socket_listener/README.md
     introduced: 1.3.0
     tags: [linux, macos, windows, networking]
 
@@ -1454,7 +1316,6 @@ input:
 
       > This plugin accesses APIs that are [chargeable](https://cloud.google.com/stackdriver/pricing#monitoring-costs).
       > You may incur costs.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/stackdriver/README.md
     introduced: 1.10.0
     tags: [linux, macos, windows, cloud]
 
@@ -1465,7 +1326,6 @@ input:
       `statsd` listener service while Telegraf is running.
       StatsD messages are formatted as described in the original
       [etsy statsd](https://github.com/etsy/statsd/blob/master/docs/metric_types.md) implementation.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/statsd/README.md
     introduced: 0.2.0
     tags: [linux, macos, windows, applications]
 
@@ -1474,9 +1334,8 @@ input:
     description: |
       The Suricata input plugin reports internal performance counters of the Suricata
       IDS/IPS engine, such as captured traffic volume, memory usage, uptime, flow counters, and more.
-      It provides a socket for the Suricata log output to write JSON stats output to
+      It provides a socket for the Suricata log output to write JSON output to
       and processes the incoming data to fit Telegraf's format.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/suricata/README.md
     introduced: 1.13.0
     tags: [linux, macos, windows, networking]
 
@@ -1489,16 +1348,14 @@ input:
       For more information about Linux swap spaces, see
       [All about Linux swap space](https://www.linux.com/news/all-about-linux-swap-space)
 
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/swap/README.md
     introduced: 1.7.0
     tags: [linux, macos, systems]
 
   - name: Synproxy
     id: synproxy
     description: |
-      The Synproxy plugin gathers the synproxy counters.
+      The Synproxy plugin gathers synproxy metrics.
       Synproxy is a Linux netfilter module used for SYN attack mitigation.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/synproxy/README.md
     introduced: 1.13.0
     tags: [linux, macos, windows, networking]
 
@@ -1508,7 +1365,6 @@ input:
       The Syslog input plugin listens for syslog messages transmitted over
       [UDP](https://tools.ietf.org/html/rfc5426) or [TCP](https://tools.ietf.org/html/rfc5425).
       Syslog messages should be formatted according to [RFC 5424](https://tools.ietf.org/html/rfc5424).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/syslog/README.md
     introduced: 1.7.0
     tags: [linux, macos, windows, logging, systems]
 
@@ -1518,7 +1374,6 @@ input:
       The Sysstat input plugin collects [sysstat](https://github.com/sysstat/sysstat)
       system metrics with the sysstat collector utility `sadc` and parses the created
       binary data file with the `sadf` utility.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/sysstat
     introduced: 0.12.1
     tags: [linux, macos, windows, systems]
 
@@ -1527,7 +1382,6 @@ input:
     description: |
       The System input plugin gathers general stats on system load, uptime, and
       number of users logged in. It is basically equivalent to the UNIX `uptime` command.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/system/README.md
     introduced: 0.1.6
     tags: [linux, macos, windows, systems]
 
@@ -1536,7 +1390,6 @@ input:
     description: |
       The Systemd Units plugin gathers systemd unit status metrics on Linux.
       It relies on `systemctl list-units --all --type=service` to collect data on service status.
-      **Linux only.**
 
       Results are tagged with the unit name and provide enumerated fields for loaded,
       active, and running fields, indicating the unit health.
@@ -1547,7 +1400,6 @@ input:
       > This plugin is related to the [Windows Services input plugin](#win_services),
       > which fulfills the same purpose on Windows.
 
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/systemd_units/README.md
     introduced: 1.13.0
     tags: [linux, systems]
 
@@ -1555,7 +1407,6 @@ input:
     id: tail
     description: |
       The Tail input plugin "tails" a log file and parses each log message.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/tail/README.md
     introduced: 1.1.2
     tags: [linux, macos, windows, logging]
 
@@ -1563,7 +1414,6 @@ input:
     id: tcp_listener
     description: |
       *Deprecated in Telegraf 1.3.0. Use the [Socket Listener input plugin](#socket_listener).*
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/tcp_listener/README.md
     introduced: 0.11.0
     deprecated: 1.3.0
     tags: [linux, macos, windows, networking, web]
@@ -1573,7 +1423,6 @@ input:
     description: |
       The Teamspeak 3 input plugin uses the Teamspeak 3 ServerQuery interface of
       the Teamspeak server to collect statistics of one or more virtual servers.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/teamspeak/README.md
     introduced: 1.5.0
     tags: [linux, macos, windows, applications, gaming]
 
@@ -1582,7 +1431,6 @@ input:
     description: |
       The Telegraf v1.x input plugin collects metrics about the Telegraf v1.x agent itself.
       Note that some metrics are aggregates across all instances of one type of plugin.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/internal/README.md
     introduced: 1.2.0
     tags: [linux, macos, windows, applications]
 
@@ -1590,7 +1438,6 @@ input:
     id: temp
     description: |
       The Temp input plugin collects temperature data from sensors.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/temp/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows, iot]
 
@@ -1600,7 +1447,6 @@ input:
       The Tengine Web Server input plugin gathers status metrics from the
       [Tengine Web Server](http://tengine.taobao.org/) using the
       [Reqstat module](http://tengine.taobao.org/document/http_reqstat.html).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/tengine/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows, servers, web]
 
@@ -1626,7 +1472,6 @@ input:
     id: udp_listener
     description: |
       *Deprecated in Telegraf 1.3.0. use the [Socket Listener input plugin](#socket_listener).*
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/udp_listener/README.md
     introduced: 0.11.0
     deprecated: 1.3.0
     tags: [linux, macos, windows, networking]
@@ -1636,7 +1481,6 @@ input:
     description: |
       The Unbound input plugin gathers statistics from [Unbound](https://www.unbound.net/),
       a validating, recursive, and caching DNS resolver.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/unbound/README.md
     introduced: 1.5.0
     tags: [linux, macos, windows, networking]
 
@@ -1644,7 +1488,6 @@ input:
     id: uwsgi
     description: |
       The uWSGI input plugin gathers metrics about uWSGI using the [uWSGI Stats Server](https://uwsgi-docs.readthedocs.io/en/latest/StatsServer.html).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/uwsgi/README.md
     introduced: 1.12.0
     tags: [linux, macos, windows, cloud]
 
@@ -1652,7 +1495,6 @@ input:
     id: varnish
     description: |
       The Varnish input plugin gathers stats from [Varnish HTTP Cache](https://varnish-cache.org/).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/varnish/README.md
     introduced: 0.13.1
     tags: [linux, macos, windows, networking]
 
@@ -1662,8 +1504,7 @@ input:
       The VMware vSphere input plugin uses the vSphere API to gather metrics from
       multiple vCenter servers (clusters, hosts, VMs, and data stores).
       For more information on the available performance metrics, see
-      [Common vSphere Performance Metrics](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/vsphere/METRICS.md).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/vsphere/README.md
+      [Common vSphere Performance Metrics](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/vsphere/METRICS.md)
     introduced: 1.8.0
     tags: [linux, macos, windows, containers]
 
@@ -1673,17 +1514,17 @@ input:
       The Webhooks input plugin starts an HTTPS server and registers multiple webhook listeners.
 
       #### Available webhooks
-      - [Filestack](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/webhooks/filestack/README.md)
-      - [GitHub](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/webhooks/github/README.md)
-      - [Mandrill](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/webhooks/mandrill/README.md)
-      - [Papertrail](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/webhooks/papertrail/README.md)
-      - [Particle.io](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/webhooks/particle/README.md)
-      - [Rollbar](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/webhooks/rollbar)
+      - [Filestack](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/filestack/)
+      - [Github](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/github/)
+      - [Mandrill](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/mandrill/)
+      - [Rollbar](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/rollbar/)
+      - [Papertrail](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/papertrail/)
+      - [Particle](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/particle/)
 
       #### Add new webhooks
       If you need a webhook that is not supported, consider
-      [adding a new webhook](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/webhooks#adding-new-webhooks-plugin).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/webhooks/README.md
+      [adding a new webhook](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/webhooks#adding-new-webhooks-plugin)
+
     introduced: 1.0.0
     tags: [linux, macos, windows, applications, web]
 
@@ -1692,7 +1533,6 @@ input:
     description: |
       The Windows Performance Counters input plugin reads Performance Counters on the
       Windows operating sytem. **Windows only**.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/win_perf_counters/README.md
     introduced: 0.10.2
     tags: [windows, systems]
 
@@ -1700,7 +1540,6 @@ input:
     id: win_services
     description: |
       The Windows Services input plugin reports Windows services info. **Windows only**.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/win_services/README.md
     introduced: 1.4.0
     tags: [windows, servers, systems]
 
@@ -1709,7 +1548,6 @@ input:
     description: |
       The Wireless input plugin gathers metrics about wireless link quality by
       reading the `/proc/net/wireless` file. **This plugin currently supports Linux only**.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/wireless/README.md
     introduced: 1.9.0
     tags: [linux, networking]
 
@@ -1718,7 +1556,6 @@ input:
     description: |
       The X.509 Certificate input plugin provides information about X.509 certificate
       accessible using the local file or network connection.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/x509_cert/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows, networking]
 
@@ -1730,7 +1567,6 @@ input:
       The ZFS input plugin provides metrics from your ZFS filesystems.
       It supports ZFS on Linux and FreeBSD.
       It gets ZFS statistics from `/proc/spl/kstat/zfs` on Linux and from `sysctl` and `zpool` on FreeBSD.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/zfs/README.md
     introduced: 0.2.1
     tags: [linux, macos, windows, systems]
 
@@ -1746,7 +1582,6 @@ output:
     id: cloudwatch
     description: |
       The Amazon CloudWatch output plugin send metrics to Amazon CloudWatch.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/cloudwatch/README.md
     introduced: 0.10.1
     tags: [linux, macos, windows, cloud]
 
@@ -1757,7 +1592,6 @@ output:
       in the early stages of development. It will batch up all of the points into
       one `PUT` request to Kinesis. This should save the number of API requests
       by a considerable level.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/kinesis/README.md
     introduced: 0.2.5
     tags: [linux, macos, windows, cloud, messaging]
 
@@ -1771,7 +1605,6 @@ output:
       If the point value being sent cannot be converted to a float64 value, the metric is skipped.
 
       Metrics are grouped by converting any `_` characters to `.` in the Point Name.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/amon/README.md
     introduced: 0.2.1
     tags: [linux, macos, windows, databases]
 
@@ -1783,7 +1616,6 @@ output:
 
       Metrics are written to a topic exchange using `tag`, defined in configuration
       file as `RoutingTag`, as a routing key.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/amqp/README.md
     introduced: 0.1.9
     tags: [linux, macos, windows, messaging]
 
@@ -1792,7 +1624,6 @@ output:
     description: |
       The Apache Kafka output plugin writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.html)
       acting a Kafka Producer.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/kafka/README.md
     introduced: 0.1.7
     tags: [linux, macos, windows, messaging]
 
@@ -1801,7 +1632,6 @@ output:
     description: |
       The CrateDB output plugin writes to [CrateDB](https://crate.io/), a real-time SQL database for
       machine data and IoT, using its [PostgreSQL protocol](https://crate.io/docs/crate/reference/protocols/postgres.html).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/cratedb/README.md
     introduced: 1.5.0
     tags: [linux, macos, windows, data-stores]
 
@@ -1811,7 +1641,6 @@ output:
       The Datadog output plugin writes to the [Datadog Metrics API](http://docs.datadoghq.com/api/#metrics)
       and requires an `apikey` which can be obtained [here](https://app.datadoghq.com/account/settings#api)
       for the account.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/datadog/README.md
     introduced: 0.1.6
     tags: [linux, macos, windows, applications, cloud]
 
@@ -1820,7 +1649,6 @@ output:
     description: |
       The Discard output plugin simply drops all metrics that are sent to it.
       It is only meant to be used for testing purposes.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/discard/README.md
     introduced: 1.2.0
     tags: [linux, macos, windows]
 
@@ -1830,7 +1658,6 @@ output:
       The Elasticsearch output plugin writes to Elasticsearch via HTTP using
       [Elastic](http://olivere.github.io/elastic/). Currently it only supports
       Elasticsearch 5.x series.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/elasticsearch/README.md
     introduced: 0.1.5
     tags: [linux, macos, windows, data-stores]
 
@@ -1838,7 +1665,6 @@ output:
     id: exec
     description: |
       The Exec output plugin sends Telegraf metrics to an external application over `stdin`.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/exec/README.md
     introduced: 1.12.0
     tags: [linux, macos, windows, systems]
 
@@ -1846,7 +1672,6 @@ output:
     id: file
     description: |
       The File output plugin writes Telegraf metrics to files.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/file/README.md
     introduced: 0.10.3
     tags: [linux, macos, windows, systems]
 
@@ -1855,7 +1680,6 @@ output:
     description: |
       The Google PubSub output plugin publishes metrics to a [Google Cloud PubSub](https://cloud.google.com/pubsub)
       topic as one of the supported [output data formats](https://docs.influxdata.com/telegraf/latest/data_formats/output).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/cloud_pubsub/README.md
     introduced: 1.10.0
     tags: [linux, macos, windows, messaging, cloud]
 
@@ -1863,7 +1687,6 @@ output:
     id: graphite
     description: |
       The Graphite output plugin writes to [Graphite](http://graphite.readthedocs.org/en/latest/index.html) via raw TCP.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/graphite/README.md
     introduced: 0.10.1
     tags: [linux, macos, windows, data-stores]
 
@@ -1871,7 +1694,6 @@ output:
     id: graylog
     description: |
       The  Graylog output plugin writes to a Graylog instance using the `gelf` format.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/graylog/README.md
     introduced: 1.0.0
     tags: [linux, macos, windows, logging]
 
@@ -1880,7 +1702,6 @@ output:
     description: |
       The HTTP output plugin sends metrics in a HTTP message encoded using one of the output data formats.
       For `data_formats` that support batching, metrics are sent in batch format.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/http/README.md
     introduced: 1.7.0
     tags: [linux, macos, windows, applications]
 
@@ -1889,7 +1710,6 @@ output:
     description: |
       The health plugin provides a HTTP health check resource that can be configured to return a failure status code based on the value of a metric.
       When the plugin is healthy it will return a 200 response; when unhealthy it will return a 503 response. The default state is healthy, one or more checks must fail in order for the resource to enter the failed state.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/health/README.md
     introduced: 1.11.0
     tags: [linux, macos, windows, applications]
 
@@ -1897,7 +1717,6 @@ output:
     id: influxdb
     description: |
       The InfluxDB v1.x output plugin writes to InfluxDB using HTTP or UDP.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/influxdb/README.md
     introduced: 0.1.1
     tags: [linux, macos, windows, data-stores]
 
@@ -1905,7 +1724,6 @@ output:
     id: influxdb_v2
     description: |
       The InfluxDB v2 output plugin writes metrics to [InfluxDB 2.0](https://github.com/influxdata/influxdb).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/influxdb_v2/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows, data-stores]
 
@@ -1919,7 +1737,6 @@ output:
       difference being that the type of stat (gauge, increment) is the first token,
       separated from the metric itself by whitespace. The increment type is only used
       if the metric comes in as a counter through `[[inputs.statsd]]`.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/instrumental/README.md
     introduced: 0.13.1
     tags: [linux, macos, windows, applications]
 
@@ -1929,7 +1746,6 @@ output:
       The Librato output plugin writes to the [Librato Metrics API](http://dev.librato.com/v1/metrics#metrics)
       and requires an `api_user` and `api_token` which can be obtained
       [here](https://metrics.librato.com/account/api_tokens) for the account.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/librato/README.md
     introduced: 0.2.0
     tags: [linux, macos, windows, cloud]
 
@@ -1938,7 +1754,6 @@ output:
     description: |
       The Microsoft Azure Application Insights output plugin writes Telegraf metrics to
       [Application Insights (Microsoft Azure)](https://azure.microsoft.com/en-us/services/application-insights/).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/application_insights/README.md
     introduced: 1.7.0
     tags: [linux, macos, windows, cloud, applications]
 
@@ -1962,7 +1777,6 @@ output:
       as the Azure Monitor metric name. All field values are written as a summarized set
       that includes `min`, `max`, `sum`, and `count`. Tags are written as a dimension
       on each Azure Monitor metric.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/azure_monitor/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows, cloud]
 
@@ -1971,7 +1785,6 @@ output:
     description: |
       The MQTT Producer output plugin writes to the MQTT server using
       [supported output data formats](https://docs.influxdata.com/telegraf/latest/data_formats/output/).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/mqtt/README.md
     introduced: 0.2.0
     tags: [linux, macos, windows, messaging]
 
@@ -1979,7 +1792,6 @@ output:
     id: nats
     description: |
       The NATS Output output plugin writes to a (list of) specified NATS instance(s).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/nats/README.md
     introduced: 1.1.0
     tags: [linux, macos, windows, messaging]
 
@@ -1988,7 +1800,6 @@ output:
     description: |
       The NSQ output plugin writes to a specified NSQD instance, usually local to the producer.
       It requires a server name and a topic name.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/nsq/README.md
     introduced: 0.2.1
     tags: [linux, macos, windows, messaging]
 
@@ -2001,7 +1812,6 @@ output:
       To use HTTP mode, set `useHttp` to true in config. You can also control how many
       metrics are sent in each HTTP request by setting `batchSize` in config.
       See the [OpenTSDB documentation](http://opentsdb.net/docs/build/html/api_http/put.html) for details.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/opentsdb/README.md
     introduced: 0.1.9
     tags: [linux, macos, windows, data-stores]
 
@@ -2010,7 +1820,6 @@ output:
     description: |
       The Prometheus Client output plugin starts a [Prometheus](https://prometheus.io/) Client,
       it exposes all metrics on `/metrics` (default) to be polled by a Prometheus server.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/prometheus_client/README.md
     introduced: 0.2.1
     tags: [linux, macos, windows, applications, data-stores]
 
@@ -2018,7 +1827,6 @@ output:
     id: riemann
     description: |
       The Riemann output plugin writes to [Riemann](http://riemann.io/) using TCP or UDP.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/riemann/README.md
     introduced: 1.3.0
     tags: [linux, macos, windows, networking, systems]
 
@@ -2037,7 +1845,6 @@ output:
     description: |
       The Socket Writer output plugin writes to a UDP, TCP, or UNIX socket.
       It can output data in any of the [supported output formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md).
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/socket_writer/README.md
     introduced: 1.3.0
     tags: [linux, macos, windows, networking]
 
@@ -2053,7 +1860,6 @@ output:
 
       Metrics are grouped by the `namespace` variable and metric key, for example
       `custom.googleapis.com/telegraf/system/load5`.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/stackdriver/README.md
     introduced: 1.9.0
     tags: [linux, macos, windows, cloud]
 
@@ -2062,7 +1868,6 @@ output:
     description: |
       The syslog output plugin sends syslog messages transmitted over UDP or TCP or TLS, with or without the octet counting framing.
       Syslog messages are formatted according to RFC 5424.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/syslog/README.md
     introduced: 1.11.0
     tags: [linux, macos, windows, logging]
 
@@ -2070,7 +1875,6 @@ output:
     id: wavefront
     description: |
       The Wavefront output plugin writes to a Wavefront proxy, in Wavefront data format over TCP.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/outputs/wavefront/README.md
     introduced: 1.5.0
     tags: [linux, macos, windows, applications, cloud]
 
@@ -2087,7 +1891,6 @@ aggregator:
     description: |
       The BasicStats aggregator plugin gives `count`, `max`, `min`, `mean`, `s2`(variance),
       and `stdev` for a set of values, emitting the aggregate every period seconds.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/aggregators/basicstats/README.md
     introduced: 1.5.0
     tags: [linux, macos, windows]
 
@@ -2098,7 +1901,6 @@ aggregator:
       A contiguous series is defined as a series which receives updates within the time period in series_timeout.
       The contiguous series may be longer than the time interval defined by period.
       This is useful for getting the final value for data sources that produce discrete time series, such as procstat, cgroup, kubernetes, etc.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/aggregators/final/README.md
     introduced: 1.11.0
     tags: [linux, macos, windows]
 
@@ -2114,7 +1916,6 @@ aggregator:
       Like other Telegraf aggregator plugins, the metric is emitted every period seconds.
       Bucket counts, however, are not reset between periods and will be non-strictly
       increasing while Telegraf is running.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/aggregators/histogram/README.md
     introduced: 1.4.0
     tags: [linux, macos, windows]
 
@@ -2125,7 +1926,6 @@ aggregator:
       multiple fields per line. This optimizes memory and network transfer efficiency.
       Use this plugin when fields are split over multiple lines of line protocol,
       with the same measurement, tag set, and timestamp on each.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/aggregators/merge/README.md
     introduced: 1.13.0
     tags: [linux, macos, windows]
 
@@ -2134,7 +1934,6 @@ aggregator:
     description: |
       The MinMax aggregator plugin aggregates `min` and `max` values of each field it sees,
       emitting the aggregrate every period seconds.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/aggregators/minmax/README.md
     introduced: 1.1.0
     tags: [linux, macos, windows]
 
@@ -2154,7 +1953,6 @@ aggregator:
 
       ValueCounter only works on fields of the type `int`, `bool`, or `string`.
       Float fields are being dropped to prevent the creating of too many fields.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/aggregators/valuecounter/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows]
 
@@ -2172,7 +1970,6 @@ processor:
       The Converter processor plugin is used to change the type of tag or field values.
       In addition to changing field types, it can convert between fields and tags.
       Values that cannot be converted are dropped.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/converter/README.md
     introduced: 1.7.0
     tags: [linux, macos, windows]
 
@@ -2181,7 +1978,6 @@ processor:
     description: |
       The Clone processor plugin creates a copy of each metric to preserve the
       original metric and allow modifications in the copied metric.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/clone/README.md
     introduced: 1.13.0
     tags: [linux, macos, windows]
 
@@ -2189,7 +1985,6 @@ processor:
     id: date
     description: |
       The Date processor plugin adds the metric timestamp as a human readable tag.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/date/README.md
     introduced: 1.12.0
     tags: [linux, macos, windows]
 
@@ -2204,7 +1999,6 @@ processor:
       not contained in the value_mappings.
       The processor supports explicit configuration of a destination field.
       By default the source field is overwritten.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/enum/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows]
 
@@ -2227,7 +2021,6 @@ processor:
 
       Use case of this plugin encompass ensuring certain tags or naming conventions
       are adhered to irrespective of input plugin configurations, e.g., by `taginclude`.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/override/README.md
     introduced: 1.6.0
     tags: [linux, macos, windows]
 
@@ -2236,7 +2029,6 @@ processor:
     description: |
       The Parser processor plugin parses defined fields containing the specified data
       format and creates new metrics based on the contents of the field.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/parser/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows]
 
@@ -2248,7 +2040,6 @@ processor:
       It also flattens data into a more compact representation for write operations with some output data formats.
 
       *To perform the reverse operation use the [Unpivot](#unpivot) processor.*
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/pivot/README.md
     introduced: 1.12.0
     tags: [linux, macos, windows]
 
@@ -2256,7 +2047,6 @@ processor:
     id: printer
     description: |
       The Printer processor plugin simply prints every metric passing through it.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/printer/README.md
     introduced: 1.1.0
     tags: [linux, macos, windows]
 
@@ -2265,7 +2055,6 @@ processor:
     description: |
       The Regex processor plugin transforms  tag and field values using a regular expression (regex) pattern.
       If `result_key `parameter is present, it can produce new tags and fields from existing ones.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/regex/README.md
     introduced: 1.7.0
     tags: [linux, macos, windows]
 
@@ -2273,7 +2062,6 @@ processor:
     id: rename
     description: |
       The Rename processor plugin renames InfluxDB measurements, fields, and tags.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/rename/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows]
 
@@ -2298,7 +2086,6 @@ processor:
       You can specify the `measurement`, `tag` or `field` that you want processed in each
       section and optionally a `dest` if you want the result stored in a new tag or field.
       You can specify lots of transformations on data with a single strings processor.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/strings/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows]
 
@@ -2311,7 +2098,6 @@ processor:
       This can be useful when dealing with output systems (e.g. Stackdriver) that impose
       hard limits on the number of tags or labels per metric or where high levels of
       cardinality are computationally or financially expensive.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/tag_limit/README.md
     introduced: 1.12.0
     tags: [linux, macos, windows]
 
@@ -2332,7 +2118,6 @@ processor:
 
       Note that depending on the amount of metrics on each computed bucket, more
       than `K` metrics may be returned.
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/topk/README.md
     introduced: 1.7.0
     tags: [linux, macos, windows]
 
@@ -2343,6 +2128,5 @@ processor:
       This transformation often results in data that is easier to aggregate across fields.
 
       *To perform the reverse operation use the [Pivot](#pivot) processor.*
-    link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/unpivot/README.md
     introduced: 1.12.0
     tags: [linux, macos, windows]

--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -584,8 +584,10 @@ input:
       The intent of the plugin is to allow Telegraf to serve as a proxy, or router,
       for the HTTP `/write` endpoint of the InfluxDB HTTP API.
 
-      > This plugin was previously known as `http_listener`. If you wish to
-      > send general metrics via HTTP, use the [HTTP Listener v2 input plugin](#http_listener_v2) instead.
+      > This plugin was previously known as `http_listener`.
+      > To send general metrics via HTTP, use the [HTTP Listener v2 input plugin](#http_listener_v2) instead.
+      >
+      > This plugin is compatible with **InfluxDB 1.x** only.
 
       The `/write` endpoint supports the `precision` query parameter and can be set
       to one of `ns`, `u`, `ms`, `s`, `m`, `h`.  All other parameters are ignored and

--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -156,6 +156,14 @@ input:
     introduced: 1.12.0
     tags: [linux, macos, windows, systems]
 
+  - name: Azure Storage Queue
+    id: azure_storage_queue
+    description: |
+      The Azure Storage Queue plugin gathers sizes of Azure Storage Queues.
+    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/azure_storage_queue/README.md
+    introduces: 1.13.0
+    tags: [linux, macos, windows, systems, cloud]
+
   - name: Bcache
     id: bcache
     description: |
@@ -391,6 +399,15 @@ input:
     introduced: 0.1.5
     tags: [linux, macos, windows, data-stores]
 
+  - name: Ethtool
+    id: ethtool
+    description: |
+      The Ethtool plugin gathers ethernet device statistics.
+      The network device and driver determine what fields are gathered.
+    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/ethtool/README.md
+    introduced: 1.13.0
+    tags: [linux, macos, windows, networking, servers]
+
   - name: Exec
     id: exec
     description: |
@@ -542,7 +559,7 @@ input:
   - name: HTTP JSON
     id: httpjson
     description: |
-      _Deprecated in Telegraf 1.6.0. Use the [HTTP input plugin](#http)._
+      *Deprecated in Telegraf 1.6.0. Use the [HTTP input plugin](#http).*
 
       The HTTP JSON input plugin collects data from HTTP URLs which respond with JSON.
       It flattens the JSON and finds all numeric values, treating them as floats.
@@ -704,7 +721,7 @@ input:
   - name: Jolokia
     id: jolokia
     description: |
-      _Deprecated in Telegraf 1.5.0. Use the [Jolokia2 input plugin](#jolokia2_agent)._
+      *Deprecated in Telegraf 1.5.0. Use the [Jolokia2 input plugin](#jolokia2_agent).*
     link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/jolokia/README.md
     introduced: 0.2.1
     deprecated: 1.5.0
@@ -1403,10 +1420,20 @@ input:
     id: snmp_legacy
     description: |
       The SNMP Legacy input plugin gathers metrics from SNMP agents.
-      _Deprecated in Telegraf 1.0.0. Use the [SNMP input plugin](#snmp)._
+      *Deprecated in Telegraf 1.0.0. Use the [SNMP input plugin](#snmp).*
     link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/snmp_legacy/README.md
     introduced: 0.10.1
     deprecated: 1.0.0
+    tags: [linux, macos, windows, networking]
+
+  - name: SNMP Trap
+    id: snmp_trap
+    description: |
+      The SNMP Trap plugin receives SNMP notifications (traps and inform requests).
+      Notifications are received over UDP on a configurable port.
+      Resolve OIDs to strings using system MIB files (just like with the [SNMP input plugin](#snmp)).
+    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/snmp_trap/README.md
+    introduced: 1.13.0
     tags: [linux, macos, windows, networking]
 
   - name: Socket Listener
@@ -1442,6 +1469,17 @@ input:
     introduced: 0.2.0
     tags: [linux, macos, windows, applications]
 
+  - name: Suricata
+    id: suricata
+    description: |
+      The Suricata input plugin reports internal performance counters of the Suricata
+      IDS/IPS engine, such as captured traffic volume, memory usage, uptime, flow counters, and more.
+      It provides a socket for the Suricata log output to write JSON stats output to
+      and processes the incoming data to fit Telegraf's format.
+    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/suricata/README.md
+    introduced: 1.13.0
+    tags: [linux, macos, windows, networking]
+
   - name: Swap
     id: swap
     description: |
@@ -1454,6 +1492,15 @@ input:
     link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/swap/README.md
     introduced: 1.7.0
     tags: [linux, macos, systems]
+
+  - name: Synproxy
+    id: synproxy
+    description: |
+      The Synproxy plugin gathers the synproxy counters.
+      Synproxy is a Linux netfilter module used for SYN attack mitigation.
+    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/synproxy/README.md
+    introduced: 1.13.0
+    tags: [linux, macos, windows, networking]
 
   - name: Syslog
     id: syslog
@@ -1484,6 +1531,26 @@ input:
     introduced: 0.1.6
     tags: [linux, macos, windows, systems]
 
+  - name: Systemd Units
+    id: systemd_units
+    description: |
+      The Systemd Units plugin gathers systemd unit status metrics on Linux.
+      It relies on `systemctl list-units --all --type=service` to collect data on service status.
+      **Linux only.**
+
+      Results are tagged with the unit name and provide enumerated fields for loaded,
+      active, and running fields, indicating the unit health.
+
+      This plugin can gather other unit types as well.
+      See `systemctl list-units --all --type help` for possible options.
+
+      > This plugin is related to the [Windows Services input plugin](#win_services),
+      > which fulfills the same purpose on Windows.
+
+    link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/systemd_units/README.md
+    introduced: 1.13.0
+    tags: [linux, systems]
+
   - name: Tail
     id: tail
     description: |
@@ -1495,7 +1562,7 @@ input:
   - name: TCP Listener
     id: tcp_listener
     description: |
-      _Deprecated in Telegraf 1.3.0. Use the [Socket Listener input plugin](#socket_listener)._
+      *Deprecated in Telegraf 1.3.0. Use the [Socket Listener input plugin](#socket_listener).*
     link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/tcp_listener/README.md
     introduced: 0.11.0
     deprecated: 1.3.0
@@ -1558,7 +1625,7 @@ input:
   - name: UDP Listener
     id: udp_listener
     description: |
-      _Deprecated in Telegraf 1.3.0. use the [Socket Listener input plugin](#socket_listener)._
+      *Deprecated in Telegraf 1.3.0. use the [Socket Listener input plugin](#socket_listener).*
     link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/udp_listener/README.md
     introduced: 0.11.0
     deprecated: 1.3.0
@@ -2051,6 +2118,17 @@ aggregator:
     introduced: 1.4.0
     tags: [linux, macos, windows]
 
+  - name: Merge
+    id: merge
+    description: |
+      The Merge aggregator plugin merges metrics together and generates line protocol with
+      multiple fields per line. This optimizes memory and network transfer efficiency.
+      Use this plugin when fields are split over multiple lines of line protocol,
+      with the same measurement, tag set, and timestamp on each.
+    link: https://github.com/influxdata/telegraf/blob/master/plugins/aggregators/merge/README.md
+    introduced: 1.13.0
+    tags: [linux, macos, windows]
+
   - name: MinMax
     id: minmax
     description: |
@@ -2096,6 +2174,15 @@ processor:
       Values that cannot be converted are dropped.
     link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/converter/README.md
     introduced: 1.7.0
+    tags: [linux, macos, windows]
+
+  - name: Clone
+    id: clone
+    description: |
+      The Clone processor plugin creates a copy of each metric to preserve the
+      original metric and allow modifications in the copied metric.
+    link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/clone/README.md
+    introduced: 1.13.0
     tags: [linux, macos, windows]
 
   - name: Date
@@ -2160,7 +2247,7 @@ processor:
       This transformation often results in data that is easier to use with mathematical operators and comparisons.
       It also flattens data into a more compact representation for write operations with some output data formats.
 
-      _To perform the reverse operation use the [Unpivot](#unpivot) processor._
+      *To perform the reverse operation use the [Unpivot](#unpivot) processor.*
     link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/pivot/README.md
     introduced: 1.12.0
     tags: [linux, macos, windows]
@@ -2255,7 +2342,7 @@ processor:
       The Unpivot processor plugin rotates a multi-field series into single-valued metrics.
       This transformation often results in data that is easier to aggregate across fields.
 
-      _To perform the reverse operation use the [Pivot](#pivot) processor._
+      *To perform the reverse operation use the [Pivot](#pivot) processor.*
     link: https://github.com/influxdata/telegraf/blob/master/plugins/processors/unpivot/README.md
     introduced: 1.12.0
     tags: [linux, macos, windows]

--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -198,7 +198,7 @@ input:
       attributes through the jolokia REST endpoint.
       All metrics are collected for each server configured.
     introduced: 0.12.1
-    deprecated: 1.7.0
+    deprecated: 1.6.4
     tags: [linux, macos, windows, data-stores]
 
   - name: Ceph Storage
@@ -507,7 +507,7 @@ input:
       The HTTP JSON input plugin collects data from HTTP URLs which respond with JSON.
       It flattens the JSON and finds all numeric values, treating them as floats.
     introduced: 0.1.6
-    deprecated: 1.6.0
+    deprecated: 1.5.3
     tags: [linux, macos, windows, servers, web]
 
   - name: HTTP Listener
@@ -518,7 +518,7 @@ input:
       For general purpose transfer of metrics in any format via HTTP, use [`http_listener_v2`](#http_listener_v2)instead.
     link: https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_listener/README.md
     introduced: 1.1.0
-    deprecated: 1.9.0
+    deprecated: 1.8.3
     tags: [linux, macos, windows, servers, web]
 
   - name: HTTP Listener v2
@@ -654,7 +654,7 @@ input:
     description: |
       *Deprecated in Telegraf 1.5.0. Use the [Jolokia2 input plugin](#jolokia2_agent).*
     introduced: 0.2.1
-    deprecated: 1.5.0
+    deprecated: 1.4.5
     tags: [linux, macos, windows, networking]
 
   - name: Jolokia2 Agent
@@ -1287,7 +1287,7 @@ input:
       The SNMP Legacy input plugin gathers metrics from SNMP agents.
       *Deprecated in Telegraf 1.0.0. Use the [SNMP input plugin](#snmp).*
     introduced: 0.10.1
-    deprecated: 1.0.0
+    deprecated: 0.13.1
     tags: [linux, macos, windows, networking]
 
   - name: SNMP Trap
@@ -1415,7 +1415,7 @@ input:
     description: |
       *Deprecated in Telegraf 1.3.0. Use the [Socket Listener input plugin](#socket_listener).*
     introduced: 0.11.0
-    deprecated: 1.3.0
+    deprecated: 1.2.1
     tags: [linux, macos, windows, networking, web]
 
   - name: Teamspeak 3
@@ -1473,7 +1473,7 @@ input:
     description: |
       *Deprecated in Telegraf 1.3.0. use the [Socket Listener input plugin](#socket_listener).*
     introduced: 0.11.0
-    deprecated: 1.3.0
+    deprecated: 1.2.1
     tags: [linux, macos, windows, networking]
 
   - name: Unbound
@@ -1837,7 +1837,7 @@ output:
       see [#1878](https://github.com/influxdata/telegraf/issues/1878) for more details & discussion.
     link: https://github.com/influxdata/telegraf/tree/master/plugins/outputs/riemann_legacy
     introduced: 0.2.3
-    deprecated: 1.3.0
+    deprecated: 1.2.1
     tags: [linux, macos, windows, applications]
 
   - name: Socket Writer

--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -1926,7 +1926,7 @@ aggregator:
     description: |
       The Merge aggregator plugin merges metrics together and generates line protocol with
       multiple fields per line. This optimizes memory and network transfer efficiency.
-      Use this plugin when fields are split over multiple lines of line protocol,
+      Use this plugin when fields are split over multiple lines of line protocol
       with the same measurement, tag set, and timestamp on each.
     introduced: 1.13.0
     tags: [linux, macos, windows]
@@ -2041,7 +2041,7 @@ processor:
       This transformation often results in data that is easier to use with mathematical operators and comparisons.
       It also flattens data into a more compact representation for write operations with some output data formats.
 
-      *To perform the reverse operation use the [Unpivot](#unpivot) processor.*
+      *To perform the reverse operation, use the [Unpivot](#unpivot) processor.*
     introduced: 1.12.0
     tags: [linux, macos, windows]
 
@@ -2129,6 +2129,6 @@ processor:
       The Unpivot processor plugin rotates a multi-field series into single-valued metrics.
       This transformation often results in data that is easier to aggregate across fields.
 
-      *To perform the reverse operation use the [Pivot](#pivot) processor.*
+      *To perform the reverse operation, use the [Pivot](#pivot) processor.*
     introduced: 1.12.0
     tags: [linux, macos, windows]

--- a/data/versions.yaml
+++ b/data/versions.yaml
@@ -1,2 +1,2 @@
 stable_version: v2.0
-telegraf_version: 1.12.0
+telegraf_version: 1.13.0

--- a/layouts/shortcodes/telegraf/plugins.html
+++ b/layouts/shortcodes/telegraf/plugins.html
@@ -13,6 +13,8 @@
       </p>
       <p>{{ .description | markdownify | safeHTML }}</p>
     </div>
-    <a class="btn github-link" href="{{ .link }}" target="_blank"><span class="icon-github"></span> <span class="hide">View</span></a>
+    <a class="btn github-link" href="{{ if .link }}{{ .link }}{{ else }}https://github.com/influxdata/telegraf/blob/release-{{ $telegrafVersion }}/plugins/{{ $type }}s/{{ .id }}/README.md{{ end }}" target="_blank">
+      <span class="icon-github"></span> <span class="hide">View</span>
+    </a>
   </div>
 {{ end }}


### PR DESCRIPTION
Closes #650 

Updates the Telegraf plugins page to include plugins added in Telegraf 1.13.

_This shouldn't be merged until Telegraf 1.13 is released._

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
