### PR TITLE
Updated CLI flag tables so shorthand and longhand flags align

### DIFF
--- a/assets/styles/layouts/article/_tables.scss
+++ b/assets/styles/layouts/article/_tables.scss
@@ -47,3 +47,9 @@ table {
     }
   }
 }
+
+#flags, #global-flags {
+  & + table {
+    td:nth-child(2) code { margin-left: -2rem; }
+  }
+}

--- a/content/v2.0/reference/cli/influx/_index.md
+++ b/content/v2.0/reference/cli/influx/_index.md
@@ -73,8 +73,8 @@ Mapped flags get the value of the environment variable.
 To override environment variables, set the flag explicitly in your command.
 
 ## Flags
-| Flag           | Description                   |
-|:---------------|:------------------------------|
-| `-h`, `--help` | Help for the `influx` command |
+| Flag |          | Description                   |
+|:---- |:---      |:-----------                   |
+| `-h` | `--help` | Help for the `influx` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/apply/_index.md
+++ b/content/v2.0/reference/cli/influx/apply/_index.md
@@ -24,23 +24,23 @@ influx apply [flags]
 `apply`, `pkg` _(deprecated)_
 
 ## Flags
-| Flag                      | Description                                                                                 | Input Type | {{< cli/mapped >}}   |
-|:----                      |:-----------------------------                                                               |:---------- |:------------------   |
-| `-c`, `--disable-color`   | Disable color in output                                                                     |            |                      |
-| `--disable-table-borders` | Disable table borders                                                                       |            |                      |
-| `-e`, `--encoding`        | Encoding of the input stream                                                                | string     |                      |
-| `--env-ref`               | Environment references to provide with the template (format: `--env-ref=REF_KEY=REF_VALUE`) | string     |                      |
-| `-f`, `--file`            | Path to template file                                                                       | string     |                      |
-| `--force`                 | Ignore warnings about destructive changes                                                   |            |                      |
-| `-h`, `--help`            | Help for the `apply` command                                                                |            |                      |
-| `--json`                  | Output data as JSON                                                                         |            | `INFLUX_OUTPUT_JSON` |
-| `-o`, `--org`             | Organization name that owns the bucket                                                      | string     | `INFLUX_ORG`         |
-| `--org-id`                | Organization ID that owns the bucket                                                        | string     | `INFLUX_ORG_ID`      |
-| `-q`, `--quiet`           | Disable output printing                                                                     |            |                      |
-| `-R`, `--recurse`         | Recurse through files in the directory specified in `-f`, `--file`                          |            |                      |
-| `--secret`                | Secrets to provide with the template (format: `--secret=SECRET_KEY=SECRET_VALUE`)           | string     |                      |
-| `--stack-id`              | Stack ID to associate when applying the template                                            | string     |                      |
-| `-u`, `--template-url`    | URL of template file                                                                        | string     |                      |
+| Flag |                           | Description                                                                                 | Input Type | {{< cli/mapped >}}   |
+|:---- |:---                       |:-----------------------------                                                               |:---------- |:------------------   |
+| `-c` | `--disable-color`         | Disable color in output                                                                     |            |                      |
+|      | `--disable-table-borders` | Disable table borders                                                                       |            |                      |
+| `-e` | `--encoding`              | Encoding of the input stream                                                                | string     |                      |
+|      | `--env-ref`               | Environment references to provide with the template (format: `--env-ref=REF_KEY=REF_VALUE`) | string     |                      |
+| `-f` | `--file`                  | Path to template file                                                                       | string     |                      |
+|      | `--force`                 | Ignore warnings about destructive changes                                                   |            |                      |
+| `-h` | `--help`                  | Help for the `apply` command                                                                |            |                      |
+|      | `--json`                  | Output data as JSON                                                                         |            | `INFLUX_OUTPUT_JSON` |
+| `-o` | `--org`                   | Organization name that owns the bucket                                                      | string     | `INFLUX_ORG`         |
+|      | `--org-id`                | Organization ID that owns the bucket                                                        | string     | `INFLUX_ORG_ID`      |
+| `-q` | `--quiet`                 | Disable output printing                                                                     |            |                      |
+| `-R` | `--recurse`               | Recurse through files in the directory specified in `-f`, `--file`                          |            |                      |
+|      | `--secret`                | Secrets to provide with the template (format: `--secret=SECRET_KEY=SECRET_VALUE`)           | string     |                      |
+|      | `--stack-id`              | Stack ID to associate when applying the template                                            | string     |                      |
+| `-u` | `--template-url`          | URL of template file                                                                        | string     |                      |
 
 {{% cli/influx-global-flags %}}
 

--- a/content/v2.0/reference/cli/influx/auth/_index.md
+++ b/content/v2.0/reference/cli/influx/auth/_index.md
@@ -30,8 +30,8 @@ influx auth [command]
 | [inactive](/v2.0/reference/cli/influx/auth/inactive) | Inactivate authorization |
 
 ## Flags
-| Flag           | Description                 |
-|:----           |:-----------                 |
-| `-h`, `--help` | Help for the `auth` command |
+| Flag |          | Description                 |
+|:---- |:---      |:-----------                 |
+| `-h` | `--help` | Help for the `auth` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/active.md
+++ b/content/v2.0/reference/cli/influx/auth/active.md
@@ -16,11 +16,11 @@ influx auth active [flags]
 ```
 
 ## Flags
-| Flag             | Description                           | Input type | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------:|:------------------    |
-| `-h`, `--help`   | Help for the `active` command         |            |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |            | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`     | **(Required)** Authorization ID       | string     |                       |
-| `--json`         | Output data as JSON (default `false`) |            | `INFLUX_OUTPUT_JSON`  |
+| Flag |                  | Description                           | Input type | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------:|:------------------    |
+| `-h` | `--help`         | Help for the `active` command         |            |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |            | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | **(Required)** Authorization ID       | string     |                       |
+|      | `--json`         | Output data as JSON (default `false`) |            | `INFLUX_OUTPUT_JSON`  |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/create.md
+++ b/content/v2.0/reference/cli/influx/auth/create.md
@@ -16,27 +16,27 @@ influx auth create [flags]
 ```
 
 ## Flags
-| Flag                 | Description                                                    | Input type  | {{< cli/mapped >}}    |
-|:----                 |:-----------                                                    |:----------: |:------------------    |
-| `-h`, `--help`       | Help for the `create` command                                  |             |                       |
-| `--hide-headers`     | Hide table headers (default `false`)                           |             | `INFLUX_HIDE_HEADERS` |
-| `--json`             | Output data as JSON (default `false`)                          |             | `INFLUX_OUTPUT_JSON`  |
-| `-o`, `--org`        | **(Required)** Organization name                               | string      | `INFLUX_ORG`          |
-| `--org-id`           | Organization ID                                                | string      | `INFLUX_ORG_ID`       |
-| `--read-bucket`      | Bucket ID                                                      | stringArray |                       |
-| `--read-buckets`     | Grants permission to read organization buckets                 |             |                       |
-| `--read-dashboards`  | Grants permission to read dashboards                           |             |                       |
-| `--read-orgs`        | Grants permission to read organizations                        |             |                       |
-| `--read-tasks`       | Grants permission to read tasks                                |             |                       |
-| `--read-telegrafs`   | Grants permission to read Telegraf configurations              |             |                       |
-| `--read-user`        | Grants permission to read organization users                   |             |                       |
-| `-u`, `--user`       | Username                                                       | string      |                       |
-| `--write-bucket`     | Bucket ID                                                      | stringArray |                       |
-| `--write-buckets`    | Grants permission to create and update organization buckets    |             |                       |
-| `--write-dashboards` | Grants permission to create and update dashboards              |             |                       |
-| `--write-orgs`       | Grants permission to create and update organizations           |             |                       |
-| `--write-tasks`      | Grants permission to create and update tasks                   |             |                       |
-| `--write-telegrafs`  | Grants permission to create and update Telegraf configurations |             |                       |
-| `--write-user`       | Grants permission to create and update organization users      |             |                       |
+| Flag |                      | Description                                                    | Input type  | {{< cli/mapped >}}    |
+|:---- |:---                  |:-----------                                                    |:----------: |:------------------    |
+| `-h` | `--help`             | Help for the `create` command                                  |             |                       |
+|      | `--hide-headers`     | Hide table headers (default `false`)                           |             | `INFLUX_HIDE_HEADERS` |
+|      | `--json`             | Output data as JSON (default `false`)                          |             | `INFLUX_OUTPUT_JSON`  |
+| `-o` | `--org`              | **(Required)** Organization name                               | string      | `INFLUX_ORG`          |
+|      | `--org-id`           | Organization ID                                                | string      | `INFLUX_ORG_ID`       |
+|      | `--read-bucket`      | Bucket ID                                                      | stringArray |                       |
+|      | `--read-buckets`     | Grants permission to read organization buckets                 |             |                       |
+|      | `--read-dashboards`  | Grants permission to read dashboards                           |             |                       |
+|      | `--read-orgs`        | Grants permission to read organizations                        |             |                       |
+|      | `--read-tasks`       | Grants permission to read tasks                                |             |                       |
+|      | `--read-telegrafs`   | Grants permission to read Telegraf configurations              |             |                       |
+|      | `--read-user`        | Grants permission to read organization users                   |             |                       |
+| `-u` | `--user`             | Username                                                       | string      |                       |
+|      | `--write-bucket`     | Bucket ID                                                      | stringArray |                       |
+|      | `--write-buckets`    | Grants permission to create and update organization buckets    |             |                       |
+|      | `--write-dashboards` | Grants permission to create and update dashboards              |             |                       |
+|      | `--write-orgs`       | Grants permission to create and update organizations           |             |                       |
+|      | `--write-tasks`      | Grants permission to create and update tasks                   |             |                       |
+|      | `--write-telegrafs`  | Grants permission to create and update Telegraf configurations |             |                       |
+|      | `--write-user`       | Grants permission to create and update organization users      |             |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/delete.md
+++ b/content/v2.0/reference/cli/influx/auth/delete.md
@@ -16,11 +16,11 @@ influx auth delete [flags]
 ```
 
 ## Flags
-| Flag             | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------: |:------------------    |
-| `-h`, `--help`   | Help for the `delete` command         |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`     | **(Required)** Authorization ID       | string      |                       |
-| `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `delete` command         |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | **(Required)** Authorization ID       | string      |                       |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/inactive.md
+++ b/content/v2.0/reference/cli/influx/auth/inactive.md
@@ -16,11 +16,11 @@ influx auth inactive [flags]
 ```
 
 ## Flags
-| Flag             | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------: |:------------------    |
-| `-h`, `--help`   | Help for the `inactive` command       |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`     | **(Required)** Authorization ID       | string      |                       |
-| `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `inactive` command       |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | **(Required)** Authorization ID       | string      |                       |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/auth/list.md
+++ b/content/v2.0/reference/cli/influx/auth/list.md
@@ -21,15 +21,15 @@ influx auth list [flags]
 `list`, `ls`, `find`
 
 ## Flags
-| Flag             | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------: |:------------------    |
-| `-h`, `--help`   | Help for the `list` command           |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`     | Authorization ID                      | string      |                       |
-| `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
-| `-o`, `--org`    | Organization name                     | string      |                       |
-| `--org-id`       | Organization ID                       | string      |                       |
-| `-u`, `--user`   | Username                              | string      |                       |
-| `--user-id`      | User ID                               | string      |                       |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `list` command           |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | Authorization ID                      | string      |                       |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+| `-o` | `--org`          | Organization name                     | string      |                       |
+|      | `--org-id`       | Organization ID                       | string      |                       |
+| `-u` | `--user`         | Username                              | string      |                       |
+|      | `--user-id`      | User ID                               | string      |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/backup/_index.md
+++ b/content/v2.0/reference/cli/influx/backup/_index.md
@@ -19,9 +19,9 @@ influx backup [flags]
 ```
 
 ## Flags
-| Flag           | Description                             | Input type | {{< cli/mapped >}} |
-|:----           |:-----------                             |:----------:|:------------------ |
-| `-h`, `--help` | Help for the `backup` command           |            |                    |
-| `-p`, `--path` | Directory path to write backup files to | string     | `INFLUX_PATH`      |
+| Flag |          | Description                             | Input type | {{< cli/mapped >}} |
+|:---- |:---      |:-----------                             |:----------:|:------------------ |
+| `-h` | `--help` | Help for the `backup` command           |            |                    |
+| `-p` | `--path` | Directory path to write backup files to | string     | `INFLUX_PATH`      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/_index.md
+++ b/content/v2.0/reference/cli/influx/bucket/_index.md
@@ -26,8 +26,8 @@ influx bucket [command]
 | [update](/v2.0/reference/cli/influx/bucket/update) | Update bucket |
 
 ## Flags
