### PR TITLE
Reorder use and create - templates.

### DIFF
--- a/content/v2.0/influxdb-templates/get_started_cloud.md
+++ b/content/v2.0/influxdb-templates/get_started_cloud.md
@@ -21,5 +21,6 @@ InfluxDB OSS 2.0 includes the InfluxDB CLI (`influx`). If you haven’t already,
 
 Next, discover how to use `influx` and `pkg` to do the following:
 
-- [Create templates](/v2.0/influxdb-templates/create/)
 - [Use templates](/v2.0/influxdb-templates/use/)
+- [Create templates](/v2.0/influxdb-templates/create/)
+

--- a/content/v2.0/influxdb-templates/use.md
+++ b/content/v2.0/influxdb-templates/use.md
@@ -27,7 +27,12 @@ others in the InfluxData community.
 Install community templates directly from GitHub using a template's download URL
 or download the template.
 
-{{% note %}} When attempting to access the community templates via the URL, the templates use the following as the root of the URL: `https://raw.githubusercontent.com/influxdata/community-templates/master/`. For example, the Docker community template can be accessed via `https://raw.githubusercontent.com/influxdata/community-templates/master/docker/docker.yml`. {{% /note %}}
+{{% note %}} When attempting to access the community templates via the URL, the templates use the following 
+as the root of the URL: `https://raw.githubusercontent.com/influxdata/community-templates/master/`. 
+
+For example, the Docker community template can be accessed via:
+`https://raw.githubusercontent.com/influxdata/community-templates/master/docker/docker.yml`. 
+{{% /note %}}
 
 <a class="btn" href="https://github.com/influxdata/community-templates/" target="\_blank">View InfluxDB Community Templates</a>
 


### PR DESCRIPTION
minor nit.... the likelihood of a cloud customer using a template is hire than creating... so, `use` should go first.

Also, minor fixes to spacing of this:
<img width="884" alt="Screen Shot 2020-04-28 at 5 51 28 PM" src="https://user-images.githubusercontent.com/23535264/80551621-e89e7100-8978-11ea-894f-58934bb8d883.png">

