### PR TITLE
Flux experimental CSV package

### DIFF
--- a/content/v2.0/reference/flux/stdlib/csv/from.md
+++ b/content/v2.0/reference/flux/stdlib/csv/from.md
@@ -22,35 +22,37 @@ _**Function type:** Input_
 ```js
 import "csv"
 
-csv.from(file: "/path/to/data-file.csv")
+csv.from(csv: csvData)
 
 // OR
 
-csv.from(csv: csvData)
+csv.from(file: "/path/to/data-file.csv")
 ```
 
 ## Parameters
 
-### file
-The file path of the CSV file to query.
-The path can be absolute or relative.
-If relative, it is relative to the working directory of the `influxd` process.
-_The CSV file must exist in the same file system running the `influxd` process._
-
-{{% cloud-msg %}}
-{{< cloud-name "short" >}} does not support the `file` parameter.
-{{% /cloud-msg %}}
-
-_**Data type:** String_
-
 ### csv
-Raw CSV-formatted text.
+Annotated CSV text.
 
 {{% note %}}
 CSV data must use Annotated CSV syntax and include all
 [annotation rows](/v2.0/reference/syntax/annotated-csv/#annotations).
 For more information, see [Annotated CSV](/v2.0/reference/syntax/annotated-csv/).
 {{% /note %}}
+
+_**Data type:** String_
+
+### file
+The file path of the CSV file to query.
+The path can be absolute or relative.
+If relative, it is relative to the working directory of the `fluxd` process.
+_The CSV file must exist in the same file system running the `fluxd` process._
+
+{{% warn %}}
+**InfluxDB OSS** and **{{< cloud-name "short" >}}** user interfaces do _**not**_ support the `file` parameter.
+Neither allow access to the underlying filesystem.
+However, the [Flux REPL](/v2.0/reference/cli/influx/repl/) does support the `file` parameter.
+{{% /warn %}}
 
 _**Data type:** String_
 

--- a/content/v2.0/reference/flux/stdlib/experimental/csv/_index.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/csv/_index.md
@@ -1,0 +1,23 @@
+---
+title: Flux CSV package
+list_title: CSV package
+description: >
+  The Flux Experimental CSV package provides functions for retrieving annotated CSV.
+  Import the `experimental/csv` package.
+menu:
+  v2_0_ref:
+    name: CSV
+    identifier: CSV-exp
+    parent: Experimental
+weight: 301
+v2.0/tags: [functions, csv, package]
+---
+
+The Flux Experimental CSV package provides functions for retrieving annotated CSV.
+Import the `experimental/csv` package:
+
+```js
+import "experimental/csv"
+```
+
+{{< children type="functions" show="pages" >}}

--- a/content/v2.0/reference/flux/stdlib/experimental/csv/from.md
+++ b/content/v2.0/reference/flux/stdlib/experimental/csv/from.md
@@ -1,0 +1,53 @@
+---
+title: csv.from() function
+description: >
+  The experimental `csv.from()` function retrieves annotated CSV from a URL.
+menu:
+  v2_0_ref:
+    name: csv.from *
+    parent: CSV-exp
+weight: 401
+---
+
+The experimental `csv.from()` function retrieves [annotated CSV](/v2.0/reference/syntax/annotated-csv/) **from a URL**.
+
+{{% note %}}
+The experimental `csv.from()` function is an alternative to the standard
+[`csv.from()` function](/v2.0/reference/flux/stdlib/csv/from/).
+{{% /note %}}
+
+_**Function type:** Input_
+
+```js
+import "experimental/csv"
+
+csv.from(url: "http://localhost:9999/")
+```
+
+## Parameters
+
+### url
+The URL to retrieve annotated CSV from.
+
+_**Data type:** String_
+
+
+## Examples
+
+##### Query annotated CSV data from a remote URL
+```js
+import "experimental/csv"
+
+csv.from(url: "http://mydomain.com/csv/example.csv")
+  |> filter(fn: (r) => r._measurement == "example-measurement")
+```
+
+## Function definition
+```js
+package csv
+
+import c "csv"
+import "experimental/http"
+
+from = (url) => c.from(csv: string(v: http.get(url: url).body))
+```

--- a/content/v2.0/reference/release-notes/flux.md
+++ b/content/v2.0/reference/release-notes/flux.md
@@ -21,6 +21,7 @@ InfluxDB until the next InfluxDB v2.0 release._
 ### Features
 - Hand-transpile `elapsed()` aggregate.
 - Hand-transpile `cumulative_sum()`.
+- Experimental `csv` package.
 
 ### Bug fixes
 - Add response reader as dependency to tune response size.


### PR DESCRIPTION
Closes #836 and influxdata/influxdb#17238

Adds the experimental CSV package, updates the Flux 0.64.0 release notes, and adds a note to the `file` parameter for the standard `csv.from()` function.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
