### PR TITLE
minor typo and omission fixes

### DIFF
--- a/content/v2.0/reference/flux/language/assignment-scope.md
+++ b/content/v2.0/reference/flux/language/assignment-scope.md
@@ -33,7 +33,7 @@ An identifier assigned to a variable in a block cannot be reassigned in the same
 An identifier can be reassigned or shadowed in an inner block.
 
 ```js
-VariableAssignment = identifier "=" Expression
+VariableAssignment = identifier "=" Expression .
 ```
 
 ##### Examples of variable assignment
@@ -55,7 +55,7 @@ f = () => {
 
 ## Option assignment
 ```js
-OptionAssignment = "option" [ identifier "." ] identifier "=" Expression
+OptionAssignment = "option" [ identifier "." ] identifier "=" Expression .
 ```
 
 An option assignment creates an option bound to an identifier and gives it a type and a value.

--- a/content/v2.0/reference/flux/language/expressions.md
+++ b/content/v2.0/reference/flux/language/expressions.md
@@ -31,6 +31,7 @@ Literal = int_lit
         | string_lit
         | regex_lit
         | duration_lit
+        | date_time_lit
         | pipe_receive_lit
         | ObjectLiteral
         | ArrayLiteral
@@ -187,8 +188,8 @@ If `obj` contains an entry with property `k`, both `obj.k` and `obj["k"]` return
 If `obj` does **not** contain an entry with property `k`, both `obj.k` and `obj["k"]` return _null_.
 
 ```js
-MemberExpression        = DotExpression  | MemberBracketExpression
-DotExpression           = "." identifer
+MemberExpression        = DotExpression  | MemberBracketExpression .
+DotExpression           = "." identifier .
 MemberBracketExpression = "[" string_lit "]" .
 ```
 
@@ -246,16 +247,16 @@ LogicalExpression        = UnaryLogicalExpression
 LogicalOperator          = "and" | "or" .
 UnaryLogicalExpression   = ComparisonExpression
                          | UnaryLogicalOperator UnaryLogicalExpression .
-UnaryLogicalOperator     = "not" | "exists".
-ComparisonExpression     = MultiplicativeExpression
-                         | ComparisonExpression ComparisonOperator MultiplicativeExpression .
+UnaryLogicalOperator     = "not" | "exists" .
+ComparisonExpression     = AdditiveExpression
+                         | ComparisonExpression ComparisonOperator AdditiveExpression .
 ComparisonOperator       = "==" | "!=" | "<" | "<=" | ">" | ">=" | "=~" | "!~" .
 AdditiveExpression       = MultiplicativeExpression
                          | AdditiveExpression AdditiveOperator MultiplicativeExpression .
 AdditiveOperator         = "+" | "-" .
 MultiplicativeExpression = PipeExpression
                          | MultiplicativeExpression MultiplicativeOperator PipeExpression .
-MultiplicativeOperator   = "*" | "/" | "%" | "^".
+MultiplicativeOperator   = "*" | "/" | "%" | "^" .
 PipeExpression           = PostfixExpression
                          | PipeExpression PipeOperator UnaryExpression .
 PipeOperator             = "|>" .

--- a/content/v2.0/reference/flux/language/statements.md
+++ b/content/v2.0/reference/flux/language/statements.md
@@ -27,7 +27,7 @@ Statement = OptionAssignment
 ## Import declaration
 
 ```js
-ImportDeclaration = "import" [identifier] string_lit
+ImportDeclaration = "import" [identifier] string_lit .
 ```
 
 A package name and an import path is associated with every package.
@@ -86,7 +86,7 @@ A named type can be created using a type assignment statement.
 A named type is equivalent to the type it describes and may be used interchangeably.
 
 ```js
-TypeAssignment    = "type" identifier "=" TypeExpression
+TypeAssignment    = "type" identifier "=" TypeExpression .
 TypeExpression    = identifier
                   | TypeParameter
                   | ObjectType

--- a/content/v2.0/reference/flux/language/system-built-ins.md
+++ b/content/v2.0/reference/flux/language/system-built-ins.md
@@ -16,7 +16,7 @@ When a built-in value is not expressible in Flux, its value may be defined by th
 All such values must have a corresponding builtin statement to declare the existence and type of the built-in value.
 
 ```js
-BuiltinStatement = "builtin" identifer ":" TypeExpression
+BuiltinStatement = "builtin" identifier ":" TypeExpression .
 ```
 
 ##### Example


### PR DESCRIPTION
* Added missing '.' characters terminating each production
* identifer -> identifier
* date_time_lit was missing from Literals, added.
* AdditiveExpression was bypassed in the expression chain, added.

Found these while making a grammar for flux.