-| Flag           | Description                   |
-|:----           |:-----------                   |
-| `-h`, `--help` | Help for the `bucket` command |
+| Flag |          | Description                   |
+|:---- |:---      |:-----------                   |
+| `-h` | `--help` | Help for the `bucket` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/create.md
+++ b/content/v2.0/reference/cli/influx/bucket/create.md
@@ -16,15 +16,15 @@ influx bucket create [flags]
 ```
 
 ## Flags
-| Flag                  | Description                                                    | Input type  | {{< cli/mapped >}}    |
-|:----                  |:-----------                                                    |:----------: |:------------------    |
-| `-d`, `--description` | Bucket description                                             | string      |                       |
-| `-h`, `--help`        | Help for the `create` command                                  |             |                       |
-| `--hide-headers`      | Hide table headers (default `false`)                           |             | `INFLUX_HIDE_HEADERS` |
-| `--json`              | Output data as JSON (default `false`)                          |             | `INFLUX_OUTPUT_JSON`  |
-| `-n`, `--name`        | Bucket name                                                    | string      | `INFLUX_BUCKET_NAME`  |
-| `-o`, `--org`         | Organization name                                              | string      | `INFLUX_ORG`          |
-| `--org-id`            | Organization ID                                                | string      | `INFLUX_ORG_ID`       |
-| `-r`, `--retention`   | Duration bucket will retain data (0 is infinite, default is 0) | duration    |                       |
+| Flag |                  | Description                                                    | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                                                    |:----------: |:------------------    |
+| `-d` | `--description`  | Bucket description                                             | string      |                       |
+| `-h` | `--help`         | Help for the `create` command                                  |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)                           |             | `INFLUX_HIDE_HEADERS` |
+|      | `--json`         | Output data as JSON (default `false`)                          |             | `INFLUX_OUTPUT_JSON`  |
+| `-n` | `--name`         | Bucket name                                                    | string      | `INFLUX_BUCKET_NAME`  |
+| `-o` | `--org`          | Organization name                                              | string      | `INFLUX_ORG`          |
+|      | `--org-id`       | Organization ID                                                | string      | `INFLUX_ORG_ID`       |
+| `-r` | `--retention`    | Duration bucket will retain data (0 is infinite, default is 0) | duration    |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/delete.md
+++ b/content/v2.0/reference/cli/influx/bucket/delete.md
@@ -18,14 +18,14 @@ influx bucket delete [flags]
 ```
 
 ## Flags
-| Flag             | Description                                  | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                                  |:----------: |:------------------    |
-| `-h`, `--help`   | Help for the `delete` command                |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)         |             | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`     | Bucket ID _(required if no `--name`)_        | string      |                       |
-| `--json`         | Output data as JSON (default `false`)        |             | `INFLUX_OUTPUT_JSON`  |
-| `-n`, `--name`   | Bucket name _(requires `--org` or `org-id`)_ | string      |                       |
-| `-o`, `--org`    | Organization name                            | string      | `INFLUX_ORG`          |
-| `--org-id`       | Organization ID                              | string      | `INFLUX_ORG_ID`       |
+| Flag |                  | Description                                  | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                                  |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `delete` command                |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)         |             | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | Bucket ID _(required if no `--name`)_        | string      |                       |
+|      | `--json`         | Output data as JSON (default `false`)        |             | `INFLUX_OUTPUT_JSON`  |
+| `-n` | `--name`         | Bucket name _(requires `--org` or `org-id`)_ | string      |                       |
+| `-o` | `--org`          | Organization name                            | string      | `INFLUX_ORG`          |
+|      | `--org-id`       | Organization ID                              | string      | `INFLUX_ORG_ID`       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/list.md
+++ b/content/v2.0/reference/cli/influx/bucket/list.md
@@ -21,14 +21,14 @@ influx bucket list [flags]
 `list`, `ls`, `find`
 
 ## Flags
-| Flag             | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------: |:------------------    |
-| `-h`, `--help`   | Help for the `list` command           |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`     | Bucket ID                             | string      |                       |
-| `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
-| `-n`, `--name`   | Bucket name                           | string      | `INFLUX_BUCKET_NAME`  |
-| `-o`, `--org`    | Organization name                     | string      | `INFLUX_ORG`          |
-| `--org-id`       | Organization ID                       | string      | `INFLUX_ORG_ID`       |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `list` command           |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | Bucket ID                             | string      |                       |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+| `-n` | `--name`         | Bucket name                           | string      | `INFLUX_BUCKET_NAME`  |
+| `-o` | `--org`          | Organization name                     | string      | `INFLUX_ORG`          |
+|      | `--org-id`       | Organization ID                       | string      | `INFLUX_ORG_ID`       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/update.md
+++ b/content/v2.0/reference/cli/influx/bucket/update.md
@@ -16,14 +16,14 @@ influx bucket update [flags]
 ```
 
 ## Flags
-| Flag                  | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----                  |:-----------                           |:----------: |:------------------    |
-| `-d`, `--description` | Bucket description                    | string      |                       |
-| `-h`, `--help`        | Help for the `update` command         |             |                       |
-| `--hide-headers`      | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`          | **(Required)** Bucket ID              | string      |                       |
-| `--json`              | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
-| `-n`, `--name`        | New bucket name                       | string      | `INFLUX_BUCKET_NAME`  |
-| `-r`, `--retention`   | New duration bucket will retain data  | duration    |                       |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-d` | `--description`  | Bucket description                    | string      |                       |
+| `-h` | `--help`         | Help for the `update` command         |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | **(Required)** Bucket ID              | string      |                       |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+| `-n` | `--name`         | New bucket name                       | string      | `INFLUX_BUCKET_NAME`  |
+| `-r` | `--retention`    | New duration bucket will retain data  | duration    |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/completion/_index.md
+++ b/content/v2.0/reference/cli/influx/completion/_index.md
@@ -20,9 +20,9 @@ influx completion [bash|zsh] [flags]
 ```
 
 ## Flags
-| Flag           | Description                       |
-|:----           |:-----------                       |
-| `-h`, `--help` | Help for the `completion` command |
+| Flag |          | Description                       |
+|:---- |:---      |:-----------                       |
+| `-h` | `--help` | Help for the `completion` command |
 
 {{% cli/influx-global-flags %}}
 
@@ -56,4 +56,3 @@ $ source <(influx completion zsh)
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
-

--- a/content/v2.0/reference/cli/influx/config/_index.md
+++ b/content/v2.0/reference/cli/influx/config/_index.md
@@ -45,8 +45,8 @@ influx config -
 | [set](/v2.0/reference/cli/influx/config/set)       | Set or update a connection configuration |
 
 ## Flags
-| Flag           | Description                   |
-|:----           |:-----------                   |
-| `-h`, `--help` | Help for the `config` command |
+| Flag |          | Description                   |
+|:---- |:---      |:-----------                   |
+| `-h` | `--help` | Help for the `config` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/config/create.md
+++ b/content/v2.0/reference/cli/influx/config/create.md
@@ -17,14 +17,14 @@ influx config create [flags]
 ```
 
 ## Flags
-| Flag              | Description                                                  | Input type  | {{< cli/mapped >}}    |
-|:----              |:-----------                                                  |:----------: |:------------------    |
-| `-a,`, `--active` | Set the specified connection to be the active configuration. |             |                       |
-| `-h`, `--help`    | Help for the `create` command                                |             |                       |
-| `--hide-headers`  | Hide table headers (default `false`)                         |             | `INFLUX_HIDE_HEADERS` |
-| `--json`          | Output data as JSON (default `false`)                        |             | `INFLUX_OUTPUT_JSON`  |
-| `-n`, `--name`    | (**Required**) Name of the new configuration.                | string      |                       |
-| `-o`, `--org`     | Organization name                                            | string      |                       |
-| `-u`, `--url`     | (**Required**) Connection URL for the new configuration.     | string      |                       |
+| Flag |                  | Description                                                  | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                                                  |:----------: |:------------------    |
+| `-a` | `--active`       | Set the specified connection to be the active configuration. |             |                       |
+| `-h` | `--help`         | Help for the `create` command                                |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)                         |             | `INFLUX_HIDE_HEADERS` |
+|      | `--json`         | Output data as JSON (default `false`)                        |             | `INFLUX_OUTPUT_JSON`  |
+| `-n` | `--name`         | (**Required**) Name of the new configuration.                | string      |                       |
+| `-o` | `--org`          | Organization name                                            | string      |                       |
+| `-u` | `--url`          | (**Required**) Connection URL for the new configuration.     | string      |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/config/delete.md
+++ b/content/v2.0/reference/cli/influx/config/delete.md
@@ -17,11 +17,11 @@ influx config delete [flags]
 ```
 
 ## Flags
-| Flag             | Description                                                        | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                                                        |:----------: |:------------------    |
-| `-h`, `--help`   | Help for the `delete` command                                      |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)                               |             | `INFLUX_HIDE_HEADERS` |
-| `--json`         | Output data as JSON (default `false`)                              |             | `INFLUX_OUTPUT_JSON`  |
-| `-n`, `--name`   | (**Required**) Name of InfluxDB connection configuration to delete | string      |                       |
+| Flag |                  | Description                                                        | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                                                        |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `delete` command                                      |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)                               |             | `INFLUX_HIDE_HEADERS` |
+|      | `--json`         | Output data as JSON (default `false`)                              |             | `INFLUX_OUTPUT_JSON`  |
+| `-n` | `--name`         | (**Required**) Name of InfluxDB connection configuration to delete | string      |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/config/list.md
+++ b/content/v2.0/reference/cli/influx/config/list.md
@@ -22,10 +22,10 @@ influx config list [flags]
 `list`, `ls`
 
 ## Flags
-| Flag             | Description                           | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:------------------    |
-| `-h`, `--help`   | Help for the `list` command           |                       |
-| `--hide-headers` | Hide table headers (default `false`)  | `INFLUX_HIDE_HEADERS` |
-| `--json`         | Output data as JSON (default `false`) | `INFLUX_OUTPUT_JSON`  |
+| Flag |                  | Description                           | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:------------------    |
+| `-h` | `--help`         | Help for the `list` command           |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  | `INFLUX_HIDE_HEADERS` |
+|      | `--json`         | Output data as JSON (default `false`) | `INFLUX_OUTPUT_JSON`  |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/config/set.md
+++ b/content/v2.0/reference/cli/influx/config/set.md
@@ -20,14 +20,14 @@ influx config set [flags]
 `set` , `update`
 
 ## Flags
-| Flag             | Description                                                               | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                                                               |:----------: |:------------------    |
-| `-a`, `--active` | Set the specified connection to active                                    |             |                       |
-| `-h`, `--help`   | Help for the `set` command                                                |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)                                      |             | `INFLUX_HIDE_HEADERS` |
-| `--json`         | Output data as JSON (default `false`)                                     |             | `INFLUX_OUTPUT_JSON`  |
-| `-n`, `--name`   | Name for the InfluxDB connection configuration to set or update           | string      |                       |
-| `-o` , `--org`   | Organization name for the connection configuration                        | string      |                       |
-| `-u`, `--url`    | (**Required**) URL for InfluxDB connection configuration to set or update | string      |                       |
+| Flag |                  | Description                                                               | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                                                               |:----------: |:------------------    |
+| `-a` | --active`        | Set the specified connection to active                                    |             |                       |
+| `-h` | --help`          | Help for the `set` command                                                |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)                                      |             | `INFLUX_HIDE_HEADERS` |
+|      | `--json`         | Output data as JSON (default `false`)                                     |             | `INFLUX_OUTPUT_JSON`  |
+| `-n` | --name`          | Name for the InfluxDB connection configuration to set or update           | string      |                       |
+| `-o` | `--org`          | Organization name for the connection configuration                        | string      |                       |
+| `-u` | --url`           | (**Required**) URL for InfluxDB connection configuration to set or update | string      |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/delete/_index.md
+++ b/content/v2.0/reference/cli/influx/delete/_index.md
@@ -23,15 +23,15 @@ timestamps between the specified `--start` and `--stop` times in the specified b
 {{% /warn %}}
 
 ## Flags
-| Flag                | Description                                                                                      | Input type | {{< cli/mapped >}}   |
-|:----                |:-----------                                                                                      |:----------:|:------------------   |
-| `-b`, `--bucket`    | Name of bucket to remove data from                                                               | string     | `INFLUX_BUCKET_NAME` |
-| `--bucket-id`       | Bucket ID                                                                                        | string     | `INFLUX_BUCKET_ID`   |
-| `-h`, `--help`      | Help for the `delete` command                                                                    |            |                      |
-| `-o`, `--org`       | Organization name                                                                                | string     | `INFLUX_ORG`         |
-| `--org-id`          | Organization ID                                                                                  | string     | `INFLUX_ORG_ID`      |
-| `-p`, `--predicate` | InfluxQL-like predicate string (see [Delete predicate](/v2.0/reference/syntax/delete-predicate)) | string     |                      |
-| `--start`           | Start time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                       | string     |                      |
-| `--stop`            | Stop time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                        | string     |                      |
+| Flag |               | Description                                                                                      | Input type | {{< cli/mapped >}}   |
+|:---- |:---           |:-----------                                                                                      |:----------:|:------------------   |
+| `-b` | `--bucket`    | Name of bucket to remove data from                                                               | string     | `INFLUX_BUCKET_NAME` |
+|      | `--bucket-id` | Bucket ID                                                                                        | string     | `INFLUX_BUCKET_ID`   |
+| `-h` | `--help`      | Help for the `delete` command                                                                    |            |                      |
+| `-o` | `--org`       | Organization name                                                                                | string     | `INFLUX_ORG`         |
+|      | `--org-id`    | Organization ID                                                                                  | string     | `INFLUX_ORG_ID`      |
+| `-p` | `--predicate` | InfluxQL-like predicate string (see [Delete predicate](/v2.0/reference/syntax/delete-predicate)) | string     |                      |
+|      | `--start`     | Start time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                       | string     |                      |
+|      | `--stop`      | Stop time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                        | string     |                      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/export/_index.md
+++ b/content/v2.0/reference/cli/influx/export/_index.md
@@ -29,20 +29,20 @@ influx export [command]
 
 ## Flags
 
-| Flag                 | Description                                                                      | Input Type |
-|:----                 |:-----------                                                                      |:---------- |
-| `--buckets`          | Comma-separated list of bucket IDs                                               | string     |
-| `--checks`           | Comma-separated list of check IDs                                                | string     |
-| `--dashboards`       | Comma-separated list of dashboard IDs                                            | string     |
-| `--endpoints`        | Comma-separated list of notification endpoint IDs                                | string     |
-| `-f`, `--file`       | Template output file. Defaults to stdout. Use `.yml` or `.json` file extensions. | string     |
-| `-h`, `--help`       | Help for the `export` command                                                    |            |
-| `--labels`           | Comma-separated list of label IDs                                                | string     |
-| `--resource-type`    | Resource type associated with all IDs via stdin                                  | string     |
-| `--rules`            | Comma-separated list of notification rule IDs                                    | string     |
-| `--tasks`            | Comma-separated list of task IDs                                                 | string     |
-| `--telegraf-configs` | Comma-separated list of Telegraf configuration IDs                               | string     |
-| `--variables`        | Comma-separated list of variable IDs                                             | string     |
+| Flag |                      | Description                                                                      | Input Type |
+|:---- |:---                  |:-----------                                                                      |:---------- |
+|      | `--buckets`          | Comma-separated list of bucket IDs                                               | string     |
+|      | `--checks`           | Comma-separated list of check IDs                                                | string     |
+|      | `--dashboards`       | Comma-separated list of dashboard IDs                                            | string     |
+|      | `--endpoints`        | Comma-separated list of notification endpoint IDs                                | string     |
+| `-f` | `--file`             | Template output file. Defaults to stdout. Use `.yml` or `.json` file extensions. | string     |
+| `-h` | `--help`             | Help for the `export` command                                                    |            |
+|      | `--labels`           | Comma-separated list of label IDs                                                | string     |
+|      | `--resource-type`    | Resource type associated with all IDs via stdin                                  | string     |
+|      | `--rules`            | Comma-separated list of notification rule IDs                                    | string     |
+|      | `--tasks`            | Comma-separated list of task IDs                                                 | string     |
+|      | `--telegraf-configs` | Comma-separated list of Telegraf configuration IDs                               | string     |
+|      | `--variables`        | Comma-separated list of variable IDs                                             | string     |
 
 {{% cli/influx-global-flags %}}
 

--- a/content/v2.0/reference/cli/influx/export/all.md
+++ b/content/v2.0/reference/cli/influx/export/all.md
@@ -23,13 +23,13 @@ influx export all [flags]
 ```
 
 ## Flags
