### PR TITLE
Flux experimental Query package

### DIFF
--- a/content/v2.0/reference/flux/stdlib/built-in/misc/length.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/misc/length.md
@@ -1,0 +1,31 @@
+---
+title: length() function
+description: The `length()` function returns the number of items in an array.
+menu:
+  v2_0_ref:
+    name: length
+    parent: built-in-misc
+weight: 401
+---
+
+The `length()` function returns the number of items in an array.
+
+_**Function type:** Miscellaneous_  
+
+```js
+length(arr: [])
+```
+
+## Parameters
+
+### arr
+The array to evaluate.
+
+## Examples
+```js
+people = ["John", "Jane", "Abed"]
+
+length(arr: people)
+
+// Returns 3
+```

--- a/content/v2.0/reference/flux/stdlib/experimental/query/_index.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/query/_index.md
@@ -34,6 +34,6 @@ query.inBucket(
   stop: now(),
   measurement: "example-measurement",
   fields: ["exampleField1", "exampleField2"],
-  predicate: (r) => true
+  predicate: (r) => r.tagA == "foo" and r.tagB != "bar"
 )
 ```

--- a/content/v2.0/reference/flux/stdlib/experimental/query/_index.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/query/_index.md
@@ -12,7 +12,7 @@ weight: 201
 v2.0/tags: [package]
 ---
 
-Flux Query functions provide functions  meant to simplify common InfluxDB queries.
+Flux Query functions provide functions meant to simplify common InfluxDB queries.
 Import the `experimental/query` package:
 
 ```js
@@ -23,7 +23,7 @@ import "experimental/query"
 
 ## inBucket()
 The primary function in this package is [`query.inBucket()`](/v2.0/reference/flux/stdlib/experimental/query/inbucket/),
-which utilizes all other functions in this package.
+which uses all other functions in this package.
 
 ```js
 import "experimental/query"

--- a/content/v2.0/reference/flux/stdlib/experimental/query/_index.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/query/_index.md
@@ -1,0 +1,39 @@
+---
+title: Flux Query package
+list_title: Query package
+description: >
+  The Flux Query package provides functions meant to simplify common InfluxDB queries.
+  Import the `experimental/query` package.
+menu:
+  v2_0_ref:
+    name: Query
+    parent: Experimental
+weight: 201
+v2.0/tags: [package]
+---
+
+Flux Query functions provide functions  meant to simplify common InfluxDB queries.
+Import the `experimental/query` package:
+
+```js
+import "experimental/query"
+```
+
+{{< children type="functions" show="pages" >}}
+
+## inBucket()
+The primary function in this package is [`query.inBucket()`](/v2.0/reference/flux/stdlib/experimental/query/inbucket/),
+which utilizes all other functions in this package.
+
+```js
+import "experimental/query"
+
+query.inBucket(
+  bucket: "example-bucket",
+  start: -1h,
+  stop: now(),
+  measurement: "example-measurement",
+  fields: ["exampleField1", "exampleField2"],
+  predicate: (r) => true
+)
+```

--- a/content/v2.0/reference/flux/stdlib/experimental/query/filterfields.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/query/filterfields.md
@@ -1,0 +1,53 @@
+---
+title: query.filterFields() function
+description: >
+  The `query.filterFields()` function filters input data by field.
+menu:
+  v2_0_ref:
+    name: query.filterFields
+    parent: Query
+weight: 301
+---
+
+The `query.filterFields()` function filters input data by field.
+
+_**Function type:** Transformation_
+
+```js
+import "experimental/query"
+
+query.filterFields(
+  fields: ["exampleField1", "exampleField2"]
+)
+```
+
+## Parameters
+
+### fields
+Fields to filter by.
+Must be exact string matches.
+
+_**Data type:** Array of strings_
+
+## Examples
+
+```js
+import "experimental/query"
+
+query.fromRange(bucket: "telegraf", start: -1h)
+  |> query.filterFields(
+    fields: ["used_percent", "available_percent"]
+  )
+```
+
+## Function definition
+```js
+package query
+
+filterFields = (tables=<-, fields=[]) =>
+  if length(arr: fields) == 0 then
+    tables
+  else
+    tables
+      |> filter(fn: (r) => contains(value: r._field, set: fields))
+```

--- a/content/v2.0/reference/flux/stdlib/experimental/query/filterfields.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/query/filterfields.md
@@ -51,3 +51,8 @@ filterFields = (tables=<-, fields=[]) =>
     tables
       |> filter(fn: (r) => contains(value: r._field, set: fields))
 ```
+
+_**Used functions:**_  
+[contains()](/v2.0/reference/flux/stdlib/built-in/tests/contains/)  
+[filter()](/v2.0/reference/flux/stdlib/built-in/transformations/filter/)  
+[length()](/v2.0/reference/flux/stdlib/built-in/misc/length/)  

