### PR TITLE
Updated influx CLI docs with mapped environment variables

### DIFF
--- a/assets/styles/layouts/_article.scss
+++ b/assets/styles/layouts/_article.scss
@@ -121,10 +121,20 @@
 
   //////////////////////////////// Miscellaneous ///////////////////////////////
 
-  .required {
+  .required, .req {
     color:#FF8564;
     font-weight:700;
     font-style: italic;
+  }
+
+  a.q-link {
+    font-size: .8rem;
+    vertical-align: super;
+    line-height: 0;
+    color: $g20-white;
+    opacity: .5;
+    transition: opacity .2s;
+    &:hover {opacity: 1;}
   }
 }
 

--- a/content/v2.0/reference/cli/influx/_index.md
+++ b/content/v2.0/reference/cli/influx/_index.md
@@ -64,9 +64,8 @@ retrieving authentication tokens._
 
 ## Mapped environment variables
 Some `influx` CLI flags are mapped to environment variables.
-If those environment variables are set, the flag automatically assumes the value
-of the environment variable.
-If the flag is included, the specified value overrides the mapped environment variable.
+Mapped flags get the value of the environment variable.
+To override environment variables, set the flag explicitly in your command.
 
 ## Flags
 | Flag           | Description                   |

--- a/content/v2.0/reference/cli/influx/_index.md
+++ b/content/v2.0/reference/cli/influx/_index.md
@@ -62,9 +62,15 @@ retrieving authentication tokens._
 | [user](/v2.0/reference/cli/influx/user)           | User management commands                             |
 | [write](/v2.0/reference/cli/influx/write)         | Write points to InfluxDB                             |
 
-{{% influx-cli-global-flags %}}
+## Mapped environment variables
+Some `influx` CLI flags are mapped to environment variables.
+If those environment variables are set, the flag automatically assumes the value
+of the environment variable.
+If the flag is included, the specified value overrides the mapped environment variable.
 
 ## Flags
 | Flag           | Description                   |
 |:---------------|:------------------------------|
 | `-h`, `--help` | Help for the `influx` command |
+
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/_index.md
+++ b/content/v2.0/reference/cli/influx/auth/_index.md
@@ -34,4 +34,4 @@ influx auth [command]
 |:----           |:-----------                 |
 | `-h`, `--help` | Help for the `auth` command |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/active.md
+++ b/content/v2.0/reference/cli/influx/auth/active.md
@@ -16,9 +16,9 @@ influx auth active [flags]
 ```
 
 ## Flags
-| Flag           | Description                         | Input type |
-|:----           |:-----------                         |:----------:|
-| `-h`, `--help` | Help for the `active` command       |            |
-| `-i`, `--id`   | The authorization ID **(Required)** | string     |
+| Flag           | Description                     | Input type |
+|:----           |:-----------                     |:----------:|
+| `-h`, `--help` | Help for the `active` command   |            |
+| `-i`, `--id`   | **(Required)** Authorization ID | string     |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/active.md
+++ b/content/v2.0/reference/cli/influx/auth/active.md
@@ -21,4 +21,4 @@ influx auth active [flags]
 | `-h`, `--help` | Help for the `active` command       |            |
 | `-i`, `--id`   | The authorization ID **(Required)** | string     |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/create.md
+++ b/content/v2.0/reference/cli/influx/auth/create.md
@@ -16,24 +16,25 @@ influx auth create [flags]
 ```
 
 ## Flags
-| Flag                 | Description                                                                    | Input type  |
-|:----                 |:-----------                                                                    |:----------: |
-| `-h`, `--help`       | Help for the `create` command                                                  |             |
-| `-o`, `--org`        | The organization name **(Required)**                                           | string      |
-| `--read-bucket`      | The bucket ID                                                                  | stringArray |
-| `--read-buckets`     | Grants the permission to perform read actions against organization buckets     |             |
-| `--read-dashboards`  | Grants the permission to read dashboards                                       |             |
-| `--read-orgs`        | Grants the permission to read organizations                                    |             |
-| `--read-tasks`       | Grants the permission to read tasks                                            |             |
-| `--read-telegrafs`   | Grants the permission to read telegraf configs                                 |             |
-| `--read-user`        | Grants the permission to perform read actions against organization users       |             |
-| `-u`, `--user`       | The user name                                                                  | string      |
-| `--write-bucket`     | The bucket ID                                                                  | stringArray |
-| `--write-buckets`    | Grants the permission to perform mutative actions against organization buckets |             |
-| `--write-dashboards` | Grants the permission to create dashboards                                     |             |
-| `--write-orgs`       | Grants the permission to create organizations                                  |             |
-| `--write-tasks`      | Grants the permission to create tasks                                          |             |
-| `--write-telegrafs`  | Grants the permission to create telegraf configs                               |             |
-| `--write-user`       | Grants the permission to perform mutative actions against organization users   |             |
+| Flag                 | Description                                                                    | Input type  | {{< cli/mapped >}} |
+|:----                 |:-----------                                                                    |:----------: |:------------------ |
+| `-h`, `--help`       | Help for the `create` command                                                  |             |                    |
+| `-o`, `--org`        | The organization name **(Required)**                                           | string      | `INFLUX_ORG`       |
+| `--org-id`           | The organization ID                                                            | string      | `INFLUX_ORG_ID`    |
+| `--read-bucket`      | The bucket ID                                                                  | stringArray |                    |
+| `--read-buckets`     | Grants the permission to perform read actions against organization buckets     |             |                    |
+| `--read-dashboards`  | Grants the permission to read dashboards                                       |             |                    |
+| `--read-orgs`        | Grants the permission to read organizations                                    |             |                    |
+| `--read-tasks`       | Grants the permission to read tasks                                            |             |                    |
+| `--read-telegrafs`   | Grants the permission to read telegraf configs                                 |             |                    |
+| `--read-user`        | Grants the permission to perform read actions against organization users       |             |                    |
+| `-u`, `--user`       | The user name                                                                  | string      |                    |
+| `--write-bucket`     | The bucket ID                                                                  | stringArray |                    |
+| `--write-buckets`    | Grants the permission to perform mutative actions against organization buckets |             |                    |
+| `--write-dashboards` | Grants the permission to create dashboards                                     |             |                    |
+| `--write-orgs`       | Grants the permission to create organizations                                  |             |                    |
+| `--write-tasks`      | Grants the permission to create tasks                                          |             |                    |
+| `--write-telegrafs`  | Grants the permission to create telegraf configs                               |             |                    |
+| `--write-user`       | Grants the permission to perform mutative actions against organization users   |             |                    |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/create.md
+++ b/content/v2.0/reference/cli/influx/auth/create.md
@@ -16,25 +16,25 @@ influx auth create [flags]
 ```
 
 ## Flags
-| Flag                 | Description                                                                    | Input type  | {{< cli/mapped >}} |
-|:----                 |:-----------                                                                    |:----------: |:------------------ |
-| `-h`, `--help`       | Help for the `create` command                                                  |             |                    |
-| `-o`, `--org`        | The organization name **(Required)**                                           | string      | `INFLUX_ORG`       |
-| `--org-id`           | The organization ID                                                            | string      | `INFLUX_ORG_ID`    |
-| `--read-bucket`      | The bucket ID                                                                  | stringArray |                    |
-| `--read-buckets`     | Grants the permission to perform read actions against organization buckets     |             |                    |
-| `--read-dashboards`  | Grants the permission to read dashboards                                       |             |                    |
-| `--read-orgs`        | Grants the permission to read organizations                                    |             |                    |
-| `--read-tasks`       | Grants the permission to read tasks                                            |             |                    |
-| `--read-telegrafs`   | Grants the permission to read telegraf configs                                 |             |                    |
-| `--read-user`        | Grants the permission to perform read actions against organization users       |             |                    |
-| `-u`, `--user`       | The user name                                                                  | string      |                    |
-| `--write-bucket`     | The bucket ID                                                                  | stringArray |                    |
-| `--write-buckets`    | Grants the permission to perform mutative actions against organization buckets |             |                    |
-| `--write-dashboards` | Grants the permission to create dashboards                                     |             |                    |
-| `--write-orgs`       | Grants the permission to create organizations                                  |             |                    |
-| `--write-tasks`      | Grants the permission to create tasks                                          |             |                    |
-| `--write-telegrafs`  | Grants the permission to create telegraf configs                               |             |                    |
-| `--write-user`       | Grants the permission to perform mutative actions against organization users   |             |                    |
+| Flag                 | Description                                                    | Input type  | {{< cli/mapped >}} |
+|:----                 |:-----------                                                    |:----------: |:------------------ |
+| `-h`, `--help`       | Help for the `create` command                                  |             |                    |
+| `-o`, `--org`        | **(Required)** Organization name                               | string      | `INFLUX_ORG`       |
+| `--org-id`           | Organization ID                                                | string      | `INFLUX_ORG_ID`    |
+| `--read-bucket`      | Bucket ID                                                      | stringArray |                    |
+| `--read-buckets`     | Grants permission to read organization buckets                 |             |                    |
+| `--read-dashboards`  | Grants permission to read dashboards                           |             |                    |
+| `--read-orgs`        | Grants permission to read organizations                        |             |                    |
+| `--read-tasks`       | Grants permission to read tasks                                |             |                    |
+| `--read-telegrafs`   | Grants permission to read Telegraf configurations              |             |                    |
+| `--read-user`        | Grants permission to read organization users                   |             |                    |
+| `-u`, `--user`       | Username                                                       | string      |                    |
+| `--write-bucket`     | Bucket ID                                                      | stringArray |                    |
+| `--write-buckets`    | Grants permission to create and update organization buckets    |             |                    |
+| `--write-dashboards` | Grants permission to create and update dashboards              |             |                    |
+| `--write-orgs`       | Grants permission to create and update organizations           |             |                    |
+| `--write-tasks`      | Grants permission to create and update tasks                   |             |                    |
+| `--write-telegrafs`  | Grants permission to create and update Telegraf configurations |             |                    |
+| `--write-user`       | Grants permission to create and update organization users      |             |                    |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/delete.md
+++ b/content/v2.0/reference/cli/influx/auth/delete.md
@@ -21,4 +21,4 @@ influx auth delete [flags]
 | `-h`, `--help` | Help for the `delete` command       |             |
 | `-i`, `--id`   | The authorization ID **(Required)** | string      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/delete.md
+++ b/content/v2.0/reference/cli/influx/auth/delete.md
@@ -16,9 +16,9 @@ influx auth delete [flags]
 ```
 
 ## Flags
-| Flag           | Description                         | Input type  |
-|:----           |:-----------                         |:----------: |
-| `-h`, `--help` | Help for the `delete` command       |             |
-| `-i`, `--id`   | The authorization ID **(Required)** | string      |
+| Flag           | Description                     | Input type  |
+|:----           |:-----------                     |:----------: |
+| `-h`, `--help` | Help for the `delete` command   |             |
+| `-i`, `--id`   | Authorization ID **(Required)** | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/delete.md
+++ b/content/v2.0/reference/cli/influx/auth/delete.md
@@ -19,6 +19,6 @@ influx auth delete [flags]
 | Flag           | Description                     | Input type  |
 |:----           |:-----------                     |:----------: |
 | `-h`, `--help` | Help for the `delete` command   |             |
-| `-i`, `--id`   | Authorization ID **(Required)** | string      |
+| `-i`, `--id`   | **(Required)** Authorization ID | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/find.md
+++ b/content/v2.0/reference/cli/influx/auth/find.md
@@ -25,4 +25,4 @@ influx auth find [flags]
 | `-u`, `--user` | The user                    | string      |
 | `--user-id`    | The user ID                 | string      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/find.md
+++ b/content/v2.0/reference/cli/influx/auth/find.md
@@ -19,10 +19,10 @@ influx auth find [flags]
 | Flag           | Description                 | Input type  |
 |:----           |:-----------                 |:----------: |
 | `-h`, `--help` | Help for the `find` command |             |
-| `-i`, `--id`   | The authorization ID        | string      |
-| `-o`, `--org`  | The organization            | string      |
-| `--org-id`     | The organization ID         | string      |
-| `-u`, `--user` | The user                    | string      |
-| `--user-id`    | The user ID                 | string      |
+| `-i`, `--id`   | Authorization ID            | string      |
+| `-o`, `--org`  | Organization name           | string      |
+| `--org-id`     | Organization ID             | string      |
+| `-u`, `--user` | Username                    | string      |
+| `--user-id`    | User ID                     | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/inactive.md
+++ b/content/v2.0/reference/cli/influx/auth/inactive.md
@@ -21,4 +21,4 @@ influx auth inactive [flags]
 | `-h`, `--help` | Help for the `inactive` command     |             |
 | `-i`, `--id`   | The authorization ID **(Required)** | string      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/inactive.md
+++ b/content/v2.0/reference/cli/influx/auth/inactive.md
@@ -19,6 +19,6 @@ influx auth inactive [flags]
 | Flag           | Description                     | Input type  |
 |:----           |:-----------                     |:----------: |
 | `-h`, `--help` | Help for the `inactive` command |             |
