### PR TITLE
Added warning about keeping empty tables on first filter call

### DIFF
--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/filter.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/filter.md
@@ -61,7 +61,7 @@ Tables without rows are output to the next transformation.
 Keeping empty tables with your first `filter()` function can have severe performance
 costs since it retains empty tables from your entire data set.
 For higher performance, use your first `filter()` function to do basic filtering,
-then keep empty tables on subsequent `filter()` calls with a smaller data set.
+then keep empty tables on subsequent `filter()` calls with smaller data sets.
 _[See the example below](#keep-empty-tables-when-filtering)._
 {{% /warn %}}
 

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/filter.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/filter.md
@@ -49,13 +49,19 @@ Defines the behavior for empty tables.
 Potential values are `keep` and `drop`.
 Defaults to `drop`.
 
+_**Data type:** String_
+
 ##### drop
-Empty tables are dropped.
+Tables left without rows are dropped.
 
 ##### keep
-Empty tables are output to the next transformation.
+Tables left without rows are output to the next transformation.
 
-_**Data type:** String_
+{{% warn %}}
+Keeping empty tables with your first `filter()` function can have severe performance costs.
+For higher performance, use your first `filter()` function to do basic filtering,
+then keep empty tables on subsequent `filter()` calls.
+{{% /warn %}}
 
 ## Examples
 

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/filter.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/filter.md
@@ -52,15 +52,17 @@ Defaults to `drop`.
 _**Data type:** String_
 
 ##### drop
-Tables left without rows are dropped.
+Tables without rows are dropped.
 
 ##### keep
-Tables left without rows are output to the next transformation.
+Tables without rows are output to the next transformation.
 
 {{% warn %}}
-Keeping empty tables with your first `filter()` function can have severe performance costs.
+Keeping empty tables with your first `filter()` function can have severe performance
+costs since it retains empty tables from your entire data set.
 For higher performance, use your first `filter()` function to do basic filtering,
-then keep empty tables on subsequent `filter()` calls.
+then keep empty tables on subsequent `filter()` calls with a smaller data set.
+_[See the example below](#keep-empty-tables-when-filtering)._
 {{% /warn %}}
 
 ## Examples
@@ -88,6 +90,14 @@ from(bucket:"example-bucket")
 from(bucket:"example-bucket")
   |> range(start:-1h)
   |> filter(fn: (r) => r._value > 50.0 and r._value < 65.0 )
+```
+
+##### Keep empty tables when filtering
+```js
+from(bucket: "example-bucket")
+  |> range(start: -1h)
+  |> filter(fn: (r) => r._measurement == "events" and r._field == "open")
+  |> filter(fn: (r) => r.doorId == "201df", onEmpty: "keep")
 ```
 
 <hr style="margin-top:4rem"/>

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/filter.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/filter.md
@@ -97,7 +97,7 @@ from(bucket:"example-bucket")
 from(bucket: "example-bucket")
   |> range(start: -1h)
   |> filter(fn: (r) => r._measurement == "events" and r._field == "open")
-  |> filter(fn: (r) => r.doorId == "201df", onEmpty: "keep")
+  |> filter(fn: (r) => r.doorId =~ /^2.*/, onEmpty: "keep")
 ```
 
 <hr style="margin-top:4rem"/>


### PR DESCRIPTION
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
