### PR TITLE
Reorganize Flux aggregate transformation section

### DIFF
--- a/content/v2.0/query-data/flux/increase.md
+++ b/content/v2.0/query-data/flux/increase.md
@@ -3,7 +3,7 @@ title: Calculate the increase
 seotitle: Calculate the increase in Flux
 list_title: Increase
 description: >
-  Use the [`increase()` function](/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/increase/)
+  Use the [`increase()` function](/v2.0/reference/flux/stdlib/built-in/transformations/increase/)
   to track increases across multiple columns in a table.
   This function is especially useful when tracking changes in counter values that
   wrap over time or periodically reset.
@@ -18,7 +18,7 @@ related:
 list_query_example: increase
 ---
 
-Use the [`increase()` function](/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/increase/)
+Use the [`increase()` function](/v2.0/reference/flux/stdlib/built-in/transformations/increase/)
 to track increases across multiple columns in a table.
 This function is especially useful when tracking changes in counter values that
 wrap over time or periodically reset.

--- a/content/v2.0/query-data/flux/rate.md
+++ b/content/v2.0/query-data/flux/rate.md
@@ -16,7 +16,7 @@ menu:
     name: Rate
 v2.0/tags: [query, rate]
 related:
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/derivative/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/derivative/
   - /v2.0/reference/flux/stdlib/experimental/aggregate/rate/
 list_query_example: rate_of_change
 ---

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/_index.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/_index.md
@@ -1,7 +1,9 @@
 ---
-title: Flux built-in aggregate functions
-list_title: Built-in aggregate functions
-description: Flux's built-in aggregate functions take values from an input table and aggregate them in some way.
+title: Flux built-in aggregate transformations
+list_title: Built-in aggregate transformations
+description: >
+  Flux's aggregate transformations take values from an input table and aggregate them in some way.
+  Output tables contain a single row with the aggregated value.
 aliases:
   - /v2.0/reference/flux/functions/transformations/aggregates
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/
@@ -16,8 +18,8 @@ related:
   - /v2.0/query-data/flux/window-aggregate/
 ---
 
-Flux's built-in aggregate functions take values from an input table and aggregate them in some way.
-The output table contains a single row with the aggregated value.
+Flux's built-in aggregate transformations take values from an input tables and aggregate them in some way.
+Output tables contain a single row with the aggregated value.
 
 Aggregate operations output a table for every input table they receive.
 You must provide a column to aggregate.

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/_index.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/_index.md
@@ -18,7 +18,7 @@ related:
   - /v2.0/query-data/flux/window-aggregate/
 ---
 
-Flux's built-in aggregate transformations take values from an input tables and aggregate them in some way.
+Flux's built-in aggregate transformations take values from an input table and aggregate them in some way.
 Output tables contain a single row with the aggregated value.
 
 Aggregate operations output a table for every input table they receive.

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/chandemomentumoscillator.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/chandemomentumoscillator.md
@@ -5,11 +5,12 @@ description: >
   developed by Tushar Chande.
 aliases:
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/chandemomentumoscillator/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/chandemomentumoscillator/
 menu:
   v2_0_ref:
     name: chandeMomentumOscillator
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
 related:
   - https://docs.influxdata.com/influxdb/latest/query_language/functions/#triple-exponential-moving-average, InfluxQL CHANDE_MOMENTUM_OSCILLATOR()
 ---
@@ -17,7 +18,7 @@ related:
 The `chandeMomentumOscillator()` function applies the technical momentum indicator
 developed by Tushar Chande.
 
-_**Function type:** Aggregate_
+_**Function type:** Transformation_
 
 ```js
 chandeMomentumOscillator(
@@ -45,10 +46,16 @@ Defaults to `["_value"]`.
 
 _**Data type: Array of Strings**_
 
+## Output tables
+For each input table with `x` rows, `chandeMomentumOscillator()` outputs a table
+with `x - n` rows.
+
 ## Examples
 
 #### Table transformation with a ten point Chande Momentum Oscillator
 
+{{< flex >}}
+{{% flex-content %}}
 ###### Input table
 | _time | _value |
 |:-----:|:------:|
@@ -81,7 +88,9 @@ _**Data type: Array of Strings**_
 | 0027  | 3      |
 | 0028  | 2      |
 | 0029  | 1      |
+{{% /flex-content %}}
 
+{{% flex-content %}}
 ###### Query
 ```js
 // ...