-| `-i`, `--id`   | Authorization ID **(Required)** | string      |
+| `-i`, `--id`   | **(Required)** Authorization ID | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/inactive.md
+++ b/content/v2.0/reference/cli/influx/auth/inactive.md
@@ -16,9 +16,9 @@ influx auth inactive [flags]
 ```
 
 ## Flags
-| Flag           | Description                         | Input type  |
-|:----           |:-----------                         |:----------: |
-| `-h`, `--help` | Help for the `inactive` command     |             |
-| `-i`, `--id`   | The authorization ID **(Required)** | string      |
+| Flag           | Description                     | Input type  |
+|:----           |:-----------                     |:----------: |
+| `-h`, `--help` | Help for the `inactive` command |             |
+| `-i`, `--id`   | Authorization ID **(Required)** | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/backup/_index.md
+++ b/content/v2.0/reference/cli/influx/backup/_index.md
@@ -19,9 +19,9 @@ influx backup [flags]
 ```
 
 ## Flags
-| Flag           | Description                             | Input type |
-|:----           |:-----------                             |:----------:|
-| `-h`, `--help` | Help for the `backup` command           |            |
-| `-p`, `--path` | Directory path to write backup files to | string     |
+| Flag           | Description                             | Input type | {{< cli/mapped >}} |
+|:----           |:-----------                             |:----------:|:------------------ |
+| `-h`, `--help` | Help for the `backup` command           |            |                    |
+| `-p`, `--path` | Directory path to write backup files to | string     | `INFLUX_PATH`      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/_index.md
+++ b/content/v2.0/reference/cli/influx/bucket/_index.md
@@ -30,4 +30,4 @@ influx bucket [command]
 |:----           |:-----------                   |
 | `-h`, `--help` | Help for the `bucket` command |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/create.md
+++ b/content/v2.0/reference/cli/influx/bucket/create.md
@@ -16,12 +16,12 @@ influx bucket create [flags]
 ```
 
 ## Flags
-| Flag                | Description                                       | Input type  |
-|:----                |:-----------                                       |:----------: |
-| `-h`, `--help`      | Help for the `create` command                     |             |
-| `-n`, `--name`      | Name of bucket that will be created               | string      |
-| `-o`, `--org`       | The name of the organization that owns the bucket | string      |
-| `--org-id`          | The ID of the organization that owns the bucket   | string      |
-| `-r`, `--retention` | Duration in nanoseconds data will live in bucket  | duration    |
+| Flag                | Description                                       | Input type  | {{< cli/mapped >}}   |
+|:----                |:-----------                                       |:----------: |:------------------   |
+| `-h`, `--help`      | Help for the `create` command                     |             |                      |
+| `-n`, `--name`      | Name of bucket that will be created               | string      | `INFLUX_BUCKET_NAME` |
+| `-o`, `--org`       | The name of the organization that owns the bucket | string      | `INFLUX_ORG`         |
+| `--org-id`          | The ID of the organization that owns the bucket   | string      | `INFLUX_ORG_ID`      |
+| `-r`, `--retention` | Duration in nanoseconds data will live in bucket  | duration    |                      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/create.md
+++ b/content/v2.0/reference/cli/influx/bucket/create.md
@@ -16,12 +16,12 @@ influx bucket create [flags]
 ```
 
 ## Flags
-| Flag                | Description                                       | Input type  | {{< cli/mapped >}}   |
-|:----                |:-----------                                       |:----------: |:------------------   |
-| `-h`, `--help`      | Help for the `create` command                     |             |                      |
-| `-n`, `--name`      | Name of bucket that will be created               | string      | `INFLUX_BUCKET_NAME` |
-| `-o`, `--org`       | The name of the organization that owns the bucket | string      | `INFLUX_ORG`         |
-| `--org-id`          | The ID of the organization that owns the bucket   | string      | `INFLUX_ORG_ID`      |
-| `-r`, `--retention` | Duration in nanoseconds data will live in bucket  | duration    |                      |
+| Flag                | Description                                     | Input type  | {{< cli/mapped >}}   |
+|:----                |:-----------                                     |:----------: |:------------------   |
+| `-h`, `--help`      | Help for the `create` command                   |             |                      |
+| `-n`, `--name`      | Bucket name                                     | string      | `INFLUX_BUCKET_NAME` |
+| `-o`, `--org`       | Organization name                               | string      | `INFLUX_ORG`         |
+| `--org-id`          | Organization ID                                 | string      | `INFLUX_ORG_ID`      |
+| `-r`, `--retention` | Duration in nanoseconds bucket will retain data | duration    |                      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/delete.md
+++ b/content/v2.0/reference/cli/influx/bucket/delete.md
@@ -21,4 +21,4 @@ influx bucket delete [flags]
 | `-h`, `--help` | Help for the `delete` command |             |
 | `-i`, `--id`   | The bucket ID **(Required)**  | string      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/delete.md
+++ b/content/v2.0/reference/cli/influx/bucket/delete.md
@@ -19,6 +19,6 @@ influx bucket delete [flags]
 | Flag           | Description                   | Input type  |
 |:----           |:-----------                   |:----------: |
 | `-h`, `--help` | Help for the `delete` command |             |
-| `-i`, `--id`   | The bucket ID **(Required)**  | string      |
+| `-i`, `--id`   | Bucket ID **(Required)**      | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/delete.md
+++ b/content/v2.0/reference/cli/influx/bucket/delete.md
@@ -19,6 +19,6 @@ influx bucket delete [flags]
 | Flag           | Description                   | Input type  |
 |:----           |:-----------                   |:----------: |
 | `-h`, `--help` | Help for the `delete` command |             |
-| `-i`, `--id`   | Bucket ID **(Required)**      | string      |
+| `-i`, `--id`   | **(Required)** Bucket ID      | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/find.md
+++ b/content/v2.0/reference/cli/influx/bucket/find.md
@@ -16,12 +16,12 @@ influx bucket find [flags]
 ```
 
 ## Flags
-| Flag           | Description                  | Input type  | {{< cli/mapped >}}   |
-|:----           |:-----------                  |:----------: |:------------------   |
-| `-h`, `--help` | Help for the `find` command  |             |                      |
-| `-i`, `--id`   | The bucket ID                | string      |                      |
-| `-n`, `--name` | The bucket name              | string      | `INFLUX_BUCKET_NAME` |
-| `-o`, `--org`  | The bucket organization name | string      | `INFLUX_ORG`         |
-| `--org-id`     | The bucket organization ID   | string      | `INFLUX_ORG_ID`      |
+| Flag           | Description                 | Input type  | {{< cli/mapped >}}   |
+|:----           |:-----------                 |:----------: |:------------------   |
+| `-h`, `--help` | Help for the `find` command |             |                      |
+| `-i`, `--id`   | Bucket ID                   | string      |                      |
+| `-n`, `--name` | Bucket name                 | string      | `INFLUX_BUCKET_NAME` |
+| `-o`, `--org`  | Organization name           | string      | `INFLUX_ORG`         |
+| `--org-id`     | Organization ID             | string      | `INFLUX_ORG_ID`      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/find.md
+++ b/content/v2.0/reference/cli/influx/bucket/find.md
@@ -16,12 +16,12 @@ influx bucket find [flags]
 ```
 
 ## Flags
-| Flag           | Description                  | Input type  |
-|:----           |:-----------                  |:----------: |
-| `-h`, `--help` | Help for the `find` command  |             |
-| `-i`, `--id`   | The bucket ID                | string      |
-| `-n`, `--name` | The bucket name              | string      |
-| `-o`, `--org`  | The bucket organization name | string      |
-| `--org-id`     | The bucket organization ID   | string      |
+| Flag           | Description                  | Input type  | {{< cli/mapped >}}   |
+|:----           |:-----------                  |:----------: |:------------------   |
+| `-h`, `--help` | Help for the `find` command  |             |                      |
+| `-i`, `--id`   | The bucket ID                | string      |                      |
+| `-n`, `--name` | The bucket name              | string      | `INFLUX_BUCKET_NAME` |
+| `-o`, `--org`  | The bucket organization name | string      | `INFLUX_ORG`         |
+| `--org-id`     | The bucket organization ID   | string      | `INFLUX_ORG_ID`      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/update.md
+++ b/content/v2.0/reference/cli/influx/bucket/update.md
@@ -19,7 +19,7 @@ influx bucket update [flags]
 | Flag                | Description                          | Input type  | {{< cli/mapped >}}   |
 |:----                |:-----------                          |:----------: |:------------------   |
 | `-h`, `--help`      | Help for the `update` command        |             |                      |
-| `-i`, `--id`        | Bucket ID **(Required)**             | string      |                      |
+| `-i`, `--id`        | **(Required)** Bucket ID             | string      |                      |
 | `-n`, `--name`      | New bucket name                      | string      | `INFLUX_BUCKET_NAME` |
 | `-r`, `--retention` | New duration bucket will retain data | duration    |                      |
 

--- a/content/v2.0/reference/cli/influx/bucket/update.md
+++ b/content/v2.0/reference/cli/influx/bucket/update.md
@@ -16,11 +16,11 @@ influx bucket update [flags]
 ```
 
 ## Flags
-| Flag                | Description                           | Input type  | {{< cli/mapped >}}   |
-|:----                |:-----------                           |:----------: |:------------------   |
-| `-h`, `--help`      | Help for the `update` command         |             |                      |
-| `-i`, `--id`        | The bucket ID **(Required)**          | string      |                      |
-| `-n`, `--name`      | New bucket name                       | string      | `INFLUX_BUCKET_NAME` |
-| `-r`, `--retention` | New duration data will live in bucket | duration    |                      |
+| Flag                | Description                          | Input type  | {{< cli/mapped >}}   |
+|:----                |:-----------                          |:----------: |:------------------   |
+| `-h`, `--help`      | Help for the `update` command        |             |                      |
+| `-i`, `--id`        | Bucket ID **(Required)**             | string      |                      |
+| `-n`, `--name`      | New bucket name                      | string      | `INFLUX_BUCKET_NAME` |
+| `-r`, `--retention` | New duration bucket will retain data | duration    |                      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/update.md
+++ b/content/v2.0/reference/cli/influx/bucket/update.md
@@ -16,11 +16,11 @@ influx bucket update [flags]
 ```
 
 ## Flags
-| Flag                | Description                           | Input type  |
-|:----                |:-----------                           |:----------: |
-| `-h`, `--help`      | Help for the `update` command         |             |
-| `-i`, `--id`        | The bucket ID **(Required)**          | string      |
-| `-n`, `--name`      | New bucket name                       | string      |
-| `-r`, `--retention` | New duration data will live in bucket | duration    |
+| Flag                | Description                           | Input type  | {{< cli/mapped >}}   |
+|:----                |:-----------                           |:----------: |:------------------   |
+| `-h`, `--help`      | Help for the `update` command         |             |                      |
+| `-i`, `--id`        | The bucket ID **(Required)**          | string      |                      |
+| `-n`, `--name`      | New bucket name                       | string      | `INFLUX_BUCKET_NAME` |
+| `-r`, `--retention` | New duration data will live in bucket | duration    |                      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/delete/_index.md
+++ b/content/v2.0/reference/cli/influx/delete/_index.md
@@ -25,13 +25,13 @@ timestamps between the specified `--start` and `--stop` times in the specified b
 ## Flags
 | Flag                | Description                                                                                      | Input type | {{< cli/mapped >}}   |
 |:----                |:-----------                                                                                      |:----------:|:------------------   |
-| `-b`, `--bucket`    | The name of bucket to remove data from                                                           | string     | `INFLUX_BUCKET_NAME` |
-| `--bucket-id`       | The ID of the bucket to remove data from                                                         | string     | `INFLUX_BUCKET_ID`   |
+| `-b`, `--bucket`    | Name of bucket to remove data from                                                               | string     | `INFLUX_BUCKET_NAME` |
+| `--bucket-id`       | Bucket ID                                                                                        | string     | `INFLUX_BUCKET_ID`   |
 | `-h`, `--help`      | Help for the `delete` command                                                                    |            |                      |
-| `-o`, `--org`       | The name of the organization that owns the bucket                                                | string     | `INFLUX_ORG`         |
-| `--org-id`          | The ID of the organization that owns the bucket                                                  | string     | `INFLUX_ORG_ID`      |
+| `-o`, `--org`       | Organization name                                                                                | string     | `INFLUX_ORG`         |
+| `--org-id`          | Organization ID                                                                                  | string     | `INFLUX_ORG_ID`      |
 | `-p`, `--predicate` | InfluxQL-like predicate string (see [Delete predicate](/v2.0/reference/syntax/delete-predicate)) | string     |                      |
-| `--start`           | The start time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                   | string     |                      |
-| `--stop`            | The stop time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                    | string     |                      |
+| `--start`           | Start time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                       | string     |                      |
+| `--stop`            | Stop time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                        | string     |                      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/delete/_index.md
+++ b/content/v2.0/reference/cli/influx/delete/_index.md
@@ -23,15 +23,15 @@ timestamps between the specified `--start` and `--stop` times in the specified b
 {{% /warn %}}
 
 ## Flags
