### PR TITLE
Clarify supported duration units for CLI

### DIFF
--- a/content/v2.0/get-started.md
+++ b/content/v2.0/get-started.md
@@ -533,8 +533,7 @@ influx setup
 3. **Confirm your password** by entering it again.
 4. Enter a name for your **primary organization**.
 5. Enter a name for your **primary bucket**.
-6. Enter a **retention period** (in hours) for your primary bucket.
-   Enter nothing for an infinite retention period.
+6. Enter a **retention period** for your primary bucket—valid units are nanoseconds (`ns`), microseconds (`us` or `µs`), milliseconds (`ms`), seconds (`s`), minutes (`m`), hours (`h`), days (`d`), and weeks (`w`). Enter nothing for an infinite retention period.
 7. Confirm the details for your primary user, organization, and bucket.
 
 InfluxDB is now initialized with a primary user, organization, bucket, and authentication token. InfluxDB also creates a configuration profile for you so that you don't have to add organization and token to every command. To view that config profile, use the [`influx config list`](/v2.0/reference/cli/influx/config) command.

--- a/content/v2.0/organizations/buckets/create-bucket.md
+++ b/content/v2.0/organizations/buckets/create-bucket.md
@@ -42,7 +42,6 @@ There are two places you can create a bucket in the UI.
     - **Older than** to choose a specific retention policy.
 5. Click **Create** to create the bucket.
 
-
 ## Create a bucket using the influx CLI
 
 Use the [`influx bucket create` command](/v2.0/reference/cli/influx/bucket/create)
@@ -50,7 +49,7 @@ to create a new bucket. A bucket requires the following:
 
 - bucket name
 - organization name or ID
-- retention period duration (`ns`, `us`, `ms`, `s`, or `h`)
+- retention period duration (`ns`, `us` (or `µs`), `ms`, `s`, `m` or `h`)
 
 ```sh
 # Syntax

--- a/content/v2.0/organizations/buckets/create-bucket.md
+++ b/content/v2.0/organizations/buckets/create-bucket.md
@@ -49,7 +49,15 @@ to create a new bucket. A bucket requires the following:
 
 - bucket name
 - organization name or ID
-- retention period duration (`ns`, `us` (or `µs`), `ms`, `s`, `m` or `h`)
+- retention period (duration to keep data) in one of the following units:
+  - nanoseconds (`ns`)
+  - microseconds (`us` or `µs`)
+  - milliseconds (`ms`)
+  - seconds (`s`)
+  - minutes (`m`)
+  - hours (`h`)
+  - days (`d`)
+  - weeks (`w`)
 
 ```sh
 # Syntax

--- a/content/v2.0/organizations/buckets/update-bucket.md
+++ b/content/v2.0/organizations/buckets/update-bucket.md
@@ -21,7 +21,6 @@ Note that updating an bucket's name will affect any assets that reference the bu
 
 If you change a bucket name, be sure to update the bucket in the above places as well.
 
-
 ## Update a bucket's name in the InfluxDB UI
 
 1. In the navigation menu on the left, select **Data (Load Data)** > **Buckets**.
@@ -52,6 +51,7 @@ to update a bucket. Updating a bucket requires the following:
 - The name or ID of the organization the bucket belongs to.
 
 ##### Update the name of a bucket
+
 ```sh
 # Syntax
 influx bucket update -i <bucket-id> -o <org-name> -n <new-bucket-name>
@@ -61,6 +61,9 @@ influx bucket update -i 034ad714fdd6f000 -o my-org -n my-new-bucket
 ```
 
 ##### Update a bucket's retention policy
+
+Valid retention policy units are `ns`, `us` (or `µs`), `ms`, `s`, `m` or `h`.
+
 ```sh
 # Syntax
 influx bucket update -i <bucket-id> -r <retention period in nanoseconds>

--- a/content/v2.0/organizations/buckets/update-bucket.md
+++ b/content/v2.0/organizations/buckets/update-bucket.md
@@ -62,7 +62,7 @@ influx bucket update -i 034ad714fdd6f000 -o my-org -n my-new-bucket
 
 ##### Update a bucket's retention policy
 
-Valid retention policy units are `ns`, `us` (or `µs`), `ms`, `s`, `m` or `h`.
+Valid retention policy duration units are nanoseconds (`ns`), microseconds (`us` or `µs`), milliseconds (`ms`), seconds (`s`), minutes (`m`), hours (`h`), days (`d`), or weeks (`w`).
 
 ```sh
 # Syntax