@@ -110,3 +119,5 @@ _**Data type: Array of Strings**_
 | 0027  | -100   |
 | 0028  | -100   |
 | 0029  | -100   |
+{{% /flex-content %}}
+{{< /flex >}}

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/cov.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/cov.md
@@ -4,17 +4,18 @@ description: The `cov()` function computes the covariance between two streams by
 aliases:
   - /v2.0/reference/flux/functions/transformations/aggregates/cov
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/cov/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/cov/
 menu:
   v2_0_ref:
     name: cov
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
 ---
 
 The `cov()` function computes the covariance between two streams by first joining the streams,
 then performing the covariance operation.
 
-_**Function type:** Aggregate  
+_**Function type:** Transformation_  
 _**Output data type:** Float_
 
 ```js

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/covariance.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/covariance.md
@@ -4,16 +4,17 @@ description: The `covariance()` function computes the covariance between two col
 aliases:
   - /v2.0/reference/flux/functions/transformations/aggregates/covariance
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/covariance/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/covariance/
 menu:
   v2_0_ref:
     name: covariance
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
 ---
 
 The `covariance()` function computes the covariance between two columns.
 
-_**Function type:** Aggregate_  
+_**Function type:** Transformation_  
 _**Output data type:** Float_
 
 ```js

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/derivative.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/derivative.md
@@ -32,9 +32,6 @@ derivative(
 )
 ```
 
-#### Output tables
-For each input table with `n` rows, `derivative()` outputs a table with `n - 1` rows.
-
 ## Parameters
 
 ### unit
@@ -60,6 +57,9 @@ The column containing time values.
 Defaults to `"_time"`.
 
 _**Data type:** String_
+
+## Output tables
+For each input table with `n` rows, `derivative()` outputs a table with `n - 1` rows.
 
 ## Examples
 ```js

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/derivative.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/derivative.md
@@ -7,8 +7,10 @@ aliases:
 menu:
   v2_0_ref:
     name: derivative
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
+aliases:
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/derivative
 related:
   - /v2.0/query-data/flux/rate/
   - https://docs.influxdata.com/influxdb/latest/query_language/functions/#derivative, InfluxQL – DERIVATIVE()
