### PR TITLE
docs: add link to Kotlin and Scala library

### DIFF
--- a/content/v2.0/reference/api/client-libraries/kotlin.md
+++ b/content/v2.0/reference/api/client-libraries/kotlin.md
@@ -1,0 +1,12 @@
+---
+title: InfluxDB Kotlin client library
+list_title: Kotlin
+description: Use the Kotlin client library to interact with InfluxDB.
+external_url: https://github.com/influxdata/influxdb-client-java/tree/master/client-kotlin
+menu:
+  v2_0_ref:
+    name: Kotlin
+    parent: Client libraries
+    url: https://github.com/influxdata/influxdb-client-java/tree/master/client-kotlin
+weight: 201
+---

--- a/content/v2.0/reference/api/client-libraries/scala.md
+++ b/content/v2.0/reference/api/client-libraries/scala.md
@@ -1,0 +1,12 @@
+---
+title: InfluxDB Scala client library
+list_title: Scala
+description: Use the Scala client library to interact with InfluxDB.
+external_url: https://github.com/influxdata/influxdb-client-java/tree/master/client-scala
+menu:
+  v2_0_ref:
+    name: Scala
+    parent: Client libraries
+    url: https://github.com/influxdata/influxdb-client-java/tree/master/client-scala
+weight: 201
+---


### PR DESCRIPTION
Added link to [Kotlin](https://github.com/influxdata/influxdb-client-java/tree/master/client-kotlin) and [Scala](https://github.com/influxdata/influxdb-client-java/tree/master/client-scala) clients that are part of Java client.

![Screenshot 2020-05-22 at 07 01 11](https://user-images.githubusercontent.com/455137/82634632-7f6bef80-9bfe-11ea-9605-2369d2f6dc96.png)


- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