-| Flag           | Description                                                                                     | Input Type      | {{< cli/mapped >}} |
-|:----           |:-----------                                                                                     |:----------      |:------------------ |
-| `-f`, `--file` | Template output file. Defaults to stdout. Use `.yml` or `.json` file extensions.                | string          |                    |
-| `--filter`     | Specify resources to export by labelName or resourceKind (format: `--filter=labelName=example`) | list of strings |
-| `-h`, `--help` | Help for the `export all` command                                                               |                 |                    |
-| `-o`, `--org`  | Organization name that owns the resources                                                       | string          | `INFLUX_ORG`       |
-| `--org-id`     | Organization ID that owns the resources                                                         | string          | `INFLUX_ORG_ID`    |
+| Flag |            | Description                                                                                     | Input Type      | {{< cli/mapped >}} |
+|:---- |:---        |:-----------                                                                                     |:----------      |:------------------ |
+| `-f` | `--file`   | Template output file. Defaults to stdout. Use `.yml` or `.json` file extensions.                | string          |                    |
+|      | `--filter` | Specify resources to export by labelName or resourceKind (format: `--filter=labelName=example`) | list of strings |
+| `-h` | `--help`   | Help for the `export all` command                                                               |                 |                    |
+| `-o` | `--org`    | Organization name that owns the resources                                                       | string          | `INFLUX_ORG`       |
+|      | `--org-id` | Organization ID that owns the resources                                                         | string          | `INFLUX_ORG_ID`    |
 
 {{% cli/influx-global-flags %}}
 

--- a/content/v2.0/reference/cli/influx/export/stack.md
+++ b/content/v2.0/reference/cli/influx/export/stack.md
@@ -19,12 +19,12 @@ influx export stack <stack_id> [flags]
 ```
 
 ## Flags
-| Flag           | Description                                                                      | Input Type | {{< cli/mapped >}} |
-|:----           |:-----------                                                                      |:---------- |:------------------ |
-| `-f`, `--file` | Template output file. Defaults to stdout. Use `.yml` or `.json` file extensions. | string     |                    |
-| `-h`, `--help` | Help for the `export stack` command                                              |            |                    |
-| `-o`, `--org`  | Organization name that owns the resources                                        | string     | `INFLUX_ORG`       |
-| `--org-id`     | Organization ID that owns the resources                                          | string     | `INFLUX_ORG_ID`    |
+| Flag |            | Description                                                                      | Input Type | {{< cli/mapped >}} |
+|:---- |:---        |:-----------                                                                      |:---------- |:------------------ |
+| `-f` | `--file`   | Template output file. Defaults to stdout. Use `.yml` or `.json` file extensions. | string     |                    |
+| `-h` | `--help`   | Help for the `export stack` command                                              |            |                    |
+| `-o` | `--org`    | Organization name that owns the resources                                        | string     | `INFLUX_ORG`       |
+|      | `--org-id` | Organization ID that owns the resources                                          | string     | `INFLUX_ORG_ID`    |
 
 {{% cli/influx-global-flags %}}
 

--- a/content/v2.0/reference/cli/influx/help/_index.md
+++ b/content/v2.0/reference/cli/influx/help/_index.md
@@ -16,8 +16,8 @@ influx help [command] [flags]
 ```
 
 ## Flags
-| Flag           | Description             |
-|:----           |:-----------             |
-| `-h`, `--help` | Help for the `help` command |
+| Flag |          | Description                 |
+|:---- |:---      |:-----------                 |
+| `-h` | `--help` | Help for the `help` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/_index.md
+++ b/content/v2.0/reference/cli/influx/org/_index.md
@@ -30,8 +30,8 @@ influx org [command]
 | [update](/v2.0/reference/cli/influx/org/update)   | Update an organization           |
 
 ## Flags
-| Flag           | Description                |
-|:----           |:-----------                |
-| `-h`, `--help` | Help for the `org` command |
+| Flag |          | Description                |
+|:---- |:---      |:-----------                |
+| `-h` | `--help` | Help for the `org` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/create.md
+++ b/content/v2.0/reference/cli/influx/org/create.md
@@ -16,12 +16,12 @@ influx org create [flags]
 ```
 
 ## Flags
-| Flag                  | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----                  |:-----------                           |:----------: |:------------------    |
-| `-d`, `--description` | Description of the organization       |             |                       |
-| `-h`, `--help`        | Help for the `create` command         |             |                       |
-| `--hide-headers`      | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `--json`              | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
-| `-n`, `--name`        | Organization name                     | string      |                       |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-d` | `--description`  | Description of the organization       |             |                       |
+| `-h` | `--help`         | Help for the `create` command         |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+| `-n` | `--name`         | Organization name                     | string      |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/delete.md
+++ b/content/v2.0/reference/cli/influx/org/delete.md
@@ -16,11 +16,11 @@ influx org delete [flags]
 ```
 
 ## Flags
-| Flag             | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------: |:------------------    |
-| `-h`, `--help`   | Help for the `delete` command         |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`     | **(Required)** Organization ID        | string      | `INFLUX_ORG_ID`       |
-| `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `delete` command         |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | **(Required)** Organization ID        | string      | `INFLUX_ORG_ID`       |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/list.md
+++ b/content/v2.0/reference/cli/influx/org/list.md
@@ -21,12 +21,12 @@ influx org list [flags]
 `list`, `ls`, `find`
 
 ## Flags
-| Flag             | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------: |:------------------    |
-| `-h`, `--help`   | Help for the `list` command           |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`     | Organization ID                       | string      | `INFLUX_ORG`          |
-| `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
-| `-n`, `--name`   | Organization name                     | string      | `INFLUX_ORG_ID`       |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `list` command           |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | Organization ID                       | string      | `INFLUX_ORG`          |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+| `-n` | `--name`         | Organization name                     | string      | `INFLUX_ORG_ID`       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/_index.md
+++ b/content/v2.0/reference/cli/influx/org/members/_index.md
@@ -25,8 +25,8 @@ influx org members [command]
 | [remove](/v2.0/reference/cli/influx/org/members/remove) | Remove organization member |
 
 ## Flags
-| Flag           | Description                    |
-|:----           |:-----------                    |
-| `-h`, `--help` | Help for the `members` command |
+| Flag |          | Description                    |
+|:---- |:---      |:-----------                    |
+| `-h` | `--help` | Help for the `members` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/add.md
+++ b/content/v2.0/reference/cli/influx/org/members/add.md
@@ -16,11 +16,11 @@ influx org members add [flags]
 ```
 
 ## Flags
-| Flag             | Description                | Input type  | {{< cli/mapped >}} |
-|:----             |:-----------                |:----------: |:------------------ |
-| `-h`, `--help`   | Help for the `add` command |             |                    |
-| `-i`, `--id`     | Organization ID            | string      | `INFLUX_ORG_ID`    |
-| `-m`, `--member` | Member ID                  | string      |                    |
-| `-n`, `--name`   | Organization name          | string      | `INFLUX_ORG`       |
+| Flag |            | Description                | Input type  | {{< cli/mapped >}} |
+|:---- |:---        |:-----------                |:----------: |:------------------ |
+| `-h` | `--help`   | Help for the `add` command |             |                    |
+| `-i` | `--id`     | Organization ID            | string      | `INFLUX_ORG_ID`    |
+| `-m` | `--member` | Member ID                  | string      |                    |
+| `-n` | `--name`   | Organization name          | string      | `INFLUX_ORG`       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/list.md
+++ b/content/v2.0/reference/cli/influx/org/members/list.md
@@ -16,12 +16,12 @@ influx org members list [flags]
 ```
 
 ## Flags
-| Flag             | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------: |:------------------    |
-| `-h`, `--help`   | Help for the `list` command           |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`     | Organization ID                       | string      | `INFLUX_ORG_ID`       |
-| `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
-| `-n`, `--name`   | Organization name                     | string      | `INFLUX_ORG`          |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `list` command           |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | Organization ID                       | string      | `INFLUX_ORG_ID`       |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+| `-n` | `--name`         | Organization name                     | string      | `INFLUX_ORG`          |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/members/remove.md
+++ b/content/v2.0/reference/cli/influx/org/members/remove.md
@@ -16,11 +16,11 @@ influx org members remove [flags]
 ```
 
 ## Flags
-| Flag             | Description                   | Input type  | {{< cli/mapped >}} |
-|:----             |:-----------                   |:----------: |:------------------ |
-| `-h`, `--help`   | Help for the `remove` command |             |                    |
-| `-i`, `--id`     | Organization ID               | string      | `INFLUX_ORG_ID`    |
-| `-o`, `--member` | Member ID                     | string      |                    |
-| `-n`, `--name`   | Organization name             | string      | `INFLUX_ORG`       |
+| Flag |            | Description                   | Input type  | {{< cli/mapped >}} |
+|:---- |:---        |:-----------                   |:----------: |:------------------ |
+| `-h` | `--help`   | Help for the `remove` command |             |                    |
+| `-i` | `--id`     | Organization ID               | string      | `INFLUX_ORG_ID`    |
+| `-o` | `--member` | Member ID                     | string      |                    |
+| `-n` | `--name`   | Organization name             | string      | `INFLUX_ORG`       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/org/update.md
+++ b/content/v2.0/reference/cli/influx/org/update.md
@@ -16,13 +16,13 @@ influx org update [flags]
 ```
 
 ## Flags
-| Flag                  | Description                           | Input type | {{< cli/mapped >}}       |
-|:----                  |:-----------                           |:----------:|:------------------       |
-| `-d`, `--description` | Description for the organization      | string     | `INFLUX_ORG_DESCRIPTION` |
-| `-h`, `--help`        | Help for the `update` command         |            |                          |
-| `--hide-headers`      | Hide table headers (default `false`)  |            | `INFLUX_HIDE_HEADERS`    |
-| `-i`, `--id`          | **(Required)** Organization ID        | string     | `INFLUX_ORG_ID`          |
-| `--json`              | Output data as JSON (default `false`) |            | `INFLUX_OUTPUT_JSON`     |
-| `-n`, `--name`        | Organization name                     | string     | `INFLUX_ORG`             |
+| Flag |                  | Description                           | Input type | {{< cli/mapped >}}       |
+|:---- |:---              |:-----------                           |:----------:|:------------------       |
+| `-d` | `--description`  | Description for the organization      | string     | `INFLUX_ORG_DESCRIPTION` |
+| `-h` | `--help`         | Help for the `update` command         |            |                          |
+|      | `--hide-headers` | Hide table headers (default `false`)  |            | `INFLUX_HIDE_HEADERS`    |
+| `-i` | `--id`           | **(Required)** Organization ID        | string     | `INFLUX_ORG_ID`          |
+|      | `--json`         | Output data as JSON (default `false`) |            | `INFLUX_OUTPUT_JSON`     |
+| `-n` | `--name`         | Organization name                     | string     | `INFLUX_ORG`             |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/ping/_index.md
+++ b/content/v2.0/reference/cli/influx/ping/_index.md
@@ -21,8 +21,8 @@ influx ping [flags]
 ```
 
 ## Flags