-| Flag                | Description                                                                                      | Input type |
-|:----                |:-----------                                                                                      |:----------:|
-| `-b`, `--bucket`    | The name of bucket to remove data from                                                           | string     |
-| `--bucket-id`       | The ID of the bucket to remove data from                                                         | string     |
-| `-h`, `--help`      | Help for the `delete` command                                                                    |            |
-| `-o`, `--org`       | The name of the organization that owns the bucket                                                | string     |
-| `--org-id`          | The ID of the organization that owns the bucket                                                  | string     |
-| `-p`, `--predicate` | InfluxQL-like predicate string (see [Delete predicate](/v2.0/reference/syntax/delete-predicate)) | string     |
-| `--start`           | The start time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                   | string     |
-| `--stop`            | The stop time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                    | string     |
+| Flag                | Description                                                                                      | Input type | {{< cli/mapped >}}   |
+|:----                |:-----------                                                                                      |:----------:|:------------------   |
+| `-b`, `--bucket`    | The name of bucket to remove data from                                                           | string     | `INFLUX_BUCKET_NAME` |
+| `--bucket-id`       | The ID of the bucket to remove data from                                                         | string     | `INFLUX_BUCKET_ID`   |
+| `-h`, `--help`      | Help for the `delete` command                                                                    |            |                      |
+| `-o`, `--org`       | The name of the organization that owns the bucket                                                | string     | `INFLUX_ORG`         |
+| `--org-id`          | The ID of the organization that owns the bucket                                                  | string     | `INFLUX_ORG_ID`      |
+| `-p`, `--predicate` | InfluxQL-like predicate string (see [Delete predicate](/v2.0/reference/syntax/delete-predicate)) | string     |                      |
+| `--start`           | The start time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                   | string     |                      |
+| `--stop`            | The stop time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                    | string     |                      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/help/_index.md
+++ b/content/v2.0/reference/cli/influx/help/_index.md
@@ -20,4 +20,4 @@ influx help [command] [flags]
 |:----           |:-----------   |
 | `-h`, `--help` | Help for help |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/help/_index.md
+++ b/content/v2.0/reference/cli/influx/help/_index.md
@@ -16,8 +16,8 @@ influx help [command] [flags]
 ```
 
 ## Flags
-| Flag           | Description   |
-|:----           |:-----------   |
-| `-h`, `--help` | Help for help |
+| Flag           | Description             |
+|:----           |:-----------             |
+| `-h`, `--help` | Help for the `help` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/_index.md
+++ b/content/v2.0/reference/cli/influx/org/_index.md
@@ -34,4 +34,4 @@ influx org [command]
 |:----           |:-----------                |
 | `-h`, `--help` | Help for the `org` command |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/create.md
+++ b/content/v2.0/reference/cli/influx/org/create.md
@@ -19,7 +19,7 @@ influx org create [flags]
 | Flag                  | Description                     | Input type  |
 |:----                  |:-----------                     |:----------: |
 | `-d`, `--description` | Description of the organization |             |
-| `-h`, `--help`        | Help for `create`               |             |
-| `-n`, `--name`        | Name of organization            | string      |
+| `-h`, `--help`        | Help for the `create` command   |             |
+| `-n`, `--name`        | Organization name               | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/create.md
+++ b/content/v2.0/reference/cli/influx/org/create.md
@@ -22,4 +22,4 @@ influx org create [flags]
 | `-h`, `--help`        | Help for `create`               |             |
 | `-n`, `--name`        | Name of organization            | string      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/delete.md
+++ b/content/v2.0/reference/cli/influx/org/delete.md
@@ -18,7 +18,7 @@ influx org delete [flags]
 ## Flags
 | Flag           | Description                    | Input type  | {{< cli/mapped >}} |
 |:----           |:-----------                    |:----------: |:------------------ |
-| `-h`, `--help` | Help for `delete`              |             |                    |
-| `-i`, `--id`   | **(Required)** Organization ID | string      | `INFLUX_ORG_ID`    |
+| `-h`, `--help` | Help for the `delete` command  |             |                    |
+| `-i`, `--id`   | Organization ID **(Required)** | string      | `INFLUX_ORG_ID`    |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/delete.md
+++ b/content/v2.0/reference/cli/influx/org/delete.md
@@ -19,6 +19,6 @@ influx org delete [flags]
 | Flag           | Description                    | Input type  | {{< cli/mapped >}} |
 |:----           |:-----------                    |:----------: |:------------------ |
 | `-h`, `--help` | Help for the `delete` command  |             |                    |
-| `-i`, `--id`   | Organization ID **(Required)** | string      | `INFLUX_ORG_ID`    |
+| `-i`, `--id`   | **(Required)** Organization ID | string      | `INFLUX_ORG_ID`    |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/delete.md
+++ b/content/v2.0/reference/cli/influx/org/delete.md
@@ -16,9 +16,9 @@ influx org delete [flags]
 ```
 
 ## Flags
-| Flag           | Description                    | Input type  |
-|:----           |:-----------                    |:----------: |
-| `-h`, `--help` | Help for `delete`              |             |
-| `-i`, `--id`   | **(Required)** Organization ID | string      |
+| Flag           | Description                    | Input type  | {{< cli/mapped >}} |
+|:----           |:-----------                    |:----------: |:------------------ |
+| `-h`, `--help` | Help for `delete`              |             |                    |
+| `-i`, `--id`   | **(Required)** Organization ID | string      | `INFLUX_ORG_ID`    |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/find.md
+++ b/content/v2.0/reference/cli/influx/org/find.md
@@ -16,10 +16,10 @@ influx org find [flags]
 ```
 
 ## Flags
-| Flag           | Description       | Input type  | {{< cli/mapped >}} |
-|:----           |:-----------       |:----------: |:------------------ |
-| `-h`, `--help` | Help for `find`   |             |                    |
-| `-i`, `--id`   | Organization ID   | string      | `INFLUX_ORG`       |
-| `-n`, `--name` | Organization name | string      | `INFLUX_ORG_ID`    |
+| Flag           | Description                 | Input type  | {{< cli/mapped >}} |
+|:----           |:-----------                 |:----------: |:------------------ |
+| `-h`, `--help` | Help for the `find` command |             |                    |
+| `-i`, `--id`   | Organization ID             | string      | `INFLUX_ORG`       |
+| `-n`, `--name` | Organization name           | string      | `INFLUX_ORG_ID`    |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/find.md
+++ b/content/v2.0/reference/cli/influx/org/find.md
@@ -16,10 +16,10 @@ influx org find [flags]
 ```
 
 ## Flags
-| Flag           | Description       | Input type  |
-|:----           |:-----------       |:----------: |
-| `-h`, `--help` | Help for `find`   |             |
-| `-i`, `--id`   | Organization ID   | string      |
-| `-n`, `--name` | Organization name | string      |
+| Flag           | Description       | Input type  | {{< cli/mapped >}} |
+|:----           |:-----------       |:----------: |:------------------ |
+| `-h`, `--help` | Help for `find`   |             |                    |
+| `-i`, `--id`   | Organization ID   | string      | `INFLUX_ORG`       |
+| `-n`, `--name` | Organization name | string      | `INFLUX_ORG_ID`    |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/_index.md
+++ b/content/v2.0/reference/cli/influx/org/members/_index.md
@@ -25,8 +25,8 @@ influx org members [command]
 | [remove](/v2.0/reference/cli/influx/org/members/remove) | Remove organization member |
 
 ## Flags
-| Flag           | Description        |
-|:----           |:-----------        |
-| `-h`, `--help` | Help for `members` |
+| Flag           | Description                    |
+|:----           |:-----------                    |
+| `-h`, `--help` | Help for the `members` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/_index.md
+++ b/content/v2.0/reference/cli/influx/org/members/_index.md
@@ -29,4 +29,4 @@ influx org members [command]
 |:----           |:-----------        |
 | `-h`, `--help` | Help for `members` |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/add.md
+++ b/content/v2.0/reference/cli/influx/org/members/add.md
@@ -16,11 +16,11 @@ influx org members add [flags]
 ```
 
 ## Flags
-| Flag             | Description           | Input type  | {{< cli/mapped >}} |
-|:----             |:-----------           |:----------: |:------------------ |
-| `-h`, `--help`   | Help for `add`        |             |                    |
-| `-i`, `--id`     | The organization ID   | string      | `INFLUX_ORG_ID`    |
-| `-o`, `--member` | The member ID         | string      |                    |
-| `-n`, `--name`   | The organization name | string      | `INFLUX_ORG`       |
+| Flag             | Description                | Input type  | {{< cli/mapped >}} |
+|:----             |:-----------                |:----------: |:------------------ |
+| `-h`, `--help`   | Help for the `add` command |             |                    |
+| `-i`, `--id`     | Organization ID            | string      | `INFLUX_ORG_ID`    |
+| `-o`, `--member` | Member ID                  | string      |                    |
+| `-n`, `--name`   | Organization name          | string      | `INFLUX_ORG`       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/add.md
+++ b/content/v2.0/reference/cli/influx/org/members/add.md
@@ -16,11 +16,11 @@ influx org members add [flags]
 ```
 
 ## Flags
-| Flag             | Description           | Input type  |
-|:----             |:-----------           |:----------: |
-| `-h`, `--help`   | Help for `add`        |             |
-| `-i`, `--id`     | The organization ID   | string      |
-| `-o`, `--member` | The member ID         | string      |
-| `-n`, `--name`   | The organization name | string      |
+| Flag             | Description           | Input type  | {{< cli/mapped >}} |
+|:----             |:-----------           |:----------: |:------------------ |
+| `-h`, `--help`   | Help for `add`        |             |                    |
+| `-i`, `--id`     | The organization ID   | string      | `INFLUX_ORG_ID`    |
+| `-o`, `--member` | The member ID         | string      |                    |
+| `-n`, `--name`   | The organization name | string      | `INFLUX_ORG`       |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/list.md
+++ b/content/v2.0/reference/cli/influx/org/members/list.md
@@ -16,10 +16,10 @@ influx org members list [flags]
 ```
 
 ## Flags
-| Flag           | Description           | Input type  | {{< cli/mapped >}} |
-|:----           |:-----------           |:----------: |:------------------ |
-| `-h`, `--help` | Help for `list`       |             |                    |
-| `-i`, `--id`   | The organization ID   | string      | `INFLUX_ORG_ID`    |
-| `-n`, `--name` | The organization name | string      | `INFLUX_ORG`       |
+| Flag           | Description                 | Input type  | {{< cli/mapped >}} |
+|:----           |:-----------                 |:----------: |:------------------ |
+| `-h`, `--help` | Help for the `list` command |             |                    |
+| `-i`, `--id`   | Organization ID             | string      | `INFLUX_ORG_ID`    |
+| `-n`, `--name` | Organization name           | string      | `INFLUX_ORG`       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/list.md
+++ b/content/v2.0/reference/cli/influx/org/members/list.md
@@ -16,10 +16,10 @@ influx org members list [flags]
 ```
 
 ## Flags
-| Flag           | Description           | Input type  |
-|:----           |:-----------           |:----------: |
-| `-h`, `--help` | Help for `list`       |             |
-| `-i`, `--id`   | The organization ID   | string      |
-| `-n`, `--name` | The organization name | string      |
+| Flag           | Description           | Input type  | {{< cli/mapped >}} |
+|:----           |:-----------           |:----------: |:------------------ |
+| `-h`, `--help` | Help for `list`       |             |                    |
+| `-i`, `--id`   | The organization ID   | string      | `INFLUX_ORG_ID`    |
+| `-n`, `--name` | The organization name | string      | `INFLUX_ORG`       |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/remove.md
+++ b/content/v2.0/reference/cli/influx/org/members/remove.md
@@ -16,11 +16,11 @@ influx org members remove [flags]
 ```
 
 ## Flags
-| Flag             | Description           | Input type  |
-|:----             |:-----------           |:----------: |
-| `-h`, `--help`   | Help for `remove`     |             |
-| `-i`, `--id`     | The organization ID   | string      |
-| `-o`, `--member` | The member ID         | string      |
-| `-n`, `--name`   | The organization name | string      |
+| Flag             | Description           | Input type  | {{< cli/mapped >}} |
+|:----             |:-----------           |:----------: |:------------------ |
+| `-h`, `--help`   | Help for `remove`     |             |                    |
+| `-i`, `--id`     | The organization ID   | string      | `INFLUX_ORG_ID`    |
+| `-o`, `--member` | The member ID         | string      |                    |
+| `-n`, `--name`   | The organization name | string      | `INFLUX_ORG`       |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/remove.md
+++ b/content/v2.0/reference/cli/influx/org/members/remove.md
@@ -16,11 +16,11 @@ influx org members remove [flags]
 ```
 
 ## Flags
