### PR TITLE
Note MySQL plugin supports MariaDB and Percona

### DIFF
--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -890,7 +890,7 @@ input:
   - name: MySQL
     id: mysql
     description: |
-      The MySQL input plugin gathers the statistics data from MySQL servers.
+      The MySQL input plugin gathers the statistics data from MySQL servers. Input plugin supports MariaDB and Percona.
     introduced: 0.1.1
     tags: [linux, macos, windows, data-stores]
 

--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -890,7 +890,7 @@ input:
   - name: MySQL
     id: mysql
     description: |
-      The MySQL input plugin gathers the statistics data from MySQL servers. Input plugin supports MariaDB and Percona.
+      The MySQL input plugin gathers the statistics data from MySQL, MariaDB, and Percona servers.
     introduced: 0.1.1
     tags: [linux, macos, windows, data-stores]
 


### PR DESCRIPTION
Scott, updated this page: https://v2.docs.influxdata.com/v2.0/reference/telegraf-plugins/

Should we note anywhere else in v2 docs?