-| Flag           | Description                 |
-|:----           |:-----------                 |
-| `-h`, `--help` | Help for the `ping` command |
+| Flag |          | Description                 |
+|:---- |:---      |:-----------                 |
+| `-h` | `--help` | Help for the `ping` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/query/_index.md
+++ b/content/v2.0/reference/cli/influx/query/_index.md
@@ -20,12 +20,12 @@ influx query [query literal] [flags]
 ```
 
 ## Flags
-| Flag           | Description                  | Input type | {{< cli/mapped >}} |
-|----------------|------------------------------|:----------:|--------------------|
-| `-f`, `--file` | Path to Flux script file     | string     |                    |
-| `-h`, `--help` | Help for the `query` command |            |                    |
-| `-o`, `--org`  | Organization name            |   string   | `INFLUX_ORG`       |
-| `--org-id`     | Organization ID              |   string   | `INFLUX_ORG_ID`    |
+| Flag |            | Description                  | Input type | {{< cli/mapped >}} |
+|:---- |:---        |:-----------                  |:----------:|:------------------ |
+| `-f` | `--file`   | Path to Flux script file     | string     |                    |
+| `-h` | `--help`   | Help for the `query` command |            |                    |
+| `-o` | `--org`    | Organization name            | string     | `INFLUX_ORG`       |
+|      | `--org-id` | Organization ID              | string     | `INFLUX_ORG_ID`    |
 
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/repl/_index.md
+++ b/content/v2.0/reference/cli/influx/repl/_index.md
@@ -26,10 +26,10 @@ Use **ctrl + d** to exit the REPL.
 To use the Flux REPL, you must first authenticate with a [token](/v2.0/security/tokens/view-tokens/).
 
 ## Flags
-| Flag           | Description                 | Input type | {{< cli/mapped >}} |
-|:----           |:-----------                 |:----------:|:------------------ |
-| `-h`, `--help` | Help for the `repl` command |            |                    |
-| `-o`, `--org`  | Organization name           | string     | `INFLUX_ORG`       |
-| `--org-id`     | Organization ID             | string     | `INFLUX_ORG_ID`    |
+| Flag |            | Description                 | Input type | {{< cli/mapped >}} |
+|:---- |:---        |:-----------                 |:----------:|:------------------ |
+| `-h` | `--help`   | Help for the `repl` command |            |                    |
+| `-o` | `--org`    | Organization name           | string     | `INFLUX_ORG`       |
+|      | `--org-id` | Organization ID             | string     | `INFLUX_ORG_ID`    |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/secret/_index.md
+++ b/content/v2.0/reference/cli/influx/secret/_index.md
@@ -25,8 +25,8 @@ influx secret [subcommand]
 | [update](/v2.0/reference/cli/influx/secret/update/) | Add or update a secret |
 
 ## Flags
-| Flag           | Description                   |
-|:----           |:-----------                   |
-| `-h`, `--help` | Help for the `secret` command |
+| Flag |          | Description                   |
+|:---- |:---      |:-----------                   |
+| `-h` | `--help` | Help for the `secret` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/secret/delete.md
+++ b/content/v2.0/reference/cli/influx/secret/delete.md
@@ -17,13 +17,13 @@ influx secret delete [flags]
 ```
 
 ## Flags
-| Flag             | Description                           | Input type | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------:|:------------------    |
-| `-h`, `--help`   | Help for the `delete` command         |            |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |            | `INFLUX_HIDE_HEADERS` |
-| `--json`         | Output data as JSON (default `false`) |            | `INFLUX_OUTPUT_JSON`  |
-| `-k`, `--key`    | **(Required)** Secret key             | string     |                       |
-| `-o`, `--org`    | Organization name                     | string     | `INFLUX_ORG`          |
-| `--org-id`       | Organization ID                       | string     | `INFLUX_ORG_ID`       |
+| Flag |                  | Description                           | Input type | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------:|:------------------    |
+| `-h` | `--help`         | Help for the `delete` command         |            |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |            | `INFLUX_HIDE_HEADERS` |
+|      | `--json`         | Output data as JSON (default `false`) |            | `INFLUX_OUTPUT_JSON`  |
+| `-k` | `--key`          | **(Required)** Secret key             | string     |                       |
+| `-o` | `--org`          | Organization name                     | string     | `INFLUX_ORG`          |
+|      | `--org-id`       | Organization ID                       | string     | `INFLUX_ORG_ID`       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/secret/list.md
+++ b/content/v2.0/reference/cli/influx/secret/list.md
@@ -20,12 +20,12 @@ influx secret list [flags]
 `list`, `ls`, `find`
 
 ## Flags
-| Flag             | Description                           | Input type | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------:|:------------------    |
-| `-h`, `--help`   | Help for the `list` command           |            |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |            | `INFLUX_HIDE_HEADERS` |
-| `--json`         | Output data as JSON (default `false`) |            | `INFLUX_OUTPUT_JSON`  |
-| `-o`, `--org`    | Organization name                     | string     | `INFLUX_ORG`          |
-| `--org-id`       | Organization ID                       | string     | `INFLUX_ORG_ID`       |
+| Flag |                  | Description                           | Input type | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------:|:------------------    |
+| `-h` | `--help`         | Help for the `list` command           |            |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |            | `INFLUX_HIDE_HEADERS` |
+|      | `--json`         | Output data as JSON (default `false`) |            | `INFLUX_OUTPUT_JSON`  |
+| `-o` | `--org`          | Organization name                     | string     | `INFLUX_ORG`          |
+|      | `--org-id`       | Organization ID                       | string     | `INFLUX_ORG_ID`       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/secret/update.md
+++ b/content/v2.0/reference/cli/influx/secret/update.md
@@ -26,14 +26,14 @@ influx secret update [flags]
 ```
 
 ## Flags
-| Flag             | Description                           | Input type | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------:|:------------------    |
-| `-h`, `--help`   | Help for the `update` command         |            |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |            | `INFLUX_HIDE_HEADERS` |
-| `--json`         | Output data as JSON (default `false`) |            | `INFLUX_OUTPUT_JSON`  |
-| `-k`, `--key`    | **(Required)** Secret key             | string     |                       |
-| `-o`, `--org`    | Organization name                     | string     | `INFLUX_ORG`          |
-| `--org-id`       | Organization ID                       | string     | `INFLUX_ORG_ID`       |
-| `-v`, `--value`  | Secret value                          | string     |                       |
+| Flag |                  | Description                           | Input type | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------:|:------------------    |
+| `-h` | `--help`         | Help for the `update` command         |            |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |            | `INFLUX_HIDE_HEADERS` |
+|      | `--json`         | Output data as JSON (default `false`) |            | `INFLUX_OUTPUT_JSON`  |
+| `-k` | `--key`          | **(Required)** Secret key             | string     |                       |
+| `-o` | `--org`          | Organization name                     | string     | `INFLUX_ORG`          |
+|      | `--org-id`       | Organization ID                       | string     | `INFLUX_ORG_ID`       |
+| `-v` | `--value`        | Secret value                          | string     |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/setup/_index.md
+++ b/content/v2.0/reference/cli/influx/setup/_index.md
@@ -20,14 +20,14 @@ influx setup [flags]
 ```
 
 ## Flags
-| Flag                | Description                                                    | Data type |
-|:----                |:-----------                                                    |:---------:|
-| `-b`, `--bucket`    | Primary bucket name                                            | string    |
-| `-f`, `--force`     | Skip confirmation prompt                                       |           |
-| `-h`, `--help`      | Help for the `setup` command                                   |           |
-| `-o`, `--org`       | Primary organization name                                      | string    |
-| `-p`, `--password`  | Password for primary user                                      | string    |
-| `-r`, `--retention` | Duration bucket will retain data (0 is infinite, default is 0) | duration  |
-| `-u`, `--username`  | Primary username                                               | string    |
+| Flag |               | Description                                                    | Data type |
+|:---- |:---           |:-----------                                                    |:---------:|
+| `-b` | `--bucket`    | Primary bucket name                                            | string    |
+| `-f` | `--force`     | Skip confirmation prompt                                       |           |
+| `-h` | `--help`      | Help for the `setup` command                                   |           |
+| `-o` | `--org`       | Primary organization name                                      | string    |
+| `-p` | `--password`  | Password for primary user                                      | string    |
+| `-r` | `--retention` | Duration bucket will retain data (0 is infinite, default is 0) | duration  |
+| `-u` | `--username`  | Primary username                                               | string    |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/stacks/_index.md
+++ b/content/v2.0/reference/cli/influx/stacks/_index.md
@@ -29,14 +29,14 @@ influx stacks [command]
 | [remove](/v2.0/reference/cli/influx/stacks/remove/) | Remove a stack     |
 
 ## Flags
-| Flag             | Description                           | Input type      | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------:     |:------------------    |
-| `-h`, `--help`   | Help for the `stacks` command         |                 |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |                 | `INFLUX_HIDE_HEADERS` |
-| `--json`         | Output data as JSON (default `false`) |                 | `INFLUX_OUTPUT_JSON`  |
-| `-o`, `--org`    | Organization name                     | string          | `INFLUX_ORG`          |
-| `--org-id`       | Organization ID                       | string          | `INFLUX_ORG_ID`       |
-| `--stack-id`     | Stack IDs to filter by                | list of strings |                       |
-| `--stack-name`   | Stack names to filter by              | list of strings |                       |
+| Flag |                  | Description                           | Input type      | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------:     |:------------------    |
+| `-h` | `--help`         | Help for the `stacks` command         |                 |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |                 | `INFLUX_HIDE_HEADERS` |
+|      | `--json`         | Output data as JSON (default `false`) |                 | `INFLUX_OUTPUT_JSON`  |
+| `-o` | `--org`          | Organization name                     | string          | `INFLUX_ORG`          |
+|      | `--org-id`       | Organization ID                       | string          | `INFLUX_ORG_ID`       |
+|      | `--stack-id`     | Stack IDs to filter by                | list of strings |                       |
+|      | `--stack-name`   | Stack names to filter by              | list of strings |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/stacks/init.md
+++ b/content/v2.0/reference/cli/influx/stacks/init.md
@@ -19,16 +19,16 @@ influx stacks init [flags]
 ```
 
 ## Flags
-| Flag                        | Description                             | Input type      | {{< cli/mapped >}}    |
-|:----                        |:-----------                             |:----------:     |:------------------    |
-| `-h`, `--help`              | Help for the `init` command             |                 |                       |
-| `--hide-headers`            | Hide table headers (default `false`)    |                 | `INFLUX_HIDE_HEADERS` |
-| `--json`                    | Output data as JSON (default `false`)   |                 | `INFLUX_OUTPUT_JSON`  |
-| `-o`, `--org`               | Organization name                       | string          | `INFLUX_ORG`          |
-| `--org-id`                  | Organization ID                         | string          | `INFLUX_ORG_ID`       |
-| `-d`, `--stack-description` | Stack description                       | string          |                       |
-| `-n`, `--stack-name`        | Stack name                              | string          |                       |
-| `-u`, `--template-url`      | Template URLs to associate with a stack | list of strings |                       |
+| Flag |                       | Description                             | Input type      | {{< cli/mapped >}}    |
+|:---- |:---                   |:-----------                             |:----------:     |:------------------    |
+| `-h` | `--help`              | Help for the `init` command             |                 |                       |
+|      | `--hide-headers`      | Hide table headers (default `false`)    |                 | `INFLUX_HIDE_HEADERS` |
+|      | `--json`              | Output data as JSON (default `false`)   |                 | `INFLUX_OUTPUT_JSON`  |
+| `-o` | `--org`               | Organization name                       | string          | `INFLUX_ORG`          |
+|      | `--org-id`            | Organization ID                         | string          | `INFLUX_ORG_ID`       |
+| `-d` | `--stack-description` | Stack description                       | string          |                       |
+| `-n` | `--stack-name`        | Stack name                              | string          |                       |
+| `-u` | `--template-url`      | Template URLs to associate with a stack | list of strings |                       |
 
 {{% cli/influx-global-flags %}}
 

--- a/content/v2.0/reference/cli/influx/stacks/remove.md
+++ b/content/v2.0/reference/cli/influx/stacks/remove.md
@@ -22,13 +22,13 @@ influx stacks remove [flags]
 `remove`, `rm`, `uninstall`
 
 ## Flags
-| Flag             | Description                           | Input type      | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------:     |:------------------    |
-| `-h`, `--help`   | Help for the `remove` command         |                 |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |                 | `INFLUX_HIDE_HEADERS` |
-| `--json`         | Output data as JSON (default `false`) |                 | `INFLUX_OUTPUT_JSON`  |
-| `-o`, `--org`    | Organization name                     | string          | `INFLUX_ORG`          |
-| `--org-id`       | Organization ID                       | string          | `INFLUX_ORG_ID`       |
-| `--stack-id`     | Stack IDs to remove                   | list of strings |                       |
+| Flag |                  | Description                           | Input type      | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------:     |:------------------    |
+| `-h` | `--help`         | Help for the `remove` command         |                 |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |                 | `INFLUX_HIDE_HEADERS` |
+|      | `--json`         | Output data as JSON (default `false`) |                 | `INFLUX_OUTPUT_JSON`  |
+| `-o` | `--org`          | Organization name                     | string          | `INFLUX_ORG`          |
+|      | `--org-id`       | Organization ID                       | string          | `INFLUX_ORG_ID`       |
+|      | `--stack-id`     | Stack IDs to remove                   | list of strings |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/_index.md
+++ b/content/v2.0/reference/cli/influx/task/_index.md
@@ -28,8 +28,8 @@ influx task [command]
 | [update](/v2.0/reference/cli/influx/task/update) | Update task          |
 
 ### Flags
-| Flag           | Description                 |
-|:----           |:-----------                 |
-| `-h`, `--help` | Help for the `task` command |
+| Flag |          | Description                 |
+|:---- |:---      |:-----------                 |
+| `-h` | `--help` | Help for the `task` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/create.md
+++ b/content/v2.0/reference/cli/influx/task/create.md
@@ -16,14 +16,14 @@ influx task create [query literal] [flags]
 ```
 
 ## Flags
