### PR TITLE
Add custom InfluxDB URLs and dynamically set URLs

### DIFF
--- a/assets/js/influxdb-url.js
+++ b/assets/js/influxdb-url.js
@@ -58,7 +58,18 @@ function storeUrl(newUrl, prevUrl) {
   Cookies.set('influxdb_url', newUrl)
 }
 
-// Preserver URLs in codeblocks that come just after or are inside a div
+// Store custom URL session cookie – influxdb_custom_url
+function storeCustomUrl(customUrl) {
+  Cookies.set('influxdb_custom_url', customUrl)
+  $('input#custom[type=radio]').val(customUrl)
+}
+
+// Remove custom URL session cookie – influxdb_custom_url
+function removeCustomUrl() {
+  Cookies.remove('influxdb_custom_url')
+}
+
+// Preserve URLs in codeblocks that come just after or are inside a div
 // with the class, .keep-url
 function addPreserve() {
   $('.keep-url').each(function () {
@@ -88,9 +99,6 @@ updateUrls(defaultUrl, getUrl())
 // Append URL selector buttons to code blocks
 appendUrlSelector(getUrl())
 
-// Set active radio button on page load
-setRadioButton(getUrl())
-
 // Update URLs whenever you focus on the browser tab
 $(window).focus(function() {
   updateUrls(getPrevUrl(), getUrl())
@@ -115,3 +123,36 @@ $('button.url-trigger, #callout-url-selector .close').click(function() {
     $('#callout-url-selector').fadeOut(200)
   }
 })
+
+// Place cursor in custom URL field when custom radio is selected
+$('input#custom[type="radio"]').click(function(e) {
+  $('input#custom-url-field').focus()
+})
+
+$("#custom-url").submit(function(e) {
+  e.preventDefault();
+  $('#modal-close').trigger('click')
+});
+
+// Store the custom InfluxDB URL when exiting the field
+$('#custom-url-field').blur(function() {
+  custUrl = $(this).val()
+  if (custUrl.length > 0 ) {
+    storeCustomUrl(custUrl)
+    updateUrls(getUrl(), custUrl)
+    storeUrl(custUrl, getPrevUrl())
+  } else {
+    $('input#custom').val('http://example.com:8080')
+    removeCustomUrl();
+    $('input[name="influxdb-loc"][value="' + defaultUrl + '"]').trigger('click')
+  }
+})
+
+// Populate the custom InfluxDB URL field on page load
+if ( Cookies.get('influxdb_custom_url') != undefined ) {
+  $('input#custom').val(Cookies.get('influxdb_custom_url'))
+  $('#custom-url-field').val(Cookies.get('influxdb_custom_url'))
+}
+
+// Set active radio button on page load
+setRadioButton(getUrl())

--- a/assets/js/influxdb-url.js
+++ b/assets/js/influxdb-url.js
@@ -161,7 +161,7 @@ setRadioButton(getUrl())
 
 /////////////////////////// Dynamically update URLs ///////////////////////////
 
-// Extract the protocol and hostname of refferrer
+// Extract the protocol and hostname of refferer
 referrerHost = document.referrer.match(/^(?:[^\/]*\/){2}[^\/]+/g)[0]
 
 // Check if the referrerHost is one of the cloud URLs

--- a/assets/js/influxdb-url.js
+++ b/assets/js/influxdb-url.js
@@ -124,6 +124,8 @@ $('button.url-trigger, #callout-url-selector .close').click(function() {
   }
 })
 
+///////////////////////////////// CUSTOM URLs /////////////////////////////////
+
 // Trigger radio button on custom URL field focus
 $('input#custom-url-field').focus(function(e) {
   $('input#custom[type="radio"]').trigger('click')
@@ -156,3 +158,16 @@ if ( Cookies.get('influxdb_custom_url') != undefined ) {
 
 // Set active radio button on page load
 setRadioButton(getUrl())
+
+/////////////////////////// Dynamically update URLs ///////////////////////////
+
+// Extract the protocol and hostname of refferrer
+referrerHost = document.referrer.match(/^(?:[^\/]*\/){2}[^\/]+/g)[0]
+
+// Check if the referrerHost is one of the cloud URLs
+// cloudUrls is built dynamically in layouts/partials/footer/javascript.html
+if (cloudUrls.includes(referrerHost)) {
+  storeUrl(referrerHost, getUrl())
+  updateUrls(getPrevUrl(), referrerHost)
+  setRadioButton(referrerHost)
+}

--- a/assets/js/influxdb-url.js
+++ b/assets/js/influxdb-url.js
@@ -124,9 +124,9 @@ $('button.url-trigger, #callout-url-selector .close').click(function() {
   }
 })
 
-// Place cursor in custom URL field when custom radio is selected
-$('input#custom[type="radio"]').click(function(e) {
-  $('input#custom-url-field').focus()
+// Trigger radio button on custom URL field focus
+$('input#custom-url-field').focus(function(e) {
+  $('input#custom[type="radio"]').trigger('click')
 })
 
 $("#custom-url").submit(function(e) {

--- a/assets/styles/layouts/_url-selector.scss
+++ b/assets/styles/layouts/_url-selector.scss
@@ -136,6 +136,42 @@
     }
   }
 
+  li.custom {
+    display: flex;
+    align-items: center;
+  }
+  #custom-url {
+    display: inline-block;
+    width: 100%;
+    padding-left: .5rem;
+    input {
+      &#custom-url-field {
+        font-family: $rubik;
+        font-weight: $medium;
+        background: $modal-field-bg;
+        border-radius: $radius;
+        border: 1px solid $sidebar-search-bg;
+        padding: .5em;
+        width: 100%;
+        color: $sidebar-search-text;
+        transition-property: border, box-shadow;
+        transition-duration: .2s;
+        box-shadow: 2px 2px 6px $sidebar-search-shadow;
+        &:focus {
+          outline: none;
+          border-color: $sidebar-search-highlight;
+          box-shadow: 1px 1px 10px rgba($sidebar-search-highlight, .5);
+          border-radius: $radius;
+        }
+        &::placeholder {
+          color: rgba($sidebar-search-text, .45);
+          font-weight: normal;
+          font-style: italic;
+        }
+      }
+    }
+  }
+
   .radio {
     position: relative;
     display: inline-block;

--- a/assets/styles/styles-default.scss
+++ b/assets/styles/styles-default.scss
@@ -22,5 +22,5 @@
         "layouts/algolia-search-overrides",
         "layouts/landing",
         "layouts/error-page",
-        "layouts/cloud-selector",
+        "layouts/url-selector",
         "layouts/feature-callouts";

--- a/assets/styles/themes/_theme-dark.scss
+++ b/assets/styles/themes/_theme-dark.scss
@@ -182,6 +182,9 @@ $tooltip-color-alt: $br-chartreuse;
 $tooltip-bg: $br-chartreuse;
 $tooltip-text: $g2-kevlar;
 
+// URL Modal colors
+$modal-field-bg: $g1-raven;
+
 // SVG colors
 $svg-table-header: $g6-smoke;
 $svg-table-stroke: $g0-obsidian;

--- a/assets/styles/themes/_theme-light.scss
+++ b/assets/styles/themes/_theme-light.scss
@@ -182,6 +182,9 @@ $tooltip-color-alt: $p-twilight !default;
 $tooltip-bg: $p-amethyst !default;
 $tooltip-text: $g20-white !default;
 
+// URL Modal colors
+$modal-field-bg: $g20-white !default;
+
 // SVG colors
 $svg-table-header: $g15-platinum !default;
 $svg-table-stroke: $g7-graphite !default;

--- a/content/v2.0/reference/urls.md
+++ b/content/v2.0/reference/urls.md
@@ -12,15 +12,6 @@ menu:
 
 InfluxDB 2.0 is available both locally (OSS) or on multiple cloud providers in multiple regions (Cloud).
 
-## InfluxDB OSS URL
-
-For InfluxDB OSS, the default URL is the following:
-
-{{< keep-url >}}
-```
-http://localhost:9999/
-```
-
 ## InfluxDB Cloud URLs
 
 Each region has a unique InfluxDB Cloud URL and API endpoint.
@@ -29,3 +20,35 @@ Use the URLs below to interact with your InfluxDB Cloud instances with the
 [`influx` CLI](/v2.0/reference/cli/influx/), or [Telegraf](/v2.0/write-data/use-telegraf/).
 
 {{< cloud_regions >}}
+
+## InfluxDB OSS URLs
+
+For InfluxDB OSS, the default URL is the following:
+
+{{< keep-url >}}
+```
+http://localhost:9999/
+```
+
+### Customize your InfluxDB OSS URL
+To customize your InfluxDB host and port, use the
+[`http-bind-address` configuration option](/v2.0/reference/config-options/#http-bind-address)
+when starting `influxd`.
+
+```sh
+# Syntax
+influxd --http-bind-adress <custom-domain>:<custom-port>
+
+# Example - Run InfluxDB at http://example.com:8080
+influxd --http-bind-address example.com:8080
+
+# Example - Run InfluxDB at http://localhost:8080
+influxd --http-bind-address :8080
+```
+
+{{% note %}}
+#### Configure DNS Routing
+You must configure DNS routing to successfully route requests to your custom hostname.
+Methods for configuring DNS routing vary depending on your operating system and
+network architecture and are not covered in this documentation.
+{{% /note %}}

--- a/content/v2.0/reference/urls.md
+++ b/content/v2.0/reference/urls.md
@@ -37,7 +37,7 @@ when starting `influxd`.
 
 ```sh
 # Syntax
-influxd --http-bind-adress <custom-domain>:<custom-port>
+influxd --http-bind-address <custom-domain>:<custom-port>
 
 # Example - Run InfluxDB at http://example.com:8080
 influxd --http-bind-address example.com:8080

--- a/data/influxdb_urls.yml
+++ b/data/influxdb_urls.yml
@@ -5,6 +5,8 @@ oss:
       regions:
         - name: localhost:9999
           url: http://localhost:9999
+    - name: Custom
+      url: http://example.com:8080
 
 cloud:
   product: InfluxDB Cloud

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -21,5 +21,5 @@
   </script>
 
   </body>
-  {{ partial "footer/javascript.html" }}
+  {{ partial "footer/javascript.html" . }}
 </html>

--- a/layouts/partials/footer/influxdb-url-modal.html
+++ b/layouts/partials/footer/influxdb-url-modal.html
@@ -14,16 +14,31 @@
               <div class="providers">
                 {{ range .providers }}
                   <div class="provider">
-                    <h5>{{ if .short_name}}{{ .short_name }}{{ else }}{{ .name }}{{ end }}</h5>
-                    <ul>
-                    {{ range .regions }}
-                      <li>
-                        <label for="{{ anchorize .name }}" {{ if .status }}class="{{ .status }}"{{ end }}>
-                          <input type="radio" name="influxdb-loc" id="{{ anchorize .name }}" value="{{ .url }}" checked>
-                          <span class="radio"></span>
-                          {{ .name }}
-                        </label>
-                      </li>
+                    {{ if eq .name "Custom" }}
+                      <h5>Custom</h5>
+                      <ul>
+                        <li class="custom">
+                          <label for="{{ anchorize .name }}">
+                            <input type="radio" name="influxdb-loc" id="{{ anchorize .name }}" value="{{ .url }}" checked>
+                            <span class="radio"></span>
+                          </label>
+                          <form action="#" id="custom-url">
+                            <input type="text" name="custom-url-field" id="custom-url-field" placeholder="{{ .url }}">
+                          </form>
+                        </li>
+                      </ul>
+                    {{ else }}
+                      <h5>{{ if .short_name}}{{ .short_name }}{{ else }}{{ .name }}{{ end }}</h5>
+                      <ul>
+                      {{ range .regions }}
+                        <li>
+                          <label for="{{ anchorize .name }}" {{ if .status }}class="{{ .status }}"{{ end }}>
+                            <input type="radio" name="influxdb-loc" id="{{ anchorize .name }}" value="{{ .url }}" checked>
+                            <span class="radio"></span>
+                            {{ .name }}
+                          </label>
+                        </li>
+                      {{ end }}
                     {{ end }}
                     </ul>
                   </div>

--- a/layouts/partials/footer/javascript.html
+++ b/layouts/partials/footer/javascript.html
@@ -3,6 +3,16 @@
 {{ $searchInteractions := resources.Get "js/search-interactions.js" }}
 {{ $telegrafFilters := resources.Get "js/telegraf-filters.js" }}
 {{ $influxdbURLs := resources.Get "js/influxdb-url.js" }}
-{{ $footerjs := slice $versionSelector $contentInteractions $searchInteractions $telegrafFilters $influxdbURLs | resources.Concat "js/footer.bundle.js" | resources.Fingerprint}}
+{{ $footerjs := slice $versionSelector $contentInteractions $searchInteractions $telegrafFilters $influxdbURLs | resources.Concat "js/footer.bundle.js" | resources.Fingerprint }}
 
+<!-- Load cloudUrls array -->
+<script type="text/javascript">
+  cloudUrls = [
+    {{- range .Site.Data.influxdb_urls.cloud.providers }}
+      {{- range .regions }}"{{ safeHTML .url }}",{{ end -}}
+    {{ end -}}
+  ]
+</script>
+
+<!-- Load footer.js -->
 <script type="text/javascript" src="{{ $footerjs.RelPermalink }}" ></script>


### PR DESCRIPTION
Closes #1115
Closes #1116 

Users can now set custom InfluxDB URLs and, if they link to the documentation from InfluxDB cloud, we auto-update the InfluxDB cloud URL to match the cloud region they came from.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