--- a/content/v2.0/reference/cli/influx/bucket/create.md
+++ b/content/v2.0/reference/cli/influx/bucket/create.md
@@ -25,6 +25,10 @@ influx bucket create [flags]
 | `-n` | `--name`         | Bucket name                                                    | string      | `INFLUX_BUCKET_NAME`  |
 | `-o` | `--org`          | Organization name                                              | string      | `INFLUX_ORG`          |
 |      | `--org-id`       | Organization ID                                                | string      | `INFLUX_ORG_ID`       |
-| `-r` | `--retention`    | Duration the bucket will retain data (0 is infinite, default is 0). Valid units are nanoseconds (`ns`), microseconds (`us` or `µs`), milliseconds (`ms`), seconds (`s`), minutes (`m`), hours (`h`), days (`d`), and weeks (`w`). | duration    |                       |
+| `-r` | `--retention`    | Duration the bucket will retain data (0 is infinite, default is 0). | duration    |                       |
+
+{{% note %}}
+Valid `--retention` units are nanoseconds (`ns`), microseconds (`us` or `µs`), milliseconds (`ms`), seconds (`s`), minutes (`m`), hours (`h`), days (`d`), and weeks (`w`).
+{{% /note %}}
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/create.md
+++ b/content/v2.0/reference/cli/influx/bucket/create.md
@@ -25,6 +25,6 @@ influx bucket create [flags]
 | `-n` | `--name`         | Bucket name                                                    | string      | `INFLUX_BUCKET_NAME`  |
 | `-o` | `--org`          | Organization name                                              | string      | `INFLUX_ORG`          |
 |      | `--org-id`       | Organization ID                                                | string      | `INFLUX_ORG_ID`       |
-| `-r` | `--retention`    | Duration the bucket will retain data (0 is infinite, default is 0). Valid units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, and `h`. | duration    |                       |
+| `-r` | `--retention`    | Duration the bucket will retain data (0 is infinite, default is 0). Valid units are nanoseconds (`ns`), microseconds (`us` or `µs`), milliseconds (`ms`), seconds (`s`), minutes (`m`), hours (`h`), days (`d`), and weeks (`w`). | duration    |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/create.md
+++ b/content/v2.0/reference/cli/influx/bucket/create.md
@@ -25,6 +25,6 @@ influx bucket create [flags]
 | `-n` | `--name`         | Bucket name                                                    | string      | `INFLUX_BUCKET_NAME`  |
 | `-o` | `--org`          | Organization name                                              | string      | `INFLUX_ORG`          |
 |      | `--org-id`       | Organization ID                                                | string      | `INFLUX_ORG_ID`       |
-| `-r` | `--retention`    | Duration bucket will retain data (0 is infinite, default is 0) | duration    |                       |
+| `-r` | `--retention`    | Duration the bucket will retain data (0 is infinite, default is 0). Valid units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, and `h`. | duration    |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/update.md
+++ b/content/v2.0/reference/cli/influx/bucket/update.md
@@ -24,6 +24,6 @@ influx bucket update [flags]
 | `-i` | `--id`           | **(Required)** Bucket ID              | string      |                       |
 |      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
 | `-n` | `--name`         | New bucket name                       | string      | `INFLUX_BUCKET_NAME`  |
-| `-r` | `--retention`    | New duration that the bucket will retain data—valid units include: `ns`, `us` (or `µs`), `ms`, `s`, `m`, and `h`.  | duration    |                       |
+| `-r` | `--retention`    | New duration the bucket will retain data (0 is infinite, default is 0). Valid units are nanoseconds (`ns`), microseconds (`us` or `µs`), milliseconds (`ms`), seconds (`s`), minutes (`m`), hours (`h`), days (`d`), and weeks (`w`). | duration    |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/update.md
+++ b/content/v2.0/reference/cli/influx/bucket/update.md
@@ -24,6 +24,6 @@ influx bucket update [flags]
 | `-i` | `--id`           | **(Required)** Bucket ID              | string      |                       |
 |      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
 | `-n` | `--name`         | New bucket name                       | string      | `INFLUX_BUCKET_NAME`  |