--- a/content/v2.0/reference/flux/stdlib/experimental/query/filtermeasurement.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/query/filtermeasurement.md
@@ -48,3 +48,6 @@ filterMeasurement = (tables=<-, measurement) =>
   tables
     |> filter(fn: (r) => r._measurement == measurement)
 ```
+
+_**Used functions:**_  
+[filter()](/v2.0/reference/flux/stdlib/built-in/transformations/filter/)

--- a/content/v2.0/reference/flux/stdlib/experimental/query/filtermeasurement.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/query/filtermeasurement.md
@@ -1,0 +1,50 @@
+---
+title: query.filterMeasurement() function
+description: >
+  The `query.filterMeasurement()` function filters input data by measurement.
+menu:
+  v2_0_ref:
+    name: query.filterMeasurement
+    parent: Query
+weight: 301
+---
+
+The `query.filterMeasurement()` function filters input data by measurement.
+
+_**Function type:** Transformation_
+
+```js
+import "experimental/query"
+
+query.filterMeasurement(
+  measurement: "example-measurement"
+)
+```
+
+## Parameters
+
+### measurement
+The name of the measurement to filter by.
+Must be an exact string match.
+
+_**Data type:** String_
+
+## Examples
+
+```js
+import "experimental/query"
+
+query.fromRange(bucket: "example-bucket", start: -1h)
+  |> query.filterMeasurement(
+    measurement: "example-measurement"
+  )
+```
+
+## Function definition
+```js
+package query
+
+filterMeasurement = (tables=<-, measurement) =>
+  tables
+    |> filter(fn: (r) => r._measurement == measurement)
+```

--- a/content/v2.0/reference/flux/stdlib/experimental/query/fromrange.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/query/fromrange.md
@@ -13,7 +13,7 @@ weight: 301
 The `query.fromRange()` function returns all data from a specified bucket within
 given time bounds.
 
-_**Function type:** Output_
+_**Function type:** Input_
 
 ```js
 import "experimental/query"

--- a/content/v2.0/reference/flux/stdlib/experimental/query/fromrange.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/query/fromrange.md
@@ -1,0 +1,72 @@
+---
+title: query.fromRange() function
+description: >
+  The `query.fromRange()` function returns all data from a specified bucket within
+  given time bounds.
+menu:
+  v2_0_ref:
+    name: query.fromRange
+    parent: Query
+weight: 301
+---
+
+The `query.fromRange()` function returns all data from a specified bucket within
+given time bounds.
+
+_**Function type:** Output_
+
+```js
+import "experimental/query"
+
+query.fromRange(
+  bucket: "example-bucket",
+  start: -1h,
+  stop: now()
+)
+```
+
+## Parameters
+
+### bucket
+The name of the bucket to query.
+
+_**Data type:** String_
+
+### start
+The earliest time to include in results.
+Results **include** points that match the specified start time.
+Use a relative duration or absolute time.
+For example, `-1h` or `2019-08-28T22:00:00Z`.
+Durations are relative to `now()`.
+
+_**Data type:** Duration | Time_
+
+### stop
+The latest time to include in results.
+Results **exclude** points that match the specified stop time.
+Use a relative duration or absolute time.
+For example, `-1h` or `2019-08-28T22:00:00Z`.
+Durations are relative to `now()`.
+Defaults to `now()`.
+
+_**Data type:** Duration | Time_
+
+## Examples
+
+```js
+import "experimental/query"
+
+query.fromRange(
+  bucket: "example-bucket",
+  start: 2020-01-01T00:00:00Z
+)
+```
+
+## Function definition
+```js
+package query
+
+fromRange = (bucket, start, stop=now()) =>
+  from(bucket: bucket)
+    |> range(start: start, stop: stop)
+```

--- a/content/v2.0/reference/flux/stdlib/experimental/query/fromrange.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/query/fromrange.md
@@ -70,3 +70,7 @@ fromRange = (bucket, start, stop=now()) =>
   from(bucket: bucket)
     |> range(start: start, stop: stop)
 ```
+
+_**Used functions:**_  
+[from()](/v2.0/reference/flux/stdlib/built-in/inputs/from/)  
+[range()](/v2.0/reference/flux/stdlib/built-in/transformations/range/)  

--- a/content/v2.0/reference/flux/stdlib/experimental/query/inbucket.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/query/inbucket.md
@@ -2,7 +2,7 @@
 title: query.inBucket() function
 description: >
   The `query.inBucket()` function queries data from a specified bucket within given
-  time bounds, filters data my measurement, field, and other column values.
+  time bounds, filters data by measurement, field, and optional predicate expressions.
 menu:
   v2_0_ref:
     name: query.inBucket
@@ -11,7 +11,7 @@ weight: 301
 ---
 
 The `query.inBucket()` function queries data from a specified bucket within given
-time bounds, filters data my measurement, field, and other column values.
+time bounds, filters data by measurement, field, and optional predicate expressions.
 
 _**Function type:** Input_
 

--- a/content/v2.0/reference/flux/stdlib/experimental/query/inbucket.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/query/inbucket.md
@@ -107,3 +107,9 @@ inBucket = (
     |> filter(fn: predicate)
     |> filterFields(fields)
 ```
