### PR TITLE
Add 'epsilon' and 'verbose' parameters to 'testing.diff'

### DIFF
--- a/content/v2.0/reference/flux/stdlib/testing/diff.md
+++ b/content/v2.0/reference/flux/stdlib/testing/diff.md
@@ -51,6 +51,7 @@ _**Data type:** Object_
 
 ### verbose
 Enable verbose output.
+Defaults to `true`.
 
 _**Data type:** Boolean_
 

--- a/content/v2.0/reference/flux/stdlib/testing/diff.md
+++ b/content/v2.0/reference/flux/stdlib/testing/diff.md
@@ -17,7 +17,12 @@ _**Function type:** Test_
 ```js
 import "testing"
 
-testing.diff(got: stream2, want: stream1)
+testing.diff(
+  got: stream2,
+  want: stream1,
+  verbose: true,
+  epsilon: 0.000000001
+)
 ```
 
 It matches tables from each stream with the same group keys.
@@ -34,15 +39,26 @@ _The `testing.diff()` function can be used to perform in-line diffs in a query._
 ## Parameters
 
 ### got
-The stream containing data to test.
+Stream containing data to test.
 _Defaults to piped-forward data (`<-`)._
 
 _**Data type:** Object_
 
 ### want
-The stream that contains the expected data to test against.
+Stream that contains the expected data to test against.
 
 _**Data type:** Object_
+
+### verbose
+Enable verbose output.
+
+_**Data type:** Boolean_
+
+### epsilon
+Specifies how far apart two **float** values can be, but still considered equal.
+Defaults to `0.000000001`.
+
+_**Data type:** Float_
 
 ## Examples
 

--- a/content/v2.0/reference/flux/stdlib/testing/diff.md
+++ b/content/v2.0/reference/flux/stdlib/testing/diff.md
@@ -20,7 +20,6 @@ import "testing"
 testing.diff(
   got: stream2,
   want: stream1,
-  verbose: true,
   epsilon: 0.000000001
 )
 ```
@@ -48,12 +47,6 @@ _**Data type:** Object_
 Stream that contains the expected data to test against.
 
 _**Data type:** Object_
-
-### verbose
-Enable verbose output.
-Defaults to `true`.
-
-_**Data type:** Boolean_
 
 ### epsilon
 Specifies how far apart two **float** values can be, but still considered equal.


### PR DESCRIPTION
Closes #911 

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