-| Flag             | Description                           | Input type | {{< cli/mapped >}}    |
-|------------------|---------------------------------------|:----------:|-----------------------|
-| `-f`, `--file`   | Path to Flux script file              |   string   |                       |
-| `-h`, `--help`   | Help for the `create` command         |            |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |            | `INFLUX_HIDE_HEADERS` |
-| `--json`         | Output data as JSON (default `false`) |            | `INFLUX_OUTPUT_JSON`  |
-| `--org`          | Organization name                     |   string   | `INFLUX_ORG`          |
-| `--org-id`       | Organization ID                       |   string   | `INFLUX_ORG_ID`       |
+| Flag |                  | Description                           | Input type | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------:|:--------------------- |
+| `-f` | `--file`         | Path to Flux script file              | string     |                       |
+| `-h` | `--help`         | Help for the `create` command         |            |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |            | `INFLUX_HIDE_HEADERS` |
+|      | `--json`         | Output data as JSON (default `false`) |            | `INFLUX_OUTPUT_JSON`  |
+| `-o` | `--org`          | Organization name                     | string     | `INFLUX_ORG`          |
+|      | `--org-id`       | Organization ID                       | string     | `INFLUX_ORG_ID`       |
 
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/delete.md
+++ b/content/v2.0/reference/cli/influx/task/delete.md
@@ -16,11 +16,11 @@ influx task delete [flags]
 ```
 
 ## Flags
-| Flag             | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------: |:------------------    |
-| `-h`, `--help`   | Help for the `delete` command         |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`     | **(Required)** Task ID                | string      |                       |
-| `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `delete` command         |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | **(Required)** Task ID                | string      |                       |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/list.md
+++ b/content/v2.0/reference/cli/influx/task/list.md
@@ -21,15 +21,15 @@ influx task list [flags]
 `list`, `ls`, `find`
 
 ## Flags
-| Flag              | Description                             | Input type  | {{< cli/mapped >}}    |
-|:----              |:-----------                             |:----------: |:------------------    |
-| `-h`, `--help`    | Help for the `list` command             |             |                       |
-| `--hide-headers`  | Hide table headers (default `false`)    |             | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`      | Task ID                                 | string      |                       |
-| `--json`          | Output data as JSON (default `false`)   |             | `INFLUX_OUTPUT_JSON`  |
-| `--limit`         | Number of tasks to find (default `100`) | integer     |                       |
-| `--org`           | Task organization name                  | string      | `INFLUX_ORG`          |
-| `--org-id`        | Task organization ID                    | string      | `INFLUX_ORG_ID`       |
-| `-n`, `--user-id` | Task owner ID                           | string      |                       |
+| Flag |                  | Description                             | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                             |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `list` command             |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)    |             | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | Task ID                                 | string      |                       |
+|      | `--json`         | Output data as JSON (default `false`)   |             | `INFLUX_OUTPUT_JSON`  |
+|      | `--limit`        | Number of tasks to find (default `100`) | integer     |                       |
+| `-o` | `--org`          | Task organization name                  | string      | `INFLUX_ORG`          |
+|      | `--org-id`       | Task organization ID                    | string      | `INFLUX_ORG_ID`       |
+| `-n` | `--user-id`      | Task owner ID                           | string      |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/log/_index.md
+++ b/content/v2.0/reference/cli/influx/task/log/_index.md
@@ -23,8 +23,8 @@ influx task log [command]
 | [list](/v2.0/reference/cli/influx/task/log/list) | List logs for task |
 
 ## Flags
-| Flag           | Description                |
-|:----           |:-----------                |
-| `-h`, `--help` | Help for the `log` command |
+| Flag |          | Description                |
+|:---- |:---      |:-----------                |
+| `-h` | `--help` | Help for the `log` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/log/list.md
+++ b/content/v2.0/reference/cli/influx/task/log/list.md
@@ -21,12 +21,12 @@ influx task log list [flags]
 `list`, `ls`, `find`
 
 ## Flags
-| Flag             | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------: |:------------------    |
-| `-h`, `--help`   | Help for the `list` command           |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `--run-id`       | Run ID                                | string      |                       |
-| `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
-| `--task-id`      | **(Required)** Task ID                | string      |                       |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `list` command           |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+|      | `--run-id`       | Run ID                                | string      |                       |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+|      | `--task-id`      | **(Required)** Task ID                | string      |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/run/_index.md
+++ b/content/v2.0/reference/cli/influx/task/run/_index.md
@@ -25,8 +25,8 @@ influx task run [command]
 | [retry](/v2.0/reference/cli/influx/task/run/retry) | Retry a task         |
 
 ## Flags
-| Flag           | Description                |
-|:----           |:-----------                |
-| `-h`, `--help` | Help for the `run` command |
+| Flag |          | Description                |
+|:---- |:---      |:-----------                |
+| `-h` | `--help` | Help for the `run` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/run/list.md
+++ b/content/v2.0/reference/cli/influx/task/run/list.md
@@ -21,15 +21,15 @@ influx task run list [flags]
 `list`, `ls`, `find`
 
 ## Flags
-| Flag             | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------: |:------------------    |
-| `--after`        | After-time for filtering              | string      |                       |
-| `--before`       | Before-time for filtering             | string      |                       |
-| `-h`,`--help`    | Help for the `list` command           |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
-| `--limit`        | Limit the number of results           | integer     |                       |
-| `--run-id`       | Run ID                                | string      |                       |
-| `--task-id`      | **(Required)** Task ID                | string      |                       |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+|      | `--after`        | After-time for filtering              | string      |                       |
+|      | `--before`       | Before-time for filtering             | string      |                       |
+| `-h` | `--help`         | Help for the `list` command           |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+|      | `--limit`        | Limit the number of results           | integer     |                       |
+|      | `--run-id`       | Run ID                                | string      |                       |
+|      | `--task-id`      | **(Required)** Task ID                | string      |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/run/retry.md
+++ b/content/v2.0/reference/cli/influx/task/run/retry.md
@@ -16,10 +16,10 @@ influx task run retry [flags]
 ```
 
 ## Flags
-| Flag              | Description                  | Input type  |
-|:----              |:-----------                  |:----------: |
-| `-h`, `--help`    | Help for the `retry` command |             |
-| `-r`, `--run-id`  | **(Required)** Run ID        | string      |
-| `-i`, `--task-id` | **(Required)** Task ID       | string      |
+| Flag |             | Description                  | Input type  |
+|:---- |:---         |:-----------                  |:----------: |
+| `-h` | `--help`    | Help for the `retry` command |             |
+| `-r` | `--run-id`  | **(Required)** Run ID        | string      |
+| `-i` | `--task-id` | **(Required)** Task ID       | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/task/update.md
+++ b/content/v2.0/reference/cli/influx/task/update.md
@@ -16,14 +16,14 @@ influx task update [flags]
 ```
 
 ## Flags
-| Flag             | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------: |:------------------    |
-| `-f`, `--file`   | Path to Flux script file              |   string    |                       |
-| `-h`, `--help`   | Help for the `update` command         |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`     | **(Required)** Task ID                | string      |                       |
-| `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
-| `--status`       | Update task status                    | string      |                       |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-f` | `--file`         | Path to Flux script file              | string      |                       |
+| `-h` | `--help`         | Help for the `update` command         |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | **(Required)** Task ID                | string      |                       |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+|      | `--status`       | Update task status                    | string      |                       |
 
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/template/_index.md
+++ b/content/v2.0/reference/cli/influx/template/_index.md
@@ -25,15 +25,15 @@ influx template [command]
 | [validate](/v2.0/reference/cli/influx/template/validate) | Validate a template |
 
 ## Flags
-| Flag                      | Description                                                        | Input Type | {{< cli/mapped >}}   |
-|:----                      |:-----------                                                        |:---------- |:------------------   |
-| `-c`, `--disable-color`   | Disable color in output                                            |            |                      |
-| `--disable-table-borders` | Disable table borders                                              |            |                      |
-| `-e`, `--encoding`        | Encoding of the input stream                                       | string     |                      |
-| `-f`, `--file`            | Template file to summarize                                         | string     |                      |
-| `-h`, `--help`            | Help for the `template` command                                    |            |                      |
-| `--json`                  | Output data as JSON (default `false`)                              |            | `INFLUX_OUTPUT_JSON` |
-| `-R`, `--recurse`         | Recurse through files in the directory specified in `-f`, `--file` |            |                      |
-| `-u`, `--template-url`    | URL of template file to summarize                                  | string     |                      |
+| Flag |                           | Description                                                        | Input Type | {{< cli/mapped >}}   |
+|:---- |:---                       |:-----------                                                        |:---------- |:------------------   |
+| `-c` | `--disable-color`         | Disable color in output                                            |            |                      |
+|      | `--disable-table-borders` | Disable table borders                                              |            |                      |
+| `-e` | `--encoding`              | Encoding of the input stream                                       | string     |                      |
+| `-f` | `--file`                  | Template file to summarize                                         | string     |                      |
+| `-h` | `--help`                  | Help for the `template` command                                    |            |                      |
+|      | `--json`                  | Output data as JSON (default `false`)                              |            | `INFLUX_OUTPUT_JSON` |
+| `-R` | `--recurse`               | Recurse through files in the directory specified in `-f`, `--file` |            |                      |
+| `-u` | `--template-url`          | URL of template file to summarize                                  | string     |                      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/template/validate.md
+++ b/content/v2.0/reference/cli/influx/template/validate.md
@@ -20,7 +20,7 @@ influx template validate [flags]
 ## Flags
 
 | Flag |                  | Description                                                        | Input Type |
-|:---- | ---              |:-----------                                                        |:---------- |
+|:---- |:---              |:-----------                                                        |:---------- |
 | `-e` | `--encoding`     | Encoding of the input stream                                       | string     |
 | `-f` | `--file`         | Template file to validate                                          | string     |
 | `-h` | `--help`         | Help for the `validate` command                                    |            |

--- a/content/v2.0/reference/cli/influx/transpile/_index.md
+++ b/content/v2.0/reference/cli/influx/transpile/_index.md
@@ -20,9 +20,9 @@ influx transpile [InfluxQL query] [flags]
 ```
 
 ## Flags
-| Flag           | Description                                                                |
-|:----           |:-----------                                                                |
-| `-h`, `--help` | Help for the `transpile` command                                           |
-| `--now`        | RFC3339Nano timestamp to use as `now()` time (default is current UTC time) |
+| Flag |          | Description                                                                |
+|:---- |:---      |:-----------                                                                |
+| `-h` | `--help` | Help for the `transpile` command                                           |
+|      | `--now`  | RFC3339Nano timestamp to use as `now()` time (default is current UTC time) |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/_index.md
+++ b/content/v2.0/reference/cli/influx/user/_index.md
@@ -27,8 +27,8 @@ influx user [command]
 | [update](/v2.0/reference/cli/influx/user/update)     | Update a user            |
 
 ## Flags
-| Flag           | Description                 |
-|:----           |:-----------                 |
-| `-h`, `--help` | Help for the `user` command |
+| Flag |          | Description                 |
+|:---- |:---      |:-----------                 |
+| `-h` | `--help` | Help for the `user` command |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/create.md
+++ b/content/v2.0/reference/cli/influx/user/create.md
@@ -16,14 +16,14 @@ influx user create [flags]
 ```
 
 ## Flags
-| Flag               | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----               |:-----------                           |:----------: |:------------------    |
-| `-h`, `--help`     | Help for the `create` command         |             |                       |
-| `--hide-headers`   | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `--json`           | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
-| `-n`, `--name`     | **(Required)** Username               | string      | `INFLUX_NAME`         |
-| `-o`, `--org`      | Organization name                     | string      | `INFLUX_ORG`          |
-| `--org-id`         | Organization ID                       | string      | `INFLUX_ORG_ID`       |
-| `-p`, `--password` | User password                         | string      |                       |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `create` command         |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+| `-n` | `--name`         | **(Required)** Username               | string      | `INFLUX_NAME`         |
+| `-o` | `--org`          | Organization name                     | string      | `INFLUX_ORG`          |
+|      | `--org-id`       | Organization ID                       | string      | `INFLUX_ORG_ID`       |
+| `-p` | `--password`     | User password                         | string      |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/delete.md
+++ b/content/v2.0/reference/cli/influx/user/delete.md
@@ -16,11 +16,11 @@ influx user delete [flags]
 ```
 
 ## Flags
-| Flag             | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------: |:------------------    |
-| `-h`, `--help`   | Help for the `delete` command         |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`     | **(Required)** User ID                | string      |                       |
-| `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `delete` command         |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | **(Required)** User ID                | string      |                       |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/list.md
+++ b/content/v2.0/reference/cli/influx/user/list.md
@@ -21,12 +21,12 @@ influx user list [flags]
 `list`, `ls`, `find`
 
 ## Flags
-| Flag             | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------: |:------------------    |
-| `-h`, `--help`   | Help for the `list` command           |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`     | User ID                               | string      |                       |
-| `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
-| `-n`, `--name`   | Username                              | string      |                       |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `list` command           |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | User ID                               | string      |                       |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+| `-n` | `--name`         | Username                              | string      |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/password.md
+++ b/content/v2.0/reference/cli/influx/user/password.md
@@ -18,10 +18,10 @@ influx user password [flags]
 ```
 
 ## Flags