-| `-r` | `--retention`    | New duration bucket will retain data  | duration    |                       |
+| `-r` | `--retention`    | New duration that the bucket will retain data—valid units include: `ns`, `us` (or `µs`), `ms`, `s`, `m`, and `h`.  | duration    |                       |
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/bucket/update.md
+++ b/content/v2.0/reference/cli/influx/bucket/update.md
@@ -24,6 +24,10 @@ influx bucket update [flags]
 | `-i` | `--id`           | **(Required)** Bucket ID              | string      |                       |
 |      | `--json`         | Output data as JSON (default `false`) |             | `INFLUX_OUTPUT_JSON`  |
 | `-n` | `--name`         | New bucket name                       | string      | `INFLUX_BUCKET_NAME`  |
-| `-r` | `--retention`    | New duration the bucket will retain data (0 is infinite, default is 0). Valid units are nanoseconds (`ns`), microseconds (`us` or `µs`), milliseconds (`ms`), seconds (`s`), minutes (`m`), hours (`h`), days (`d`), and weeks (`w`). | duration    |                       |
+| `-r` | `--retention`    | New duration the bucket will retain data (0 is infinite, default is 0). | duration    |                       |
+
+{{% note %}}
+Valid `--retention` units are nanoseconds (`ns`), microseconds (`us` or `µs`), milliseconds (`ms`), seconds (`s`), minutes (`m`), hours (`h`), days (`d`), and weeks (`w`).
+{{% /note %}}
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/setup/_index.md
+++ b/content/v2.0/reference/cli/influx/setup/_index.md
@@ -20,14 +20,18 @@ influx setup [flags]
 ```
 
 ## Flags
-| Flag |               | Description                                                    | Data type |
-|:---- |:---           |:-----------                                                    |:---------:|
-| `-b` | `--bucket`    | Primary bucket name                                            | string    |
-| `-f` | `--force`     | Skip confirmation prompt                                       |           |
-| `-h` | `--help`      | Help for the `setup` command                                   |           |
-| `-o` | `--org`       | Primary organization name                                      | string    |
-| `-p` | `--password`  | Password for primary user                                      | string    |
-| `-r` | `--retention` | Duration the bucket will retain data (0 is infinite, default is 0). Valid units are nanoseconds (`ns`), microseconds (`us` or `µs`), milliseconds (`ms`), seconds (`s`), minutes (`m`), hours (`h`), days (`d`), and weeks (`w`).| duration  |
-| `-u` | `--username`  | Primary username                                               | string    |
+| Flag |               | Description                                                         | Data type |
+|:---- |:---           |:-----------                                                         |:---------:|
+| `-b` | `--bucket`    | Primary bucket name                                                 | string    |
+| `-f` | `--force`     | Skip confirmation prompt                                            |           |
+| `-h` | `--help`      | Help for the `setup` command                                        |           |
+| `-o` | `--org`       | Primary organization name                                           | string    |
+| `-p` | `--password`  | Password for primary user                                           | string    |
+| `-r` | `--retention` | Duration the bucket will retain data (0 is infinite, default is 0). | duration  |
+| `-u` | `--username`  | Primary username                                                    | string    |
+
+{{% note %}}
+Valid `--retention` units are nanoseconds (`ns`), microseconds (`us` or `µs`), milliseconds (`ms`), seconds (`s`), minutes (`m`), hours (`h`), days (`d`), and weeks (`w`).
+{{% /note %}}
 
 {{% cli/influx-global-flags %}}

--- a/content/v2.0/reference/cli/influx/setup/_index.md
+++ b/content/v2.0/reference/cli/influx/setup/_index.md
@@ -27,7 +27,7 @@ influx setup [flags]
 | `-h` | `--help`      | Help for the `setup` command                                   |           |
 | `-o` | `--org`       | Primary organization name                                      | string    |
 | `-p` | `--password`  | Password for primary user                                      | string    |
-| `-r` | `--retention` | Duration bucket will retain data (0 is infinite, default is 0) | duration  |
+| `-r` | `--retention` | Duration the bucket will retain data (0 is infinite, default is 0). Valid units are nanoseconds (`ns`), microseconds (`us` or `µs`), milliseconds (`ms`), seconds (`s`), minutes (`m`), hours (`h`), days (`d`), and weeks (`w`).| duration  |
 | `-u` | `--username`  | Primary username                                               | string    |
 
 {{% cli/influx-global-flags %}}


### PR DESCRIPTION
Hi @sanderson @abalone23, PR updated to add support for [days](https://github.com/influxdata/influxdb/pull/18658) and [weeks](https://github.com/influxdata/influxdb/pull/18659). Thank you @jsteenb2! Also updated the `influx setup` and Getting Started with CLI docs.

Closes [DAR 93](https://github.com/influxdata/DAR/issues/93)

- Add supported duration units when creating or updating buckets via the CLI