-| Flag             | Description           | Input type  | {{< cli/mapped >}} |
-|:----             |:-----------           |:----------: |:------------------ |
-| `-h`, `--help`   | Help for `remove`     |             |                    |
-| `-i`, `--id`     | The organization ID   | string      | `INFLUX_ORG_ID`    |
-| `-o`, `--member` | The member ID         | string      |                    |
-| `-n`, `--name`   | The organization name | string      | `INFLUX_ORG`       |
+| Flag             | Description                   | Input type  | {{< cli/mapped >}} |
+|:----             |:-----------                   |:----------: |:------------------ |
+| `-h`, `--help`   | Help for the `remove` command |             |                    |
+| `-i`, `--id`     | Organization ID               | string      | `INFLUX_ORG_ID`    |
+| `-o`, `--member` | Member ID                     | string      |                    |
+| `-n`, `--name`   | Organization name             | string      | `INFLUX_ORG`       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/update.md
+++ b/content/v2.0/reference/cli/influx/org/update.md
@@ -20,7 +20,7 @@ influx org update [flags]
 |:----                  |:-----------                      |:----------:|:------------------       |
 | `-d`, `--description` | Description for the organization | string     | `INFLUX_ORG_DESCRIPTION` |
 | `-h`, `--help`        | Help for the `update` command    |            |                          |
-| `-i`, `--id`          | Organization ID **(Required)**   | string     | `INFLUX_ORG_ID`          |
+| `-i`, `--id`          | **(Required)** Organization ID   | string     | `INFLUX_ORG_ID`          |
 | `-n`, `--name`        | Organization name                | string     | `INFLUX_ORG`             |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/update.md
+++ b/content/v2.0/reference/cli/influx/org/update.md
@@ -16,11 +16,11 @@ influx org update [flags]
 ```
 
 ## Flags
-| Flag                  | Description                      | Input type |
-|:----                  |:-----------                      |:----------:|
-| `-d`, `--description` | Description for the organization | string     |
-| `-h`, `--help`        | Help for `update`                |            |
-| `-i`, `--id`          | **(Required)** Organization ID   | string     |
-| `-n`, `--name`        | Organization name                | string     |
+| Flag                  | Description                      | Input type | {{< cli/mapped >}}       |
+|:----                  |:-----------                      |:----------:|:------------------       |
+| `-d`, `--description` | Description for the organization | string     | `INFLUX_ORG_DESCRIPTION` |
+| `-h`, `--help`        | Help for `update`                |            |                          |
+| `-i`, `--id`          | **(Required)** Organization ID   | string     | `INFLUX_ORG_ID`          |
+| `-n`, `--name`        | Organization name                | string     | `INFLUX_ORG`             |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/update.md
+++ b/content/v2.0/reference/cli/influx/org/update.md
@@ -19,8 +19,8 @@ influx org update [flags]
 | Flag                  | Description                      | Input type | {{< cli/mapped >}}       |
 |:----                  |:-----------                      |:----------:|:------------------       |
 | `-d`, `--description` | Description for the organization | string     | `INFLUX_ORG_DESCRIPTION` |
-| `-h`, `--help`        | Help for `update`                |            |                          |
-| `-i`, `--id`          | **(Required)** Organization ID   | string     | `INFLUX_ORG_ID`          |
+| `-h`, `--help`        | Help for the `update` command    |            |                          |
+| `-i`, `--id`          | Organization ID **(Required)**   | string     | `INFLUX_ORG_ID`          |
 | `-n`, `--name`        | Organization name                | string     | `INFLUX_ORG`             |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/ping/_index.md
+++ b/content/v2.0/reference/cli/influx/ping/_index.md
@@ -25,4 +25,4 @@ influx ping [flags]
 |:----           |:-----------                 |
 | `-h`, `--help` | Help for the `ping` command |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/pkg/_index.md
+++ b/content/v2.0/reference/cli/influx/pkg/_index.md
@@ -26,20 +26,20 @@ influx pkg [command]
 
 ## Flags
 
-| Flag                      | Description                                                                                     | Input Type |
-|:----                      |:-----------------------------                                                                   |:---------- |
-| `-c`, `--disable-color`   | Disable color in output                                                                         |            |
-| `--disable-table-borders` | Disable table borders                                                                           |            |
-| `-e`, `--encoding`        | Encoding of the input stream                                                                    | string     |
-| `--env-ref`               | Environment references to provide alongside the package (format: `--env-ref=REF_KEY=REF_VALUE`) | string     |
-| `-f`, `--file`            | Path to package file                                                                            | string     |
-| `--force`                 | Ignore warnings about destructive changes                                                       |            |
-| `-h`, `--help`            | Help for the `pkg` command                                                                      |            |
-| `-o`, `--org`             | The name of the organization that owns the bucket                                               | string     |
-| `--org-id`                | The ID of the organization that owns the bucket                                                 | string     |
-| `-q`, `--quiet`           | Disable output printing                                                                         |            |
-| `-R`, `--recurse`         | Recurse through files in the directory specified in `-f`, `--file`                              |            |
-| `--secret`                | Secrets to provide alongside the package (format: `--secret=SECRET_KEY=SECRET_VALUE`)           | string     |
-| `-u`, `--url`             | URL of package file                                                                             | string     |
+| Flag                      | Description                                                                                     | Input Type | {{< cli/mapped >}} |
+|:----                      |:-----------------------------                                                                   |:---------- |:------------------ |
+| `-c`, `--disable-color`   | Disable color in output                                                                         |            |                    |
+| `--disable-table-borders` | Disable table borders                                                                           |            |                    |
+| `-e`, `--encoding`        | Encoding of the input stream                                                                    | string     |                    |
+| `--env-ref`               | Environment references to provide alongside the package (format: `--env-ref=REF_KEY=REF_VALUE`) | string     |                    |
+| `-f`, `--file`            | Path to package file                                                                            | string     |                    |
+| `--force`                 | Ignore warnings about destructive changes                                                       |            |                    |
+| `-h`, `--help`            | Help for the `pkg` command                                                                      |            |                    |
+| `-o`, `--org`             | The name of the organization that owns the bucket                                               | string     | `INFLUX_ORG`       |
+| `--org-id`                | The ID of the organization that owns the bucket                                                 | string     | `INFLUX_ORG_ID`    |
+| `-q`, `--quiet`           | Disable output printing                                                                         |            |                    |
+| `-R`, `--recurse`         | Recurse through files in the directory specified in `-f`, `--file`                              |            |                    |
+| `--secret`                | Secrets to provide alongside the package (format: `--secret=SECRET_KEY=SECRET_VALUE`)           | string     |                    |
+| `-u`, `--url`             | URL of package file                                                                             | string     |                    |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/pkg/_index.md
+++ b/content/v2.0/reference/cli/influx/pkg/_index.md
@@ -31,7 +31,7 @@ influx pkg [command]
 | `-c`, `--disable-color`   | Disable color in output                                                                         |            |                    |
 | `--disable-table-borders` | Disable table borders                                                                           |            |                    |
 | `-e`, `--encoding`        | Encoding of the input stream                                                                    | string     |                    |
-| `--env-ref`               | Environment references to provide alongside the package (format: `--env-ref=REF_KEY=REF_VALUE`) | string     |                    |
+| `--env-ref`               | Environment references to provide with the package (format: `--env-ref=REF_KEY=REF_VALUE`) | string     |                    |
 | `-f`, `--file`            | Path to package file                                                                            | string     |                    |
 | `--force`                 | Ignore warnings about destructive changes                                                       |            |                    |
 | `-h`, `--help`            | Help for the `pkg` command                                                                      |            |                    |
@@ -39,7 +39,7 @@ influx pkg [command]
 | `--org-id`                | The ID of the organization that owns the bucket                                                 | string     | `INFLUX_ORG_ID`    |
 | `-q`, `--quiet`           | Disable output printing                                                                         |            |                    |
 | `-R`, `--recurse`         | Recurse through files in the directory specified in `-f`, `--file`                              |            |                    |
-| `--secret`                | Secrets to provide alongside the package (format: `--secret=SECRET_KEY=SECRET_VALUE`)           | string     |                    |
+| `--secret`                | Secrets to provide with the package (format: `--secret=SECRET_KEY=SECRET_VALUE`)           | string     |                    |
 | `-u`, `--url`             | URL of package file                                                                             | string     |                    |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/pkg/export/_index.md
+++ b/content/v2.0/reference/cli/influx/pkg/export/_index.md
@@ -37,4 +37,4 @@ influx pkg export [command]
 | `--telegraf-configs`  | Comma-separated list of Telegraf configuration IDs                              | string     |
 | `--variables`         | Comma-separated list of variable IDs                                            | string     |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/pkg/export/all.md
+++ b/content/v2.0/reference/cli/influx/pkg/export/all.md
@@ -17,12 +17,11 @@ influx pkg export all [flags]
 ```
 
 ## Flags
+| Flag           | Description                                                                     | Input Type | {{< cli/mapped >}} |
+|:----           |:-----------                                                                     |:---------- |:------------------ |
+| `-f`, `--file` | Package output file. Defaults to stdout. Use `.yml` or `.json` file extensions. | string     |                    |
+| `-h`, `--help` | Help for the `export` command                                                   |            |                    |
+| `-o`, `--org`  | The name of the organization that owns the resources                            | string     | `INFLUX_ORG`       |
+| `--org-id`     | The ID of the organization that owns the resources                              | string     | `INFLUX_ORG_ID`    |
 
-| Flag                  | Description                                                                     | Input Type |
-|:----                  |:-----------                                                                     |:---------- |
-| `-f`, `--file`        | Package output file. Defaults to stdout. Use `.yml` or `.json` file extensions. | string     |
-| `-h`, `--help`        | Help for the `export` command                                                   |            |
-| `-o`, `--org`         | The name of the organization that owns the resources                            | string     |
-| `--org-id`            | The ID of the organization that owns the resources                              | string     |
-
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/pkg/summary.md
+++ b/content/v2.0/reference/cli/influx/pkg/summary.md
@@ -28,4 +28,4 @@ influx pkg summary [flags]
 | `-u`, `--url`             | URL of package file to summarize                                   | string     |
 
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/pkg/validate.md
+++ b/content/v2.0/reference/cli/influx/pkg/validate.md
@@ -25,4 +25,4 @@ influx pkg validate [flags]
 | `-R`, `--recurse`  | Recurse through files in the directory specified in `-f`, `--file` |            |
 | `-u`, `--url`      | URL of package file to validate                                    | string     |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/query/_index.md
+++ b/content/v2.0/reference/cli/influx/query/_index.md
@@ -20,9 +20,10 @@ influx query [query literal or @/path/to/query.flux] [flags]
 ```
 
 ## Flags
-| Flag           | Description                | Input type |
-|:----           |:-----------                |:----------:|
-| `-h`, `--help` | Help for the query command |            |
-| `--org-id`     | The organization ID        | string     |
+| Flag           | Description                | Input type | {{< cli/mapped >}} |
+|:----           |:-----------                |:----------:|:------------------ |
+| `-h`, `--help` | Help for the query command |            |                    |
+| `-o`, `--org`  | The organization name      | string     | `INFLUX_ORG`       |
+| `--org-id`     | The organization ID        | string     | `INFLUX_ORG_ID`    |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/query/_index.md
+++ b/content/v2.0/reference/cli/influx/query/_index.md
@@ -20,10 +20,10 @@ influx query [query literal or @/path/to/query.flux] [flags]
 ```
 
 ## Flags
-| Flag           | Description                | Input type | {{< cli/mapped >}} |
-|:----           |:-----------                |:----------:|:------------------ |
-| `-h`, `--help` | Help for the query command |            |                    |
-| `-o`, `--org`  | The organization name      | string     | `INFLUX_ORG`       |
-| `--org-id`     | The organization ID        | string     | `INFLUX_ORG_ID`    |
+| Flag           | Description                  | Input type | {{< cli/mapped >}} |
+|:----           |:-----------                  |:----------:|:------------------ |
+| `-h`, `--help` | Help for the `query` command |            |                    |
+| `-o`, `--org`  | Organization name            | string     | `INFLUX_ORG`       |
+| `--org-id`     | Organization ID              | string     | `INFLUX_ORG_ID`    |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/repl/_index.md
+++ b/content/v2.0/reference/cli/influx/repl/_index.md
@@ -26,10 +26,10 @@ Use **ctrl + d** to exit the REPL.
 To use the Flux REPL, you must first authenticate with a [token](/v2.0/security/tokens/view-tokens/).
 
 ## Flags
-| Flag           | Description                     | Input type |
-|:----           |:-----------                     |:----------:|
-| `-h`, `--help` | Help for the `repl` command     |            |
-| `-o`, `--org`  | The name of the organization    | string     |
-| `--org-id`     | The ID of organization to query | string     |
+| Flag           | Description                     | Input type | {{< cli/mapped >}} |
+|:----           |:-----------                     |:----------:|:------------------ |
+| `-h`, `--help` | Help for the `repl` command     |            |                    |
+| `-o`, `--org`  | The name of the organization    | string     | `INFLUX_ORG`       |
+| `--org-id`     | The ID of organization to query | string     | `INFLUX_ORG_ID`    |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/repl/_index.md
+++ b/content/v2.0/reference/cli/influx/repl/_index.md
@@ -26,10 +26,10 @@ Use **ctrl + d** to exit the REPL.
 To use the Flux REPL, you must first authenticate with a [token](/v2.0/security/tokens/view-tokens/).
 
 ## Flags
