### PR TITLE
Bugfix/kubernetes docs

### DIFF
--- a/content/v2.0/get-started.md
+++ b/content/v2.0/get-started.md
@@ -235,7 +235,7 @@ The instructions below use Minikube, but the steps should be similar in any Kube
 6. Forward port 9999 from inside the cluster to localhost:
 
     ```
-    kubectl port-forward -n influxdb svc/influxdb 9999:9999 &
+    kubectl port-forward -n influxdb svc/influxdb 9999:9999
     ```
 
 {{% /tab-content %}}

--- a/content/v2.0/get-started.md
+++ b/content/v2.0/get-started.md
@@ -225,11 +225,11 @@ The instructions below use Minikube, but the steps should be similar in any Kube
     ```
     kubectl get pods -n influxdb
     ```
-    
-5. Ensure the service is running:
+
+5. Ensure the service is available. You should see an IP address after `Endpoints`:
 
     ```
-    kubectl get service -n influxdb
+    kubectl describe service -n influxdb influxdb
     ```
 
 6. Forward port 9999 from inside the cluster to localhost:


### PR DESCRIPTION
Fixed the language used to "check" the service

Removed bash style "background" tasking, I don't believe this should be encouraged. Allow the user to keep it front and centre or open a new tab on their own (otherwise we need to explain how to `fg` and kill it?)

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [x] Rebased/mergeable
