### PR TITLE
Default port update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -649,7 +649,7 @@ When a user selects an InfluxDB product and region, example URLs in code blocks
 throughout the documentation are updated to match their product and region.
 InfluxDB URLs are configured in `/data/influxdb_urls.yml`.
 
-By default, the InfluxDB URL replaced inside of code blocks is `http://localhost:9999`.
+By default, the InfluxDB URL replaced inside of code blocks is `http://localhost:8086`.
 Use this URL in all code examples that should be updated with a selected provider and region.
 
 For example:
@@ -657,14 +657,14 @@ For example:
 ~~~
 ```sh
 # This URL will get updated
-http://localhost:9999
+http://localhost:8086
 
 # This URL will NOT get updated
 http://example.com
 ```
 ~~~
 
-If the user selects the **US West (Oregon)** region, all occurrences of `http://localhost:9999`
+If the user selects the **US West (Oregon)** region, all occurrences of `http://localhost:8086`
 in code blocks will get updated to `https://us-west-2-1.aws.cloud2.influxdata.com`.
 
 ### Exempt URLs from getting updated
@@ -675,7 +675,7 @@ just before the code block.
 {{< keep-url >}}
 ```
 // This URL won't get updated
-http://localhost:9999
+http://localhost:8086
 ```
 ~~~
 

--- a/assets/js/influxdb-url.js
+++ b/assets/js/influxdb-url.js
@@ -1,7 +1,8 @@
-var defaultUrl = "http://localhost:9999"
+var defaultUrl = "http://localhost:8086"
 var placeholderCloudUrl = "https://cloud2.influxdata.com"
 var defaultCloudUrl = "https://us-west-2-1.aws.cloud2.influxdata.com"
 var elementSelector = ".article--content pre:not(.preserve)"