-| Flag           | Description                     | Input type | {{< cli/mapped >}} |
-|:----           |:-----------                     |:----------:|:------------------ |
-| `-h`, `--help` | Help for the `repl` command     |            |                    |
-| `-o`, `--org`  | The name of the organization    | string     | `INFLUX_ORG`       |
-| `--org-id`     | The ID of organization to query | string     | `INFLUX_ORG_ID`    |
+| Flag           | Description                 | Input type | {{< cli/mapped >}} |
+|:----           |:-----------                 |:----------:|:------------------ |
+| `-h`, `--help` | Help for the `repl` command |            |                    |
+| `-o`, `--org`  | Organization name           | string     | `INFLUX_ORG`       |
+| `--org-id`     | Organization ID             | string     | `INFLUX_ORG_ID`    |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/secret/_index.md
+++ b/content/v2.0/reference/cli/influx/secret/_index.md
@@ -29,4 +29,4 @@ influx secret [subcommand]
 |:----           |:-----------                   |
 | `-h`, `--help` | Help for the `secret` command |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/secret/delete.md
+++ b/content/v2.0/reference/cli/influx/secret/delete.md
@@ -17,11 +17,11 @@ influx secret delete [flags]
 ```
 
 ## Flags
-| Flag           | Description                 | Input type |
-|:----           |:-----------                 |:----------:|
-| `-h`, `--help` | Help for `secret delete`    |            |
-| `-k`, `--key`  | Secret key _**(required)**_ | string     |
-| `-o`, `--org`  | Organization name           | string     |
-| `--org-id`     | Organization ID             | string     |
+| Flag           | Description                 | Input type | {{< cli/mapped >}} |
+|:----           |:-----------                 |:----------:|:------------------ |
+| `-h`, `--help` | Help for `secret delete`    |            |                    |
+| `-k`, `--key`  | Secret key _**(required)**_ | string     |                    |
+| `-o`, `--org`  | Organization name           | string     | `INFLUX_ORG`       |
+| `--org-id`     | Organization ID             | string     | `INFLUX_ORG_ID`    |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/secret/delete.md
+++ b/content/v2.0/reference/cli/influx/secret/delete.md
@@ -20,7 +20,7 @@ influx secret delete [flags]
 | Flag           | Description                   | Input type | {{< cli/mapped >}} |
 |:----           |:-----------                   |:----------:|:------------------ |
 | `-h`, `--help` | Help for the `delete` command |            |                    |
-| `-k`, `--key`  | Secret key _**(required)**_   | string     |                    |
+| `-k`, `--key`  | **(Required)** Secret key     | string     |                    |
 | `-o`, `--org`  | Organization name             | string     | `INFLUX_ORG`       |
 | `--org-id`     | Organization ID               | string     | `INFLUX_ORG_ID`    |
 

--- a/content/v2.0/reference/cli/influx/secret/delete.md
+++ b/content/v2.0/reference/cli/influx/secret/delete.md
@@ -17,11 +17,11 @@ influx secret delete [flags]
 ```
 
 ## Flags
-| Flag           | Description                 | Input type | {{< cli/mapped >}} |
-|:----           |:-----------                 |:----------:|:------------------ |
-| `-h`, `--help` | Help for `secret delete`    |            |                    |
-| `-k`, `--key`  | Secret key _**(required)**_ | string     |                    |
-| `-o`, `--org`  | Organization name           | string     | `INFLUX_ORG`       |
-| `--org-id`     | Organization ID             | string     | `INFLUX_ORG_ID`    |
+| Flag           | Description                   | Input type | {{< cli/mapped >}} |
+|:----           |:-----------                   |:----------:|:------------------ |
+| `-h`, `--help` | Help for the `delete` command |            |                    |
+| `-k`, `--key`  | Secret key _**(required)**_   | string     |                    |
+| `-o`, `--org`  | Organization name             | string     | `INFLUX_ORG`       |
+| `--org-id`     | Organization ID               | string     | `INFLUX_ORG_ID`    |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/secret/find.md
+++ b/content/v2.0/reference/cli/influx/secret/find.md
@@ -17,10 +17,10 @@ influx secret find [flags]
 ```
 
 ## Flags
-| Flag           | Description            | Input type | {{< cli/mapped >}} |
-|:----           |:-----------            |:----------:|:------------------ |
-| `-h`, `--help` | Help for `secret find` |            |                    |
-| `-o`, `--org`  | Organization name      | string     | `INFLUX_ORG`       |
-| `--org-id`     | Organization ID        | string     | `INFLUX_ORG_ID`    |
+| Flag           | Description                 | Input type | {{< cli/mapped >}} |
+|:----           |:-----------                 |:----------:|:------------------ |
+| `-h`, `--help` | Help for the `find` command |            |                    |
+| `-o`, `--org`  | Organization name           | string     | `INFLUX_ORG`       |
+| `--org-id`     | Organization ID             | string     | `INFLUX_ORG_ID`    |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/secret/find.md
+++ b/content/v2.0/reference/cli/influx/secret/find.md
@@ -17,10 +17,10 @@ influx secret find [flags]
 ```
 
 ## Flags
-| Flag           | Description            | Input type |
-|:----           |:-----------            |:----------:|
-| `-h`, `--help` | Help for `secret find` |            |
-| `-o`, `--org`  | Organization name      | string     |
-| `--org-id`     | Organization ID        | string     |
+| Flag           | Description            | Input type | {{< cli/mapped >}} |
+|:----           |:-----------            |:----------:|:------------------ |
+| `-h`, `--help` | Help for `secret find` |            |                    |
+| `-o`, `--org`  | Organization name      | string     | `INFLUX_ORG`       |
+| `--org-id`     | Organization ID        | string     | `INFLUX_ORG_ID`    |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/secret/update.md
+++ b/content/v2.0/reference/cli/influx/secret/update.md
@@ -22,7 +22,7 @@ influx secret update [flags]
 | Flag           | Description                   | Input type | {{< cli/mapped >}} |
 |:----           |:-----------                   |:----------:|:------------------ |
 | `-h`, `--help` | Help for the `update` command |            |                    |
-| `-k`, `--key`  | Secret key _**(Required)**_   | string     |                    |
+| `-k`, `--key`  | **(Required)** Secret key     | string     |                    |
 | `-o`, `--org`  | Organization name             | string     | `INFLUX_ORG`       |
 | `--org-id`     | Organization ID               | string     | `INFLUX_ORG_ID`    |
 

--- a/content/v2.0/reference/cli/influx/secret/update.md
+++ b/content/v2.0/reference/cli/influx/secret/update.md
@@ -19,11 +19,11 @@ influx secret update [flags]
 ```
 
 ## Flags
-| Flag           | Description                 | Input type | {{< cli/mapped >}} |
-|:----           |:-----------                 |:----------:|:------------------ |
-| `-h`, `--help` | Help for `secret update`    |            |                    |
-| `-k`, `--key`  | Secret key _**(required)**_ | string     |                    |
-| `-o`, `--org`  | Organization name           | string     | `INFLUX_ORG`       |
-| `--org-id`     | Organization ID             | string     | `INFLUX_ORG_ID`    |
+| Flag           | Description                   | Input type | {{< cli/mapped >}} |
+|:----           |:-----------                   |:----------:|:------------------ |
+| `-h`, `--help` | Help for the `update` command |            |                    |
+| `-k`, `--key`  | Secret key _**(Required)**_   | string     |                    |
+| `-o`, `--org`  | Organization name             | string     | `INFLUX_ORG`       |
+| `--org-id`     | Organization ID               | string     | `INFLUX_ORG_ID`    |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/secret/update.md
+++ b/content/v2.0/reference/cli/influx/secret/update.md
@@ -19,11 +19,11 @@ influx secret update [flags]
 ```
 
 ## Flags
-| Flag           | Description                 | Input type |
-|:----           |:-----------                 |:----------:|
-| `-h`, `--help` | Help for `secret update`    |            |
-| `-k`, `--key`  | Secret key _**(required)**_ | string     |
-| `-o`, `--org`  | Organization name           | string     |
-| `--org-id`     | Organization ID             | string     |
+| Flag           | Description                 | Input type | {{< cli/mapped >}} |
+|:----           |:-----------                 |:----------:|:------------------ |
+| `-h`, `--help` | Help for `secret update`    |            |                    |
+| `-k`, `--key`  | Secret key _**(required)**_ | string     |                    |
+| `-o`, `--org`  | Organization name           | string     | `INFLUX_ORG`       |
+| `--org-id`     | Organization ID             | string     | `INFLUX_ORG_ID`    |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/setup/_index.md
+++ b/content/v2.0/reference/cli/influx/setup/_index.md
@@ -24,4 +24,4 @@ influx setup [flags]
 |:----           |:-----------                  |
 | `-h`, `--help` | Help for the `setup` command |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/_index.md
+++ b/content/v2.0/reference/cli/influx/task/_index.md
@@ -33,4 +33,4 @@ influx task [command]
 |:----           |:-----------                 |
 | `-h`, `--help` | Help for the `task` command |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/create.md
+++ b/content/v2.0/reference/cli/influx/task/create.md
@@ -16,10 +16,10 @@ influx task create [query literal or @/path/to/query.flux] [flags]
 ```
 
 ## Flags
-| Flag           | Description                               | Input type  |
-|:----           |:-----------                               |:----------: |
-| `-h`, `--help` | Help for `create`                         |             |
-| `--org`        | Organization name                         | string      |
-| `--org-id`     | ID of the organization that owns the task | string      |
+| Flag           | Description                               | Input type  | {{< cli/mapped >}} |
+|:----           |:-----------                               |:----------: |:------------------ |
+| `-h`, `--help` | Help for `create`                         |             |                    |
+| `--org`        | Organization name                         | string      | `INFLUX_ORG`       |
+| `--org-id`     | ID of the organization that owns the task | string      | `INFLUX_ORG_ID`    |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/create.md
+++ b/content/v2.0/reference/cli/influx/task/create.md
@@ -16,10 +16,10 @@ influx task create [query literal or @/path/to/query.flux] [flags]
 ```
 
 ## Flags
-| Flag           | Description                               | Input type  | {{< cli/mapped >}} |
-|:----           |:-----------                               |:----------: |:------------------ |
-| `-h`, `--help` | Help for `create`                         |             |                    |
-| `--org`        | Organization name                         | string      | `INFLUX_ORG`       |
-| `--org-id`     | ID of the organization that owns the task | string      | `INFLUX_ORG_ID`    |
+| Flag           | Description                   | Input type  | {{< cli/mapped >}} |
+|:----           |:-----------                   |:----------: |:------------------ |
+| `-h`, `--help` | Help for the `create` command |             |                    |
+| `--org`        | Organization name             | string      | `INFLUX_ORG`       |
+| `--org-id`     | Organiztion ID                | string      | `INFLUX_ORG_ID`    |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/delete.md
+++ b/content/v2.0/reference/cli/influx/task/delete.md
@@ -21,4 +21,4 @@ influx task delete [flags]
 | `-h`, `--help` | Help for `delete`      |             |
 | `-i`, `--id`   | Task id **(Required)** | string      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/delete.md
+++ b/content/v2.0/reference/cli/influx/task/delete.md
@@ -16,9 +16,9 @@ influx task delete [flags]
 ```
 
 ## Flags
-| Flag           | Description            | Input type  |
-|:----           |:-----------            |:----------: |
-| `-h`, `--help` | Help for `delete`      |             |
-| `-i`, `--id`   | Task id **(Required)** | string      |
+| Flag           | Description                   | Input type  |
+|:----           |:-----------                   |:----------: |
+| `-h`, `--help` | Help for the `delete` command |             |
+| `-i`, `--id`   | Task ID **(Required)**        | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/delete.md
+++ b/content/v2.0/reference/cli/influx/task/delete.md
@@ -19,6 +19,6 @@ influx task delete [flags]
 | Flag           | Description                   | Input type  |
 |:----           |:-----------                   |:----------: |
 | `-h`, `--help` | Help for the `delete` command |             |
-| `-i`, `--id`   | Task ID **(Required)**        | string      |
+| `-i`, `--id`   | **(Required)** Task ID        | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/find.md
+++ b/content/v2.0/reference/cli/influx/task/find.md
@@ -16,13 +16,13 @@ influx task find [flags]
 ```
 
 ## Flags
