### PR TITLE
fix: update data parameter for monitor.check with required shape

### DIFF
--- a/content/v2.0/reference/flux/stdlib/monitor/check.md
+++ b/content/v2.0/reference/flux/stdlib/monitor/check.md
@@ -66,7 +66,8 @@ The message is stored in the `_message` column.
 _**Data type:** Function_
 
 ### data
-Data to append to the output.
+Meta data used to identify this check.
+
 **InfluxDB populates check data.**
 
 _**Data type:** Object_
@@ -93,6 +94,12 @@ from(bucket: "telegraf")
       if r._level == "crit" then "Critical alert!! Disk usage is at ${r._value}%!"
       else if r._level == "warn" then "Warning! Disk usage is at ${r._value}%."
       else if r._level == "info" then "Disk usage is at ${r._value}%."
-      else "Things are looking good."
+      else "Things are looking good.",
+    data: {
+      _check_name: "Disk Utilization (Used Percentage)",
+      _check_id: "disk_used_percent",
+      _type: "threshold",
+      tags: {}
+    }
   )
 ```


### PR DESCRIPTION
It would appear that the `data` parameter cannot be `{}` any longer and requires the check metadata to be defined

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
