### PR TITLE
Update docs search implementation

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,20 +7,7 @@
   {{ partial "footer/feature-callout.html" . }}
 
   <!-- Docsearch JS -->
-  <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-  <script>
-  docsearch({
-    apiKey: 'ba4435a9d456ac0d954cc276206eac06',
-    appId: 'WHM9UWMP6M',
-    indexName: 'influxdata',
-    inputSelector: '#algolia-search-input',
-    // Set debug to true if you want to inspect the dropdown
-    debug: true,
-    algoliaOptions: {
-      'facetFilters': ["version:{{ $currentVersion }}"]
-  },
-  });
-  </script>
+  {{ partial "footer/search.html" . }}
 
   </body>
   {{ partial "footer/javascript.html" . }}

--- a/layouts/partials/footer/search.html
+++ b/layouts/partials/footer/search.html
@@ -1,0 +1,27 @@
+{{ $productPathData := findRE "[^/]+.*?" .RelPermalink }}
+{{ $product := index $productPathData 0 }}
+{{ $currentVersion := index $productPathData 1 }}
+{{ $latestV2 := (index (last 1 (findRE `v2\.[0-9]{1,2}` (delimit .Site.Data.products.influxdb.versions " "))) 0) }}
+
+<script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script>
+docsearch({
+  apiKey: 'ba4435a9d456ac0d954cc276206eac06',
+  appId: 'WHM9UWMP6M',
+  indexName: 'influxdata',
+  inputSelector: '#algolia-search-input',
+  // Set debug to true if you want to inspect the dropdown
+  debug: true,
+  algoliaOptions: {
+    'facetFilters': [
+      {{ if or (eq $product "platform") (le (len $productPathData) 1) }}
+        'latest:true'
+      {{ else if and (eq $product "influxdb") (gt (len (findRE `v1\.[7,8]` $currentVersion)) 0) }}
+        ['project: influxdb', 'flux:true'], ['version: {{ $currentVersion }}', 'version: {{ $latestV2 }}']
+      {{ else }}
+        'project: {{ $product }}', 'version: {{ $currentVersion }}'
+      {{ end }}
+    ]
+  },
+});
+</script>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -20,6 +20,7 @@
     {{ partial "header/google-fonts.html" }}
     {{ partial "header/marketing.html" }}
     {{ partial "header/javascript.html" }}
+    {{ partial "header/search-attributes.html" . }}
 
     <meta name="Copyright" content="InfluxData Inc." />
   </head>

--- a/layouts/partials/header/search-attributes.html
+++ b/layouts/partials/header/search-attributes.html
@@ -1,0 +1,16 @@
+{{ $productPathData := findRE "[^/]+.*?" .RelPermalink }}
+{{ $product := index $productPathData 0 }}
+{{ $currentVersion := index $productPathData 1 }}
+{{ $latestV2 := (index (last 1 (findRE `v2\.[0-9]{1,2}` (delimit .Site.Data.products.influxdb.versions " "))) 0) }}
+{{ $fluxPath := print "/influxdb/" $latestV2 "/reference/flux/" }}
+{{ $isFlux := cond (in .RelPermalink $fluxPath) true false }}
+
+{{ if not .IsHome }}
+  {{ if or (eq $currentVersion (index $.Site.Data.products $product).latest) (eq $currentVersion (index $.Site.Data.products $product).latest_override) }}
+    <meta name="docsearch:latest" content="true">
+  {{ end }}
+{{ end }}
+
+{{ if $isFlux }}
+  <meta name="docsearch:flux" content="true">
+{{ end }}


### PR DESCRIPTION
Closes #1317

This updates the search functionality to account for v1 and v2 content. Search will now have the following behavior:

- Homepage and platform pages will search all latest versions across all products (this currently includes both InfluxDB v1.8 and v2.0)
- InfluxDB v1.7 and v1.8 search pages specific to those versions as well as the Flux reference documentation in the latest v2 version.
- All other projects only search content for the current project and version.

---

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