-| Flag              | Description                                 | Input type  | {{< cli/mapped >}} |
-|:----              |:-----------                                 |:----------: |:------------------ |
-| `-h`, `--help`    | Help for `find`                             |             |                    |
-| `-i`, `--id`      | Task ID                                     | string      |                    |
-| `--limit`         | The number of tasks to find (default `100`) | integer     |                    |
-| `--org`           | Task organization name                      | string      | `INFLUX_ORG`       |
-| `--org-id`        | Task organization ID                        | string      | `INFLUX_ORG_ID`    |
-| `-n`, `--user-id` | Task owner ID                               | string      |                    |
+| Flag              | Description                             | Input type  | {{< cli/mapped >}} |
+|:----              |:-----------                             |:----------: |:------------------ |
+| `-h`, `--help`    | Help for the `find` command             |             |                    |
+| `-i`, `--id`      | Task ID                                 | string      |                    |
+| `--limit`         | Number of tasks to find (default `100`) | integer     |                    |
+| `--org`           | Task organization name                  | string      | `INFLUX_ORG`       |
+| `--org-id`        | Task organization ID                    | string      | `INFLUX_ORG_ID`    |
+| `-n`, `--user-id` | Task owner ID                           | string      |                    |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/find.md
+++ b/content/v2.0/reference/cli/influx/task/find.md
@@ -16,13 +16,13 @@ influx task find [flags]
 ```
 
 ## Flags
-| Flag              | Description                                 | Input type  |
-|:----              |:-----------                                 |:----------: |
-| `-h`, `--help`    | Help for `find`                             |             |
-| `-i`, `--id`      | Task ID                                     | string      |
-| `--limit`         | The number of tasks to find (default `100`) | integer     |
-| `--org`           | Task organization name                      | string      |
-| `--org-id`        | Task organization ID                        | string      |
-| `-n`, `--user-id` | Task owner ID                               | string      |
+| Flag              | Description                                 | Input type  | {{< cli/mapped >}} |
+|:----              |:-----------                                 |:----------: |:------------------ |
+| `-h`, `--help`    | Help for `find`                             |             |                    |
+| `-i`, `--id`      | Task ID                                     | string      |                    |
+| `--limit`         | The number of tasks to find (default `100`) | integer     |                    |
+| `--org`           | Task organization name                      | string      | `INFLUX_ORG`       |
+| `--org-id`        | Task organization ID                        | string      | `INFLUX_ORG_ID`    |
+| `-n`, `--user-id` | Task owner ID                               | string      |                    |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/log/_index.md
+++ b/content/v2.0/reference/cli/influx/task/log/_index.md
@@ -27,4 +27,4 @@ influx task log [command]
 |:----           |:-----------    |
 | `-h`, `--help` | Help for `log` |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/log/_index.md
+++ b/content/v2.0/reference/cli/influx/task/log/_index.md
@@ -23,8 +23,8 @@ influx task log [command]
 | [find](/v2.0/reference/cli/influx/task/log/find) | Find logs for task |
 
 ## Flags
-| Flag           | Description    |
-|:----           |:-----------    |
-| `-h`, `--help` | Help for `log` |
+| Flag           | Description                |
+|:----           |:-----------                |
+| `-h`, `--help` | Help for the `log` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/log/find.md
+++ b/content/v2.0/reference/cli/influx/task/log/find.md
@@ -20,6 +20,6 @@ influx task log find [flags]
 |:----           |:-----------                 |:----------: |
 | `-h`, `--help` | Help for the `find` command |             |
 | `--run-id`     | Run ID                      | string      |
-| `--task-id`    | Task ID **(Required)**      | string      |
+| `--task-id`    | **(Required)** Task ID      | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/log/find.md
+++ b/content/v2.0/reference/cli/influx/task/log/find.md
@@ -19,8 +19,7 @@ influx task log find [flags]
 | Flag           | Description            | Input type  |
 |:----           |:-----------            |:----------: |
 | `-h`, `--help` | Help for `find`        |             |
-| `--org-id`     | Organization ID        | string      |
 | `--run-id`     | Run ID                 | string      |
 | `--task-id`    | Task ID **(Required)** | string      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/log/find.md
+++ b/content/v2.0/reference/cli/influx/task/log/find.md
@@ -16,10 +16,10 @@ influx task log find [flags]
 ```
 
 ## Flags
-| Flag           | Description            | Input type  |
-|:----           |:-----------            |:----------: |
-| `-h`, `--help` | Help for `find`        |             |
-| `--run-id`     | Run ID                 | string      |
-| `--task-id`    | Task ID **(Required)** | string      |
+| Flag           | Description                 | Input type  |
+|:----           |:-----------                 |:----------: |
+| `-h`, `--help` | Help for the `find` command |             |
+| `--run-id`     | Run ID                      | string      |
+| `--task-id`    | Task ID **(Required)**      | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/retry.md
+++ b/content/v2.0/reference/cli/influx/task/retry.md
@@ -22,4 +22,4 @@ influx task retry [flags]
 | `-r`, `--run-id`  | Run id **(Required)**  | string      |
 | `-i`, `--task-id` | Task id **(Required)** | string      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/retry.md
+++ b/content/v2.0/reference/cli/influx/task/retry.md
@@ -16,10 +16,10 @@ influx task retry [flags]
 ```
 
 ## Flags
-| Flag              | Description            | Input type  |
-|:----              |:-----------            |:----------: |
-| `-h`, `--help`    | Help for `retry`       |             |
-| `-r`, `--run-id`  | Run id **(Required)**  | string      |
-| `-i`, `--task-id` | Task id **(Required)** | string      |
+| Flag              | Description                  | Input type  |
+|:----              |:-----------                  |:----------: |
+| `-h`, `--help`    | Help for the `retry` command |             |
+| `-r`, `--run-id`  | Run ID **(Required)**        | string      |
+| `-i`, `--task-id` | Task ID **(Required)**       | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/retry.md
+++ b/content/v2.0/reference/cli/influx/task/retry.md
@@ -19,7 +19,7 @@ influx task retry [flags]
 | Flag              | Description                  | Input type  |
 |:----              |:-----------                  |:----------: |
 | `-h`, `--help`    | Help for the `retry` command |             |
-| `-r`, `--run-id`  | Run ID **(Required)**        | string      |
-| `-i`, `--task-id` | Task ID **(Required)**       | string      |
+| `-r`, `--run-id`  | **(Required)** Run ID        | string      |
+| `-i`, `--task-id` | **(Required)** Task ID       | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/run/_index.md
+++ b/content/v2.0/reference/cli/influx/task/run/_index.md
@@ -28,4 +28,4 @@ influx task run [command]
 |:----           |:-----------    |
 | `-h`, `--help` | Help for `run` |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/run/_index.md
+++ b/content/v2.0/reference/cli/influx/task/run/_index.md
@@ -24,8 +24,8 @@ influx task run [command]
 | [find](/v2.0/reference/cli/influx/task/run/find) | Find runs for a task |
 
 ## Flags
-| Flag           | Description    |
-|:----           |:-----------    |
-| `-h`, `--help` | Help for `run` |
+| Flag           | Description                |
+|:----           |:-----------                |
+| `-h`, `--help` | Help for the `run` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/run/find.md
+++ b/content/v2.0/reference/cli/influx/task/run/find.md
@@ -22,8 +22,7 @@ influx task run find [flags]
 | `--before`    | Before-time for filtering   | string      |
 | `-h`,`--help` | Help for `find`             |             |
 | `--limit`     | Limit the number of results | integer     |
-| `--org-id`    | Organization ID             | string      |
 | `--run-id`    | Run ID                      | string      |
 | `--task-id`   | Task ID **(Required)**      | string      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/run/find.md
+++ b/content/v2.0/reference/cli/influx/task/run/find.md
@@ -23,6 +23,6 @@ influx task run find [flags]
 | `-h`,`--help` | Help for the `find` command |             |
 | `--limit`     | Limit the number of results | integer     |
 | `--run-id`    | Run ID                      | string      |
-| `--task-id`   | Task ID **(Required)**      | string      |
+| `--task-id`   | **(Required)** Task ID      | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/run/find.md
+++ b/content/v2.0/reference/cli/influx/task/run/find.md
@@ -20,7 +20,7 @@ influx task run find [flags]
 |:----          |:-----------                 |:----------: |
 | `--after`     | After-time for filtering    | string      |
 | `--before`    | Before-time for filtering   | string      |
-| `-h`,`--help` | Help for `find`             |             |
+| `-h`,`--help` | Help for the `find` command |             |
 | `--limit`     | Limit the number of results | integer     |
 | `--run-id`    | Run ID                      | string      |
 | `--task-id`   | Task ID **(Required)**      | string      |

--- a/content/v2.0/reference/cli/influx/task/update.md
+++ b/content/v2.0/reference/cli/influx/task/update.md
@@ -19,7 +19,7 @@ influx task update [flags]
 | Flag           | Description                   | Input type  |
 |:----           |:-----------                   |:----------: |
 | `-h`, `--help` | Help for the `update` command |             |
-| `-i`, `--id`   | Task ID **(Required)**        | string      |
+| `-i`, `--id`   | **(Required)** Task ID        | string      |
 | `--status`     | Update task status            | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/update.md
+++ b/content/v2.0/reference/cli/influx/task/update.md
@@ -16,10 +16,10 @@ influx task update [flags]
 ```
 
 ## Flags
-| Flag           | Description            | Input type  |
-|:----           |:-----------            |:----------: |
-| `-h`, `--help` | Help for `update`      |             |
-| `-i`, `--id`   | Task ID **(Required)** | string      |
-| `--status`     | Update task status     | string      |
+| Flag           | Description                   | Input type  |
+|:----           |:-----------                   |:----------: |
+| `-h`, `--help` | Help for the `update` command |             |
+| `-i`, `--id`   | Task ID **(Required)**        | string      |
+| `--status`     | Update task status            | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/update.md
+++ b/content/v2.0/reference/cli/influx/task/update.md
@@ -22,4 +22,4 @@ influx task update [flags]
 | `-i`, `--id`   | Task ID **(Required)** | string      |
 | `--status`     | Update task status     | string      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/transpile/_index.md
+++ b/content/v2.0/reference/cli/influx/transpile/_index.md
@@ -25,4 +25,4 @@ influx transpile [InfluxQL query] [flags]
 | `-h`, `--help` | Help for the `transpile` command                                           |
 | `--now`        | RFC3339Nano timestamp to use as `now()` time (default is current UTC time) |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/_index.md
+++ b/content/v2.0/reference/cli/influx/user/_index.md
@@ -31,4 +31,4 @@ influx user [command]
 |:----           |:-----------                 |
 | `-h`, `--help` | Help for the `user` command |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/create.md
+++ b/content/v2.0/reference/cli/influx/user/create.md
@@ -16,12 +16,12 @@ influx user create [flags]
 ```
 
 ## Flags
-| Flag               | Description                                     | Input type  | {{< cli/mapped >}} |
-|:----               |:-----------                                     |:----------: |:------------------ |
-| `-h`, `--help`     | Help for `create`                               |             |                    |
-| `-n`, `--name`     | The username **(Required)**                     | string      | `INFLUX_NAME`      |
-| `-o`, `--org`      | The name of the organization to add the user to | string      | `INFLUX_ORG`       |
-| `--org-id`         | The ID of the organization to add the user to   | string      | `INFLUX_ORG_ID`    |
-| `-p`, `--password` | The user password                               | string      |                    |
+| Flag               | Description                   | Input type  | {{< cli/mapped >}} |
+|:----               |:-----------                   |:----------: |:------------------ |
+| `-h`, `--help`     | Help for the `create` command |             |                    |
+| `-n`, `--name`     | Username **(Required)**       | string      | `INFLUX_NAME`      |
+| `-o`, `--org`      | Organization name             | string      | `INFLUX_ORG`       |
+| `--org-id`         | Organization ID               | string      | `INFLUX_ORG_ID`    |
+| `-p`, `--password` | User password                 | string      |                    |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/create.md
+++ b/content/v2.0/reference/cli/influx/user/create.md
@@ -19,7 +19,7 @@ influx user create [flags]
 | Flag               | Description                   | Input type  | {{< cli/mapped >}} |
 |:----               |:-----------                   |:----------: |:------------------ |
 | `-h`, `--help`     | Help for the `create` command |             |                    |
-| `-n`, `--name`     | Username **(Required)**       | string      | `INFLUX_NAME`      |
+| `-n`, `--name`     | **(Required)** Username       | string      | `INFLUX_NAME`      |
 | `-o`, `--org`      | Organization name             | string      | `INFLUX_ORG`       |
 | `--org-id`         | Organization ID               | string      | `INFLUX_ORG_ID`    |
 | `-p`, `--password` | User password                 | string      |                    |

--- a/content/v2.0/reference/cli/influx/user/create.md
+++ b/content/v2.0/reference/cli/influx/user/create.md
@@ -16,12 +16,12 @@ influx user create [flags]
 ```
 
 ## Flags