+var isInfluxDBv1 = /influxdb\/v1/.test(window.location.href)
 
 // Retrieve the selected URL from the influxdb_url session cookie
 function getUrl() {
@@ -25,23 +26,29 @@ function getPrevUrl() {
 }
 
 // Iterate through code blocks and update InfluxDB urls
+// Ignore URLs in InfluxDB 1.x docs
 function updateUrls(currentUrl, newUrl) {
-  if (typeof currentUrl != newUrl) {
-    $(elementSelector).each(function() {
-      $(this).html($(this).html().replace(currentUrl,  newUrl));
-    });
+  if (!isInfluxDBv1) {
+    if (typeof currentUrl != newUrl) {
+      $(elementSelector).each(function() {
+        $(this).html($(this).html().replace(currentUrl,  newUrl));
+      });
+    }
   }
 }
 
 // Append the URL selector button to each codeblock with an InfluxDB URL
+// Ignore codeblocks on InfluxDB v1.x pages
 function appendUrlSelector(currentUrl, selectorText) {
-  $(elementSelector).each(function() {
-    var code = $(this).html()
-    if (code.includes(currentUrl)) {
-      $(this).after("<div class='select-url'><a class='url-trigger' href='#'>" + selectorText + "</a></div>")
-      $('.select-url').fadeIn(400)
-    }
-  });
+  if (!isInfluxDBv1) {
+    $(elementSelector).each(function() {
+      var code = $(this).html()
+      if (code.includes(currentUrl)) {
+        $(this).after("<div class='select-url'><a class='url-trigger' href='#'>" + selectorText + "</a></div>")
+        $('.select-url').fadeIn(400)
+      }
+    });
+  }
 }
 
 // Toggle the URL selector modal window

--- a/content/chronograf/v1.6/administration/creating-connections.md
+++ b/content/chronograf/v1.6/administration/creating-connections.md
@@ -51,6 +51,7 @@ An `.src` files contains the details for a single InfluxDB connection.
 Create a new file named `example.src` (the filename is arbitrary) and place it at Chronograf's `resource-path`.
 All `.src` files should contain the following:
 
+{{< keep-url >}}
 ```json
 {
   "id": "10000",

--- a/content/chronograf/v1.6/administration/managing-influxdb-users.md
+++ b/content/chronograf/v1.6/administration/managing-influxdb-users.md
@@ -65,6 +65,7 @@ Run the `curl` command below to create an admin user, replacing:
 * `chronothan` with your own username
 * `supersecret` with your own password (note that the password requires single quotes)
 
+{{< keep-url >}}
 ```
 ~# curl -XPOST "http://localhost:8086/query" --data-urlencode "q=CREATE USER chronothan WITH PASSWORD 'supersecret' WITH ALL PRIVILEGES"
 ```

--- a/content/chronograf/v1.6/guides/live_leaderboard.md
+++ b/content/chronograf/v1.6/guides/live_leaderboard.md
@@ -187,6 +187,7 @@ max
 
 Since we are writing data back to InfluxDB create a database `game` for our results.
 
+{{< keep-url >}}
 ```
 curl -G 'http://localhost:8086/query?' --data-urlencode 'q=CREATE DATABASE game'
 ```
@@ -274,6 +275,7 @@ Hit the endpoint several times to see that the scores are updating once a second
 
 Now, let's check InfluxDB to see our historical data.
 
+{{< keep-url >}}
 ```bash
 curl \
     -G 'http://localhost:8086/query?db=game' \

--- a/content/chronograf/v1.6/guides/monitoring-influxenterprise-clusters.md
+++ b/content/chronograf/v1.6/guides/monitoring-influxenterprise-clusters.md
@@ -85,6 +85,7 @@ Because you enabled authentication, you must perform this step before moving on 
 Run the command below to create an admin user, replacing `chronothan` and `supersecret` with your own username and password.
 Note that the password requires single quotes.
 
+{{< keep-url >}}
 ```
 ~# curl -XPOST "http://localhost:8086/query" --data-urlencode "q=CREATE USER chronothan WITH PASSWORD 'supersecret' WITH ALL PRIVILEGES"
 ```
@@ -173,6 +174,8 @@ Repeat steps one through four for each data node in your cluster.
 
 Run the following command on your InfluxDB OSS instance to see if your Telegraf instances are successfully collecting and writing data.
 Replace the `chronothan` and `supersecret` values with your actual username and password.
+
+{{< keep-url >}}
 ```
 ~# curl -G "http://localhost:8086/query?db=telegraf&u=chronothan&p=supersecret&pretty=true" --data-urlencode "q=SHOW TAG VALUES FROM cpu WITH KEY=host"
 ```

--- a/content/chronograf/v1.7/administration/creating-connections.md
+++ b/content/chronograf/v1.7/administration/creating-connections.md
@@ -85,6 +85,7 @@ An `.src` files contains the details for a single InfluxDB connection.
 Create a new file named `example.src` (the filename is arbitrary) and place it at Chronograf's `resource-path`.
 All `.src` files should contain the following:
 
+{{< keep-url >}}
 ```json
 {
   "id": "10000",

--- a/content/chronograf/v1.7/administration/managing-influxdb-users.md
+++ b/content/chronograf/v1.7/administration/managing-influxdb-users.md
@@ -64,6 +64,7 @@ Run the `curl` command below to create an admin user, replacing:
 * `chronothan` with your own username
 * `supersecret` with your own password (note that the password requires single quotes)
 
+{{< keep-url >}}
 ```
 ~# curl -XPOST "http://localhost:8086/query" --data-urlencode "q=CREATE USER chronothan WITH PASSWORD 'supersecret' WITH ALL PRIVILEGES"
 ```

--- a/content/chronograf/v1.7/guides/live_leaderboard.md
+++ b/content/chronograf/v1.7/guides/live_leaderboard.md
@@ -187,6 +187,7 @@ max
 
 Since we are writing data back to InfluxDB create a database `game` for our results.
 
+{{< keep-url >}}
 ```
 curl -G 'http://localhost:8086/query?' --data-urlencode 'q=CREATE DATABASE game'
 ```
@@ -274,6 +275,7 @@ Hit the endpoint several times to see that the scores are updating once a second
 
 Now, let's check InfluxDB to see our historical data.
 
+{{< keep-url >}}
 ```bash
 curl \
     -G 'http://localhost:8086/query?db=game' \

--- a/content/chronograf/v1.7/guides/monitoring-influxenterprise-clusters.md
+++ b/content/chronograf/v1.7/guides/monitoring-influxenterprise-clusters.md
@@ -85,6 +85,7 @@ Because you enabled authentication, you must perform this step before moving on 
 Run the command below to create an admin user, replacing `chronothan` and `supersecret` with your own username and password.
 Note that the password requires single quotes.
 
+{{< keep-url >}}
 ```
 ~# curl -XPOST "http://localhost:8086/query" --data-urlencode "q=CREATE USER chronothan WITH PASSWORD 'supersecret' WITH ALL PRIVILEGES"
 ```
@@ -173,6 +174,8 @@ Repeat steps one through four for each data node in your cluster.
 
 Run the following command on your InfluxDB OSS instance to see if your Telegraf instances are successfully collecting and writing data.
 Replace the `chronothan` and `supersecret` values with your actual username and password.
+
+{{< keep-url >}}
 ```
 ~# curl -G "http://localhost:8086/query?db=telegraf&u=chronothan&p=supersecret&pretty=true" --data-urlencode "q=SHOW TAG VALUES FROM cpu WITH KEY=host"
 ```

--- a/content/chronograf/v1.8/administration/creating-connections.md
+++ b/content/chronograf/v1.8/administration/creating-connections.md
@@ -85,6 +85,7 @@ An `.src` files contains the details for a single InfluxDB connection.
 Create a new file named `example.src` (the filename is arbitrary) and place it at Chronograf's `resource-path`.
 All `.src` files should contain the following:
 
+{{< keep-url >}}
 ```json
 {
   "id": "10000",

--- a/content/chronograf/v1.8/administration/managing-influxdb-users.md
+++ b/content/chronograf/v1.8/administration/managing-influxdb-users.md
@@ -66,6 +66,7 @@ Run the `curl` command below to create an admin user, replacing:
 * `chronothan` with your own username
 * `supersecret` with your own password (note that the password requires single quotes)
 
+{{< keep-url >}}
 ```
 ~# curl -XPOST "http://localhost:8086/query" --data-urlencode "q=CREATE USER chronothan WITH PASSWORD 'supersecret' WITH ALL PRIVILEGES"
 ```

--- a/content/chronograf/v1.8/guides/live_leaderboard.md
+++ b/content/chronograf/v1.8/guides/live_leaderboard.md
@@ -187,6 +187,7 @@ max
 
 Since we are writing data back to InfluxDB create a database `game` for our results.
 
+{{< keep-url >}}
 ```
 curl -G 'http://localhost:8086/query?' --data-urlencode 'q=CREATE DATABASE game'
 ```
@@ -274,6 +275,7 @@ Hit the endpoint several times to see that the scores are updating once a second
 
 Now, let's check InfluxDB to see our historical data.
 
+{{< keep-url >}}
 ```bash
 curl \
     -G 'http://localhost:8086/query?db=game' \

--- a/content/chronograf/v1.8/guides/monitoring-influxenterprise-clusters.md
+++ b/content/chronograf/v1.8/guides/monitoring-influxenterprise-clusters.md
@@ -85,6 +85,7 @@ Because you enabled authentication, you must perform this step before moving on 
 Run the command below to create an admin user, replacing `chronothan` and `supersecret` with your own username and password.
 Note that the password requires single quotes.
 
+{{< keep-url >}}
 ```
 ~# curl -XPOST "http://localhost:8086/query" --data-urlencode "q=CREATE USER chronothan WITH PASSWORD 'supersecret' WITH ALL PRIVILEGES"
 ```
@@ -199,6 +200,7 @@ $ influx
 
 Replace the `chronothan` and `supersecret` values with your actual username and password.
 
+{{< keep-url >}}
 ```
 ~# curl -G "http://localhost:8086/query?db=telegraf&u=chronothan&p=supersecret&pretty=true" --data-urlencode "q=SHOW TAG VALUES FROM cpu WITH KEY=host"
 ```

--- a/content/enterprise_influxdb/v1.8/administration/anti-entropy-api.md
+++ b/content/enterprise_influxdb/v1.8/administration/anti-entropy-api.md
@@ -17,7 +17,7 @@ Use the [Anti-Entropy service](/enterprise_influxdb/v1.8/administration/anti-ent
 The base URL is:
 
 ```text
-http://localhost:8086/shard-repair`
+http://localhost:8086/shard-repair
 ```
 
 ## GET `/status`

--- a/content/influxdb/v2.0/get-started.md
+++ b/content/influxdb/v2.0/get-started.md
@@ -84,7 +84,7 @@ Currently, we do **not support** using an existing InfluxDB Cloud 2.0 account to
 
 {{% cloud %}}
 All InfluxDB 2.0 documentation applies to {{< cloud-name "short" >}} unless otherwise specified.
-References to the InfluxDB user interface (UI) or localhost:9999 refer to your
+References to the InfluxDB user interface (UI) or localhost:8086 refer to your
 {{< cloud-name >}} UI.
 {{% /cloud %}}
 
@@ -149,7 +149,7 @@ In a terminal, run the following command:
 ```sh
    # Set up a configuration profile
    influx config create -n default \
-     -u http://localhost:9999 \
+     -u http://localhost:8086 \
      -o example-org \
      -t mySuP3rS3cr3tT0keN \
      -a
@@ -209,7 +209,7 @@ In a terminal, run the following command:
 ```sh
    # Set up a configuration profile
    influx config create -n default \
-     -u http://localhost:9999 \
+     -u http://localhost:8086 \
      -o example-org \
      -t mySuP3rS3cr3tT0keN \
      -a
@@ -291,7 +291,7 @@ If you rename the binaries, all references to `influx` and `influxd` in this doc
 
 #### Networking ports
 
-By default, InfluxDB uses TCP port `9999` for client-server communication over
+By default, InfluxDB uses TCP port `8086` for client-server communication over
 the [InfluxDB HTTP API](/influxdb/v2.0/reference/api/).
 
 ### Start InfluxDB
@@ -374,7 +374,7 @@ If you rename the binaries, all references to `influx` and `influxd` in this doc
 
 #### Networking ports
 
-By default, InfluxDB uses TCP port `9999` for client-server communication over
+By default, InfluxDB uses TCP port `8086` for client-server communication over
 the [InfluxDB HTTP API](/influxdb/v2.0/reference/api/).
 
 ### Start InfluxDB
@@ -415,11 +415,11 @@ influxd --reporting-disabled
 ### Download and run InfluxDB v2.0 beta
 
 Use `docker run` to download and run the InfluxDB v2.0 beta Docker image.
-Expose port `9999`, which InfluxDB uses for client-server communication over
+Expose port `8086`, which InfluxDB uses for client-server communication over
 the [InfluxDB HTTP API](/influxdb/v2.0/reference/api/).
 
 ```sh
-docker run --name influxdb -p 9999:9999 quay.io/influxdb/influxdb:2.0.0-beta
+docker run --name influxdb -p 8086:8086 quay.io/influxdb/influxdb:2.0.0-beta
 ```
 _To run InfluxDB in [detached mode](https://docs.docker.com/engine/reference/run/#detached-vs-foreground), include the `-d` flag in the `docker run` command._
 
@@ -434,7 +434,7 @@ To opt-out of sending telemetry data back to InfluxData, include the
 `--reporting-disabled` flag when starting the InfluxDB container.
 
 ```bash
-docker run -p 9999:9999 quay.io/influxdb/influxdb:2.0.0-beta --reporting-disabled
+docker run -p 8086:8086 quay.io/influxdb/influxdb:2.0.0-beta --reporting-disabled
 ```
 {{% /note %}}
 
@@ -495,10 +495,10 @@ The instructions below use Minikube, but the steps should be similar in any Kube
 
     You should see an IP address after `Endpoints` in the command's output.
 
-6. Forward port 9999 from inside the cluster to localhost:
+6. Forward port 8086 from inside the cluster to localhost:
 
     ```sh
-    kubectl port-forward -n influxdb service/influxdb 9999:9999
+    kubectl port-forward -n influxdb service/influxdb 8086:8086
     ```
 
 {{% /tab-content %}}
@@ -523,7 +523,7 @@ the `influx` command line interface (CLI).
 {{% tab-content %}}
 ### Set up InfluxDB through the UI
 
-1. With InfluxDB running, visit [localhost:9999](http://localhost:9999).
+1. With InfluxDB running, visit [localhost:8086](http://localhost:8086).
 2. Click **Get Started**
 
 #### Set up your initial user
@@ -546,7 +546,7 @@ If you set up InfluxDB through the UI and want to use the [`influx` CLI](/influx
     ```sh
       # Set up a configuration profile
       influx config create -n default \
-        -u http://localhost:9999 \
+        -u http://localhost:8086 \
         -o example-org \
         -t mySuP3rS3cr3tT0keN \
         -a

--- a/content/influxdb/v2.0/monitor-alert/templates/infrastructure/aws.md
+++ b/content/influxdb/v2.0/monitor-alert/templates/infrastructure/aws.md
@@ -35,7 +35,7 @@ The AWS CloudWatch Monitoring template includes the following:
    ```sh
     ## k8s
     [[outputs.influxdb_v2]]
-     urls = ["http://influxdb.monitoring:9999"]
+     urls = ["http://influxdb.monitoring:8086"]
      organization = "InfluxData"
      bucket = "kubernetes"
      token = "secret-token"

--- a/content/influxdb/v2.0/organizations/view-orgs.md
+++ b/content/influxdb/v2.0/organizations/view-orgs.md
@@ -45,7 +45,7 @@ After logging in to the InfluxDB UI, your organization ID appears in the URL.
 
 
 <pre class="highlight">
-http://localhost:9999/orgs/<span class="bp" style="font-weight:bold;margin:0 .15rem">03a2bbf46249a000</span>/...
+http://localhost:8086/orgs/<span class="bp" style="font-weight:bold;margin:0 .15rem">03a2bbf46249a000</span>/...
 </pre>
 
 

--- a/content/influxdb/v2.0/query-data/execute-queries.md
+++ b/content/influxdb/v2.0/query-data/execute-queries.md
@@ -80,7 +80,7 @@ Below is an example `curl` command that queries InfluxDB:
 
 {{% code-tab-content %}}
 ```bash
-curl http://localhost:9999/api/v2/query?org=my-org -XPOST -sS \
+curl http://localhost:8086/api/v2/query?org=my-org -XPOST -sS \
   -H 'Authorization: Token YOURAUTHTOKEN' \
   -H 'Accept: application/csv' \
   -H 'Content-type: application/vnd.flux' \
@@ -93,7 +93,7 @@ curl http://localhost:9999/api/v2/query?org=my-org -XPOST -sS \
 
 {{% code-tab-content %}}
 ```bash
-curl http://localhost:9999/api/v2/query?org=my-org -XPOST -sS \
+curl http://localhost:8086/api/v2/query?org=my-org -XPOST -sS \
   -H 'Authorization: Token YOURAUTHTOKEN' \
   -H 'Accept: application/csv' \
   -H 'Content-type: application/vnd.flux' \

--- a/content/influxdb/v2.0/query-data/execute-queries.md
+++ b/content/influxdb/v2.0/query-data/execute-queries.md
@@ -14,7 +14,7 @@ There are multiple ways to execute queries with InfluxDB.
 This guide covers the different options:
 
 - [Data Explorer](#data-explorer)
-- [Influx REPL](#influx-repl)
+- [Flux REPL](#flux-repl)
 - [Influx query command](#influx-query-command)
 - [InfluxDB API](#influxdb-api)
 
@@ -23,18 +23,13 @@ Queries can be built, executed, and visualized in InfluxDB UI's Data Explorer.
 
 ![Data Explorer with Flux](/img/influxdb/2-0-data-explorer.png)
 
-## Influx REPL
+## Flux REPL
 The [Flux REPL](/influxdb/v2.0/tools/repl/) starts an interactive
 Read-Eval-Print Loop (REPL) where you can write and execute Flux queries.
 
-<!-- TODO: is this still accurate? -->
-<!-- ```bash -->
-<!-- ./flux repl --org org-name -->
-<!-- ``` -->
-
-{{% note %}}
-`ctrl-d` will close the REPL.
-{{% /note %}}
+```sh
+./flux repl
+```
 
 ## Influx query command
 You can pass queries to the [`influx query` command](/influxdb/v2.0/reference/cli/influx/query)

--- a/content/influxdb/v2.0/query-data/flux/sql.md
+++ b/content/influxdb/v2.0/query-data/flux/sql.md
@@ -204,7 +204,7 @@ to store your database credentials as secrets.
 {{% /tabs %}}
 {{% tab-content %}}
 ```sh
-curl -X PATCH http://localhost:9999/api/v2/orgs/<org-id>/secrets \
+curl -X PATCH http://localhost:8086/api/v2/orgs/<org-id>/secrets \
   -H 'Authorization: Token YOURAUTHTOKEN' \
   -H 'Content-type: application/json' \
   -d '{

--- a/content/influxdb/v2.0/reference/api/_index.md
+++ b/content/influxdb/v2.0/reference/api/_index.md
@@ -17,7 +17,7 @@ Include your authentication token as an `Authorization` header in each request.
 
 ```sh
 curl --request POST \
-  --url http://localhost:9999/api/v2/write?org=my-org&bucket=example-bucket \
+  --url http://localhost:8086/api/v2/write?org=my-org&bucket=example-bucket \
   --header 'Authorization: Token YOURAUTHTOKEN'
 ```
 
@@ -28,7 +28,7 @@ curl --request POST \
 InfluxDB API documentation is built into the `influxd` service and represents
 the API specific to the current version of InfluxDB.
 To view the API documentation locally, [start InfluxDB](/influxdb/v2.0/get-started/#start-influxdb)
-and visit the `/docs` endpoint in a browser ([localhost:9999/docs](http://localhost:9999/docs)).
+and visit the `/docs` endpoint in a browser ([localhost:8086/docs](http://localhost:8086/docs)).
 
 ## InfluxDB client libraries
 InfluxDB client libraries are language-specific packages that integrate with the InfluxDB v2 API.

--- a/content/influxdb/v2.0/reference/api/client-libraries/go.md
+++ b/content/influxdb/v2.0/reference/api/client-libraries/go.md
@@ -57,7 +57,7 @@ Use the Go library to write and query data from InfluxDB.
    org := "example-org"
    token := "example-token"
    // Store the URL of your InfluxDB instance
-   url := "http://localhost:9999"
+   url := "http://localhost:8086"
    ```
 
 3. Create the the InfluxDB Go client and pass in the `url` and `token` parameters.
@@ -103,7 +103,7 @@ Use the Go library to write data to InfluxDB.
   org := "example-org"
   token := "example-token"
   // Store the URL of your InfluxDB instance
-  url := "http://localhost:9999"
+  url := "http://localhost:8086"
 	// Create new client with default option for server url authenticate by token
 	client := influxdb2.NewClient(url, token)
 	// User blocking write client for writes to desired bucket

--- a/content/influxdb/v2.0/reference/api/client-libraries/python.md
+++ b/content/influxdb/v2.0/reference/api/client-libraries/python.md
@@ -27,7 +27,7 @@ If just getting started, see [Get started with InfluxDB](/influxdb/v2.0/get-star
     ```
 
 2. Ensure that InfluxDB is running.
-   If running InfluxDB locally, visit http://localhost:9999.
+   If running InfluxDB locally, visit http://localhost:8086.
    (If using InfluxDB Cloud, visit the URL of your InfluxDB Cloud UI.
    For example: https://us-west-2-1.aws.cloud2.influxdata.com.)
 
@@ -49,7 +49,7 @@ We are going to write some data in [line protocol](/influxdb/v2.0/reference/synt
    org = "<my-org>"
    token = "<my-token>"
    # Store the URL of your InfluxDB instance
-   url="http://localhost:9999"
+   url="http://localhost:8086"
    ```
 
 3. Instantiate the client. The `InfluxDBClient` object takes three named parameters: `url`, `org`, and `token`. Pass in the named parameters.
@@ -86,7 +86,7 @@ bucket = "<my-bucket>"
 org = "<my-org>"
 token = "<my-token>"
 # Store the URL of your InfluxDB instance
-url="http://localhost:9999"
+url="http://localhost:8086"
 
 client = influxdb_client.InfluxDBClient(
     url=url,

--- a/content/influxdb/v2.0/reference/api/postman.md
+++ b/content/influxdb/v2.0/reference/api/postman.md
@@ -36,5 +36,5 @@ Use the **Authorization** tab in Postman to include the credentials required whe
 5. Ensure that the **Add to** option is set to **Header**.
 
 To test the authentication, enter the `/health` endpoint of a local or Cloud instance of InfluxDB into the address bar
-(for example, http://localhost:9999/api/v2/health or https://us-west-2-1.aws.cloud2.influxdata.com/api/v2/health)
+(for example, http://localhost:8086/api/v2/health or https://us-west-2-1.aws.cloud2.influxdata.com/api/v2/health)
 and then click **Send**.

--- a/content/influxdb/v2.0/reference/cli/influx/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/_index.md
@@ -32,7 +32,7 @@ influx [command]
   ```sh
    # Set up a configuration profile
    influx config create -n default \
-     -u http://localhost:9999 \
+     -u http://localhost:8086 \
      -o example-org \
      -t mySuP3rS3cr3tT0keN \
      -a

--- a/content/influxdb/v2.0/reference/cli/influx/apply/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/apply/_index.md
@@ -33,7 +33,7 @@ influx apply [flags]
 |      | `--filter`                | Resources to skip when applying the template (filter by `kind` or `resource`)               | string     |                      |
 |      | `--force`                 | Ignore warnings about destructive changes                                                   |            |                      |
 | `-h` | `--help`                  | Help for the `apply` command                                                                |            |                      |
-|      | `--host`                  | HTTP address of InfluxDB (default `http://localhost:9999`)                                  | string     | `INFLUX_HOST`        |
+|      | `--host`                  | HTTP address of InfluxDB (default `http://localhost:8086`)                                  | string     | `INFLUX_HOST`        |
 |      | `--json`                  | Output data as JSON                                                                         |            | `INFLUX_OUTPUT_JSON` |
 | `-o` | `--org`                   | Organization name that owns the bucket                                                      | string     | `INFLUX_ORG`         |
 |      | `--org-id`                | Organization ID that owns the bucket                                                        | string     | `INFLUX_ORG_ID`      |

--- a/content/influxdb/v2.0/reference/cli/influx/auth/active.md
+++ b/content/influxdb/v2.0/reference/cli/influx/auth/active.md
@@ -22,7 +22,7 @@ influx auth active [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string     |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `active` command                                         |            |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |            | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string     | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string     | `INFLUX_HOST`         |
 | `-i` | `--id`            | **(Required)** Authorization ID                                       | string     |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |            | `INFLUX_OUTPUT_JSON`  |
 |      | `--skip-verify`   | Skip TLS certificate verification                                     |            |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/auth/create.md
+++ b/content/influxdb/v2.0/reference/cli/influx/auth/create.md
@@ -22,7 +22,7 @@ influx auth create [flags]
 |      | `--configs-path`     | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`             | Help for the `create` command                                         |             |                       |
 |      | `--hide-headers`     | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`             | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`             | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 |      | `--json`             | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 | `-o` | `--org`              | **(Required)** Organization name                                      | string      | `INFLUX_ORG`          |
 |      | `--org-id`           | Organization ID                                                       | string      | `INFLUX_ORG_ID`       |

--- a/content/influxdb/v2.0/reference/cli/influx/auth/delete.md
+++ b/content/influxdb/v2.0/reference/cli/influx/auth/delete.md
@@ -22,7 +22,7 @@ influx auth delete [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `delete` command                                         |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 | `-i` | `--id`            | **(Required)** Authorization ID                                       | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 |      | `--skip-verify`   | Skip TLS certificate verification                                     |             |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/auth/inactive.md
+++ b/content/influxdb/v2.0/reference/cli/influx/auth/inactive.md
@@ -22,7 +22,7 @@ influx auth inactive [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `inactive` command                                       |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 | `-i` | `--id`            | **(Required)** Authorization ID                                       | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 |      | `--skip-verify`   | Skip TLS certificate verification                                     |             |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/auth/list.md
+++ b/content/influxdb/v2.0/reference/cli/influx/auth/list.md
@@ -27,7 +27,7 @@ influx auth list [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `list` command                                           |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 | `-i` | `--id`            | Authorization ID                                                      | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 | `-o` | `--org`           | Organization name                                                     | string      |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/backup/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/backup/_index.md
@@ -24,7 +24,7 @@ influx backup [flags]
 | `-c` | `--active-config` | CLI configuration to use for command                                  | string     |                      |
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string     |`INFLUX_CONFIGS_PATH` |
 | `-h` | `--help`          | Help for the `backup` command                                         |            |                      |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string     | `INFLUX_HOST`        |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string     | `INFLUX_HOST`        |
 | `-p` | `--path`          | Directory path to write backup files to                               | string     | `INFLUX_PATH`        |
 |      | `--skip-verify`   | Skip TLS certificate verification                                     |            |                      |
 | `-t` | `--token`         | Authentication token                                                  | string     | `INFLUX_TOKEN`       |

--- a/content/influxdb/v2.0/reference/cli/influx/bucket/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/bucket/_index.md
@@ -31,6 +31,6 @@ influx bucket [command]
 | `-c` | `--active-config` | CLI configuration to use for command                                  | string     |                      |
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string     |`INFLUX_CONFIGS_PATH` |
 | `-h` | `--help`          | Help for the `bucket` command                                         |            |                      |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string     | `INFLUX_HOST`        |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string     | `INFLUX_HOST`        |
 |      | `--skip-verify`   | Skip TLS certificate verification                                     |            |                      |
 | `-t` | `--token`         | Authentication token                                                  | string     | `INFLUX_TOKEN`       |

--- a/content/influxdb/v2.0/reference/cli/influx/bucket/create.md
+++ b/content/influxdb/v2.0/reference/cli/influx/bucket/create.md
@@ -25,7 +25,7 @@ influx bucket create [flags]
 | `-d` | `--description`   | Bucket description                                                    | string      |                       |
 | `-h` | `--help`          | Help for the `create` command                                         |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 | `-n` | `--name`          | Bucket name                                                           | string      | `INFLUX_BUCKET_NAME`  |
 | `-o` | `--org`           | Organization name                                                     | string      | `INFLUX_ORG`          |

--- a/content/influxdb/v2.0/reference/cli/influx/bucket/delete.md
+++ b/content/influxdb/v2.0/reference/cli/influx/bucket/delete.md
@@ -26,7 +26,7 @@ influx bucket delete [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `delete` command                                         |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 | `-i` | `--id`            | Bucket ID _(required if no `--name`)_                                 | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 | `-n` | `--name`          | Bucket name _(requires `--org` or `org-id`)_                          | string      |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/bucket/list.md
+++ b/content/influxdb/v2.0/reference/cli/influx/bucket/list.md
@@ -28,7 +28,7 @@ influx bucket list [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `list` command                                           |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 | `-i` | `--id`            | Bucket ID                                                             | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 | `-n` | `--name`          | Bucket name                                                           | string      | `INFLUX_BUCKET_NAME`  |

--- a/content/influxdb/v2.0/reference/cli/influx/bucket/update.md
+++ b/content/influxdb/v2.0/reference/cli/influx/bucket/update.md
@@ -25,7 +25,7 @@ influx bucket update [flags]
 | `-d` | `--description`   | Bucket description                                                    | string      |                       |
 | `-h` | `--help`          | Help for the `update` command                                         |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 | `-i` | `--id`            | **(Required)** Bucket ID                                              | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 | `-n` | `--name`          | New bucket name                                                       | string      | `INFLUX_BUCKET_NAME`  |

--- a/content/influxdb/v2.0/reference/cli/influx/config/create.md
+++ b/content/influxdb/v2.0/reference/cli/influx/config/create.md
@@ -33,14 +33,14 @@ influx config create [flags]
 # Create a connection configuration and set it active
 influx config create --active \
   -n config-name \
-  -u http://localhost:9999 \
+  -u http://localhost:8086 \
   -t mySuP3rS3cr3tT0keN \
   -o example-org
 
 # Create a connection configuration without setting it active
 influx config create \
   -n config-name \
-  -u http://localhost:9999 \
+  -u http://localhost:8086 \
   -t mySuP3rS3cr3tT0keN \
   -o example-org
 ```

--- a/content/influxdb/v2.0/reference/cli/influx/dashboards/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/dashboards/_index.md
@@ -24,7 +24,7 @@ influx dashboards [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `dashboards` command                                     |             |                       |
 |      | `--hide-headers`  | Hide table headers                                                    |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `$INFLUX_HOST`        |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `$INFLUX_HOST`        |
 | `-i` | `--id`            | Dashboard ID to retrieve                                              | string      |                       |
 |      | `--json`          | Output data as JSON                                                   |             | `INFLUX_OUTPUT_JSON`  |
 | `-o` | `--org`           | Organization name                                                     | string      | `INFLUX_ORG`          |

--- a/content/influxdb/v2.0/reference/cli/influx/delete/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/delete/_index.md
@@ -31,7 +31,7 @@ timestamps between the specified `--start` and `--stop` times in the specified b
 |      | `--bucket-id`     | Bucket ID                                                                                                 | string     | `INFLUX_BUCKET_ID`   |
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`)                                     | string     |`INFLUX_CONFIGS_PATH` |
 | `-h` | `--help`          | Help for the `delete` command                                                                             |            |                      |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)                                                | string     | `INFLUX_HOST`        |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)                                                | string     | `INFLUX_HOST`        |
 | `-o` | `--org`           | Organization name                                                                                         | string     | `INFLUX_ORG`         |
 |      | `--org-id`        | Organization ID                                                                                           | string     | `INFLUX_ORG_ID`      |
 | `-p` | `--predicate`     | InfluxQL-like predicate string (see [Delete predicate](/influxdb/v2.0/reference/syntax/delete-predicate)) | string     |                      |

--- a/content/influxdb/v2.0/reference/cli/influx/export/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/export/_index.md
@@ -39,7 +39,7 @@ influx export [command]
 |      | `--endpoints`        | Comma-separated list of notification endpoint IDs                                | string     |                      |
 | `-f` | `--file`             | Template output file. Defaults to stdout. Use `.yml` or `.json` file extensions. | string     |                      |
 | `-h` | `--help`             | Help for the `export` command                                                    |            |                      |
-|      | `--host`             | HTTP address of InfluxDB (default `http://localhost:9999`)                       | string     | `INFLUX_HOST`        |
+|      | `--host`             | HTTP address of InfluxDB (default `http://localhost:8086`)                       | string     | `INFLUX_HOST`        |
 |      | `--labels`           | Comma-separated list of label IDs                                                | string     |                      |
 |      | `--resource-type`    | Resource type associated with all IDs via stdin                                  | string     |                      |
 |      | `--rules`            | Comma-separated list of notification rule IDs                                    | string     |                      |

--- a/content/influxdb/v2.0/reference/cli/influx/export/all.md
+++ b/content/influxdb/v2.0/reference/cli/influx/export/all.md
@@ -30,7 +30,7 @@ influx export all [flags]
 | `-f` | `--file`          | Template output file. Defaults to stdout. Use `.yml` or `.json` file extensions.                | string          |                      |
 |      | `--filter`        | Specify resources to export by labelName or resourceKind (format: `--filter=labelName=example`) | list of strings |                      |
 | `-h` | `--help`          | Help for the `export all` command                                                               |                 |                      |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)                                      | string          | `INFLUX_HOST`        |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)                                      | string          | `INFLUX_HOST`        |
 | `-o` | `--org`           | Organization name that owns the resources                                                       | string          | `INFLUX_ORG`         |
 |      | `--org-id`        | Organization ID that owns the resources                                                         | string          | `INFLUX_ORG_ID`      |
 |      | `--skip-verify`   | Skip TLS certificate verification                                                               |                 |                      |

--- a/content/influxdb/v2.0/reference/cli/influx/export/stack.md
+++ b/content/influxdb/v2.0/reference/cli/influx/export/stack.md
@@ -25,7 +25,7 @@ influx export stack <stack_id> [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`)            | string     |`INFLUX_CONFIGS_PATH` |
 | `-f` | `--file`          | Template output file. Defaults to stdout. Use `.yml` or `.json` file extensions. | string     |                      |
 | `-h` | `--help`          | Help for the `export stack` command                                              |            |                      |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)                       | string     | `INFLUX_HOST`        |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)                       | string     | `INFLUX_HOST`        |
 | `-o` | `--org`           | Organization name that owns the resources                                        | string     | `INFLUX_ORG`         |
 |      | `--org-id`        | Organization ID that owns the resources                                          | string     | `INFLUX_ORG_ID`      |
 |      | `--skip-verify`   | Skip TLS certificate verification                                                |            |                      |

--- a/content/influxdb/v2.0/reference/cli/influx/org/create.md
+++ b/content/influxdb/v2.0/reference/cli/influx/org/create.md
@@ -23,7 +23,7 @@ influx org create [flags]
 | `-d` | `--description`   | Description of the organization                                       |             |                       |
 | `-h` | `--help`          | Help for the `create` command                                         |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 | `-n` | `--name`          | Organization name                                                     | string      |                       |
 |      | `--skip-verify`   | Skip TLS certificate verification                                     |             |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/org/delete.md
+++ b/content/influxdb/v2.0/reference/cli/influx/org/delete.md
@@ -22,7 +22,7 @@ influx org delete [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `delete` command                                         |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 | `-i` | `--id`            | **(Required)** Organization ID                                        | string      | `INFLUX_ORG_ID`       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 |      | `--skip-verify`   | Skip TLS certificate verification                                     |             |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/org/list.md
+++ b/content/influxdb/v2.0/reference/cli/influx/org/list.md
@@ -27,7 +27,7 @@ influx org list [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `list` command                                           |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 | `-i` | `--id`            | Organization ID                                                       | string      | `INFLUX_ORG`          |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 | `-n` | `--name`          | Organization name                                                     | string      | `INFLUX_ORG_ID`       |

--- a/content/influxdb/v2.0/reference/cli/influx/org/members/add.md
+++ b/content/influxdb/v2.0/reference/cli/influx/org/members/add.md
@@ -19,7 +19,7 @@ influx org members add [flags]
 | Flag |                 | Description                                                | Input type  | {{< cli/mapped >}} |
 |:---- |:---             |:-----------                                                |:----------: |:------------------ |
 | `-h` | `--help`        | Help for the `add` command                                 |             |                    |
-|      | `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string      | `INFLUX_HOST`      |
+|      | `--host`        | HTTP address of InfluxDB (default `http://localhost:8086`) | string      | `INFLUX_HOST`      |
 | `-i` | `--id`          | Organization ID                                            | string      | `INFLUX_ORG_ID`    |
 | `-m` | `--member`      | Member ID                                                  | string      |                    |
 | `-n` | `--name`        | Organization name                                          | string      | `INFLUX_ORG`       |

--- a/content/influxdb/v2.0/reference/cli/influx/org/members/list.md
+++ b/content/influxdb/v2.0/reference/cli/influx/org/members/list.md
@@ -20,7 +20,7 @@ influx org members list [flags]
 |:---- |:---              |:-----------                                                |:----------: |:------------------    |
 | `-h` | `--help`         | Help for the `list` command                                |             |                       |
 |      | `--hide-headers` | Hide table headers (default `false`)                       |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`         | HTTP address of InfluxDB (default `http://localhost:9999`) | string      | `INFLUX_HOST`         |
+|      | `--host`         | HTTP address of InfluxDB (default `http://localhost:8086`) | string      | `INFLUX_HOST`         |
 | `-i` | `--id`           | Organization ID                                            | string      | `INFLUX_ORG_ID`       |
 |      | `--json`         | Output data as JSON (default `false`)                      |             | `INFLUX_OUTPUT_JSON`  |
 | `-n` | `--name`         | Organization name                                          | string      | `INFLUX_ORG`          |

--- a/content/influxdb/v2.0/reference/cli/influx/org/members/remove.md
+++ b/content/influxdb/v2.0/reference/cli/influx/org/members/remove.md
@@ -19,7 +19,7 @@ influx org members remove [flags]
 | Flag |                 | Description                                                | Input type  | {{< cli/mapped >}} |
 |:---- |:---             |:-----------                                                |:----------: |:------------------ |
 | `-h` | `--help`        | Help for the `remove` command                              |             |                    |
-|      | `--host`        | HTTP address of InfluxDB (default `http://localhost:9999`) | string      | `INFLUX_HOST`      |
+|      | `--host`        | HTTP address of InfluxDB (default `http://localhost:8086`) | string      | `INFLUX_HOST`      |
 | `-i` | `--id`          | Organization ID                                            | string      | `INFLUX_ORG_ID`    |
 | `-o` | `--member`      | Member ID                                                  | string      |                    |
 | `-n` | `--name`        | Organization name                                          | string      | `INFLUX_ORG`       |

--- a/content/influxdb/v2.0/reference/cli/influx/org/update.md
+++ b/content/influxdb/v2.0/reference/cli/influx/org/update.md
@@ -23,7 +23,7 @@ influx org update [flags]
 | `-d` | `--description`   | Description for the organization                                      | string     | `INFLUX_ORG_DESCRIPTION` |
 | `-h` | `--help`          | Help for the `update` command                                         |            |                          |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |            | `INFLUX_HIDE_HEADERS`    |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string     | `INFLUX_HOST`            |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string     | `INFLUX_HOST`            |
 | `-i` | `--id`            | **(Required)** Organization ID                                        | string     | `INFLUX_ORG_ID`          |
 |      | `--json`          | Output data as JSON (default `false`)                                 |            | `INFLUX_OUTPUT_JSON`     |
 | `-n` | `--name`          | Organization name                                                     | string     | `INFLUX_ORG`             |

--- a/content/influxdb/v2.0/reference/cli/influx/ping/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/ping/_index.md
@@ -24,5 +24,5 @@ influx ping [flags]
 | Flag |                 | Description                                               | Input type | {{< cli/mapped >}} |
 |:---- |:---             |:-----------                                               |:---------- |:-----------------  |
 | `-h` | `--help`        | Help for the `ping` command                               |            |                    |
-|      | `--host`        | HTTP address of InfluxDB (default `http://localhost9999`) | string     | `INFLUX_HOST`      |
+|      | `--host`        | HTTP address of InfluxDB (default `http://localhost:8086`) | string     | `INFLUX_HOST`      |
 |      | `--skip-verify` | Skip TLS certificate verification                         |            |                    |

--- a/content/influxdb/v2.0/reference/cli/influx/query/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/query/_index.md
@@ -26,7 +26,7 @@ influx query [query literal] [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string     |`INFLUX_CONFIGS_PATH` |
 | `-f` | `--file`          | Path to Flux script file                                              | string     |                      |
 | `-h` | `--help`          | Help for the `query` command                                          |            |                      |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string     | `INFLUX_HOST`        |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string     | `INFLUX_HOST`        |
 | `-o` | `--org`           | Organization name                                                     | string     | `INFLUX_ORG`         |
 |      | `--org-id`        | Organization ID                                                       | string     | `INFLUX_ORG_ID`      |
 | `-r` | `--raw`           | Output raw query results (annotated CSV)                              |            |                      |

--- a/content/influxdb/v2.0/reference/cli/influx/repl/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/repl/_index.md
@@ -33,7 +33,7 @@ To use the Flux REPL, you must first authenticate with a [token](/influxdb/v2.0/
 | `-c` | `--active-config` | CLI configuration to use for command                                  | string     |                      |
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string     |`INFLUX_CONFIGS_PATH` |
 | `-h` | `--help`          | Help for the `repl` command                                           |            |                      |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string     | `INFLUX_HOST`        |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string     | `INFLUX_HOST`        |
 | `-o` | `--org`           | Organization name                                                     | string     | `INFLUX_ORG`         |
 |      | `--org-id`        | Organization ID                                                       | string     | `INFLUX_ORG_ID`      |
 |      | `--skip-verify`   | Skip TLS certificate verification                                     |            |                      |

--- a/content/influxdb/v2.0/reference/cli/influx/secret/delete.md
+++ b/content/influxdb/v2.0/reference/cli/influx/secret/delete.md
@@ -23,7 +23,7 @@ influx secret delete [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string     |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `delete` command                                         |            |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |            | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string     | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string     | `INFLUX_HOST`         |
 |      | `--json`          | Output data as JSON (default `false`)                                 |            | `INFLUX_OUTPUT_JSON`  |
 | `-k` | `--key`           | **(Required)** Secret key                                             | string     |                       |
 | `-o` | `--org`           | Organization name                                                     | string     | `INFLUX_ORG`          |

--- a/content/influxdb/v2.0/reference/cli/influx/secret/list.md
+++ b/content/influxdb/v2.0/reference/cli/influx/secret/list.md
@@ -26,7 +26,7 @@ influx secret list [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string     |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `list` command                                           |            |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |            | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string     | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string     | `INFLUX_HOST`         |
 |      | `--json`          | Output data as JSON (default `false`)                                 |            | `INFLUX_OUTPUT_JSON`  |
 | `-o` | `--org`           | Organization name                                                     | string     | `INFLUX_ORG`          |
 |      | `--org-id`        | Organization ID                                                       | string     | `INFLUX_ORG_ID`       |

--- a/content/influxdb/v2.0/reference/cli/influx/secret/update.md
+++ b/content/influxdb/v2.0/reference/cli/influx/secret/update.md
@@ -32,7 +32,7 @@ influx secret update [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string     |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `update` command                                         |            |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |            | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string     | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string     | `INFLUX_HOST`         |
 |      | `--json`          | Output data as JSON (default `false`)                                 |            | `INFLUX_OUTPUT_JSON`  |
 | `-k` | `--key`           | **(Required)** Secret key                                             | string     |                       |
 | `-o` | `--org`           | Organization name                                                     | string     | `INFLUX_ORG`          |

--- a/content/influxdb/v2.0/reference/cli/influx/setup/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/setup/_index.md
@@ -27,7 +27,7 @@ influx setup [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string    |`INFLUX_CONFIGS_PATH` |
 | `-f` | `--force`         | Skip confirmation prompt                                              |           |                      |
 | `-h` | `--help`          | Help for the `setup` command                                          |           |                      |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string    | `INFLUX_HOST`        |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string    | `INFLUX_HOST`        |
 | `-o` | `--org`           | Primary organization name                                             | string    |                      |
 | `-p` | `--password`      | Password for primary user                                             | string    |                      |
 | `-r` | `--retention`     | Duration bucket will retain data (0 is infinite, default is 0)        | duration  |                      |

--- a/content/influxdb/v2.0/reference/cli/influx/stacks/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/stacks/_index.md
@@ -35,7 +35,7 @@ influx stacks [command]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string          |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `stacks` command                                         |                 |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |                 | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string          | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string          | `INFLUX_HOST`         |
 |      | `--json`          | Output data as JSON (default `false`)                                 |                 | `INFLUX_OUTPUT_JSON`  |
 | `-o` | `--org`           | Organization name                                                     | string          | `INFLUX_ORG`          |
 |      | `--org-id`        | Organization ID                                                       | string          | `INFLUX_ORG_ID`       |

--- a/content/influxdb/v2.0/reference/cli/influx/stacks/init.md
+++ b/content/influxdb/v2.0/reference/cli/influx/stacks/init.md
@@ -25,7 +25,7 @@ influx stacks init [flags]
 |      | `--configs-path`      | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string          |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`              | Help for the `init` command                                           |                 |                       |
 |      | `--hide-headers`      | Hide table headers (default `false`)                                  |                 | `INFLUX_HIDE_HEADERS` |
-|      | `--host`              | HTTP address of InfluxDB (default `http://localhost:9999`)            | string          | `INFLUX_HOST`         |
+|      | `--host`              | HTTP address of InfluxDB (default `http://localhost:8086`)            | string          | `INFLUX_HOST`         |
 |      | `--json`              | Output data as JSON (default `false`)                                 |                 | `INFLUX_OUTPUT_JSON`  |
 | `-o` | `--org`               | Organization name                                                     | string          | `INFLUX_ORG`          |
 |      | `--org-id`            | Organization ID                                                       | string          | `INFLUX_ORG_ID`       |

--- a/content/influxdb/v2.0/reference/cli/influx/stacks/remove.md
+++ b/content/influxdb/v2.0/reference/cli/influx/stacks/remove.md
@@ -28,7 +28,7 @@ influx stacks remove [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string          |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `remove` command                                         |                 |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |                 | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string          | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string          | `INFLUX_HOST`         |
 |      | `--json`          | Output data as JSON (default `false`)                                 |                 | `INFLUX_OUTPUT_JSON`  |
 | `-o` | `--org`           | Organization name                                                     | string          | `INFLUX_ORG`          |
 |      | `--org-id`        | Organization ID                                                       | string          | `INFLUX_ORG_ID`       |

--- a/content/influxdb/v2.0/reference/cli/influx/stacks/update.md
+++ b/content/influxdb/v2.0/reference/cli/influx/stacks/update.md
@@ -25,7 +25,7 @@ influx stacks update [flags]
 | `-f` | `--export-file`       | Destination for exported template                                     | string          |                       |
 | `-h` | `--help`              | Help for the `update` command                                         |                 |                       |
 |      | `--hide-headers`      | Hide table headers (default `false`)                                  |                 | `INFLUX_HIDE_HEADERS` |
-|      | `--host`              | HTTP address of InfluxDB (default `http://localhost:9999`)            | string          | `INFLUX_HOST`         |
+|      | `--host`              | HTTP address of InfluxDB (default `http://localhost:8086`)            | string          | `INFLUX_HOST`         |
 | `-i` | `--stack-id`          | The stack ID to update                                                | string          |                       |
 |      | `--json`              | Output data as JSON (default `false`)                                 |                 | `INFLUX_OUTPUT_JSON`  |
 |      | `--skip-verify`       | Skip TLS certificate verification                                     |                 |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/task/create.md
+++ b/content/influxdb/v2.0/reference/cli/influx/task/create.md
@@ -23,7 +23,7 @@ influx task create [query literal] [flags]
 | `-f` | `--file`          | Path to Flux script file                                              | string     |                       |
 | `-h` | `--help`          | Help for the `create` command                                         |            |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |            | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string     | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string     | `INFLUX_HOST`         |
 |      | `--json`          | Output data as JSON (default `false`)                                 |            | `INFLUX_OUTPUT_JSON`  |
 | `-o` | `--org`           | Organization name                                                     | string     | `INFLUX_ORG`          |
 |      | `--org-id`        | Organization ID                                                       | string     | `INFLUX_ORG_ID`       |

--- a/content/influxdb/v2.0/reference/cli/influx/task/delete.md
+++ b/content/influxdb/v2.0/reference/cli/influx/task/delete.md
@@ -22,7 +22,7 @@ influx task delete [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `delete` command                                         |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 | `-i` | `--id`            | **(Required)** Task ID                                                | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 |      | `--skip-verify`   | Skip TLS certificate verification                                     |             |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/task/list.md
+++ b/content/influxdb/v2.0/reference/cli/influx/task/list.md
@@ -27,7 +27,7 @@ influx task list [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `list` command                                           |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 | `-i` | `--id`            | Task ID                                                               | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 |      | `--limit`         | Number of tasks to find (default `100`)                               | integer     |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/task/log/list.md
+++ b/content/influxdb/v2.0/reference/cli/influx/task/log/list.md
@@ -27,7 +27,7 @@ influx task log list [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `list` command                                           |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 |      | `--run-id`        | Run ID                                                                | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 |      | `--skip-verify`   | Skip TLS certificate verification                                     |             |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/task/run/list.md
+++ b/content/influxdb/v2.0/reference/cli/influx/task/run/list.md
@@ -29,7 +29,7 @@ influx task run list [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `list` command                                           |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 |      | `--limit`         | Limit the number of results                                           | integer     |                       |
 |      | `--run-id`        | Run ID                                                                | string      |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/task/run/retry.md
+++ b/content/influxdb/v2.0/reference/cli/influx/task/run/retry.md
@@ -21,7 +21,7 @@ influx task run retry [flags]
 | `-c` | `--active-config` | CLI configuration to use for command                                  | string      |                      |
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH` |
 | `-h` | `--help`          | Help for the `retry` command                                          |             |                      |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`        |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`        |
 | `-r` | `--run-id`        | **(Required)** Run ID                                                 | string      |                      |
 |      | `--skip-verify`   | Skip TLS certificate verification                                     |             |                      |
 | `-i` | `--task-id`       | **(Required)** Task ID                                                | string      |                      |

--- a/content/influxdb/v2.0/reference/cli/influx/task/update.md
+++ b/content/influxdb/v2.0/reference/cli/influx/task/update.md
@@ -23,7 +23,7 @@ influx task update [flags]
 | `-f` | `--file`          | Path to Flux script file                                              | string      |                       |
 | `-h` | `--help`          | Help for the `update` command                                         |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 | `-i` | `--id`            | **(Required)** Task ID                                                | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 |      | `--skip-verify`   | Skip TLS certificate verification                                     |             |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/user/create.md
+++ b/content/influxdb/v2.0/reference/cli/influx/user/create.md
@@ -22,7 +22,7 @@ influx user create [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `create` command                                         |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 | `-n` | `--name`          | **(Required)** Username                                               | string      | `INFLUX_NAME`         |
 | `-o` | `--org`           | Organization name                                                     | string      | `INFLUX_ORG`          |

--- a/content/influxdb/v2.0/reference/cli/influx/user/delete.md
+++ b/content/influxdb/v2.0/reference/cli/influx/user/delete.md
@@ -22,7 +22,7 @@ influx user delete [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `delete` command                                         |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 | `-i` | `--id`            | **(Required)** User ID                                                | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 |      | `--skip-verify`   | Skip TLS certificate verification                                     |             |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/user/list.md
+++ b/content/influxdb/v2.0/reference/cli/influx/user/list.md
@@ -27,7 +27,7 @@ influx user list [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `list` command                                           |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 | `-i` | `--id`            | User ID                                                               | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 | `-n` | `--name`          | Username                                                              | string      |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/user/password.md
+++ b/content/influxdb/v2.0/reference/cli/influx/user/password.md
@@ -23,7 +23,7 @@ influx user password [flags]
 | `-c` | `--active-config` | CLI configuration to use for command                                  | string      |                      |
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH` |
 | `-h` | `--help`          | Help for the `password` command                                       |             |                      |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`        |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`        |
 | `-i` | `--id`            | User ID                                                               | string      |                      |
 | `-n` | `--name`          | Username                                                              | string      |                      |
 |      | `--skip-verify`   | Skip TLS certificate verification                                     |             |                      |

--- a/content/influxdb/v2.0/reference/cli/influx/user/update.md
+++ b/content/influxdb/v2.0/reference/cli/influx/user/update.md
@@ -23,7 +23,7 @@ influx user update [flags]
 |      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string      |`INFLUX_CONFIGS_PATH`  |
 | `-h` | `--help`          | Help for the `update` command                                         |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:9999`)            | string      | `INFLUX_HOST`         |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
 | `-i` | `--id`            | **(Required)** User ID                                                | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 | `-n` | `--name`          | Username                                                              | string      |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/write/_index.md
@@ -42,7 +42,7 @@ influx write [command]
 |      | `--format`         | Input format (`lp` or `csv`, default `lp`)                            | string     |                      |
 |      | `--header`         | Prepend header line to CSV input data                                 | string     |                      |
 | `-h` | `--help`           | Help for the `dryrun` command                                         |            |                      |
-|      | `--host`           | HTTP address of InfluxDB (default `http://localhost:9999`)            | string     | `INFLUX_HOST`        |
+|      | `--host`           | HTTP address of InfluxDB (default `http://localhost:8086`)            | string     | `INFLUX_HOST`        |
 | `-o` | `--org`            | Organization name                                                     | string     | `INFLUX_ORG`         |
 |      | `--org-id`         | Organization ID                                                       | string     | `INFLUX_ORG_ID`      |
 | `-p` | `--precision`      | Precision of the timestamps (default `ns`)                            | string     | `INFLUX_PRECISION`   |

--- a/content/influxdb/v2.0/reference/cli/influx/write/dryrun.md
+++ b/content/influxdb/v2.0/reference/cli/influx/write/dryrun.md
@@ -36,7 +36,7 @@ influx write dryrun [flags]
 |      | `--format`         | Input format (`lp` or `csv`, default `lp`)                            | string     |                      |
 |      | `--header`         | Prepend header line to CSV input data                                 | string     |                      |
 | `-h` | `--help`           | Help for the `dryrun` command                                         |            |                      |
-|      | `--host`           | HTTP address of InfluxDB (default `http://localhost:9999`)            | string     | `INFLUX_HOST`        |
+|      | `--host`           | HTTP address of InfluxDB (default `http://localhost:8086`)            | string     | `INFLUX_HOST`        |
 | `-o` | `--org`            | Organization name                                                     | string     | `INFLUX_ORG`         |
 |      | `--org-id`         | Organization ID                                                       | string     | `INFLUX_ORG_ID`      |
 | `-p` | `--precision`      | Precision of the timestamps (default `ns`)                            | string     | `INFLUX_PRECISION`   |

--- a/content/influxdb/v2.0/reference/config-options.md
+++ b/content/influxdb/v2.0/reference/config-options.md
@@ -322,7 +322,7 @@ engine-path = "/users/user/.influxdbv2/engine"
 Define the bind address for the InfluxDB HTTP API.
 Customize the URL and port for the InfluxDB API and UI.
 
-**Default:** `:9999`  
+**Default:** `:8086`  
 
 | influxd flag          | Environment variable        | Configuration key   |
 |:------------          |:--------------------        |:-----------------   |
@@ -330,12 +330,12 @@ Customize the URL and port for the InfluxDB API and UI.
 
 ###### influxd flag
 ```sh
-influxd --http-bind-address=:9999
+influxd --http-bind-address=:8086
 ```
 
 ###### Environment variable
 ```sh
-export INFLUXD_HTTP_BIND_ADDRESS=:9999
+export INFLUXD_HTTP_BIND_ADDRESS=:8086
 ```
 
 ###### Configuration file
@@ -347,18 +347,18 @@ export INFLUXD_HTTP_BIND_ADDRESS=:9999
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```yml
-http-bind-address: ":9999"
+http-bind-address: ":8086"
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```toml
-http-bind-address = ":9999"
+http-bind-address = ":8086"
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```json
 {
-  "http-bind-address": ":9999"
+  "http-bind-address": ":8086"
 }
 ```
 {{% /code-tab-content %}}

--- a/content/influxdb/v2.0/reference/flux/language/lexical-elements.md
+++ b/content/influxdb/v2.0/reference/flux/language/lexical-elements.md
@@ -364,7 +364,7 @@ regexp_escape_char = `\` (`/` | `\`)
 
 ```js
 /.*/
-/http:\/\/localhost:9999/
+/http:\/\/localhost:8086/
 /^\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e(ZZ)?$/
 /^日本語(ZZ)?$/ // the above two lines are equivalent
 /\\xZZ/ // this becomes the literal pattern "\xZZ"

--- a/content/influxdb/v2.0/reference/flux/stdlib/experimental/csv/from.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/experimental/csv/from.md
@@ -22,7 +22,7 @@ _**Function type:** Input_
 ```js
 import "experimental/csv"
 
-csv.from(url: "http://localhost:9999/")
+csv.from(url: "http://localhost:8086/")
 ```
 
 ## Parameters

--- a/content/influxdb/v2.0/reference/flux/stdlib/experimental/http/get.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/experimental/http/get.md
@@ -19,7 +19,7 @@ _**Function type:** Miscellaneous_
 import "experimental/http"
 
 http.get(
-  url: "http://localhost:9999/",
+  url: "http://localhost:8086/",
   headers: {x:"a", y:"b", z:"c"},
   timeout: 30s
 )
@@ -76,7 +76,7 @@ import "csv"
 token = secrets.get(key: "READONLY_TOKEN")
 
 response = http.get(
-    url: "http://localhost:9999/health",
+    url: "http://localhost:8086/health",
     headers: {Authorization: "Token ${token}"}
   )
 

--- a/content/influxdb/v2.0/reference/flux/stdlib/experimental/prometheus/scrape.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/experimental/prometheus/scrape.md
@@ -22,7 +22,7 @@ _**Function type:** Input_
 import "experimental/prometheus"
 
 prometheus.scrape(
-  url: "http://localhost:9999/metrics"
+  url: "http://localhost:8086/metrics"
 )
 ```
 

--- a/content/influxdb/v2.0/reference/flux/stdlib/http/post.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/http/post.md
@@ -21,7 +21,7 @@ _**Function type:** Output_
 import "http"
 
 http.post(
-  url: "http://localhost:9999/",
+  url: "http://localhost:8086/",
   headers: {x:"a", y:"b", z:"c"},
   data: bytes(v: "body")
 )

--- a/content/influxdb/v2.0/reference/glossary.md
+++ b/content/influxdb/v2.0/reference/glossary.md
@@ -962,7 +962,7 @@ string values are annotated with the `string` datatype.
 
 ### TCP
 
-InfluxDB uses Transmission Control Protocol (TCP) port 9999 for client-server communication over the InfluxDB HTTP API.
+InfluxDB uses Transmission Control Protocol (TCP) port 8086 for client-server communication over the InfluxDB HTTP API.
 
 <!--ports for InfluxDB Enterprise -->
 

--- a/content/influxdb/v2.0/reference/urls.md
+++ b/content/influxdb/v2.0/reference/urls.md
@@ -27,7 +27,7 @@ For InfluxDB OSS, the default URL is the following:
 
 {{< keep-url >}}
 ```
-http://localhost:9999/
+http://localhost:8086/
 ```
 
 ### Customize your InfluxDB OSS URL

--- a/content/influxdb/v2.0/security/enable-tls.md
+++ b/content/influxdb/v2.0/security/enable-tls.md
@@ -104,13 +104,13 @@ InfluxDB supports three types of TLS certificates:
     Ensure you can connect over HTTPS by running
 
     ```
-    curl -v https://localhost:9999/api/v2/ping
+    curl -v https://localhost:8086/api/v2/ping
     ```
 
     If using a self-signed certificate, use the `-k` flag to skip certificate verification:
 
     ```
-    curl -vk https://localhost:9999/api/v2/ping
+    curl -vk https://localhost:8086/api/v2/ping
     ```
 
     With this command, you should see output confirming a succussful TLS handshake.
@@ -136,7 +136,7 @@ update the following `influxdb_v2` output settings in your Telegraf configuratio
   ##
   ## Multiple URLs can be specified for a single cluster, only ONE of the
   ## urls will be written to each interval.
-  urls = ["https://127.0.0.1:9999"]
+  urls = ["https://127.0.0.1:8086"]
 
   [...]
 

--- a/content/influxdb/v2.0/security/secrets/manage-secrets/add.md
+++ b/content/influxdb/v2.0/security/secrets/manage-secrets/add.md
@@ -43,7 +43,7 @@ add a new secret to your organization.
 
 <!-- -->
 ```sh
-curl -XPATCH http://localhost:9999/api/v2/orgs/<org-id>/secrets \
+curl -XPATCH http://localhost:8086/api/v2/orgs/<org-id>/secrets \
   -H 'Authorization: Token YOURAUTHTOKEN' \
   -H 'Content-type: application/json' \
   --data '{

--- a/content/influxdb/v2.0/security/secrets/manage-secrets/delete.md
+++ b/content/influxdb/v2.0/security/secrets/manage-secrets/delete.md
@@ -35,7 +35,7 @@ to delete one or more secrets.
 
 <!-- -->
 ```bash
-curl -XGET http://localhost:9999/api/v2/orgs/<org-id>/secrets/delete \
+curl -XGET http://localhost:8086/api/v2/orgs/<org-id>/secrets/delete \
   --H 'Authorization: Token YOURAUTHTOKEN'
   --data '{
   "secrets": [

--- a/content/influxdb/v2.0/security/secrets/manage-secrets/update.md
+++ b/content/influxdb/v2.0/security/secrets/manage-secrets/update.md
@@ -43,7 +43,7 @@ to update a secret in your organization.
 
 <!-- -->
 ```sh
-curl -XPATCH http://localhost:9999/api/v2/orgs/<org-id>/secrets \
+curl -XPATCH http://localhost:8086/api/v2/orgs/<org-id>/secrets \
   -H 'Authorization: Token YOURAUTHTOKEN' \
   -H 'Content-type: application/json' \
   --data '{

--- a/content/influxdb/v2.0/security/secrets/manage-secrets/view.md
+++ b/content/influxdb/v2.0/security/secrets/manage-secrets/view.md
@@ -29,6 +29,6 @@ to view your organization's secrets keys.
 
 <!-- -->
 ```sh
-curl -XGET http://localhost:9999/api/v2/orgs/<org-id>/secrets \
+curl -XGET http://localhost:8086/api/v2/orgs/<org-id>/secrets \
   -H 'Authorization: Token YOURAUTHTOKEN'
 ```

--- a/content/influxdb/v2.0/telegraf-configs/_index.md
+++ b/content/influxdb/v2.0/telegraf-configs/_index.md
@@ -23,7 +23,7 @@ the configuration from an InfluxDB HTTP(S) endpoint.
   InfluxDB Telegraf configuration. For example:
 
     ```sh
-    telegraf --config http://localhost:9999/api/v2/telegrafs/<telegraf-config-id>
+    telegraf --config http://localhost:8086/api/v2/telegrafs/<telegraf-config-id>
     ```
 
 {{% note %}}

--- a/content/influxdb/v2.0/tools/repl.md
+++ b/content/influxdb/v2.0/tools/repl.md
@@ -30,7 +30,7 @@ to the [`from()` function](/influxdb/v2.0/reference/flux/stdlib/built-in/inputs/
 
 ```js
 from(bucket: "example-bucket",
-  host: "http://localhost:9999",
+  host: "http://localhost:8086",
   org: "example-org",
   token: "My5uP3rS3cRetT0k3n"
   )

--- a/content/influxdb/v2.0/visualize-data/dashboards/_index.md
+++ b/content/influxdb/v2.0/visualize-data/dashboards/_index.md
@@ -23,7 +23,7 @@ Use the InfluxDB UI or `influx` CLI to view your dashboard ID.
 When viewing a dashboard in the InfluxDB UI, your dashboard ID appears in the URL.
 
 <pre class="highlight">
-http://localhost:9999/orgs/03a2bbf46249a000/dashboards/<span class="bp" style="font-weight:bold;margin:0 .15rem">04b6b15034cc000</span>/...
+http://localhost:8086/orgs/03a2bbf46249a000/dashboards/<span class="bp" style="font-weight:bold;margin:0 .15rem">04b6b15034cc000</span>/...
 </pre>
 
 ### Dashboard ID in the CLI

--- a/content/influxdb/v2.0/visualize-data/other-tools/grafana.md
+++ b/content/influxdb/v2.0/visualize-data/other-tools/grafana.md
@@ -51,7 +51,7 @@ configure your InfluxDB connection:
     - **URL**: Your [InfluxDB URL](/influxdb/v2.0/reference/urls/) **with the `/api/v2` path**.
 
         ```sh
-        http://localhost:9999/api/v2
+        http://localhost:8086/api/v2
         ```
 
     - **Organization**: Your InfluxDB [organization name **or** ID](/influxdb/v2.0/organizations/view-orgs/).

--- a/content/influxdb/v2.0/write-data/_index.md
+++ b/content/influxdb/v2.0/write-data/_index.md
@@ -152,7 +152,7 @@ Click **Quick Start**.
 
 InfluxDB creates and configures a new [scraper](/influxdb/v2.0/write-data/no-code/scrape-data/).
 The target URL points to the `/metrics` HTTP endpoint of your local InfluxDB instance
-(for example, `http://localhost:9999/metrics`), which outputs internal InfluxDB
+(for example, `http://localhost:8086/metrics`), which outputs internal InfluxDB
 metrics in the [Prometheus data format](https://prometheus.io/docs/instrumenting/exposition_formats/).
 The scraper stores the scraped metrics in the bucket created during the
 [initial setup process](/influxdb/v2.0/get-started/#set-up-influxdb).

--- a/content/influxdb/v2.0/write-data/best-practices/optimize-writes.md
+++ b/content/influxdb/v2.0/write-data/best-practices/optimize-writes.md
@@ -74,7 +74,7 @@ In the `influxdb_v2` output plugin configuration in your `telegraf.conf`, set th
 
 ```toml
 [[outputs.influxdb_v2]]
-  urls = ["http://localhost:9999"]
+  urls = ["http://localhost:8086"]
   # ...
   content_encoding = "gzip"
 ```
@@ -94,7 +94,7 @@ When using the InfluxDB API `/write` endpoint to write data, set the `Content-En
 header to `gzip` to compress the request data.
 
 ```sh
-curl -XPOST "http://localhost:9999/api/v2/write?org=YOUR_ORG&bucket=YOUR_BUCKET&precision=s" \
+curl -XPOST "http://localhost:8086/api/v2/write?org=YOUR_ORG&bucket=YOUR_BUCKET&precision=s" \
   --header "Authorization: Token YOURAUTHTOKEN" \
   --header "Content-Encoding: gzip" \
   --data-raw "mem,host=host1 used_percent=23.43234543 1556896326"

--- a/content/influxdb/v2.0/write-data/developer-tools/api.md
+++ b/content/influxdb/v2.0/write-data/developer-tools/api.md
@@ -36,7 +36,7 @@ Compressing write requests reduces network bandwidth, but increases server-side 
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```sh
-curl -XPOST "http://localhost:9999/api/v2/write?org=YOUR_ORG&bucket=YOUR_BUCKET&precision=s" \
+curl -XPOST "http://localhost:8086/api/v2/write?org=YOUR_ORG&bucket=YOUR_BUCKET&precision=s" \
   --header "Authorization: Token YOURAUTHTOKEN" \
   --data-raw "
 mem,host=host1 used_percent=23.43234543 1556896326
@@ -48,7 +48,7 @@ mem,host=host2 used_percent=27.18294630 1556896336
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```bash
-curl -XPOST "http://localhost:9999/api/v2/write?org=YOUR_ORG&bucket=YOUR_BUCKET&precision=s" \
+curl -XPOST "http://localhost:8086/api/v2/write?org=YOUR_ORG&bucket=YOUR_BUCKET&precision=s" \
   --header "Authorization: Token YOURAUTHTOKEN" \
   --header "Content-Encoding: gzip" \
   --data-raw "

--- a/content/influxdb/v2.0/write-data/no-code/scrape-data/manage-scrapers/create-a-scraper.md
+++ b/content/influxdb/v2.0/write-data/no-code/scrape-data/manage-scrapers/create-a-scraper.md
@@ -23,7 +23,7 @@ Create a new scraper in the InfluxDB user interface (UI).
 4. Enter a **Name** for the scraper.
 5. Select a **Bucket** to store the scraped data.
 6. Enter the **Target URL** to scrape.
-   The default URL value is `http://localhost:9999/metrics`,
+   The default URL value is `http://localhost:8086/metrics`,
    which provides InfluxDB-specific metrics in the [Prometheus data format](https://prometheus.io/docs/instrumenting/exposition_formats/).
 7. Click **Create**.
 

--- a/content/influxdb/v2.0/write-data/no-code/third-party.md
+++ b/content/influxdb/v2.0/write-data/no-code/third-party.md
@@ -70,7 +70,7 @@ To configure Apache JMeter, complete the following steps in InfluxDB and JMeter.
       ```
    - **influxdbUrl**: _(include the bucket and org you created in InfluxDB)_
       ```
-      http://localhost:9999/api/v2/write?org=my-org&bucket=jmeter
+      http://localhost:8086/api/v2/write?org=my-org&bucket=jmeter
       ```
    - **application**: `InfluxDB2`
    - **influxdbToken**: _your InfluxDB authentication token_

--- a/content/influxdb/v2.0/write-data/no-code/use-telegraf/auto-config.md
+++ b/content/influxdb/v2.0/write-data/no-code/use-telegraf/auto-config.md
@@ -32,7 +32,7 @@ for using Telegraf with InfluxDB v2.0._
 
 ## Create a Telegraf configuration
 
-1. Open the InfluxDB UI _(default: [localhost:9999](http://localhost:9999))_.
+1. Open the InfluxDB UI _(default: [localhost:8086](http://localhost:8086))_.
 2. In the navigation menu on the left, select **Data** (**Load Data**) > **Telegraf**.
 
     {{< nav-icon "load data" >}}
@@ -140,7 +140,7 @@ For the exact command, see the Telegraf configuration **Setup Instructions** in 
 {{% /note %}}
 
 ```sh
-telegraf -config http://localhost:9999/api/v2/telegrafs/0xoX00oOx0xoX00o
+telegraf -config http://localhost:8086/api/v2/telegrafs/0xoX00oOx0xoX00o
 ```
 
 ## Manage Telegraf configurations

--- a/content/influxdb/v2.0/write-data/no-code/use-telegraf/manual-config.md
+++ b/content/influxdb/v2.0/write-data/no-code/use-telegraf/manual-config.md
@@ -129,7 +129,7 @@ The example below illustrates an `influxdb_v2` configuration.
 # ...
 
 [[outputs.influxdb_v2]]
-  urls = ["http://localhost:9999"]
+  urls = ["http://localhost:8086"]
   token = "$INFLUX_TOKEN"
   organization = "example-org"
   bucket = "example-bucket"

--- a/content/kapacitor/v1.4/administration/configuration.md
+++ b/content/kapacitor/v1.4/administration/configuration.md
@@ -298,6 +298,7 @@ but one InfluxDB table array configuration must be flagged as the `default`.
 
 **Example 8 &ndash; An InfluxDB Connection grouping**
 
+{{< keep-url >}}
 ```toml
 ...
 [[influxdb]]

--- a/content/kapacitor/v1.4/administration/security.md
+++ b/content/kapacitor/v1.4/administration/security.md
@@ -60,6 +60,7 @@ When testing with a **self-signed certificate** it is also important to switch o
 certificate verification with the property `insecure-skip-verify`.  Failure to do
 so will result in x509 certificate errors as follows:
 
+{{< keep-url >}}
 ```
 ts=2018-02-19T13:26:11.437+01:00 lvl=error msg="failed to connect to InfluxDB, retrying..." service=influxdb cluster=localhost err="Get https://localhost:8086/ping: x509: certificate is valid for lenovo-TP02, not localhost"
 ```
@@ -71,6 +72,8 @@ ts=2018-02-19T13:26:11.437+01:00 lvl=error msg="failed to connect to InfluxDB, r
 In the configuration file these values are set according to the following example.
 
 **Example 1 &ndash; TLS Configuration Properties for InfluxDB &ndash; kapacitor.conf**
+
+{{< keep-url >}}
 ```toml
 [[influxdb]]
   # Connect to an InfluxDB cluster
@@ -106,6 +109,8 @@ Note that when a CA file contains the certificate and key together the property
 As environment variables these properties can be set as follows:
 
 **Example 2 &ndash; TLS Configuration Properties for InfluxDB &ndash; ENVARS**
+
+{{< keep-url >}}
 ```
 KAPACITOR_INFLUXDB_0_URLS_0="https://localhost:8086"
 KAPACITOR_INFLUXDB_0_SSL_CERT="/etc/ssl/influxdb-selfsigned.crt"
@@ -129,6 +134,7 @@ This results in the following file:
 
 **Example 3 &ndash; The InfluxDB part of the Kapacitor configuration**
 
+{{< keep-url >}}
 ```json
 {
     "elements": [
@@ -223,6 +229,7 @@ file, as environment variables or over the HTTP API.
 
 **Example 4 &ndash; InfluxDB Authentication Parameters &ndash; kapacitor.conf**
 
+{{< keep-url >}}
 ```toml
 [[influxdb]]
   # Connect to an InfluxDB cluster

--- a/content/kapacitor/v1.4/guides/live_leaderboard.md
+++ b/content/kapacitor/v1.4/guides/live_leaderboard.md
@@ -188,6 +188,7 @@ max
 
 Since we are writing data back to InfluxDB create a database `game` for our results.
 
+{{< keep-url >}}
 ```
 curl -G 'http://localhost:8086/query?' --data-urlencode 'q=CREATE DATABASE game'
 ```
@@ -275,6 +276,7 @@ Hit the endpoint several times to see that the scores are updating once a second
 
 Now, let's check InfluxDB to see our historical data.
 
+{{< keep-url >}}
 ```bash
 curl \
     -G 'http://localhost:8086/query?db=game' \

--- a/content/kapacitor/v1.4/introduction/getting-started.md
+++ b/content/kapacitor/v1.4/introduction/getting-started.md
@@ -114,6 +114,8 @@ The Telegraf configuration file can be found at its default location: `/etc/tele
    * `[[inputs.cpu]]` - declares how to collect the system cpu metrics to be sent to InfluxDB.
 
 *Example - relevant sections of `/etc/telegraf/telegraf.conf`*
+
+{{< keep-url >}}
 ```
 [agent]
   ## Default data collection interval for all inputs
@@ -191,6 +193,7 @@ InfluxDB and Telegraf are now running and listening on localhost.  Wait about a 
 
 This can be achieved with the following query:
 
+{{< keep-url >}}
 ```bash
 $ curl -G 'http://localhost:8086/query?db=telegraf' --data-urlencode 'q=SELECT mean(usage_idle) FROM cpu'
 ```
@@ -376,6 +379,7 @@ Telegraf will log errors if it cannot communicate to InfluxDB.
 InfluxDB will log an error about `connection refused` if it cannot send data to Kapacitor.
 Run the query `SHOW SUBSCRIPTIONS` to find the endpoint that InfluxDB is using to send data to Kapacitor.
 
+{{< keep-url >}}
 ```
 $ curl -G 'http://localhost:8086/query?db=telegraf' --data-urlencode 'q=SHOW SUBSCRIPTIONS'
 

--- a/content/kapacitor/v1.4/introduction/install-docker.md
+++ b/content/kapacitor/v1.4/introduction/install-docker.md
@@ -127,6 +127,7 @@ At this point there should be running on the host machine: InfluxDB, Telegraf an
 
 The running configuration can be further inspected by using the `influx` command line client directly from the InfluxDB Container.
 
+{{< keep-url >}}
 ```
 $ docker exec -it tik_influxdb_1 influx --precision rfc3339
 Connected to http://localhost:8086 version 1.3.3

--- a/content/kapacitor/v1.4/working/api.md
+++ b/content/kapacitor/v1.4/working/api.md
@@ -1860,6 +1860,7 @@ Retrieve all the configuration sections which can be overridden.
 GET /kapacitor/v1/config
 ```
 
+{{< keep-url >}}
 ```json
 {
     "link" : {"rel": "self", "href": "/kapacitor/v1/config"},
@@ -1986,6 +1987,7 @@ Retrieve only the InfluxDB section.
 GET /kapacitor/v1/config/influxdb
 ```
 
+{{< keep-url >}}
 ```json
 {
     "link" : {"rel": "self", "href": "/kapacitor/v1/config/influxdb"},

--- a/content/kapacitor/v1.5/administration/configuration.md
+++ b/content/kapacitor/v1.5/administration/configuration.md
@@ -340,6 +340,7 @@ To use Kapacitor with an InfluxDB instance that requires authentication,
 it must authenticate using an InfluxDB user with **read and write** permissions.
 {{% /note %}}
 
+{{< keep-url >}}
 ```toml
 ...
 [[influxdb]]

--- a/content/kapacitor/v1.5/administration/security.md
+++ b/content/kapacitor/v1.5/administration/security.md
@@ -59,6 +59,7 @@ When testing with a **self-signed certificate** it is also important to switch o
 certificate verification with the property `insecure-skip-verify`.  Failure to do
 so will result in x509 certificate errors as follows:
 
+{{< keep-url >}}
 ```
 ts=2018-02-19T13:26:11.437+01:00 lvl=error msg="failed to connect to InfluxDB, retrying..." service=influxdb cluster=localhost err="Get https://localhost:8086/ping: x509: certificate is valid for lenovo-TP02, not localhost"
 ```
@@ -70,6 +71,8 @@ ts=2018-02-19T13:26:11.437+01:00 lvl=error msg="failed to connect to InfluxDB, r
 In the configuration file these values are set according to the following example.
 
 **Example 1 &ndash; TLS Configuration Properties for InfluxDB &ndash; kapacitor.conf**
+
+{{< keep-url >}}
 ```toml
 [[influxdb]]
   # Connect to an InfluxDB cluster
@@ -105,6 +108,8 @@ Note that when a CA file contains the certificate and key together the property
 As environment variables these properties can be set as follows:
 
 **Example 2 &ndash; TLS Configuration Properties for InfluxDB &ndash; ENVARS**
+
+{{< keep-url >}}
 ```
 KAPACITOR_INFLUXDB_0_URLS_0="https://localhost:8086"
 KAPACITOR_INFLUXDB_0_SSL_CERT="/etc/ssl/influxdb-selfsigned.crt"
@@ -128,6 +133,7 @@ This results in the following file:
 
 **Example 3 &ndash; The InfluxDB part of the Kapacitor configuration**
 
+{{< keep-url >}}
 ```json
 {
     "elements": [
@@ -222,6 +228,7 @@ file, as environment variables or over the HTTP API.
 
 **Example 4 &ndash; InfluxDB Authentication Parameters &ndash; kapacitor.conf**
 
+{{< keep-url >}}
 ```toml
 [[influxdb]]
   # Connect to an InfluxDB cluster

--- a/content/kapacitor/v1.5/guides/live_leaderboard.md
+++ b/content/kapacitor/v1.5/guides/live_leaderboard.md
@@ -190,6 +190,7 @@ max
 
 Since we are writing data back to InfluxDB create a database `game` for our results.
 
+{{< keep-url >}}
 ```
 curl -G 'http://localhost:8086/query?' --data-urlencode 'q=CREATE DATABASE game'
 ```
@@ -277,6 +278,7 @@ Hit the endpoint several times to see that the scores are updating once a second
 
 Now, let's check InfluxDB to see our historical data.
 
+{{< keep-url >}}
 ```bash
 curl \
     -G 'http://localhost:8086/query?db=game' \

--- a/content/kapacitor/v1.5/introduction/getting-started.md
+++ b/content/kapacitor/v1.5/introduction/getting-started.md
@@ -46,6 +46,7 @@ To get started, do the following:
 
 2. In the Telegraf configuration file (`/etc/telegraf/telegraf.conf`), configure `[[outputs.influxd]]` to specify how to connect to InfluxDB and the destination database.
 
+    {{< keep-url >}}
     ```sh
     [[outputs.influxdb]]
     ## InfluxDB url is required and must be in the following form: http/udp "://" host [ ":" port]
@@ -67,6 +68,7 @@ To get started, do the following:
 
 4. After a minute, run the following command to use the InfluxDB API to query for the Telegraf data:
 
+    {{< keep-url >}}
     ```bash
     $ curl -G 'http://localhost:8086/query?db=telegraf' --data-urlencode 'q=SELECT mean(usage_idle) FROM cpu'
     ```
@@ -276,8 +278,9 @@ Complete the following steps to ensure log files and communication channels aren
     InfluxDB logs an error about `connection refused` if it cannot send data to Kapacitor.
     Run the query `SHOW SUBSCRIPTIONS` against InfluxDB to find the endpoint that InfluxDB is using to send data to Kapacitor.
 
-    In the following example, InfluxDB must be running on localhost:8086:
+    In the following example, InfluxDB must be running on `localhost:8086`:
 
+    {{< keep-url >}}
     ```
     $ curl -G 'http://localhost:8086/query?db=telegraf' --data-urlencode 'q=SHOW SUBSCRIPTIONS'
 

--- a/content/kapacitor/v1.5/introduction/install-docker.md
+++ b/content/kapacitor/v1.5/introduction/install-docker.md
@@ -126,6 +126,7 @@ At this point there should be running on the host machine: InfluxDB, Telegraf an
 
 The running configuration can be further inspected by using the `influx` command line client directly from the InfluxDB Container.
 
+{{< keep-url >}}
 ```
 $ docker exec -it tik_influxdb_1 influx --precision rfc3339
 Connected to http://localhost:8086 version 1.3.3

--- a/content/kapacitor/v1.5/working/api.md
+++ b/content/kapacitor/v1.5/working/api.md
@@ -1864,6 +1864,7 @@ Retrieve all the configuration sections which can be overridden.
 GET /kapacitor/v1/config
 ```
 
+{{< keep-url >}}
 ```json
 {
     "link" : {"rel": "self", "href": "/kapacitor/v1/config"},
@@ -1990,6 +1991,7 @@ Retrieve only the InfluxDB section.
 GET /kapacitor/v1/config/influxdb
 ```
 
+{{< keep-url >}}
 ```json
 {
     "link" : {"rel": "self", "href": "/kapacitor/v1/config/influxdb"},

--- a/content/telegraf/v1.10/administration/configuration.md
+++ b/content/telegraf/v1.10/administration/configuration.md
@@ -73,7 +73,7 @@ Each plugin will sleep for a random time within jitter before collecting.
 This can be used to avoid many plugins querying things like sysfs at the
 same time, which can have a measurable effect on the system.
 * **flush_interval**: Default data flushing interval for all outputs.
-You should not set this below `interval`. 
+You should not set this below `interval`.
 Maximum `flush_interval` will be `flush_interval` + `flush_jitter`
 * **flush_jitter**: Jitter the flush interval by a random amount.
 This is primarily to avoid
@@ -322,6 +322,7 @@ Additional inputs (or outputs) of the same type can be specified by defining the
 
 #### Output configuration examples:
 
+{{< keep-url >}}
 ```toml
 [[outputs.influxdb]]
   urls = [ "http://localhost:8086" ]

--- a/content/telegraf/v1.11/administration/configuration.md
+++ b/content/telegraf/v1.11/administration/configuration.md
@@ -73,7 +73,7 @@ Each plugin will sleep for a random time within jitter before collecting.
 This can be used to avoid many plugins querying things like sysfs at the
 same time, which can have a measurable effect on the system.
 * **flush_interval**: Default data flushing interval for all outputs.
-You should not set this below `interval`. 
+You should not set this below `interval`.
 Maximum `flush_interval` will be `flush_interval` + `flush_jitter`
 * **flush_jitter**: Jitter the flush interval by a random amount.
 This is primarily to avoid
@@ -322,6 +322,7 @@ Additional inputs (or outputs) of the same type can be specified by defining the
 
 #### Output configuration examples:
 
+{{< keep-url >}}
 ```toml
 [[outputs.influxdb]]
   urls = [ "http://localhost:8086" ]

--- a/content/telegraf/v1.12/administration/configuration.md
+++ b/content/telegraf/v1.12/administration/configuration.md
@@ -73,7 +73,7 @@ Each plugin will sleep for a random time within jitter before collecting.
 This can be used to avoid many plugins querying things like sysfs at the
 same time, which can have a measurable effect on the system.
 * **flush_interval**: Default data flushing interval for all outputs.
-You should not set this below `interval`. 
+You should not set this below `interval`.
 Maximum `flush_interval` will be `flush_interval` + `flush_jitter`
 * **flush_jitter**: Jitter the flush interval by a random amount.
 This is primarily to avoid
@@ -322,6 +322,7 @@ Additional inputs (or outputs) of the same type can be specified by defining the
 
 #### Output configuration examples:
 
+{{< keep-url >}}
 ```toml
 [[outputs.influxdb]]
   urls = [ "http://localhost:8086" ]

--- a/content/telegraf/v1.13/administration/configuration.md
+++ b/content/telegraf/v1.13/administration/configuration.md
@@ -41,7 +41,7 @@ configuration files.
 ## Set environment variables
 
 Add environment variables anywhere in the configuration file by prepending them with `$`.
-For strings, variables must be in quotes (for example, `"$STR_VAR"`). 
+For strings, variables must be in quotes (for example, `"$STR_VAR"`).
 For numbers and Booleans, variables must be unquoted (for example, `$INT_VAR`, `$BOOL_VAR`).
 
 You can also set environment variables using the Linux `export` command: `export password=mypassword`
@@ -52,6 +52,7 @@ You can also set environment variables using the Linux `export` command: `export
 
 In the Telegraf environment variables file (`/etc/default/telegraf`):
 
+{{< keep-url >}}
 ```sh
 USER="alice"
 INFLUX_URL="http://localhost:8086"
@@ -75,6 +76,7 @@ In the Telegraf configuration file (`/etc/telegraf.conf`):
 
 The environment variables above add the following configuration settings to Telegraf:
 
+{{< keep-url >}}
 ```sh
 [global_tags]
   user = "alice"
@@ -361,6 +363,7 @@ Additional inputs (or outputs) of the same type can be specified by defining the
 
 #### Output configuration examples:
 
+{{< keep-url >}}
 ```toml
 [[outputs.influxdb]]
   urls = [ "http://localhost:8086" ]

--- a/content/telegraf/v1.14/administration/configuration.md
+++ b/content/telegraf/v1.14/administration/configuration.md
@@ -42,7 +42,7 @@ configuration files.
 ## Set environment variables
 
 Add environment variables anywhere in the configuration file by prepending them with `$`.
-For strings, variables must be in quotes (for example, `"$STR_VAR"`). 
+For strings, variables must be in quotes (for example, `"$STR_VAR"`).
 For numbers and Booleans, variables must be unquoted (for example, `$INT_VAR`, `$BOOL_VAR`).
 
 You can also set environment variables using the Linux `export` command: `export password=mypassword`
@@ -53,6 +53,7 @@ You can also set environment variables using the Linux `export` command: `export
 
 In the Telegraf environment variables file (`/etc/default/telegraf`):
 
+{{< keep-url >}}
 ```sh
 USER="alice"
 INFLUX_URL="http://localhost:8086"
@@ -76,6 +77,7 @@ In the Telegraf configuration file (`/etc/telegraf.conf`):
 
 The environment variables above add the following configuration settings to Telegraf:
 
+{{< keep-url >}}
 ```sh
 [global_tags]
   user = "alice"
@@ -361,6 +363,7 @@ Additional inputs (or outputs) of the same type can be specified by defining the
 
 #### Output configuration examples:
 
+{{< keep-url >}}
 ```toml
 [[outputs.influxdb]]
   urls = [ "http://localhost:8086" ]

--- a/content/telegraf/v1.15/administration/configuration.md
+++ b/content/telegraf/v1.15/administration/configuration.md
@@ -53,6 +53,7 @@ You can also set environment variables using the Linux `export` command: `export
 
 In the Telegraf environment variables file (`/etc/default/telegraf`):
 
+{{< keep-url >}}
 ```sh
 USER="alice"
 INFLUX_URL="http://localhost:8086"
@@ -76,6 +77,7 @@ In the Telegraf configuration file (`/etc/telegraf.conf`):
 
 The environment variables above add the following configuration settings to Telegraf:
 
+{{< keep-url >}}
 ```sh
 [global_tags]
   user = "alice"
@@ -362,6 +364,7 @@ Additional inputs (or outputs) of the same type can be specified by defining the
 
 #### Output configuration examples:
 
+{{< keep-url >}}
 ```toml
 [[outputs.influxdb]]
   urls = [ "http://localhost:8086" ]

--- a/content/telegraf/v1.9/administration/configuration.md
+++ b/content/telegraf/v1.9/administration/configuration.md
@@ -322,6 +322,7 @@ Additional inputs (or outputs) of the same type can be specified by defining the
 
 #### Output configuration examples:
 
+{{< keep-url >}}
 ```toml
 [[outputs.influxdb]]
   urls = [ "http://localhost:8086" ]

--- a/data/influxdb_urls.yml
+++ b/data/influxdb_urls.yml
@@ -3,8 +3,8 @@ oss:
   providers:
     - name: Default
       regions:
-        - name: localhost:9999
-          url: http://localhost:9999
+        - name: localhost:8086
+          url: http://localhost:8086
     - name: Custom
       url: http://example.com:8080
 

--- a/data/influxdb_urls.yml
+++ b/data/influxdb_urls.yml
@@ -1,5 +1,5 @@
 oss:
-  product: InfluxDB v2 OSS
+  product: InfluxDB OSS
   providers:
     - name: Default
       regions:

--- a/data/influxdb_urls.yml
+++ b/data/influxdb_urls.yml
@@ -1,5 +1,5 @@
 oss:
-  product: InfluxDB OSS
+  product: InfluxDB v2 OSS
   providers:
     - name: Default
       regions:

--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -613,7 +613,7 @@ input:
       ```toml
       [[inputs.prometheus]]
         ## An array of urls to scrape metrics from.
-        urls = ["http://localhost:9999/metrics"]
+        urls = ["http://localhost:8086/metrics"]
       ```
       </div>
     introduced: 1.8.0

--- a/data/versions.yaml
+++ b/data/versions.yaml
@@ -1,1 +1,0 @@
-stable_version: v2.0

--- a/layouts/partials/footer/influxdb-url-modal.html
+++ b/layouts/partials/footer/influxdb-url-modal.html
@@ -6,7 +6,7 @@
       <a id="modal-close"href="#"><span class="icon-ui-remove"></span></a>
       <div class="modal-content">
         <h3>Where are you running InfluxDB?</h3>
-        <p>Select where you're using <strong>InfluxDB Cloud</strong> or <strong>InfluxDB v2 OSS</strong> and we'll customize code examples with your <strong>InfluxDB URL</strong>.</p>
+        <p>Select where you're using <strong>InfluxDB Cloud</strong> or <strong>InfluxDB OSS</strong> and we'll customize code examples with your <strong>InfluxDB URL</strong>.</p>
         <div class="products">
           {{ range sort .Site.Data.influxdb_urls "product" "desc" }}
             <div class="product">

--- a/layouts/partials/footer/influxdb-url-modal.html
+++ b/layouts/partials/footer/influxdb-url-modal.html
@@ -1,4 +1,4 @@
-{{ $currentVersion := (index (findRE "[^/]+.*?" .RelPermalink) 0) .RelPermalink | default "v2.0" }}
+{{ $latestInfluxDBVersion := index (last 1 $.Site.Data.products.influxdb.versions) 0 }}
 <div class="modal">
   <div class="modal-overlay"></div>
   <div class="modal-wrapper">
@@ -6,7 +6,7 @@
       <a id="modal-close"href="#"><span class="icon-ui-remove"></span></a>
       <div class="modal-content">
         <h3>Where are you running InfluxDB?</h3>
-        <p>Select where you're using InfluxDB and we'll customize code examples with your <strong>InfluxDB URL</strong>.</p>
+        <p>Select where you're using <strong>InfluxDB Cloud</strong> or <strong>InfluxDB v2 OSS</strong> and we'll customize code examples with your <strong>InfluxDB URL</strong>.</p>
         <div class="products">
           {{ range sort .Site.Data.influxdb_urls "product" "desc" }}
             <div class="product">
@@ -47,7 +47,7 @@
             </div>
           {{ end }}
         </div>
-        <p class="note">For more information, see <a href='{{ print "/influxdb/v2.0/reference/urls/"}}'>InfluxDB URLs</a>.</p>
+        <p class="note">For more information, see <a href='{{ print "/influxdb/" $latestInfluxDBVersion "/reference/urls/"}}'>InfluxDB URLs</a>.</p>
       </div>
     </div>
   </div>

--- a/layouts/shortcodes/cli/influxd-flags.md
+++ b/layouts/shortcodes/cli/influxd-flags.md
@@ -5,7 +5,7 @@
 |      | `--e2e-testing`                | Add /debug/flush endpoint to clear stores; used for end-to-end tests (default `false`)                            |            | `INFLUXD_E2E_TESTING`                |
 |      | `--engine-path`                | Path to persistent engine files (default `~/.influxdbv2/engine`)                                                  | string     | `INFLUXD_ENGINE_PATH`                |
 | `-h` | `--help`                       | Help for the `influxd` command                                                                                    |            |                                      |
-|      | `--http-bind-address`          | Bind address for the REST HTTP API (default `:9999`)                                                              | string     | `INFLUXD_HTTP_BIND_ADDRESS`          |
+|      | `--http-bind-address`          | Bind address for the REST HTTP API (default `:8086`)                                                              | string     | `INFLUXD_HTTP_BIND_ADDRESS`          |
 |      | `--log-level`                  | Supported log levels are debug, info, and error (default `info`)                                                  | string     | `INFLUXD_LOG_LEVEL`                  |
 |      | `--new-meta-store`             | Enables the new meta store                                                                                        |            | `INFLUXD_NEW_META_STORE`             |
 |      | `--new-meta-store-read-only`   | Toggle read-only mode for the new meta store and duplicate reads between old and new store (default `true`)       |            | `INFLUXD_NEW_META_STORE_READ_ONLY`   |

--- a/static/downloads/air-sensor-data.rb
+++ b/static/downloads/air-sensor-data.rb
@@ -8,7 +8,7 @@ require "uri"
 options = {
   protocol: "http",
   host: "localhost",
-  port: "9999",
+  port: "8086",
   interval: 5
 }
 
@@ -31,7 +31,7 @@ OptionParser.new do |opt|
     options[:host] = host
   end
 
-  opt.on("-p","--port port","Your InfluxDB port. Defaults to '9999'") do |port|
+  opt.on("-p","--port port","Your InfluxDB port. Defaults to '8086'") do |port|
     options[:port] = port
   end
 

--- a/static/downloads/influxdb-k8-minikube.yaml
+++ b/static/downloads/influxdb-k8-minikube.yaml
@@ -26,7 +26,7 @@ spec:
               - image: quay.io/influxdb/influxdb:2.0.0-beta
                 name: influxdb
                 ports:
-                  - containerPort: 9999
+                  - containerPort: 8086
                     name: influxdb
                 volumeMounts:
                   - mountPath: /root/.influxdbv2
@@ -50,8 +50,8 @@ metadata:
 spec:
     ports:
       - name: influxdb
-        port: 9999
-        targetPort: 9999
+        port: 8086
+        targetPort: 8086
     selector:
         app: influxdb
     type: ClusterIP


### PR DESCRIPTION
Closes #1392 

Changed the default port from `9999` to `8086` and update the InfluxDB URLs functionality.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
