### PR TITLE
Typo: remove duplicate "apply" from code block.

### DIFF
--- a/content/v2.0/influxdb-templates/stacks/update.md
+++ b/content/v2.0/influxdb-templates/stacks/update.md
@@ -18,7 +18,7 @@ related:
   - /v2.0/reference/cli/influx/stacks/update/
 list_code_example: |
   ```sh
-  influx applyapply \
+  influx apply \
     -o example-org \
     -u http://example.com/template-1.yml \
     -u http://example.com/template-2.yml \


### PR DESCRIPTION
Simple typo fix for this page: https://v2.docs.influxdata.com/v2.0/influxdb-templates/stacks/

From: `applyapply` to `apply`

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