-| Flag               | Description                                     | Input type  |
-|:----               |:-----------                                     |:----------: |
-| `-h`, `--help`     | Help for `create`                               |             |
-| `-n`, `--name`     | The username **(Required)**                     | string      |
-| `-o`, `--org`      | The name of the organization to add the user to | string      |
-| `--org-id`         | The ID of the organization to add the user to   | string      |
-| `-p`, `--password` | The user password                               | string      |
+| Flag               | Description                                     | Input type  | {{< cli/mapped >}} |
+|:----               |:-----------                                     |:----------: |:------------------ |
+| `-h`, `--help`     | Help for `create`                               |             |                    |
+| `-n`, `--name`     | The username **(Required)**                     | string      | `INFLUX_NAME`      |
+| `-o`, `--org`      | The name of the organization to add the user to | string      | `INFLUX_ORG`       |
+| `--org-id`         | The ID of the organization to add the user to   | string      | `INFLUX_ORG_ID`    |
+| `-p`, `--password` | The user password                               | string      |                    |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/delete.md
+++ b/content/v2.0/reference/cli/influx/user/delete.md
@@ -16,9 +16,9 @@ influx user delete [flags]
 ```
 
 ## Flags
-| Flag           | Description                | Input type  |
-|:----           |:-----------                |:----------: |
-| `-h`, `--help` | Help for `delete`          |             |
-| `-i`, `--id`   | The user ID **(Required)** | string      |
+| Flag           | Description                   | Input type  |
+|:----           |:-----------                   |:----------: |
+| `-h`, `--help` | Help for the `delete` command |             |
+| `-i`, `--id`   | User ID **(Required)**        | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/delete.md
+++ b/content/v2.0/reference/cli/influx/user/delete.md
@@ -19,6 +19,6 @@ influx user delete [flags]
 | Flag           | Description                   | Input type  |
 |:----           |:-----------                   |:----------: |
 | `-h`, `--help` | Help for the `delete` command |             |
-| `-i`, `--id`   | User ID **(Required)**        | string      |
+| `-i`, `--id`   | **(Required)** User ID        | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/delete.md
+++ b/content/v2.0/reference/cli/influx/user/delete.md
@@ -21,4 +21,4 @@ influx user delete [flags]
 | `-h`, `--help` | Help for `delete`          |             |
 | `-i`, `--id`   | The user ID **(Required)** | string      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/find.md
+++ b/content/v2.0/reference/cli/influx/user/find.md
@@ -16,10 +16,10 @@ influx user find [flags]
 ```
 
 ## Flags
-| Flag           | Description     | Input type  |
-|:----           |:-----------     |:----------: |
-| `-h`, `--help` | Help for `find` |             |
-| `-i`, `--id`   | The user ID     | string      |
-| `-n`, `--name` | The username    | string      |
+| Flag           | Description                 | Input type  |
+|:----           |:-----------                 |:----------: |
+| `-h`, `--help` | Help for the `find` command |             |
+| `-i`, `--id`   | User ID                     | string      |
+| `-n`, `--name` | Username                    | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/find.md
+++ b/content/v2.0/reference/cli/influx/user/find.md
@@ -22,4 +22,4 @@ influx user find [flags]
 | `-i`, `--id`   | The user ID     | string      |
 | `-n`, `--name` | The username    | string      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/password.md
+++ b/content/v2.0/reference/cli/influx/user/password.md
@@ -24,4 +24,4 @@ influx user password [flags]
 | `-i`, `--id`   | The user ID         | string      |
 | `-n`, `--name` | The username        | string      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/password.md
+++ b/content/v2.0/reference/cli/influx/user/password.md
@@ -18,10 +18,10 @@ influx user password [flags]
 ```
 
 ## Flags
-| Flag           | Description         | Input type  |
-|:----           |:-----------         |:----------: |
-| `-h`, `--help` | Help for `password` |             |
-| `-i`, `--id`   | The user ID         | string      |
-| `-n`, `--name` | The username        | string      |
+| Flag           | Description                     | Input type  |
+|:----           |:-----------                     |:----------: |
+| `-h`, `--help` | Help for the `password` command |             |
+| `-i`, `--id`   | User ID                         | string      |
+| `-n`, `--name` | Username                        | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/update.md
+++ b/content/v2.0/reference/cli/influx/user/update.md
@@ -17,10 +17,10 @@ influx user update [flags]
 ```
 
 ## Flags
-| Flag           | Description                | Input type  |
-|:----           |:-----------                |:----------: |
-| `-h`, `--help` | Help for `update`          |             |
-| `-i`, `--id`   | The user ID **(Required)** | string      |
-| `-n`, `--name` | The username               | string      |
+| Flag           | Description                   | Input type  |
+|:----           |:-----------                   |:----------: |
+| `-h`, `--help` | Help for the `update` command |             |
+| `-i`, `--id`   | User ID **(Required)**        | string      |
+| `-n`, `--name` | Username                      | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/update.md
+++ b/content/v2.0/reference/cli/influx/user/update.md
@@ -23,4 +23,4 @@ influx user update [flags]
 | `-i`, `--id`   | The user ID **(Required)** | string      |
 | `-n`, `--name` | The username               | string      |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/update.md
+++ b/content/v2.0/reference/cli/influx/user/update.md
@@ -20,7 +20,7 @@ influx user update [flags]
 | Flag           | Description                   | Input type  |
 |:----           |:-----------                   |:----------: |
 | `-h`, `--help` | Help for the `update` command |             |
-| `-i`, `--id`   | User ID **(Required)**        | string      |
+| `-i`, `--id`   | **(Required)** User ID        | string      |
 | `-n`, `--name` | Username                      | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/write/_index.md
+++ b/content/v2.0/reference/cli/influx/write/_index.md
@@ -20,13 +20,13 @@ influx write [line protocol or @/path/to/points.txt] [flags]
 ```
 
 ## Flags
-| Flag                | Description                                             | Input type | {{< cli/mapped >}} |
-|:----                |:-----------                                             |:----------:|:------------------ |
-| `-b`, `--bucket`    | The name of destination bucket                          | string     | `INFLUX_BUCKET_NAME` |
-| `--bucket-id`       | The ID of destination bucket                            | string     | `INFLUX_BUCKET_ID` |
-| `-h`, `--help`      | Help for the write command                              |            | |
-| `-o`, `--org`       | The name of the organization that owns the bucket       | string     | `INFLUX_ORG` |
-| `--org-id`          | The ID of the organization that owns the bucket         | string     | `INFLUX_ORG_ID` |
-| `-p`, `--precision` | Precision of the timestamps of the lines (default `ns`) | string     | `INFLUX_PRECISION` |
+| Flag                | Description                                | Input type | {{< cli/mapped >}}   |
+|:----                |:-----------                                |:----------:|:------------------   |
+| `-b`, `--bucket`    | Bucket name                                | string     | `INFLUX_BUCKET_NAME` |
+| `--bucket-id`       | Bucket ID                                  | string     | `INFLUX_BUCKET_ID`   |
+| `-h`, `--help`      | Help for the `write` command               |            |                      |
+| `-o`, `--org`       | Organization name                          | string     | `INFLUX_ORG`         |
+| `--org-id`          | Organization ID                            | string     | `INFLUX_ORG_ID`      |
+| `-p`, `--precision` | Precision of the timestamps (default `ns`) | string     | `INFLUX_PRECISION`   |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/write/_index.md
+++ b/content/v2.0/reference/cli/influx/write/_index.md
@@ -20,13 +20,13 @@ influx write [line protocol or @/path/to/points.txt] [flags]
 ```
 
 ## Flags
-| Flag                | Description                                             | Input type |
-|:----                |:-----------                                             |:----------:|
-| `-b`, `--bucket`    | The name of destination bucket                          | string     |
-| `--bucket-id`       | The ID of destination bucket                            | string     |
-| `-h`, `--help`      | Help for the write command                              |            |
-| `-o`, `--org`       | The name of the organization that owns the bucket       | string     |
-| `--org-id`          | The ID of the organization that owns the bucket         | string     |
-| `-p`, `--precision` | Precision of the timestamps of the lines (default `ns`) | string     |
+| Flag                | Description                                             | Input type | {{< cli/mapped >}} |
+|:----                |:-----------                                             |:----------:|:------------------ |
+| `-b`, `--bucket`    | The name of destination bucket                          | string     | `INFLUX_BUCKET_NAME` |
+| `--bucket-id`       | The ID of destination bucket                            | string     | `INFLUX_BUCKET_ID` |
+| `-h`, `--help`      | Help for the write command                              |            | |
+| `-o`, `--org`       | The name of the organization that owns the bucket       | string     | `INFLUX_ORG` |
+| `--org-id`          | The ID of the organization that owns the bucket         | string     | `INFLUX_ORG_ID` |
+| `-p`, `--precision` | Precision of the timestamps of the lines (default `ns`) | string     | `INFLUX_PRECISION` |
 
-{{% influx-cli-global-flags %}}
+{{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influxd/_index.md
+++ b/content/v2.0/reference/cli/influxd/_index.md
@@ -36,7 +36,7 @@ influxd [command]
 | `--bolt-path`              | Path to boltdb database (default `~/.influxdbv2/influxd.bolt`)                                        | string     |
 | `--e2e-testing`            | Add /debug/flush endpoint to clear stores; used for end-to-end tests (default `false`)                |            |
 | `--engine-path`            | Path to persistent engine files (default `~/.influxdbv2/engine`)                                      | string     |
-| `-h`, `--help`             | Help for `influxd`                                                                                    |            |
+| `-h`, `--help`             | Help for the `influxd` command                                                                        |            |
 | `--http-bind-address`      | Bind address for the REST HTTP API (default `:9999`)                                                  | string     |
 | `--log-level`              | Supported log levels are debug, info, and error (default `info`)                                      | string     |
 | `--reporting-disabled`     | Disable sending telemetry data to **https:<nolink>//telemetry.influxdata.com**                        |            |

--- a/content/v2.0/reference/cli/influxd/generate/_index.md
+++ b/content/v2.0/reference/cli/influxd/generate/_index.md
@@ -36,11 +36,11 @@ influxd generate [subcommand]
 | Flag           | Description                                                               | Input Type |
 |:----           |:-----------                                                               |:----------:|
 | `--print`      | Print data spec and exit                                                  |            |
-| `--org`        | Name of organization                                                      | string     |
-| `--bucket`     | Name of bucket                                                            | string     |
+| `--org`        | Organiztion name                                                          | string     |
+| `--bucket`     | Bucket Name                                                               | string     |
 | `--start-time` | Start time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of one week ago) | string     |
 | `--end-time`   | End time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of current day)    | string     |
 | `--clean`      | Clean time series data files (`none`, `tsm` or `all`) (default `none`)    | string     |
 | `--cpuprofile` | Collect a CPU profile                                                     | string     |
 | `--memprofile` | Collect a memory profile                                                  | string     |
-| `-h`, `--help` | Help for `generate`                                                       |            |
+| `-h`, `--help` | Help for the `generate` command                                           |            |

--- a/content/v2.0/reference/cli/influxd/generate/help-schema.md
+++ b/content/v2.0/reference/cli/influxd/generate/help-schema.md
@@ -24,14 +24,14 @@ influxd generate help-schema [flags]
 | Flag           | Description                                                               | Input Type |
 |:----           |:-----------                                                               |:----------:|
 | `--print`      | Print data spec and exit                                                  |            |
-| `--org`        | Name of organization                                                      | string     |
-| `--bucket`     | Name of bucket                                                            | string     |
+| `--org`        | Organization name                                                         | string     |
+| `--bucket`     | Bucket name                                                               | string     |
 | `--start-time` | Start time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of one week ago) | string     |
 | `--end-time`   | End time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of current day)    | string     |
 | `--clean`      | Clean time series data files (`none`, `tsm` or `all`) (default `none`)    | string     |
 | `--cpuprofile` | Collect a CPU profile                                                     | string     |
 | `--memprofile` | Collect a memory profile                                                  | string     |
-| `-h`, `--help` | Help for `generate help-schema`                                           |            |
+| `-h`, `--help` | Help for the `help-schema` command                                        |            |
 
 ## Example output
 {{% truncate %}}

--- a/content/v2.0/reference/cli/influxd/generate/simple.md
+++ b/content/v2.0/reference/cli/influxd/generate/simple.md
@@ -30,11 +30,11 @@ influxd generate simple [flags]
 | Flag           | Description                                                               | Input Type |
 |:----           |:-----------                                                               |:----------:|
 | `--print`      | Print data spec and exit                                                  |            |
-| `--org`        | Name of organization                                                      | string     |
-| `--bucket`     | Name of bucket                                                            | string     |
+| `--org`        | Organization name                                                         | string     |
+| `--bucket`     | Bucket name                                                               | string     |
 | `--start-time` | Start time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of one week ago) | string     |
 | `--end-time`   | End time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of current day)    | string     |
 | `--clean`      | Clean time series data files (`none`, `tsm` or `all`) (default `none`)    | string     |
 | `--cpuprofile` | Collect a CPU profile                                                     | string     |
 | `--memprofile` | Collect a memory profile                                                  | string     |
-| `-h`, `--help` | Help for `generate simple`                                                |            |
+| `-h`, `--help` | Help for the `simple` command                                             |            |