@@ -18,7 +20,7 @@ The `derivative()` function computes the rate of change per [`unit`](#unit) of t
 It assumes rows are ordered by the `_time` column.
 The output table schema is the same as the input table.
 
-_**Function type:** Aggregate_  
+_**Function type:** Transformation_  
 _**Output data type:** Float_
 
 ```js
@@ -29,6 +31,9 @@ derivative(
   timeSrc: "_time"
 )
 ```
+
+#### Output tables
+For each input table with `n` rows, `derivative()` outputs a table with `n - 1` rows.
 
 ## Parameters
 

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/difference.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/difference.md
@@ -7,8 +7,10 @@ aliases:
 menu:
   v2_0_ref:
     name: difference
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
+aliases:
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/difference
 related:
   - https://docs.influxdata.com/influxdb/latest/query_language/functions/#difference, InfluxQL – DIFFERENCE()
 ---
@@ -16,7 +18,7 @@ related:
 The `difference()` function computes the difference between subsequent records.  
 The user-specified columns of numeric type are subtracted while others are kept intact.
 
-_**Function type:** Aggregate_  
+_**Function type:** Transformation_  
 _**Output data type:** Float_
 
 ```js
@@ -26,6 +28,9 @@ difference(
   keepFirst: false
 )
 ```
+
+#### Output tables
+For each input table with `n` rows, `difference()` outputs a table with `n - 1` rows.
 
 ## Parameters
 

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/difference.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/difference.md
@@ -29,9 +29,6 @@ difference(
 )
 ```
 
-#### Output tables
-For each input table with `n` rows, `difference()` outputs a table with `n - 1` rows.
-
 ## Parameters
 
 ### nonNegative
@@ -60,6 +57,8 @@ _**Data type:** Boolean_
 - Some value `v` minus `null` is `v` minus the last non-null value seen before `v`;
   or `null` if `v` is the first non-null value seen.
 
+## Output tables
+For each input table with `n` rows, `difference()` outputs a table with `n - 1` rows.
 
 ## Examples
 

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/doubleema.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/doubleema.md
@@ -6,16 +6,17 @@ description: >
   the rate of `exponentialMovingAverage()`.
 aliases:
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/doubleema/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/doubleema/
 menu:
   v2_0_ref:
     name: doubleEMA
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
 related:
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/movingaverage/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/tripleema/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/timedmovingaverage/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/exponentialmovingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/movingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/tripleema/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/timedmovingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/exponentialmovingaverage/
   - https://docs.influxdata.com/influxdb/latest/query_language/functions/#double-exponential-moving-average, InfluxQL DOUBLE_EXPONENTIAL_MOVING_AVERAGE()
 ---
 
@@ -23,7 +24,7 @@ The `doubleEMA()` function calculates the exponential moving average of values i
 the `_value` column grouped into `n` number of points, giving more weight to recent
 data at double the rate of [`exponentialMovingAverage()`](/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/exponentialmovingaverage/).
 
-_**Function type:** Aggregate_  
+_**Function type:** Transformation_  
 
 ```js
 doubleEMA(n: 5)

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/exponentialmovingaverage.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/exponentialmovingaverage.md
@@ -5,16 +5,17 @@ description: >
   in the `_value` column grouped into `n` number of points, giving more weight to recent data.
 aliases:
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/exponentialmovingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/exponentialmovingaverage/
 menu:
   v2_0_ref:
     name: exponentialMovingAverage
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
 related:
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/movingaverage/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/timedmovingaverage/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/doubleema/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/tripleema/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/movingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/timedmovingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/doubleema/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/tripleema/
   - https://docs.influxdata.com/influxdb/latest/query_language/functions/#exponential-moving-average, InfluxQL EXPONENTIAL_MOVING_AVERAGE()
 ---
 

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/holtwinters.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/holtwinters.md
@@ -5,18 +5,19 @@ description: >
 aliases:
   - /v2.0/reference/flux/functions/transformations/aggregates/holtwinters
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/holtwinters/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/holtwinters/
 menu:
   v2_0_ref:
     name: holtWinters
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
 related:
   - https://docs.influxdata.com/influxdb/latest/query_language/functions/#holt-winters, InfluxQL HOLT_WINTERS()
 ---
 
 The `holtWinters()` function applies the Holt-Winters forecasting method to input tables.
 
-_**Function type:** Aggregate_  
+_**Function type:** Transformation_  
 _**Output data type:** Float_
 
 ```js

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/increase.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/increase.md
@@ -6,11 +6,12 @@ description: >
 aliases:
   - /v2.0/reference/flux/functions/transformations/aggregates/increase
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/increase/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/increase/
 menu:
   v2_0_ref:
     name: increase
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
 related:
   - /v2.0/query-data/flux/increase/
 ---
@@ -22,7 +23,7 @@ when they hit a threshold or are reset.
 In the case of a wrap/reset, we can assume that the absolute delta between two
 points will be at least their non-negative difference.
 
-_**Function type:** Aggregate_  
+_**Function type:** Transformation_  
 _**Output data type:** Float_
 
 ```js
@@ -37,6 +38,9 @@ Defaults to `["_value"]`.
 
 _**Data type:** Array of strings_
 
+## Output tables
+For each input table with `n` rows, `derivative()` outputs a table with `n - 1` rows.
+
 ## Examples
 ```js
 from(bucket: "example-bucket")
@@ -48,6 +52,8 @@ from(bucket: "example-bucket")
   |> increase()
 ```
 
+{{< flex >}}
+{{% flex-content %}}
 Given the following input table:
 
 | _time | _value |
@@ -56,7 +62,8 @@ Given the following input table:
 | 00002 | 5      |
 | 00003 | 3      |
 | 00004 | 4      |
-
+{{% /flex-content %}}
+{{% flex-content %}}
 `increase()` produces the following table:
 
 | _time | _value |
@@ -64,6 +71,8 @@ Given the following input table:
 | 00002 | 4      |
 | 00003 | 4      |
 | 00004 | 5      |
+{{% /flex-content %}}
+{{< /flex >}}
 
 ## Function definition
 ```js

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/kaufmansama.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/kaufmansama.md
@@ -5,20 +5,21 @@ description: >
   using values in an input table.
 aliases:
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/kaufmansama/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/kaufmansama/
 menu:
   v2_0_ref:
     name: kaufmansAMA
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
 related:
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/kaufmanser/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/kaufmanser/
   - https://docs.influxdata.com/influxdb/latest/query_language/functions/#kaufmans-adaptive-moving-average, InfluxQL KAUFMANS_ADAPTIVE_MOVING_AVERAGE()
 ---
 
 The `kaufmansAMA()` function calculates the Kaufman's Adaptive Moving Average (KAMA)
 using values in an input table.
 
-_**Function type:** Aggregate_
+_**Function type:** Transformation_
 
 ```js
 kaufmansAMA(

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/kaufmanser.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/kaufmanser.md
@@ -5,13 +5,14 @@ description: >
   values in an input table.
 aliases:
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/kaufmanser/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/kaufmanser/
 menu:
   v2_0_ref:
     name: kaufmansER
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
 related:
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/kaufmansama/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/kaufmansama/
   - https://docs.influxdata.com/influxdb/latest/query_language/functions/#kaufmans-efficiency-ratio, InfluxQL KAUFMANS_EFFICIENCY_RATIO()
 ---
 
@@ -19,7 +20,7 @@ The `kaufmansER()` function calculates the Kaufman's Efficiency Ratio (KER) usin
 values in an input table.
 The function operates on the `_value` column.
 
-_**Function type:** Aggregate_
+_**Function type:** Transformation_
 
 ```js
 kaufmansER(n: 10)

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/movingaverage.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/movingaverage.md
@@ -4,24 +4,25 @@ description: >
   The `movingAverage()` function calculates the mean of values grouped into `n` number of points.
 aliases:
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/movingaverage/
+  - /v2.0/reference/flux/functions/built-in/transformations/movingaverage/
 menu:
   v2_0_ref:
     name: movingAverage
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
 related:
   - /v2.0/query-data/flux/moving-average/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/timedmovingaverage/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/exponentialmovingaverage/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/doubleema/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/tripleema/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/timedmovingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/exponentialmovingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/doubleema/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/tripleema/
   - https://docs.influxdata.com/influxdb/latest/query_language/functions/#moving-average, InfluxQL MOVING_AVERAGE()
 ---
 
 The `movingAverage()` function calculates the mean of values in the `_values` column
 grouped into `n` number of points.
 
-_**Function type:** Aggregate_  
+_**Function type:** Transformation_  
 
 ```js
 movingAverage(n: 5)

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/pearsonr.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/pearsonr.md
@@ -4,17 +4,18 @@ description: The `pearsonr()` function computes the Pearson R correlation coeffi
 aliases:
   - /v2.0/reference/flux/functions/transformations/aggregates/pearsonr
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/pearsonr/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/pearsonr/
 menu:
   v2_0_ref:
     name: pearsonr
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
 ---
 
 The `pearsonr()` function computes the Pearson R correlation coefficient between two streams
 by first joining the streams, then performing the covariance operation normalized to compute R.
 
-_**Function type:** Aggregate_  
+_**Function type:** Transformation_  
 _**Output data type:** Float_
 
 ```js

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/relativestrengthindex.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/relativestrengthindex.md
@@ -5,22 +5,23 @@ description: >
   values in an input table.
 aliases:
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/relativestrengthindex/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/relativestrengthindex/
 menu:
   v2_0_ref:
     name: relativeStrengthIndex
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
 related:
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/movingaverage/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/timedmovingaverage/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/exponentialmovingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/movingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/timedmovingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/exponentialmovingaverage/
   - https://docs.influxdata.com/influxdb/latest/query_language/functions/#relative-strength-index, InfluxQL RELATIVE_STRENGTH_INDEX()
 ---
 
 The `relativeStrengthIndex()` function measures the relative speed and change of
 values in an input table.
 
-_**Function type:** Aggregate_  
+_**Function type:** Transformation_  
 
 ```js
 relativeStrengthIndex(
@@ -50,6 +51,10 @@ Columns to operate on. _Defaults to `["_value"]`_.
 
 _**Data type:** Array of Strings_
 
+## Output tables
+For each input table with `x` rows, `relativeStrengthIndex()` outputs a table
+with `x - n` rows.
+
 ## Examples
 
 #### Calculate a five point relative strength index
@@ -61,6 +66,8 @@ from(bucket: "example-bucket"):
 
 #### Table transformation with a ten point RSI
 
+{{< flex >}}
+{{% flex-content %}}
 ###### Input table:
 | _time | A    | B    | tag |
 |:-----:|:----:|:----:|:---:|
@@ -82,7 +89,8 @@ from(bucket: "example-bucket"):
 | 0016  | 16   | 16   | tv  |
 | 0017  | 17   | null | tv  |
 | 0018  | 18   | 17   | tv  |
-
+{{% /flex-content %}}
+{{% flex-content %}}
 ###### Query:
 ```js
 // ...
@@ -103,3 +111,5 @@ from(bucket: "example-bucket"):
 |  0016 |  90  |  90  |  tv |
 |  0017 |  81  |  90  |  tv |
 |  0018 | 72.9 |  81  |  tv |
+{{% flex-content %}}
+{{< /flex >}}

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/timedmovingaverage.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/timedmovingaverage.md
@@ -5,23 +5,24 @@ description: >
   range at a specified frequency.
 aliases:
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/timedmovingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/timedmovingaverage/
 menu:
   v2_0_ref:
     name: timedMovingAverage
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
 related:
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/movingaverage/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/exponentialmovingaverage/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/doubleema/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/tripleema/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/movingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/exponentialmovingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/doubleema/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/tripleema/
   - https://docs.influxdata.com/influxdb/latest/query_language/functions/#moving-average, InfluxQL MOVING_AVERAGE()
 ---
 
 The `timedMovingAverage()` function calculates the mean of values in a defined time
 range at a specified frequency.
 
-_**Function type:** Aggregate_  
+_**Function type:** Transformation_  
 
 ```js
 timedMovingAverage(

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/tripleema.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/tripleema.md
@@ -6,16 +6,17 @@ description: >
   than `exponentialMovingAverage()` and `doubleEMA()`.
 aliases:
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/tripleema/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/tripleema/
 menu:
   v2_0_ref:
     name: tripleEMA
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
 related:
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/movingaverage/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/doubleema/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/timedmovingaverage/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/exponentialmovingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/movingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/doubleema/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/timedmovingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/exponentialmovingaverage/
   - https://docs.influxdata.com/influxdb/latest/query_language/functions/#triple-exponential-moving-average, InfluxQL TRIPLE_EXPONENTIAL_MOVING_AVERAGE()
 ---
 
@@ -25,7 +26,7 @@ data with less lag than
 [`exponentialMovingAverage()`](/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/exponentialmovingaverage/)
 and [`doubleEMA()`](/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/doubleema/).
 
-_**Function type:** Aggregate_  
+_**Function type:** Transformation_  
 
 ```js
 tripleEMA(n: 5)

--- a/content/v2.0/reference/flux/stdlib/built-in/transformations/tripleexponentialderivative.md
+++ b/content/v2.0/reference/flux/stdlib/built-in/transformations/tripleexponentialderivative.md
@@ -5,18 +5,19 @@ description: >
   derivative (TRIX) of input tables using `n` points.
 aliases:
   - /v2.0/reference/flux/functions/built-in/transformations/aggregates/tripleexponentialderivative/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/tripleexponentialderivative/
 menu:
   v2_0_ref:
     name: tripleExponentialDerivative
-    parent: built-in-aggregates
-weight: 501
+    parent: built-in-transformations
+weight: 402
 v2.0/tags: [technical analysis]
 related:
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/movingaverage/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/doubleema/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/tripleema/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/timedmovingaverage/
-  - /v2.0/reference/flux/stdlib/built-in/transformations/aggregates/exponentialmovingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/movingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/doubleema/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/tripleema/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/timedmovingaverage/
+  - /v2.0/reference/flux/stdlib/built-in/transformations/exponentialmovingaverage/
   - https://docs.influxdata.com/influxdb/latest/query_language/functions/#triple-exponential-derivative, InfluxQL TRIPLE_EXPONENTIAL_DERIVATIVE()
 ---
 
@@ -24,7 +25,7 @@ The `tripleExponentialDerivative()` function calculates a triple exponential
 derivative ([TRIX](https://en.wikipedia.org/wiki/Trix_(technical_analysis))) of
 input tables using `n` points.
 
-_**Function type:** Aggregate_  
+_**Function type:** Transformation_  
 
 ```js
 tripleExponentialDerivative(n: 5)


### PR DESCRIPTION
Closes #1059 

This PR removes functions/transformations from the "Aggregates" directory that are technically not aggregates. This is likely the beginning of a continued reorganization of Flux function/transformation docs.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
