### PR TITLE
Backup and restore

### DIFF
--- a/content/v2.0/backup-restore/_index.md
+++ b/content/v2.0/backup-restore/_index.md
@@ -2,12 +2,15 @@
 title: Back up & restore data
 seotitle: Backup and restore data with InfluxDB
 description: >
-  placeholder
+  InfluxDB provides tools that let you back up and restore data and metadata stored
+  in InfluxDB.
 v2.0/tags: [backup, restore]
-menu: v2_0
+#menu: v2_0
 weight: 10
+draft: true
 ---
 
-placeholder
+InfluxDB provides tools that let you back up and restore data and metadata stored
+in InfluxDB.
 
 {{< children >}}

--- a/content/v2.0/backup-restore/_index.md
+++ b/content/v2.0/backup-restore/_index.md
@@ -1,0 +1,13 @@
+---
+title: Back up & restore data
+seotitle: Backup and restore data with InfluxDB
+description: >
+  placeholder
+v2.0/tags: [backup, restore]
+menu: v2_0
+weight: 10
+---
+
+placeholder
+
+{{< children >}}

--- a/content/v2.0/backup-restore/_index.md
+++ b/content/v2.0/backup-restore/_index.md
@@ -1,16 +1,17 @@
 ---
-title: Back up & restore data
+title: Back up and restore data
 seotitle: Backup and restore data with InfluxDB
 description: >
   InfluxDB provides tools that let you back up and restore data and metadata stored
   in InfluxDB.
 v2.0/tags: [backup, restore]
-#menu: v2_0
+menu:
+  v2_0:
+    name: Back up & restore data
 weight: 10
-draft: true
+#draft: true
 ---
 
-InfluxDB provides tools that let you back up and restore data and metadata stored
-in InfluxDB.
+InfluxDB provides tools to back up and restore data and metadata stored in InfluxDB.
 
 {{< children >}}

--- a/content/v2.0/backup-restore/backup.md
+++ b/content/v2.0/backup-restore/backup.md
@@ -2,7 +2,7 @@
 title: Back up data
 seotitle: Back up data in InfluxDB
 description: >
-  Use the `influx backup` command to back up all data and metadata stored in InfluxDB.
+  Use the `influx backup` command to back up data and metadata stored in InfluxDB.
 menu:
   v2_0:
     parent: Back up & restore data
@@ -10,18 +10,18 @@ weight: 101
 related:
   - /v2.0/backup-restore/restore/
   - /v2.0/reference/cli/influx/backup/
-draft: true
+#draft: true
 ---
 
 Use the [`influx backup` command](/v2.0/reference/cli/influx/backup/) to back up
-all data and metadata stored in InfluxDB.
-InfluxDB copies all data and metadata to a file set stored in a specified location
+data and metadata stored in InfluxDB.
+InfluxDB copies all data and metadata to a set of files stored in a specified directory
 on your local filesystem.
 
 {{% warn %}}
-If your InfluxDB instance was set up using a version of InfluxDB **v2.0.0-beta.2**,
-you will not be able to successfully back up data.
-Root tokens created prior to v2.0.0-beta.2 do not have the necessary permissions.
+If you set up InfluxDB using **v2.0.0-beta.1** or earlier, you cannot back up data.
+Root tokens created prior to **v2.0.0-beta.2** do not have the necessary permissions.
+To succesfully use the backup tool, set up a new InfluxDB instance using **v2.0.0-beta.2+**.
 {{% /warn %}}
 
 {{% cloud-msg %}}