--- a/content/v2.0/reference/cli/influxd/inspect/_index.md
+++ b/content/v2.0/reference/cli/influxd/inspect/_index.md
@@ -30,6 +30,6 @@ influxd inspect [subcommand]
 | [verify-wal](/v2.0/reference/cli/influxd/inspect/verify-wal/)               | Check for corrupt WAL files            |
 
 ## Flags
-| Flag           | Description        |
-|:----           |:-----------        |
-| `-h`, `--help` | Help for `inspect` |
+| Flag           | Description                    |
+|:----           |:-----------                    |
+| `-h`, `--help` | Help for the `inspect` command |

--- a/content/v2.0/reference/cli/influxd/inspect/build-tsi.md
+++ b/content/v2.0/reference/cli/influxd/inspect/build-tsi.md
@@ -48,7 +48,7 @@ higher memory usage.
 |:----                  |:-----------                                                                                     |:----------:|
 | `--batch-size`        | The size of the batches to write to the index. Defaults to `10000`. [See above](#batch-size).   | integer    |
 | `--concurrency`       | Number of workers to dedicate to shard index building. Defaults to `GOMAXPROCS` (8 by default). | integer    |
-| `-h`, `--help`        | Help for `build-tsi`.                                                                           |            |
+| `-h`, `--help`        | Help for the `build-tsi` command.                                                               |            |
 | `--max-cache-size`    | Maximum cache size. Defaults to `1073741824`. [See above](#max-cache-size).                     | uinteger   |
 | `--max-log-file-size` | Maximum log file size. Defaults to `1048576`. [See above](#max-log-file-size) .                 | integer    |
 | `--sfile-path`        | Path to the series file directory. Defaults to `~/.influxdbv2/engine/_series`.                  | string     |

--- a/content/v2.0/reference/cli/influxd/inspect/dump-tsi.md
+++ b/content/v2.0/reference/cli/influxd/inspect/dump-tsi.md
@@ -20,7 +20,7 @@ influxd inspect dump-tsi [flags]
 ## Flags
 | Flag                   | Description                                                                     | Input Type |
 |:----                   |:-----------                                                                     |:----------:|
-| `-h`, `--help`         | Help for `dump-tsi`.                                                            |            |
+| `-h`, `--help`         | Help for the `dump-tsi` command.                                                |            |
 | `--index-path`         | Path to data engine index directory (defaults to `~/.influxdbv2/engine/index`). | string     |
 | `--measurement-filter` | Regular expression measurement filter.                                          | string     |
 | `--measurements`       | Show raw measurement data.                                                      |            |

--- a/content/v2.0/reference/cli/influxd/inspect/dumpwal.md
+++ b/content/v2.0/reference/cli/influxd/inspect/dumpwal.md
@@ -33,7 +33,7 @@ that matches the specified [globbing patterns](#globbing-patterns):
 that matches the specified [globbing patterns](#globbing-patterns):
 
 - The file name
-- A list of keys with timestamps in the wrong order 
+- A list of keys with timestamps in the wrong order
 
 ## Arguments
 
@@ -62,7 +62,7 @@ foo/**/baz
 ```
 
 ## Flags
-| Flag                | Description                                            |
-|:----                |:-----------                                            |
+| Flag                | Description                                                                |
+|:----                |:-----------                                                                |
 | `--find-duplicates` | Ignore dumping entries; only report keys in the WAL that are out of order. |
-| `-h`, `--help`      | Help for `dumpwal`.                                    |
+| `-h`, `--help`      | Help for the `dumpwal` cinnabd.                                            |

--- a/content/v2.0/reference/cli/influxd/inspect/export-blocks.md
+++ b/content/v2.0/reference/cli/influxd/inspect/export-blocks.md
@@ -19,6 +19,6 @@ influxd inspect export-blocks [flags]
 ```
 
 ## Flags
-| Flag           | Description               |
-|:----           |:-----------               |
-| `-h`, `--help` | Help for `export-blocks`. |
+| Flag           | Description                           |
+|:----           |:-----------                           |
+| `-h`, `--help` | Help for the `export-blocks` command. |

--- a/content/v2.0/reference/cli/influxd/inspect/export-index.md
+++ b/content/v2.0/reference/cli/influxd/inspect/export-index.md
@@ -21,6 +21,6 @@ influxd inspect export-index [flags]
 ## Flags
 | Flag            | Description                                                             | Input type |
 |:----            |:-----------                                                             |:----------:|
-| `-h`, `--help`  | Help for `export-index`.                                                |            |
+| `-h`, `--help`  | Help for the `export-index` command.                                    |            |
 | `--index-path`  | Path to the index directory. Defaults to `~/.influxdbv2/engine/index`). | string     |
 | `--series-path` | Path to series file. Defaults to `~/.influxdbv2/engine/_series`).       | string     |

--- a/content/v2.0/reference/cli/influxd/inspect/report-tsi.md
+++ b/content/v2.0/reference/cli/influxd/inspect/report-tsi.md
@@ -36,7 +36,7 @@ influxd inspect report-tsi [flags]
 | Flag                   | Description                                                               | Input Type |
 |:----                   |:-----------                                                               |:----------:|
 | `--bucket-id`          | Process data for specified bucket ID. _Requires `org-id` flag to be set._ | string     |
-| `-h`, `--help`         | View help for `report-tsi`.                                               |            |
+| `-h`, `--help`         | View Help for the `report-tsi` command.                                   |            |
 | `-m`, `--measurements` | Group cardinality by measurements.                                        |            |
 | `-o`, `--org-id`       | Process data for specified organization ID.                               | string     |
 | `--path`               | Specify path to index. Defaults to `~/.influxdbv2/engine/index`.          | string     |

--- a/content/v2.0/reference/cli/influxd/inspect/report-tsm.md
+++ b/content/v2.0/reference/cli/influxd/inspect/report-tsm.md
@@ -52,6 +52,6 @@ in the following ways:
 | `--data-dir`   | Use provided data directory (defaults to `~/.influxdbv2/engine/data`).                           | string     |
 | `--detailed`   | Emit series cardinality segmented by measurements, tag keys, and fields. _**May take a while**_. |            |
 | `--exact`      | Calculate an exact cardinality count. _**May use significant memory**_.                          |            |
-| `-h`, `--help` | Help for `report-tsm`.                                                                           |            |
+| `-h`, `--help` | Help for the `report-tsm` command.                                                               |            |
 | `--org-id`     | Process only data belonging to organization ID.                                                  | string     |
 | `--pattern`    | Only process TSM files containing pattern.                                                       | string     |

--- a/content/v2.0/reference/cli/influxd/inspect/verify-seriesfile.md
+++ b/content/v2.0/reference/cli/influxd/inspect/verify-seriesfile.md
@@ -20,6 +20,6 @@ influxd inspect verify-seriesfile [flags]
 | Flag              | Description                                                       | Input Type |
 |:----              |:-----------                                                       |:----------:|
 | `-c`, `--c`       | Number of workers to run concurrently (defaults to 8).            | integer    |
-| `-h`, `--help`    | Help for `verify-seriesfile`.                                     |            |
+| `-h`, `--help`    | Help for the `verify-seriesfile` command.                         |            |
 | `--series-file`   | Path to series file (defaults to `~/.influxdbv2/engine/_series`). | string     |
 | `-v`, `--verbose` | Enable verbose output.                                            |            |

--- a/content/v2.0/reference/cli/influxd/inspect/verify-tsm.md
+++ b/content/v2.0/reference/cli/influxd/inspect/verify-tsm.md
@@ -30,5 +30,5 @@ A list of files or directories in which to search for TSM files.
 | Flag           | Description                                               | Input Type |
 |:----           |:-----------                                               |:----------:|
 | `--bucket-id`  | Limit analysis to a specific bucket ID. _Optional._       | string     |
-| `-h`, `--help` | Help for `verify-tsm`.                                    |            |
+| `-h`, `--help` | Help for the `verify-tsm` command.                        |            |
 | `--org-id`     | Limit analysis to a specific organization ID. _Optional._ | string     |

--- a/content/v2.0/reference/cli/influxd/inspect/verify-wal.md
+++ b/content/v2.0/reference/cli/influxd/inspect/verify-wal.md
@@ -36,4 +36,4 @@ After the verification is complete, it returns a summary with:
 | Flag           | Description                                                      | Input Type |
 |:----           |:-----------                                                      |:----------:|
 | `--data-dir`   | The data directory to scan (default `~/.influxdbv2/engine/wal`). | string     |
-| `-h`, `--help` | Help for `verify-wal`.                                           |            |
+| `-h`, `--help` | Help for the `verify-wal` command.                               |            |

--- a/content/v2.0/reference/cli/influxd/restore.md
+++ b/content/v2.0/reference/cli/influxd/restore.md
@@ -45,4 +45,4 @@ influxd restore [flags]
 | `--credentials-path` | Path to target persistent credentials files (default is `~/.influxdbv2/credentials`)   | string     |
 | `--backup-path`      | Path to backup files                                                                   | string     |
 | `--rebuild-index`    | Rebuild the TSI index and series file based on the `--engine-path` (default is `true`) |            |
-| `-h`, `--help`       | Help for `restore`                                                                     |            |
+| `-h`, `--help`       | Help for the `restore` command                                                         |            |

--- a/content/v2.0/reference/cli/influxd/run.md
+++ b/content/v2.0/reference/cli/influxd/run.md
@@ -34,7 +34,7 @@ influxd run
 | `--bolt-path`              | Path to boltdb database (default `~/.influxdbv2/influxd.bolt`)                                        | string     |
 | `--e2e-testing`            | Add /debug/flush endpoint to clear stores; used for end-to-end tests (default `false`)                |            |
 | `--engine-path`            | Path to persistent engine files (default `~/.influxdbv2/engine`)                                      | string     |
-| `-h`, `--help`             | Help for `influxd`                                                                                    |            |
+| `-h`, `--help`             | Help for the `influxd` command                                                                        |            |
 | `--http-bind-address`      | Bind address for the REST HTTP API (default `:9999`)                                                  | string     |
 | `--log-level`              | Supported log levels are debug, info, and error (default `info`)                                      | string     |
 | `--reporting-disabled`     | Disable sending telemetry data to **https:<nolink>//telemetry.influxdata.com**                        |            |

--- a/content/v2.0/reference/cli/influxd/version.md
+++ b/content/v2.0/reference/cli/influxd/version.md
@@ -18,6 +18,6 @@ influxd version [flags]
 
 ## Flags
 
-| Flag           | Description        |
-|:----           |:-----------        |
-| `-h`, `--help` | Help for `version` |
+| Flag           | Description                    |
+|:----           |:-----------                    |
+| `-h`, `--help` | Help for the `version` command |

--- a/layouts/shortcodes/cli/influx-global-flags.md
+++ b/layouts/shortcodes/cli/influx-global-flags.md
@@ -1,0 +1,11 @@
+{{ $currentVersion := (index (findRE "[^/]+.*?" .Page.RelPermalink) 0) }}
+{{ $link := print "/" $currentVersion "/reference/cli/influx/#mapped-environment-variables"}}
+
+## Global Flags
+
+| Flag            | Description                                                                                 | Input type | Maps to <a class ="q-link" href ="{{ $link }}">?</a> |
+|:----------------|:--------------------------------------------------------------------------------------------|:----------:|:---------------------------------------------------- |
+| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`)                                  | string     | `INFLUX_HOST`                                        |
+| `--local`       | Run commands against the local filesystem                                                   |            |                                                      |
+| `--skip-verify` | Skip certificate verification (use when connecting over TLS with a self-signed certificate) |            |                                                      |
+| `-t`, `--token` | API token to use in client calls                                                            | string     | `INFLUX_TOKEN`                                       |

--- a/layouts/shortcodes/cli/mapped.html
+++ b/layouts/shortcodes/cli/mapped.html
@@ -1,0 +1,5 @@
+{{ $currentVersion := (index (findRE "[^/]+.*?" .Page.RelPermalink) 0) }}
+{{ $cli := replaceRE "/cli/" "" (index (findRE "/cli/[a-z]*" .Page.RelPermalink) 0) }}
+{{ $link := print "/" $currentVersion "/reference/cli/" $cli "/#mapped-environment-variables"}}
+
+Maps to <a class="q-link" href="{{ $link }}">?</a>

--- a/layouts/shortcodes/influx-cli-global-flags.md
+++ b/layouts/shortcodes/influx-cli-global-flags.md
@@ -1,8 +1,0 @@
-## Global Flags
-
-| Flag            | Description                                                                                 | Input type |
-|:----------------|:--------------------------------------------------------------------------------------------|:----------:|
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`)                                  | string     |
-| `--local`       | Run commands against the local filesystem                                                   |            |
-| `--skip-verify` | Skip certificate verification (use when connecting over TLS with a self-signed certificate) |            |
-| `-t`, `--token` | API token to use in client calls                                                            | string     |


### PR DESCRIPTION
Closes #656

Updated `influx` CLI docs with mapped environment variables. It uses a shortcode that points to a section on the `influx` landing page that talks about mapped environment variables and how they work.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
