### PR TITLE
Add load data

### DIFF
--- a/content/influxdb/v2.0/write-data/_index.md
+++ b/content/influxdb/v2.0/write-data/_index.md
@@ -19,14 +19,17 @@ related:
   - /influxdb/v2.0/reference/cli/influx/write
 ---
 
-Collect and write time series data to InfluxDB Cloud and InfluxDB OSS. Discover how to quickly start collecting data, and then explore other ways to write data using no-code solutions or developer tools.
-
+Discover what you'll need to write data into InfluxDB Cloud or OSS (open source). Learn how to quickly start collecting data, and then explore ways to write data, best practices, and what we recommend if you're migrating a large amount of historical data.
 
 - [What you'll need](#what-you-ll-need)
 - [Quickly start collecting data](#quickly-start-collecting-data)
   - [Demo data for InfluxDB Cloud](#demo-data-for-influxdb-cloud)
   - [Quick Start for InfluxDB OSS](#quick-start-for-influxdb-oss)
-- [Other ways to write data](#other-ways-to-write-data)
+- [Load data from sources in the InfluxDB UI](#load-data-from-sources-in-the-influxdb-user-interface-ui)
+- [Use no-code solutions](/influxdb/v2.0/write-data/no-code)
+- [Use developer tools](/influxdb/v2.0/write-data/developer-tools)
+- [Best practices for writing data](/influxdb/v2.0/write-data/best-practices/)
+- [Migrate historical data](/influxdb/v2.0/write-data/bulk-ingest-cloud/)
 - [Next steps](#next-steps)
 
 ### What you'll need
@@ -163,15 +166,41 @@ If you missed the Quick Start option, you can [manually create a scraper](/influ
 that scrapes data from the `/metrics` endpoint.
 {{% /note %}}
 
-
 ---
 
-## Other ways to write data
+## Load data from sources in the InfluxDB user interface (UI)
 
-There are multiple options for writing data into InfluxDB, including both no-code and developer solutions.
+Load data from the following sources in the InfluxDB user interface (UI):
 
-  - [No-code solutions](/influxdb/v2.0/write-data/no-code)
-  - [Developer tools](/influxdb/v2.0/write-data/developer-tools)
+- [Client libraries](#load-data-from-a-client-library-in-the-ui)
+- [Telegraf plugins](#load-data-from-a-telegraf-plugin-in-the-ui)
+
+### Load data from a client library in the UI
+
+1.  In the navigation menu on the left, click **Data (Load Data)** > **Sources**.
+    {{< nav-icon "data" >}}
+2. Do one of the following:
+   - Enter a specific client library to search for in the **Search data writing methods** field.
+   - Scroll down to browse available client libraries.
+3. Click the client library to load data from.
+4. Under **Code Sample Options**, you'll see a list of your InfluxDB [tokens](/influxdb/v2.0/reference/glossary/#token) and [buckets](/influxdb/v2.0/reference/glossary/#bucket). Select both an authentication token and a bucket to write your data to. The selected token and bucket are automatically added to scripts on the page that you can use to initialize a client and write data.
+5. Click the **Copy to Clipboard** buttons under a script to easily paste the script into your terminal or save the script to reuse for automation.
+6. Run the scripts on the page to do the following as needed:
+   - Install the package, libraries, or client
+   - Write data
+   - Execute a Flux query
+
+### Load data from a Telegraf plugin in the UI
+
+1. In the navigation menu on the left, click **Data (Load Data)** > **Sources**.
+    {{< nav-icon "data" >}}
+2. Do one of the following:
+   - Enter a specific Telegraf plugin to search for in the **Search data writing methods** field.
+   - Scroll down to browse available plugins.
+3. Click the plugin to load data from.
+4. [Install Telegraf](/telegraf/v1.15/introduction/installation/).
+5. Copy the default configuration script in the UI, and then add the script to your [Telegraf configurations](/influxdb/v2.0/telegraf-configs/).
+7. Adjust configuration settings as needed. To find configuration settings for a specific plugin, see [Telegraf plugins](/telegraf/v1.15/plugins/).
 
 ---
 

--- a/content/influxdb/v2.0/write-data/_index.md
+++ b/content/influxdb/v2.0/write-data/_index.md
@@ -25,7 +25,7 @@ Discover what you'll need to write data into InfluxDB Cloud or OSS (open source)
 - [Quickly start collecting data](#quickly-start-collecting-data)
   - [Demo data for InfluxDB Cloud](#demo-data-for-influxdb-cloud)
   - [Quick Start for InfluxDB OSS](#quick-start-for-influxdb-oss)
-- [Load data from sources in the InfluxDB UI](#load-data-from-sources-in-the-influxdb-user-interface-ui)
+- [Load data from sources in the InfluxDB UI](/influxdb/v2.0/write-data/load-data/)
 - [Use no-code solutions](/influxdb/v2.0/write-data/no-code)
 - [Use developer tools](/influxdb/v2.0/write-data/developer-tools)
 - [Best practices for writing data](/influxdb/v2.0/write-data/best-practices/)
@@ -165,42 +165,6 @@ Quick Start is only available in the last step of the setup process.
 If you missed the Quick Start option, you can [manually create a scraper](/influxdb/v2.0/write-data/no-code/scrape-data/)
 that scrapes data from the `/metrics` endpoint.
 {{% /note %}}
-
----
-
-## Load data from sources in the InfluxDB user interface (UI)
-
-Load data from the following sources in the InfluxDB user interface (UI):
-
-- [Client libraries](#load-data-from-a-client-library-in-the-ui)
-- [Telegraf plugins](#load-data-from-a-telegraf-plugin-in-the-ui)
-
-### Load data from a client library in the UI
-
-1.  In the navigation menu on the left, click **Data (Load Data)** > **Sources**.
-    {{< nav-icon "data" >}}
-2. Do one of the following:
-   - Enter a specific client library to search for in the **Search data writing methods** field.
-   - Scroll down to browse available client libraries.
-3. Click the client library to load data from.
-4. Under **Code Sample Options**, you'll see a list of your InfluxDB [tokens](/influxdb/v2.0/reference/glossary/#token) and [buckets](/influxdb/v2.0/reference/glossary/#bucket). Select both an authentication token and a bucket to write your data to. The selected token and bucket are automatically added to scripts on the page that you can use to initialize a client and write data.
-5. Click the **Copy to Clipboard** buttons under a script to easily paste the script into your terminal or save the script to reuse for automation.
-6. Run the scripts on the page to do the following as needed:
-   - Install the package, libraries, or client
-   - Write data
-   - Execute a Flux query
-
-### Load data from a Telegraf plugin in the UI
-
-1. In the navigation menu on the left, click **Data (Load Data)** > **Sources**.
-    {{< nav-icon "data" >}}
-2. Do one of the following:
-   - Enter a specific Telegraf plugin to search for in the **Search data writing methods** field.
-   - Scroll down to browse available plugins.
-3. Click the plugin to load data from.
-4. [Install Telegraf](/telegraf/v1.15/introduction/installation/).
-5. Copy the default configuration script in the UI, and then add the script to your [Telegraf configurations](/influxdb/v2.0/telegraf-configs/).
-7. Adjust configuration settings as needed. To find configuration settings for a specific plugin, see [Telegraf plugins](/telegraf/v1.15/plugins/).
 
 ---
 

--- a/content/influxdb/v2.0/write-data/load-data.md
+++ b/content/influxdb/v2.0/write-data/load-data.md
@@ -1,0 +1,45 @@
+---
+title: Load data from sources in the InfluxDB user interface (UI)
+seotitle: Load data source in UI
+list_title: Load data source in UI
+weight: 105
+description: >
+  Load data source in UI
+menu:
+  influxdb_2_0:
+    name: Load data source in UI
+    parent: Write data
+---
+
+Load data from the following sources in the InfluxDB user interface (UI):
+
+- [Client libraries](#load-data-from-a-client-library-in-the-ui)
+- [Telegraf plugins](#load-data-from-a-telegraf-plugin-in-the-ui)
+
+### Load data from a client library in the UI
+
+1.  In the navigation menu on the left, click **Data (Load Data)** > **Sources**.
+    {{< nav-icon "data" >}}
+2. Do one of the following:
+   - Enter a specific client library to search for in the **Search data writing methods** field.
+   - Scroll down to browse available client libraries.
+3. Click the client library to load data from.
+4. Under **Code Sample Options**, you'll see a list of your InfluxDB [tokens](/influxdb/v2.0/reference/glossary/#token) and [buckets](/influxdb/v2.0/reference/glossary/#bucket). Select both an authentication token and a bucket to write your data to. The selected token and bucket are automatically added to scripts on the page that you can use to initialize a client and write data.
+5. Click the **Copy to Clipboard** buttons under a script to easily paste the script into your terminal or save the script to reuse for automation.
+6. Run the scripts on the page to do the following as needed:
+   - Install the package, libraries, or client
+   - Write data
+   - Execute a Flux query
+
+### Load data from a Telegraf plugin in the UI
+
+1. In the navigation menu on the left, click **Data (Load Data)** > **Sources**.
+    {{< nav-icon "data" >}}
+2. Do one of the following:
+   - Enter a specific Telegraf plugin to search for in the **Search data writing methods** field.
+   - Scroll down to browse available plugins.
+3. Click the plugin to load data from.
+4. [Install Telegraf](/telegraf/v1.15/introduction/installation/).
+5. Copy the default configuration script in the UI, and then add the script to [Configure Telegraf](https://docs.influxdata.com/telegraf/v1.15/introduction/getting-started/#configure-telegraf).
+6. Adjust configuration settings as needed. To find configuration settings for a specific plugin, see [Telegraf plugins](/telegraf/v1.15/plugins/).
+7. (Optional) To add the Telegraf configuration to InfluxDB, see [Telegraf configuration](/influxdb/v2.0/telegraf-configs/).

--- a/content/influxdb/v2.0/write-data/load-data.md
+++ b/content/influxdb/v2.0/write-data/load-data.md
@@ -4,7 +4,7 @@ seotitle: Load data source in UI
 list_title: Load data source in UI
 weight: 105
 description: >
-  Load data source in UI
+  Load data from sources in the InfluxDB user interface (UI). Choose from popular client libraries (such as Python, Ruby, Scala, and more!) or load data with a Telegraf plugin (like MQTT Consumer, MySQL, File, and many more!).
 menu:
   influxdb_2_0:
     name: Load data source in UI

--- a/content/influxdb/v2.0/write-data/load-data.md
+++ b/content/influxdb/v2.0/write-data/load-data.md
@@ -40,6 +40,6 @@ Load data from the following sources in the InfluxDB user interface (UI):
    - Scroll down to browse available plugins.
 3. Click the plugin to load data from.
 4. [Install Telegraf](/telegraf/v1.15/introduction/installation/).
-5. Copy the default configuration script in the UI, and then add the script to [Configure Telegraf](https://docs.influxdata.com/telegraf/v1.15/introduction/getting-started/#configure-telegraf).
+5. Copy the default configuration script in the UI, and then add the script to [Configure Telegraf](/telegraf/v1.15/introduction/getting-started/#configure-telegraf).
 6. Adjust configuration settings as needed. To find configuration settings for a specific plugin, see [Telegraf plugins](/telegraf/v1.15/plugins/).
 7. (Optional) To add the Telegraf configuration to InfluxDB, see [Telegraf configuration](/influxdb/v2.0/telegraf-configs/).


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/1311

- Add procedures for how to load data from client library or Telegraf plugin via the UI
- Update intro on Write data page to include load data, best practices, and bulk ingest

Note, while the original issue mentions adding the following sections to the UI:
Client libraries
Telegraf plugins
Flux sources
Integrations
Developer tools
Demo data (cloud-only)

....only the client libraries and Telegraf plugins have been added thus far