-| Flag           | Description                     | Input type  |
-|:----           |:-----------                     |:----------: |
-| `-h`, `--help` | Help for the `password` command |             |
-| `-i`, `--id`   | User ID                         | string      |
-| `-n`, `--name` | Username                        | string      |
+| Flag |          | Description                     | Input type  |
+|:---- |:---      |:-----------                     |:----------: |
+| `-h` | `--help` | Help for the `password` command |             |
+| `-i` | `--id`   | User ID                         | string      |
+| `-n` | `--name` | Username                        | string      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/user/update.md
+++ b/content/v2.0/reference/cli/influx/user/update.md
@@ -17,12 +17,12 @@ influx user update [flags]
 ```
 
 ## Flags
-| Flag             | Description                           | Input type  | {{< cli/mapped >}}    |
-|:----             |:-----------                           |:----------: |:------------------    |
-| `-h`, `--help`   | Help for the `update` command         |             |                       |
-| `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
-| `-i`, `--id`     | **(Required)** User ID                | string      |                       |
-| `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
-| `-n`, `--name`   | Username                              | string      |                       |
+| Flag |                  | Description                           | Input type  | {{< cli/mapped >}}    |
+|:---- |:---              |:-----------                           |:----------: |:------------------    |
+| `-h` | `--help`         | Help for the `update` command         |             |                       |
+|      | `--hide-headers` | Hide table headers (default `false`)  |             | `INFLUX_HIDE_HEADERS` |
+| `-i` | `--id`           | **(Required)** User ID                | string      |                       |
+|      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
+| `-n` | `--name`         | Username                              | string      |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/write/_index.md
+++ b/content/v2.0/reference/cli/influx/write/_index.md
@@ -30,21 +30,21 @@ influx write [command]
 | [dryrun](/v2.0/reference/cli/influx/write/dryrun) | Write to stdout instead of InfluxDB |
 
 ## Flags
-| Flag                | Description                                          | Input type | {{< cli/mapped >}}   |
-|:----                |:-----------                                          |:----------:|:------------------   |
-| `-b`, `--bucket`    | Bucket name                                          | string     | `INFLUX_BUCKET_NAME` |
-| `--bucket-id`       | Bucket ID                                            | string     | `INFLUX_BUCKET_ID`   |
-| `--debug`           | Output errors to stderr                              |            |                      |
-| `--encoding`        | Character encoding of input (default `UTF-8`)        | string     |                      |
-| `-f`, `--file`      | File to import                                       | string     |                      |
-| `--format`          | Input format (`lp` or `csv`, default `lp`)           | string     |                      |
-| `--header`          | Prepend header line to CSV input data                | string     |                      |
-| `-h`, `--help`      | Help for the `dryrun` command                        |            |                      |
-| `-o`, `--org`       | Organization name                                    | string     | `INFLUX_ORG`         |
-| `--org-id`          | Organization ID                                      | string     | `INFLUX_ORG_ID`      |
-| `-p`, `--precision` | Precision of the timestamps (default `ns`)           | string     | `INFLUX_PRECISION`   |
-| `--skipHeader`      | Skip first n rows of input data                      | integer    |                      |
-| `--skipRowOnError`  | Output CSV errors to stderr, but continue processing |            |                      |
-| `-u`, `--url`       | URL to import data from                              | string     |                      |
+| Flag |                    | Description                                          | Input type | {{< cli/mapped >}}   |
+|:---- |:---                |:-----------                                          |:----------:|:------------------   |
+| `-b` | `--bucket`         | Bucket name                                          | string     | `INFLUX_BUCKET_NAME` |
+|      | `--bucket-id`      | Bucket ID                                            | string     | `INFLUX_BUCKET_ID`   |
+|      | `--debug`          | Output errors to stderr                              |            |                      |
+|      | `--encoding`       | Character encoding of input (default `UTF-8`)        | string     |                      |
+| `-f` | `--file`           | File to import                                       | string     |                      |
+|      | `--format`         | Input format (`lp` or `csv`, default `lp`)           | string     |                      |
+|      | `--header`         | Prepend header line to CSV input data                | string     |                      |
+| `-h` | `--help`           | Help for the `dryrun` command                        |            |                      |
+| `-o` | `--org`            | Organization name                                    | string     | `INFLUX_ORG`         |
+|      | `--org-id`         | Organization ID                                      | string     | `INFLUX_ORG_ID`      |
+| `-p` | `--precision`      | Precision of the timestamps (default `ns`)           | string     | `INFLUX_PRECISION`   |
+|      | `--skipHeader`     | Skip first n rows of input data                      | integer    |                      |
+|      | `--skipRowOnError` | Output CSV errors to stderr, but continue processing |            |                      |
+| `-u` | `--url`            | URL to import data from                              | string     |                      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/write/dryrun.md
+++ b/content/v2.0/reference/cli/influx/write/dryrun.md
@@ -24,21 +24,21 @@ influx write dryrun [flags]
 ```
 
 ## Flags
-| Flag                | Description                                          | Input type | {{< cli/mapped >}}   |
-|:----                |:-----------                                          |:----------:|:------------------   |
-| `-b`, `--bucket`    | Bucket name                                          | string     | `INFLUX_BUCKET_NAME` |
-| `--bucket-id`       | Bucket ID                                            | string     | `INFLUX_BUCKET_ID`   |
-| `--debug`           | Output errors to stderr                              |            |                      |
-| `--encoding`        | Character encoding of input (default `UTF-8`)        | string     |                      |
-| `-f`, `--file`      | File to import                                       | string     |                      |
-| `--format`          | Input format (`lp` or `csv`, default `lp`)           | string     |                      |
-| `--header`          | Prepend header line to CSV input data                | string     |                      |
-| `-h`, `--help`      | Help for the `dryrun` command                        |            |                      |
-| `-o`, `--org`       | Organization name                                    | string     | `INFLUX_ORG`         |
-| `--org-id`          | Organization ID                                      | string     | `INFLUX_ORG_ID`      |
-| `-p`, `--precision` | Precision of the timestamps (default `ns`)           | string     | `INFLUX_PRECISION`   |
-| `--skipHeader`      | Skip first n rows of input data                      | integer    |                      |
-| `--skipRowOnError`  | Output CSV errors to stderr, but continue processing |            |                      |
-| `-u`, `--url`       | URL to import data from                              | string     |                      |
+| Flag |                    | Description                                          | Input type | {{< cli/mapped >}}   |
+|:---- |:---                |:-----------                                          |:----------:|:------------------   |
+| `-b` | `--bucket`         | Bucket name                                          | string     | `INFLUX_BUCKET_NAME` |
+|      | `--bucket-id`      | Bucket ID                                            | string     | `INFLUX_BUCKET_ID`   |
+|      | `--debug`          | Output errors to stderr                              |            |                      |
+|      | `--encoding`       | Character encoding of input (default `UTF-8`)        | string     |                      |
+| `-f` | `--file`           | File to import                                       | string     |                      |
+|      | `--format`         | Input format (`lp` or `csv`, default `lp`)           | string     |                      |
+|      | `--header`         | Prepend header line to CSV input data                | string     |                      |
+| `-h` | `--help`           | Help for the `dryrun` command                        |            |                      |
+| `-o` | `--org`            | Organization name                                    | string     | `INFLUX_ORG`         |
+|      | `--org-id`         | Organization ID                                      | string     | `INFLUX_ORG_ID`      |
+| `-p` | `--precision`      | Precision of the timestamps (default `ns`)           | string     | `INFLUX_PRECISION`   |
+|      | `--skipHeader`     | Skip first n rows of input data                      | integer    |                      |
+|      | `--skipRowOnError` | Output CSV errors to stderr, but continue processing |            |                      |
+| `-u` | `--url`            | URL to import data from                              | string     |                      |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influxd/generate/_index.md
+++ b/content/v2.0/reference/cli/influxd/generate/_index.md
@@ -34,14 +34,14 @@ influxd generate [subcommand]
 | [simple](/v2.0/reference/cli/influxd/generate/simple)           | Generate simple data sets using defaults and CLI flags. |
 
 ## Flags
-| Flag           | Description                                                               | Input Type |
-|:----           |:-----------                                                               |:----------:|
-| `--print`      | Print data spec and exit                                                  |            |
-| `--org`        | Organiztion name                                                          | string     |
-| `--bucket`     | Bucket Name                                                               | string     |
-| `--start-time` | Start time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of one week ago) | string     |
-| `--end-time`   | End time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of current day)    | string     |
-| `--clean`      | Clean time series data files (`none`, `tsm` or `all`) (default `none`)    | string     |
-| `--cpuprofile` | Collect a CPU profile                                                     | string     |
-| `--memprofile` | Collect a memory profile                                                  | string     |
-| `-h`, `--help` | Help for the `generate` command                                           |            |
+| Flag |                | Description                                                               | Input Type |
+|:---- |:---            |:-----------                                                               |:----------:|
+|      | `--print`      | Print data spec and exit                                                  |            |
+|      | `--org`        | Organiztion name                                                          | string     |
+|      | `--bucket`     | Bucket Name                                                               | string     |
+|      | `--start-time` | Start time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of one week ago) | string     |
+|      | `--end-time`   | End time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of current day)    | string     |
+|      | `--clean`      | Clean time series data files (`none`, `tsm` or `all`) (default `none`)    | string     |
+|      | `--cpuprofile` | Collect a CPU profile                                                     | string     |
+|      | `--memprofile` | Collect a memory profile                                                  | string     |
+| `-h` | `--help`       | Help for the `generate` command                                           |            |

--- a/content/v2.0/reference/cli/influxd/generate/help-schema.md
+++ b/content/v2.0/reference/cli/influxd/generate/help-schema.md
@@ -22,17 +22,17 @@ influxd generate help-schema [flags]
 ```
 
 ## Flags
-| Flag           | Description                                                               | Input Type |
-|:----           |:-----------                                                               |:----------:|
-| `--print`      | Print data spec and exit                                                  |            |
-| `--org`        | Organization name                                                         | string     |
-| `--bucket`     | Bucket name                                                               | string     |
-| `--start-time` | Start time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of one week ago) | string     |
-| `--end-time`   | End time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of current day)    | string     |
-| `--clean`      | Clean time series data files (`none`, `tsm` or `all`) (default `none`)    | string     |
-| `--cpuprofile` | Collect a CPU profile                                                     | string     |
-| `--memprofile` | Collect a memory profile                                                  | string     |
-| `-h`, `--help` | Help for the `help-schema` command                                        |            |
+| Flag |                | Description                                                               | Input Type |
+|:---- |:---            |:-----------                                                               |:----------:|
+|      | `--print`      | Print data spec and exit                                                  |            |
+|      | `--org`        | Organization name                                                         | string     |
+|      | `--bucket`     | Bucket name                                                               | string     |
+|      | `--start-time` | Start time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of one week ago) | string     |
+|      | `--end-time`   | End time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of current day)    | string     |
+|      | `--clean`      | Clean time series data files (`none`, `tsm` or `all`) (default `none`)    | string     |
+|      | `--cpuprofile` | Collect a CPU profile                                                     | string     |
+|      | `--memprofile` | Collect a memory profile                                                  | string     |
+| `-h` | `--help`       | Help for the `help-schema` command                                        |            |
 
 ## Example output
 {{% truncate %}}

--- a/content/v2.0/reference/cli/influxd/generate/simple.md
+++ b/content/v2.0/reference/cli/influxd/generate/simple.md
@@ -28,14 +28,14 @@ influxd generate simple [flags]
 ```
 
 ## Flags
-| Flag           | Description                                                               | Input Type |
-|:----           |:-----------                                                               |:----------:|
-| `--print`      | Print data spec and exit                                                  |            |
-| `--org`        | Organization name                                                         | string     |
-| `--bucket`     | Bucket name                                                               | string     |
-| `--start-time` | Start time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of one week ago) | string     |
-| `--end-time`   | End time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of current day)    | string     |
-| `--clean`      | Clean time series data files (`none`, `tsm` or `all`) (default `none`)    | string     |
-| `--cpuprofile` | Collect a CPU profile                                                     | string     |
-| `--memprofile` | Collect a memory profile                                                  | string     |
-| `-h`, `--help` | Help for the `simple` command                                             |            |
+| Flag |                | Description                                                               | Input Type |
+|:---- |:---            |:-----------                                                               |:----------:|
+|      | `--print`      | Print data spec and exit                                                  |            |
+|      | `--org`        | Organization name                                                         | string     |
+|      | `--bucket`     | Bucket name                                                               | string     |
+|      | `--start-time` | Start time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of one week ago) | string     |
+|      | `--end-time`   | End time (`YYYY-MM-DDT00:00:00Z`) (default is 00:00:00 of current day)    | string     |
+|      | `--clean`      | Clean time series data files (`none`, `tsm` or `all`) (default `none`)    | string     |
+|      | `--cpuprofile` | Collect a CPU profile                                                     | string     |
+|      | `--memprofile` | Collect a memory profile                                                  | string     |
+| `-h` | `--help`       | Help for the `simple` command                                             |            |

--- a/content/v2.0/reference/cli/influxd/inspect/_index.md
+++ b/content/v2.0/reference/cli/influxd/inspect/_index.md
@@ -32,6 +32,6 @@ influxd inspect [subcommand]
 | [verify-wal](/v2.0/reference/cli/influxd/inspect/verify-wal/)                  | Check for corrupt WAL files           |
 
 ## Flags
-| Flag           | Description                    |
-|:----           |:-----------                    |
-| `-h`, `--help` | Help for the `inspect` command |
+| Flag |          | Description                    |
+|:---- |:---      |:-----------                    |
+| `-h` | `--help` | Help for the `inspect` command |