@@ -31,7 +31,8 @@ The `influx backup` command **cannot** back up data stored in **{{< cloud-name "
 The `influx backup` command requires:
 
 - The directory path for where to store the backup file set
-- The **root authorization token** created when InfluxDB was initially set up
+- The **root authorization token** (the token created for the first user in the
+  [InfluxDB setup process](/v2.0/get-started/)).
 
 ##### Back up data with the influx CLI
 ```sh

--- a/content/v2.0/backup-restore/backup.md
+++ b/content/v2.0/backup-restore/backup.md
@@ -1,0 +1,35 @@
+---
+title: Back up data
+seotitle: Back up data in InfluxDB
+description: >
+  Use `influx` command line interface (CLI) to backup data and metadata stored in InfluxDB.
+menu:
+  v2_0:
+    parent: Back up & restore data
+weight: 101
+---
+
+Use `influx` command line interface (CLI) to backup data and metadata stored in InfluxDB.
+
+{{% cloud-msg %}}
+The `influx backup` command cannot back up data stored in **{{< cloud-name "short" >}}**.
+{{% /cloud-msg %}}
+
+- Backups are stored as a file set on your local filesystem.
+
+Use the [`influx backup` command](/v2.0/reference/cli/influx/backup/)
+to create a backup of all data and metadata stored in InfluxDB.
+
+- Directory path for where to store the backup file set
+- [Authorization token](/v2.0/security/tokens/create-token/) with all-access permissions
+
+##### Back up data with the influx CLI
+```sh
+# Syntax
+influx backup -p <backup-path> -t <token>
+
+# Example
+influx backup -p path/to/backup_$(date '+%Y-%m-%dT%H:%M:%SZ')
+```
+
+When prompted, enter and confirm the new password.

--- a/content/v2.0/backup-restore/backup.md
+++ b/content/v2.0/backup-restore/backup.md
@@ -2,34 +2,44 @@
 title: Back up data
 seotitle: Back up data in InfluxDB
 description: >
-  Use `influx` command line interface (CLI) to backup data and metadata stored in InfluxDB.
+  Use the `influx backup` command to back up all data and metadata stored in InfluxDB.
 menu:
   v2_0:
     parent: Back up & restore data
 weight: 101
+related:
+  - /v2.0/backup-restore/restore/
+  - /v2.0/reference/cli/influx/backup/
+draft: true
 ---
 
-Use `influx` command line interface (CLI) to backup data and metadata stored in InfluxDB.
+Use the [`influx backup` command](/v2.0/reference/cli/influx/backup/) to back up
+all data and metadata stored in InfluxDB.
+InfluxDB copies all data and metadata to a file set stored in a specified location
+on your local filesystem.
+
+{{% warn %}}
+If your InfluxDB instance was set up using a version of InfluxDB **v2.0.0-beta.2**,
+you will not be able to successfully back up data.
+Root tokens created prior to v2.0.0-beta.2 do not have the necessary permissions.
+{{% /warn %}}
 
 {{% cloud-msg %}}
-The `influx backup` command cannot back up data stored in **{{< cloud-name "short" >}}**.
+The `influx backup` command **cannot** back up data stored in **{{< cloud-name "short" >}}**.
 {{% /cloud-msg %}}
 
-- Backups are stored as a file set on your local filesystem.
+The `influx backup` command requires:
 
-Use the [`influx backup` command](/v2.0/reference/cli/influx/backup/)
-to create a backup of all data and metadata stored in InfluxDB.
-
-- Directory path for where to store the backup file set
-- [Authorization token](/v2.0/security/tokens/create-token/) with all-access permissions
+- The directory path for where to store the backup file set
+- The **root authorization token** created when InfluxDB was initially set up
 
 ##### Back up data with the influx CLI
 ```sh
 # Syntax
-influx backup -p <backup-path> -t <token>
+influx backup -p <backup-path> -t <root-token>
 
 # Example
-influx backup -p path/to/backup_$(date '+%Y-%m-%dT%H:%M:%SZ')
+influx backup \
+  -p path/to/backup_$(date '+%Y-%m-%d_%H-%M') \
+  -t xXXXX0xXX0xxX0xx_x0XxXxXXXxxXX0XXX0XXxXxX0XxxxXX0Xx0xx==
 ```
-
-When prompted, enter and confirm the new password.

--- a/content/v2.0/backup-restore/restore.md
+++ b/content/v2.0/backup-restore/restore.md
@@ -2,8 +2,7 @@
 title: Restore data
 seotitle: Restore data in InfluxDB
 description: >
-  Use the `influxd restore` command to restore data and metadata from an InfluxDB
-  backup file set.
+  Use the `influxd restore` command to restore backup data and metadata from InfluxDB.
 menu:
   v2_0:
     parent: Back up & restore data
@@ -12,12 +11,11 @@ v2.0/tags: [restore]
 related:
   - /v2.0/backup-restore/backup/
   - /v2.0/reference/cli/influxd/restore/
-draft: true
+#draft: true
 ---
 
-Use the `influxd restore` command to restore data and metadata from an InfluxDB backup file set.
-InfluxDB only supports "offline" data restoration, meaning InfluxDB must be stopped
-to safely and successfully restore data.
+Use the `influxd restore` command to restore backup data and metadata from InfluxDB.
+You must stop InfluxDB before restoring data.
 
 {{% cloud-msg %}}
 The `influxd restore` command only restores data to InfluxDB OSS, **not {{< cloud-name "short" >}}**.
@@ -25,15 +23,15 @@ The `influxd restore` command only restores data to InfluxDB OSS, **not {{< clou
 
 When restoring data from a backup file set, InfluxDB temporarily moves existing
 data and metadata while the restore process runs.
-After the process completes, the temporary data is deleted.
+Once the process completes, the temporary data is deleted.
+If the restore process fails, InfluxDB preserves the data in the temporary location.
+_See [Recover from a failed restore](#recover-from-a-failed-restore)._
 
-To restore a backup:
-
+## Restore data with the influxd CLI
 1. **Stop the `influxd` server.**
 2. Use the `influxd restore` command and specify the path to the backup directory
    using the `--backup-path` flag.
 
-    ##### Restore data with the influxd CLI
     ```sh
     # Syntax
     influxd restore --backup-path <path-to-backup-directory>
@@ -46,8 +44,9 @@ To restore a backup:
     [`influxd restore` documentation](/v2.0/reference/cli/influxd/restore/)._
 
 ## Customize the TSI rebuild process
-By default, InfluxDB rebuilds the index and series file when restoring data.
-It uses the default options for [`influxd inspect build-tsi`](/v2.0/reference/cli/influxd/inspect/build-tsi/).
+By default, InfluxDB rebuilds the index and [series file](/v2.0/reference/glossary/#series-file) when restoring data.
+When rebuilding the Time Series Index (TSI), it uses the
+[default `build-tsi` options](/v2.0/reference/cli/influxd/inspect/build-tsi/).
 To customize the Time Series Index (TSI) rebuild process:
 
 1. Disable rebuilding the index and series files when restoring data:
@@ -66,6 +65,17 @@ To customize the Time Series Index (TSI) rebuild process:
     ```
 
     {{% note %}}
-Use this method to [adjust the performance](/v2.0/reference/cli/influxd/inspect/build-tsi/#adjust-performance)
+Manually rebuild the TSI index to [adjust the performance](/v2.0/reference/cli/influxd/inspect/build-tsi/#adjust-performance)
 of the TSI rebuild process.
     {{% /note %}}
+
+## Recover from a failed restore
+If the restoration process fails, InfluxDB preserves existing data in a `tmp`
+directory in the [target engine path](/v2.0/reference/cli/influxd/restore/#flags)
+(default is `~/.influxdbv2/engine`).
+
+To recover from a failed restore:
+
+1. Copy the temporary files back into the `engine` directory.
+2. Remove the `.tmp` extensions from each of the copied files.
+3. Restart the `influxd` server.

--- a/content/v2.0/backup-restore/restore.md
+++ b/content/v2.0/backup-restore/restore.md
@@ -1,0 +1,12 @@
+---
+title: Restore data
+seotitle: Restore data in InfluxDB
+description: >
+  placeholder
+menu:
+  v2_0:
+    parent: Back up & restore data
+weight: 101
+---
+
+placeholder

--- a/content/v2.0/backup-restore/restore.md
+++ b/content/v2.0/backup-restore/restore.md
@@ -2,11 +2,70 @@
 title: Restore data
 seotitle: Restore data in InfluxDB
 description: >
-  placeholder
+  Use the `influxd restore` command to restore data and metadata from an InfluxDB
+  backup file set.
 menu:
   v2_0:
     parent: Back up & restore data
 weight: 101
+v2.0/tags: [restore]
+related:
+  - /v2.0/backup-restore/backup/
+  - /v2.0/reference/cli/influxd/restore/
+draft: true
 ---
 
-placeholder
+Use the `influxd restore` command to restore data and metadata from an InfluxDB backup file set.
+InfluxDB only supports "offline" data restoration, meaning InfluxDB must be stopped
+to safely and successfully restore data.
+
+{{% cloud-msg %}}
+The `influxd restore` command only restores data to InfluxDB OSS, **not {{< cloud-name "short" >}}**.
+{{% /cloud-msg %}}
+
+When restoring data from a backup file set, InfluxDB temporarily moves existing
+data and metadata while the restore process runs.
+After the process completes, the temporary data is deleted.
+
+To restore a backup:
+
+1. **Stop the `influxd` server.**
+2. Use the `influxd restore` command and specify the path to the backup directory
+   using the `--backup-path` flag.
+
+    ##### Restore data with the influxd CLI
+    ```sh
+    # Syntax
+    influxd restore --backup-path <path-to-backup-directory>
+
+    # Example
+    influxd restore --backup-path ~/backups/2020-01-20_12-00/
+    ```
+
+    _For more information about restore options and flags, see the
+    [`influxd restore` documentation](/v2.0/reference/cli/influxd/restore/)._
+
+## Customize the TSI rebuild process
+By default, InfluxDB rebuilds the index and series file when restoring data.
+It uses the default options for [`influxd inspect build-tsi`](/v2.0/reference/cli/influxd/inspect/build-tsi/).
+To customize the Time Series Index (TSI) rebuild process:
+
+1. Disable rebuilding the index and series files when restoring data:
+
+    ```sh
+    influxd restore --rebuild-index false
+    ```
+
+2. Manually run `influxd inspect build-tsi` with any
+   [custom options](/v2.0/reference/cli/influxd/inspect/build-tsi/#flags).
+
+    ```sh
+    influxd inspect build-tsi \
+      --max-log-file-size=1048576 \
+      --max-cache-size=1073741824
+    ```
+
+    {{% note %}}
+Use this method to [adjust the performance](/v2.0/reference/cli/influxd/inspect/build-tsi/#adjust-performance)
+of the TSI rebuild process.
+    {{% /note %}}

--- a/content/v2.0/reference/cli/influx/_index.md
+++ b/content/v2.0/reference/cli/influx/_index.md
@@ -46,6 +46,7 @@ retrieving authentication tokens._
 | Command                                           | Description                                          |
 |:-------                                           |:-----------                                          |
 | [auth](/v2.0/reference/cli/influx/auth)           | Authorization management commands                    |
+| [backup](/v2.0/reference/cli/influx/backup)       | Back up data                                         |
 | [bucket](/v2.0/reference/cli/influx/bucket)       | Bucket management commands                           |
 | [delete](/v2.0/reference/cli/influx/delete)       | Delete points from InfluxDB                          |
 | [help](/v2.0/reference/cli/influx/help)           | Help about any command                               |

--- a/content/v2.0/reference/cli/influx/backup/_index.md
+++ b/content/v2.0/reference/cli/influx/backup/_index.md
@@ -7,6 +7,8 @@ menu:
     parent: influx
 weight: 101
 v2.0/tags: [backup]
+related:
+  - /v2.0/backup-restore/backup/
 ---
 
 The `influx backup` command backs up data stored in InfluxDB.

--- a/content/v2.0/reference/cli/influx/backup/_index.md
+++ b/content/v2.0/reference/cli/influx/backup/_index.md
@@ -1,0 +1,25 @@
+---
+title: influx backup – Back up data in InfluxDB
+description: The 'influx backup' command backs up data stored in InfluxDB.
+menu:
+  v2_0_ref:
+    name: influx backup
+    parent: influx
+weight: 101
+v2.0/tags: [backup]
+---
+
+The `influx backup` command backs up data stored in InfluxDB.
+
+## Usage
+```
+influx backup [flags]
+```
+
+## Flags
+| Flag           | Description                             | Input type |
+|:----           |:-----------                             |:----------:|
+| `-h`, `--help` | Help for the `backup` command           |            |
+| `-p`, `--path` | Directory path to write backup files to | string     |
+
+{{% influx-cli-global-flags %}}

--- a/content/v2.0/reference/cli/influxd/_index.md
+++ b/content/v2.0/reference/cli/influxd/_index.md
@@ -24,6 +24,7 @@ influxd [command]
 |:-------                                          |:-----------                                       |
 | [generate](/v2.0/reference/cli/influxd/generate) | Generate time series data sets using TOML schema. |
 | [inspect](/v2.0/reference/cli/influxd/inspect)   | Inspect on-disk database data.                    |
+| [restore](/v2.0/reference/cli/influxd/restore)   | Restore data and metadata from a backup file set  |
 | [run](/v2.0/reference/cli/influxd/run)           | Start the influxd server _**(default)**_          |
 | [version](/v2.0/reference/cli/influxd/version)   | Output the current version of InfluxDB            |
 

--- a/content/v2.0/reference/cli/influxd/restore.md
+++ b/content/v2.0/reference/cli/influxd/restore.md
@@ -1,23 +1,29 @@
 ---
 title: influxd restore
-description: The `influxd restore` command restores data and metadata from an InfluxDB backup file set.
+description: The `influxd restore` command restores backup data and metadata from an InfluxDB backup directory.
 v2.0/tags: [restore]
 menu:
   v2_0_ref:
     parent: influxd
 weight: 201
+related:
+  - /v2.0/backup-restore/restore/
 ---
 
-The `influxd restore` command restores data and metadata from an InfluxDB backup file set.
+The `influxd restore` command restores backup data and metadata from an InfluxDB backup directory.
 
 {{% warn %}}
-Shut down `influxd` server before restoring data.
+Shut down the `influxd` server before restoring data.
 {{% /warn %}}
 
 ### The restore process
 When restoring data from a backup file set, InfluxDB temporarily moves existing
 data and metadata while `restore` runs.
 After `restore` completes, the temporary data is deleted.
+If the restore process fails, InfluxDB preserves the data in the temporary location.
+
+_For information about recovering from a failed restore process, see
+[Restore data](/v2.0/backup-restore/restore/#recover-from-a-failed-restore)._
 
 By default, `restore` rebuilds the index and series file using the default options
 for [`influxd inspect build-tsi`](/v2.0/reference/cli/influxd/inspect/build-tsi/).

--- a/content/v2.0/reference/cli/influxd/restore.md
+++ b/content/v2.0/reference/cli/influxd/restore.md
@@ -1,0 +1,42 @@
+---
+title: influxd restore
+description: The `influxd restore` command restores data and metadata from an InfluxDB backup file set.
+v2.0/tags: [restore]
+menu:
+  v2_0_ref:
+    parent: influxd
+weight: 201
+---
+
+The `influxd restore` command restores data and metadata from an InfluxDB backup file set.
+
+{{% warn %}}
+Shut down `influxd` server before restoring data.
+{{% /warn %}}
+
+### The restore process
+When restoring data from a backup file set, InfluxDB temporarily moves existing
+data and metadata while `restore` runs.
+After `restore` completes, the temporary data is deleted.
+
+By default, `restore` rebuilds the index and series file using the default options
+for [`influxd inspect build-tsi`](/v2.0/reference/cli/influxd/inspect/build-tsi/).
+To customize the [`build-tsi` performance options](/v2.0/reference/cli/influxd/inspect/build-tsi/#adjust-performance),
+include `--rebuild-index false` with `influxd restore`, then manually run `influxd inspect build-tsi`.
+
+## Usage
+
+```
+influxd restore [flags]
+```
+
+## Flags
+
+| Flag                 | Description                                                                            | Input type |
+|:----                 |:-----------                                                                            |:----------:|
+| `--bolt-path`        | Path to target boltdb database (default is `~/.influxdbv2/influxd.bolt`)               | string     |
+| `--engine-path`      | Path to target persistent engine files (default is `~/.influxdbv2/engine`)             | string     |
+| `--credentials-path` | Path to target persistent credentials files (default is `~/.influxdbv2/credentials`)   | string     |
+| `--backup-path`      | Path to backup files                                                                   | string     |
+| `--rebuild-index`    | Rebuild the TSI index and series file based on the `--engine-path` (default is `true`) |            |
+| `-h`, `--help`       | Help for `restore`                                                                     |            |

--- a/content/v2.0/reference/glossary.md
+++ b/content/v2.0/reference/glossary.md
@@ -836,7 +836,12 @@ The series cardinality would remain unchanged at 6, as `firstname` is already sc
 
 Related entries: [field key](#field-key),[measurement](#measurement), [tag key](#tag-key), [tag set](#tag-set)
 
-## series key
+### series file
+
+A file created and used by the [InfluxDB storage engine](/v2.0/reference/internals/storage-engine/)
+that contains a set of all series keys across the entire database.
+
+### series key
 
 A series key identifies a particular series by measurement, tag set, and field key.
 


### PR DESCRIPTION
Closes #723 

Adds backup and restore documentation. There is a known issue with backups that's noted in these additions. The task-based backup and restore docs are marked as draft and won't show up until that issue is address.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