+
+_**Used functions:**_  
+[filter()](/v2.0/reference/flux/stdlib/built-in/transformations/filter/)  
+[query.filterFields()](/v2.0/reference/flux/stdlib/experimental/query/filterfields/)  
+[query.filterMeasurement()](/v2.0/reference/flux/stdlib/experimental/query/filtermeasurement/)  
+[query.fromRange()](/v2.0/reference/flux/stdlib/experimental/query/fromrange/)  

--- a/content/v2.0/reference/flux/stdlib/experimental/query/inbucket.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/query/inbucket.md
@@ -67,10 +67,10 @@ Must be exact string matches.
 _**Data type:** Array of strings_
 
 ### predicate
-A single argument predicate function that evaluates true or false.
+A single argument function that evaluates true or false.
 Records are passed to the function.
-Those that evaluate to true are included in the output tables.
-Records that evaluate to _null_ or false are not included in the output tables.
+Those that evaluate to `true` are included in the output tables.
+Records that evaluate to `null` or `false` are not included in the output tables.
 Default is `(r) => true`.
 
 _**Data type:** Function_

--- a/content/v2.0/reference/flux/stdlib/experimental/query/inbucket.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/query/inbucket.md
@@ -1,0 +1,109 @@
+---
+title: query.inBucket() function
+description: >
+  The `query.inBucket()` function queries data from a specified bucket within given
+  time bounds, filters data my measurement, field, and other column values.
+menu:
+  v2_0_ref:
+    name: query.inBucket
+    parent: Query
+weight: 301
+---
+
+The `query.inBucket()` function queries data from a specified bucket within given
+time bounds, filters data my measurement, field, and other column values.
+
+_**Function type:** Input_
+
+```js
+import "experimental/query"
+
+query.inBucket(
+  bucket: "example-bucket",
+  start: -1h,
+  stop: now(),
+  measurement: "example-measurement",
+  fields: ["exampleField1", "exampleField2"],
+  predicate: (r) => true
+)
+```
+
+## Parameters
+
+### bucket
+The name of the bucket to query.
+
+_**Data type:** String_
+
+### start
+The earliest time to include in results.
+Results **include** points that match the specified start time.
+Use a relative duration or absolute time.
+For example, `-1h` or `2019-08-28T22:00:00Z`.
+Durations are relative to `now()`.
+
+_**Data type:** Duration | Time_
+
+### stop
+The latest time to include in results.
+Results **exclude** points that match the specified stop time.
+Use a relative duration or absolute time.
+For example, `-1h` or `2019-08-28T22:00:00Z`.
+Durations are relative to `now()`.
+Defaults to `now()`.
+
+_**Data type:** Duration | Time_
+
+### measurement
+The name of the measurement to filter by.
+Must be an exact string match.
+
+_**Data type:** String_
+
+### fields
+Fields to filter by.
+Must be exact string matches.
+
+_**Data type:** Array of strings_
+
+### predicate
+A single argument predicate function that evaluates true or false.
+Records are passed to the function.
+Those that evaluate to true are included in the output tables.
+Records that evaluate to _null_ or false are not included in the output tables.
+Default is `(r) => true`.
+
+_**Data type:** Function_
+
+## Examples
+
+##### Query memory data from host1
+```js
+import "experimental/query"
+
+query.inBucket(
+  bucket: "telegraf",
+  start: -1h,
+  measurement: "mem",
+  fields: ["used_percent", "available_percent"],
+  predicate: (r) => r.host == "host1"
+)
+```
+
+## Function definition
+```js
+package query
+
+inBucket = (
+  bucket,
+  start,
+  stop=now(),
+  measurement,  
+  fields=[],
+  predicate=(r) => true
+) =>
+  fromRange(bucket: bucket, start: start, stop: stop)
+    |> filterMeasurement(measurement)
+    |> filter(fn: predicate)
+    |> filterFields(fields)
+```

--- a/layouts/partials/article/flux-experimental.html
+++ b/layouts/partials/article/flux-experimental.html
@@ -16,7 +16,7 @@
       <div class="warn block">
         <p>
           The {{ if $.Params.list_title }}{{ $.Params.list_title }}{{ else }}{{ .Title }}{{ end }} is experimental and subject to change at any time.
-          By using this function, you accept the <a href="{{ $expRiskURL }}">risks of experimental functions</a>.
+          By using this package, you accept the <a href="{{ $expRiskURL }}">risks of experimental functions</a>.
         </p>
       </div>
     {{ end }}


### PR DESCRIPTION
Closes #767 and #755 

Added the Flux experimental Query package as well as the `length()` function.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