--- a/content/v2.0/reference/cli/influxd/inspect/build-tsi.md
+++ b/content/v2.0/reference/cli/influxd/inspect/build-tsi.md
@@ -45,15 +45,15 @@ Altering the batch size can improve performance but may result in significantly
 higher memory usage.
 
 ## Flags
-| Flag                  | Description                                                                                     | Input Type |
-|:----                  |:-----------                                                                                     |:----------:|
-| `--batch-size`        | The size of the batches to write to the index. Defaults to `10000`. [See above](#batch-size).   | integer    |
-| `--concurrency`       | Number of workers to dedicate to shard index building. Defaults to `GOMAXPROCS` (8 by default). | integer    |
-| `-h`, `--help`        | Help for the `build-tsi` command.                                                               |            |
-| `--max-cache-size`    | Maximum cache size. Defaults to `1073741824`. [See above](#max-cache-size).                     | uinteger   |
-| `--max-log-file-size` | Maximum log file size. Defaults to `1048576`. [See above](#max-log-file-size) .                 | integer    |
-| `--sfile-path`        | Path to the series file directory. Defaults to `~/.influxdbv2/engine/_series`.                  | string     |
-| `--tsi-path`          | Path to the TSI index directory. Defaults to `~/.influxdbv2/engine/index`.                      | string     |
-| `--tsm-path`          | Path to the TSM data directory. Defaults to `~/.influxdbv2/engine/data`.                        | string     |
-| `-v`, `--verbose`     | Enable verbose output.                                                                          |            |
-| `--wal-path`          | Path to the WAL data directory. Defaults to `~/.influxdbv2/engine/wal`.                         | string     |
+| Flag |                       | Description                                                                                     | Input Type |
+|:---- |:---                   |:-----------                                                                                     |:----------:|
+|      | `--batch-size`        | The size of the batches to write to the index. Defaults to `10000`. [See above](#batch-size).   | integer    |
+|      | `--concurrency`       | Number of workers to dedicate to shard index building. Defaults to `GOMAXPROCS` (8 by default). | integer    |
+| `-h` | `--help`              | Help for the `build-tsi` command.                                                               |            |
+|      | `--max-cache-size`    | Maximum cache size. Defaults to `1073741824`. [See above](#max-cache-size).                     | uinteger   |
+|      | `--max-log-file-size` | Maximum log file size. Defaults to `1048576`. [See above](#max-log-file-size) .                 | integer    |
+|      | `--sfile-path`        | Path to the series file directory. Defaults to `~/.influxdbv2/engine/_series`.                  | string     |
+|      | `--tsi-path`          | Path to the TSI index directory. Defaults to `~/.influxdbv2/engine/index`.                      | string     |
+|      | `--tsm-path`          | Path to the TSM data directory. Defaults to `~/.influxdbv2/engine/data`.                        | string     |
+| `-v` | `--verbose`           | Enable verbose output.                                                                          |            |
+|      | `--wal-path`          | Path to the WAL data directory. Defaults to `~/.influxdbv2/engine/wal`.                         | string     |

--- a/content/v2.0/reference/cli/influxd/inspect/compact-series-file.md
+++ b/content/v2.0/reference/cli/influxd/inspect/compact-series-file.md
@@ -20,9 +20,9 @@ influxd inspect compact-series-file [flags]
 ```
 
 ## Flags
-| Flag            | Description                                                                   | Input Type |
-|:----            |:-----------                                                                   |:----------:|
-| `--concurrency` | Number of workers to dedicate to compaction (default = `GOMAXPROCS`, max `8`) | integer    |
-| `-h`, `--help`  | Help for the `compact-series-file` command                                    |            |
-| `--sfile-path`  | Path to the series file directory (default: `~/.influxdbv2/engine/_series`)   | string     |
-| `--tsi-path`    | Path to the TSI index directory (default: `~/.influxdbv2/engine/index`)       | string     |
+| Flag |                | Description                                                                   | Input Type |
+|:---- |:---            |:-----------                                                                   |:----------:|
+|      |`--concurrency` | Number of workers to dedicate to compaction (default = `GOMAXPROCS`, max `8`) | integer    |
+| `-h` | `--help`       | Help for the `compact-series-file` command                                    |            |
+|      | `--sfile-path` | Path to the series file directory (default: `~/.influxdbv2/engine/_series`)   | string     |
+|      | `--tsi-path`   | Path to the TSI index directory (default: `~/.influxdbv2/engine/index`)       | string     |

--- a/content/v2.0/reference/cli/influxd/inspect/dump-tsi.md
+++ b/content/v2.0/reference/cli/influxd/inspect/dump-tsi.md
@@ -19,16 +19,16 @@ influxd inspect dump-tsi [flags]
 ```
 
 ## Flags
-| Flag                   | Description                                                                     | Input Type |
-|:----                   |:-----------                                                                     |:----------:|
-| `-h`, `--help`         | Help for the `dump-tsi` command.                                                |            |
-| `--index-path`         | Path to data engine index directory (defaults to `~/.influxdbv2/engine/index`). | string     |
-| `--measurement-filter` | Regular expression measurement filter.                                          | string     |
-| `--measurements`       | Show raw measurement data.                                                      |            |
-| `--series`             | Show raw series data.                                                           |            |
-| `--series-path`        | Path to series file (defaults to `~/.influxdbv2/engine/_series`).               | string     |
-| `--tag-key-filter`     | Regular expression tag key filter.                                              | string     |
-| `--tag-keys`           | Show raw tag key data.                                                          |            |
-| `--tag-value-filter`   | Regular expression tag value filter.                                            | string     |
-| `--tag-value-series`   | Show raw series data for each value.                                            |            |
-| `--tag-values`         | Show raw tag value data.                                                        |            |
+| Flag |                        | Description                                                                     | Input Type |
+|:---- |:---                    |:-----------                                                                     |:----------:|
+| `-h` | `--help`               | Help for the `dump-tsi` command.                                                |            |
+|      | `--index-path`         | Path to data engine index directory (defaults to `~/.influxdbv2/engine/index`). | string     |
+|      | `--measurement-filter` | Regular expression measurement filter.                                          | string     |
+|      | `--measurements`       | Show raw measurement data.                                                      |            |
+|      | `--series`             | Show raw series data.                                                           |            |
+|      | `--series-path`        | Path to series file (defaults to `~/.influxdbv2/engine/_series`).               | string     |
+|      | `--tag-key-filter`     | Regular expression tag key filter.                                              | string     |
+|      | `--tag-keys`           | Show raw tag key data.                                                          |            |
+|      | `--tag-value-filter`   | Regular expression tag value filter.                                            | string     |
+|      | `--tag-value-series`   | Show raw series data for each value.                                            |            |
+|      | `--tag-values`         | Show raw tag value data.                                                        |            |

--- a/content/v2.0/reference/cli/influxd/inspect/dumpwal.md
+++ b/content/v2.0/reference/cli/influxd/inspect/dumpwal.md
@@ -63,7 +63,7 @@ foo/**/baz
 ```
 
 ## Flags
-| Flag                | Description                                                                |
-|:----                |:-----------                                                                |
-| `--find-duplicates` | Ignore dumping entries; only report keys in the WAL that are out of order. |
-| `-h`, `--help`      | Help for the `dumpwal` cinnabd.                                            |
+| Flag |                     | Description                                                                |
+|:---- |:---                 |:-----------                                                                |
+|      | `--find-duplicates` | Ignore dumping entries; only report keys in the WAL that are out of order. |
+| `-h` | `--help`            | Help for the `dumpwal` cinnabd.                                            |

--- a/content/v2.0/reference/cli/influxd/inspect/export-blocks.md
+++ b/content/v2.0/reference/cli/influxd/inspect/export-blocks.md
@@ -20,6 +20,6 @@ influxd inspect export-blocks [flags]
 ```
 
 ## Flags
-| Flag           | Description                           |
-|:----           |:-----------                           |
-| `-h`, `--help` | Help for the `export-blocks` command. |
+| Flag |          | Description                           |
+|:---- |:---      |:-----------                           |
+| `-h` | `--help` | Help for the `export-blocks` command. |

--- a/content/v2.0/reference/cli/influxd/inspect/export-index.md
+++ b/content/v2.0/reference/cli/influxd/inspect/export-index.md
@@ -20,8 +20,8 @@ influxd inspect export-index [flags]
 ```
 
 ## Flags
-| Flag            | Description                                                             | Input type |
-|:----            |:-----------                                                             |:----------:|
-| `-h`, `--help`  | Help for the `export-index` command.                                    |            |
-| `--index-path`  | Path to the index directory. Defaults to `~/.influxdbv2/engine/index`). | string     |
-| `--series-path` | Path to series file. Defaults to `~/.influxdbv2/engine/_series`).       | string     |
+| Flag |                | Description                                                             | Input type |
+|:---- |:---            |:-----------                                                             |:----------:|
+| `-h` | `--help`       | Help for the `export-index` command.                                    |            |
+|      |`--index-path`  | Path to the index directory. Defaults to `~/.influxdbv2/engine/index`). | string     |
+|      |`--series-path` | Path to series file. Defaults to `~/.influxdbv2/engine/_series`).       | string     |

--- a/content/v2.0/reference/cli/influxd/inspect/report-tsi.md
+++ b/content/v2.0/reference/cli/influxd/inspect/report-tsi.md
@@ -34,12 +34,12 @@ influxd inspect report-tsi [flags]
 ```
 
 ## Flags
-| Flag                   | Description                                                               | Input Type |
-|:----                   |:-----------                                                               |:----------:|
-| `--bucket-id`          | Process data for specified bucket ID. _Requires `org-id` flag to be set._ | string     |
-| `-h`, `--help`         | View Help for the `report-tsi` command.                                   |            |
-| `-m`, `--measurements` | Group cardinality by measurements.                                        |            |
-| `-o`, `--org-id`       | Process data for specified organization ID.                               | string     |
-| `--path`               | Specify path to index. Defaults to `~/.influxdbv2/engine/index`.          | string     |
-| `--series-file`        | Specify path to series file. Defaults to `~/.influxdbv2/engine/_series`.  | string     |
-| `-t`, `-top`           | Limit results to the top n.                                               | integer    |
+| Flag |                  | Description                                                               | Input Type |
+|:---- |:---              |:-----------                                                               |:----------:|
+|      | `--bucket-id`    | Process data for specified bucket ID. _Requires `org-id` flag to be set._ | string     |
+| `-h` | `--help`         | View Help for the `report-tsi` command.                                   |            |
+| `-m` | `--measurements` | Group cardinality by measurements.                                        |            |
+| `-o` | `--org-id`       | Process data for specified organization ID.                               | string     |
+|      | `--path`         | Specify path to index. Defaults to `~/.influxdbv2/engine/index`.          | string     |
+|      | `--series-file`  | Specify path to series file. Defaults to `~/.influxdbv2/engine/_series`.  | string     |
+| `-t` | `-top`           | Limit results to the top n.                                               | integer    |

--- a/content/v2.0/reference/cli/influxd/inspect/report-tsm.md
+++ b/content/v2.0/reference/cli/influxd/inspect/report-tsm.md
@@ -47,12 +47,12 @@ in the following ways:
 - Number of tag values for each tag key.
 
 ## Flags
-| Flag           | Description                                                                                      | Input Type |
-|:----           |:-----------                                                                                      |:----------:|
-| `--bucket-id`  | Process only data belonging to bucket ID. _Requires `org-id` flag to be set._                    | string     |
-| `--data-dir`   | Use provided data directory (defaults to `~/.influxdbv2/engine/data`).                           | string     |
-| `--detailed`   | Emit series cardinality segmented by measurements, tag keys, and fields. _**May take a while**_. |            |
-| `--exact`      | Calculate an exact cardinality count. _**May use significant memory**_.                          |            |
-| `-h`, `--help` | Help for the `report-tsm` command.                                                               |            |
-| `--org-id`     | Process only data belonging to organization ID.                                                  | string     |
-| `--pattern`    | Only process TSM files containing pattern.                                                       | string     |
+| Flag |               | Description                                                                                      | Input Type |
+|:---- |:---           |:-----------                                                                                      |:----------:|
+|      | `--bucket-id` | Process only data belonging to bucket ID. _Requires `org-id` flag to be set._                    | string     |
+|      | `--data-dir`  | Use provided data directory (defaults to `~/.influxdbv2/engine/data`).                           | string     |
+|      | `--detailed`  | Emit series cardinality segmented by measurements, tag keys, and fields. _**May take a while**_. |            |
+|      | `--exact`     | Calculate an exact cardinality count. _**May use significant memory**_.                          |            |
+| `-h` | `--help`      | Help for the `report-tsm` command.                                                               |            |
+|      | `--org-id`    | Process only data belonging to organization ID.                                                  | string     |
+|      | `--pattern`   | Only process TSM files containing pattern.                                                       | string     |

--- a/content/v2.0/reference/cli/influxd/inspect/verify-seriesfile.md
+++ b/content/v2.0/reference/cli/influxd/inspect/verify-seriesfile.md
@@ -18,9 +18,9 @@ influxd inspect verify-seriesfile [flags]
 ```
 
 ## Flags
-| Flag              | Description                                                       | Input Type |
-|:----              |:-----------                                                       |:----------:|
-| `-c`, `--c`       | Number of workers to run concurrently (defaults to 8).            | integer    |
-| `-h`, `--help`    | Help for the `verify-seriesfile` command.                         |            |
-| `--series-file`   | Path to series file (defaults to `~/.influxdbv2/engine/_series`). | string     |
-| `-v`, `--verbose` | Enable verbose output.                                            |            |
+| Flag |                | Description                                                       | Input Type |
+|:---- |:---            |:-----------                                                       |:----------:|
+| `-c` | `--c`          | Number of workers to run concurrently (defaults to 8).            | integer    |
+| `-h` | `--help`       | Help for the `verify-seriesfile` command.                         |            |
+|      |`--series-file` | Path to series file (defaults to `~/.influxdbv2/engine/_series`). | string     |
+| `-v` | `--verbose`    | Enable verbose output.                                            |            |

--- a/content/v2.0/reference/cli/influxd/inspect/verify-tsm.md
+++ b/content/v2.0/reference/cli/influxd/inspect/verify-tsm.md
@@ -28,8 +28,8 @@ influxd inspect verify-tsm <pathspec>... [flags]
 A list of files or directories in which to search for TSM files.
 
 ## Flags
-| Flag           | Description                                               | Input Type |
-|:----           |:-----------                                               |:----------:|
-| `--bucket-id`  | Limit analysis to a specific bucket ID. _Optional._       | string     |
-| `-h`, `--help` | Help for the `verify-tsm` command.                        |            |
-| `--org-id`     | Limit analysis to a specific organization ID. _Optional._ | string     |
+| Flag |               | Description                                               | Input Type |
+|:---- |:---           |:-----------                                               |:----------:|
+|      | `--bucket-id` | Limit analysis to a specific bucket ID. _Optional._       | string     |
+| `-h` | `--help`      | Help for the `verify-tsm` command.                        |            |
+|      | `--org-id`    | Limit analysis to a specific organization ID. _Optional._ | string     |

--- a/content/v2.0/reference/cli/influxd/inspect/verify-wal.md
+++ b/content/v2.0/reference/cli/influxd/inspect/verify-wal.md
@@ -34,7 +34,7 @@ After the verification is complete, it returns a summary with:
 - A list of files found to be corrupt.
 
 ## Flags
-| Flag           | Description                                                      | Input Type |
-|:----           |:-----------                                                      |:----------:|
-| `--data-dir`   | The data directory to scan (default `~/.influxdbv2/engine/wal`). | string     |
-| `-h`, `--help` | Help for the `verify-wal` command.                               |            |
+| Flag |              | Description                                                      | Input Type |
+|:---- |:---          |:-----------                                                      |:----------:|
+|      | `--data-dir` | The data directory to scan (default `~/.influxdbv2/engine/wal`). | string     |
+| `-h` | `--help`     | Help for the `verify-wal` command.                               |            |

--- a/content/v2.0/reference/cli/influxd/restore.md
+++ b/content/v2.0/reference/cli/influxd/restore.md
@@ -39,11 +39,11 @@ influxd restore [flags]
 
 ## Flags
 
-| Flag                 | Description                                                                            | Input type |
-|:----                 |:-----------                                                                            |:----------:|
-| `--bolt-path`        | Path to target boltdb database (default is `~/.influxdbv2/influxd.bolt`)               | string     |
-| `--engine-path`      | Path to target persistent engine files (default is `~/.influxdbv2/engine`)             | string     |
-| `--credentials-path` | Path to target persistent credentials files (default is `~/.influxdbv2/credentials`)   | string     |
-| `--backup-path`      | Path to backup files                                                                   | string     |
-| `--rebuild-index`    | Rebuild the TSI index and series file based on the `--engine-path` (default is `true`) |            |
-| `-h`, `--help`       | Help for the `restore` command                                                         |            |
+| Flag |                      | Description                                                                            | Input type |
+|:---- |:---                  |:-----------                                                                            |:----------:|
+|      | `--bolt-path`        | Path to target boltdb database (default is `~/.influxdbv2/influxd.bolt`)               | string     |
+|      | `--engine-path`      | Path to target persistent engine files (default is `~/.influxdbv2/engine`)             | string     |
+|      | `--credentials-path` | Path to target persistent credentials files (default is `~/.influxdbv2/credentials`)   | string     |
+|      | `--backup-path`      | Path to backup files                                                                   | string     |
+|      | `--rebuild-index`    | Rebuild the TSI index and series file based on the `--engine-path` (default is `true`) |            |
+| `-h` | `--help`             | Help for the `restore` command                                                         |            |

--- a/content/v2.0/reference/cli/influxd/version.md
+++ b/content/v2.0/reference/cli/influxd/version.md
@@ -19,6 +19,6 @@ influxd version [flags]
 
 ## Flags
 
-| Flag           | Description                    |
-|:----           |:-----------                    |
-| `-h`, `--help` | Help for the `version` command |
+| Flag |          | Description                    |
+|:---- |:---      |:-----------                    |
+| `-h` | `--help` | Help for the `version` command |

--- a/layouts/shortcodes/cli/influx-global-flags.md
+++ b/layouts/shortcodes/cli/influx-global-flags.md
@@ -3,9 +3,9 @@
 
 ## Global Flags
 
-| Flag            | Description                                                                                 | Input type | Maps to <a class ="q-link" href ="{{ $link }}">?</a> |
-|:----------------|:--------------------------------------------------------------------------------------------|:----------:|:---------------------------------------------------- |
-| `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`)                                  | string     | `INFLUX_HOST`                                        |
-| `--local`       | Run commands against the local filesystem                                                   |            |                                                      |
-| `--skip-verify` | Skip certificate verification (use when connecting over TLS with a self-signed certificate) |            |                                                      |
-| `-t`, `--token` | API token to use in client calls                                                            | string     | `INFLUX_TOKEN`                                       |
+| Flag |                 | Description                                                                                 | Input type | Maps to <a class ="q-link" href ="{{ $link }}">?</a> |
+|:---- |:---             |:-----------                                                                                 |:----------:|:---------------------------------------------------- |
+|      | `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`)                                  | string     | `INFLUX_HOST`                                        |
+|      | `--local`       | Run commands against the local filesystem                                                   |            |                                                      |
+|      | `--skip-verify` | Skip certificate verification (use when connecting over TLS with a self-signed certificate) |            |                                                      |
+| `-t` | `--token`       | API token to use in client calls                                                            | string     | `INFLUX_TOKEN`                                       |

--- a/layouts/shortcodes/cli/influxd-flags.md
+++ b/layouts/shortcodes/cli/influxd-flags.md
@@ -1,35 +1,35 @@
-| Flag                           | Description                                                                                                       | Input type |
-|:----                           |:-----------                                                                                                       | :--------: |
-| `--assets-path`                | Override default assets by serving from a specific directory (developer mode)                                     | string     |
-| `--bolt-path`                  | Path to boltdb database (default `~/.influxdbv2/influxd.bolt`)                                                    | string     |
-| `--e2e-testing`                | Add /debug/flush endpoint to clear stores; used for end-to-end tests (default `false`)                            |            |
-| `--engine-path`                | Path to persistent engine files (default `~/.influxdbv2/engine`)                                                  | string     |
-| `-h`, `--help`                 | Help for the `influxd` command                                                                                    |            |
-| `--http-bind-address`          | Bind address for the REST HTTP API (default `:9999`)                                                              | string     |
-| `--log-level`                  | Supported log levels are debug, info, and error (default `info`)                                                  | string     |
-| `--new-meta-store`             | Enables the new meta store                                                                                        |            |
-| `--new-meta-store-read-only`   | Toggle read-only mode for the new meta store and duplicate reads between old and new store (default `true`)       |            |
-| `--no-tasks`                   | Disables the task scheduler                                                                                       |            |
-| `--query-concurrency`          | Number of queries allowed to execute concurrently (default `10`)                                                  | integer    |
-| `--query-initial-memory-bytes` | Initial bytes of memory allocated for a query (default = `query-memory-bytes`)                                    | integer    |
-| `--query-max-memory-bytes`     | Maximum total bytes of memory allowed for queries (default = `query-concurrency` × `query-memory-bytes`)          | integer    |
-| `--query-memory-bytes`         | Maximum bytes of memory allowed for a single query (default _unlimited_, must be >= `query-initial-memory-bytes`) | integer    |
-| `--query-queue-size`           | Maximum number of queries allowed in execution queue (default `10`)                                               | integer    |
-| `--reporting-disabled`         | Disable sending telemetry data to **https:<nolink>//telemetry.influxdata.com**                                    |            |
-| `--secret-store`               | Data store for secrets (bolt or vault) (default `bolt`)                                                           | string     |
-| `--session-length`             | TTL in minutes for newly created sessions (default `60`)                                                          | integer    |
-| `--session-renew-disabled`     | Disables automatically extending session TTL on request                                                           |            |
-| `--store`                      | Data store for REST resources (bolt or memory) (default `bolt`)                                                   | string     |
-| `--tls-cert`                   | Path to TLS certificate file                                                                                      | string     |
-| `--tls-key`                    | Path to TLS private key file                                                                                      | string     |
-| `--tracing-type`               | Supported tracing types (log or jaeger)                                                                           | string     |
-| `--vault-addr `                | Address of the Vault server (example: `https://127.0.0.1:8200/`)                                                  | string     |
-| `--vault-cacert`               | Path to a PEM-encoded CA certificate file                                                                         | string     |
-| `--vault-capath`               | Path to a directory of PEM-encoded CA certificate files                                                           | string     |
-| `--vault-client-cert`          | Path to a PEM-encoded client certificate                                                                          | string     |
-| `--vault-client-key`           | Path to an unencrypted, PEM-encoded private key which corresponds to the matching client certificate              | string     |
-| `--vault-max-retries`          | Maximum number of retries when encountering a 5xx error code (default `2`)                                        | integer    |
-| `--vault-client-timeout`       | Vault client timeout (default `60s`)                                                                              | duration   |
-| `--vault-skip-verify`          | Skip certificate verification when communicating with Vault                                                       |            |
-| `--vault-tls-server-name`      | Name to use as the SNI host when connecting to Vault via TLS                                                      | string     |
-| `--vault-token`                | Vault authentication token                                                                                        | string     |
+| Flag |                                | Description                                                                                                       | Input type |
+|:---- |:---                            |:-----------                                                                                                       | :--------: |
+|      | `--assets-path`                | Override default assets by serving from a specific directory (developer mode)                                     | string     |
+|      | `--bolt-path`                  | Path to boltdb database (default `~/.influxdbv2/influxd.bolt`)                                                    | string     |
+|      | `--e2e-testing`                | Add /debug/flush endpoint to clear stores; used for end-to-end tests (default `false`)                            |            |
+|      | `--engine-path`                | Path to persistent engine files (default `~/.influxdbv2/engine`)                                                  | string     |
+| `-h` | `--help`                       | Help for the `influxd` command                                                                                    |            |
+|      | `--http-bind-address`          | Bind address for the REST HTTP API (default `:9999`)                                                              | string     |
+|      | `--log-level`                  | Supported log levels are debug, info, and error (default `info`)                                                  | string     |
+|      | `--new-meta-store`             | Enables the new meta store                                                                                        |            |
+|      | `--new-meta-store-read-only`   | Toggle read-only mode for the new meta store and duplicate reads between old and new store (default `true`)       |            |
+|      | `--no-tasks`                   | Disables the task scheduler                                                                                       |            |
+|      | `--query-concurrency`          | Number of queries allowed to execute concurrently (default `10`)                                                  | integer    |
+|      | `--query-initial-memory-bytes` | Initial bytes of memory allocated for a query (default = `query-memory-bytes`)                                    | integer    |
+|      | `--query-max-memory-bytes`     | Maximum total bytes of memory allowed for queries (default = `query-concurrency` × `query-memory-bytes`)          | integer    |
+|      | `--query-memory-bytes`         | Maximum bytes of memory allowed for a single query (default _unlimited_, must be >= `query-initial-memory-bytes`) | integer    |
+|      | `--query-queue-size`           | Maximum number of queries allowed in execution queue (default `10`)                                               | integer    |
+|      | `--reporting-disabled`         | Disable sending telemetry data to **https:<nolink>//telemetry.influxdata.com**                                    |            |
+|      | `--secret-store`               | Data store for secrets (bolt or vault) (default `bolt`)                                                           | string     |
+|      | `--session-length`             | TTL in minutes for newly created sessions (default `60`)                                                          | integer    |
+|      | `--session-renew-disabled`     | Disables automatically extending session TTL on request                                                           |            |
+|      | `--store`                      | Data store for REST resources (bolt or memory) (default `bolt`)                                                   | string     |
+|      | `--tls-cert`                   | Path to TLS certificate file                                                                                      | string     |
+|      | `--tls-key`                    | Path to TLS private key file                                                                                      | string     |
+|      | `--tracing-type`               | Supported tracing types (log or jaeger)                                                                           | string     |
+|      | `--vault-addr `                | Address of the Vault server (example: `https://127.0.0.1:8200/`)                                                  | string     |
+|      | `--vault-cacert`               | Path to a PEM-encoded CA certificate file                                                                         | string     |
+|      | `--vault-capath`               | Path to a directory of PEM-encoded CA certificate files                                                           | string     |
+|      | `--vault-client-cert`          | Path to a PEM-encoded client certificate                                                                          | string     |
+|      | `--vault-client-key`           | Path to an unencrypted, PEM-encoded private key which corresponds to the matching client certificate              | string     |
+|      | `--vault-max-retries`          | Maximum number of retries when encountering a 5xx error code (default `2`)                                        | integer    |
+|      | `--vault-client-timeout`       | Vault client timeout (default `60s`)                                                                              | duration   |
+|      | `--vault-skip-verify`          | Skip certificate verification when communicating with Vault                                                       |            |
+|      | `--vault-tls-server-name`      | Name to use as the SNI host when connecting to Vault via TLS                                                      | string     |
+|      | `--vault-token`                | Vault authentication token                                                                                        | string     |


### PR DESCRIPTION
Updated all the CLI Flag tables so that shorthand and longhand flags align.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
