### PR TITLE
V2 equivalent pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -666,8 +666,8 @@ canonical: /{{< latest "influxdb" "v2" >}}/path/to/canonical/doc/
 ```
 
 ## v2 equivalent documentation
-To display a notice about and link to equivalent v2 pages for pages in the 1.x
-documentation, use the `v2` frontmatter on 1.x pages:
+To display a notice on a 1.x page that links to an equivalent 2.0 page,
+add the following frontmatter to the 1.x page:
 
 ```yaml
 v2: /influxdb/v2.0/get-started/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,7 @@ list_query_example: # Code examples included with article descriptions in childr
   # References to examples in data/query_examples
 products: # List of products that the page specifically applies to: [oss, cloud, enterprise]
 canonical: # Path to canonical page, overrides auto-gen'd canonical URL
+v2: # Path to v2 equivalent page
 ```
 
 #### Title usage
@@ -662,6 +663,14 @@ canonical: /path/to/canonical/doc/
 # OR
 
 canonical: /{{< latest "influxdb" "v2" >}}/path/to/canonical/doc/
+```
+
+## v2 equivalent documentation
+To display a notice about and link to equivalent v2 pages for pages in the 1.x
+documentation, use the `v2` frontmatter on 1.x pages:
+
+```yaml
+v2: /influxdb/v2.0/get-started/
 ```
 
 ## InfluxDB URLs

--- a/content/influxdb/v1.7/introduction/installation.md
+++ b/content/influxdb/v1.7/introduction/installation.md
@@ -5,6 +5,7 @@ menu:
     name: Installing
     weight: 20
     parent: Introduction
+v2: /influxdb/v2.0/get-started/
 ---
 
 This page provides directions for installing, starting, and configuring InfluxDB open source (OSS).

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -6,6 +6,7 @@ menu:
     name: Release notes
     weight: 10
     parent: About the project
+v2: /influxdb/v2.0/reference/release-notes/influxdb/
 ---
 
 ## v1.8.2 [2020-08-13]

--- a/content/influxdb/v1.8/administration/authentication_and_authorization.md
+++ b/content/influxdb/v1.8/administration/authentication_and_authorization.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication and authorization in InfluxDB
-description: Set up and manage authentication and authorization in InfluxDB OSS. 
+description: Set up and manage authentication and authorization in InfluxDB OSS.
 aliases:
     - influxdb/v1.8/administration/authentication_and_authorization/
 menu:
@@ -8,6 +8,7 @@ menu:
     name: Manage authentication and authorization
     weight: 20
     parent: Administration
+v2: /influxdb/v2.0/security/tokens/
 ---
 
 This document covers setting up and managing authentication and authorization in InfluxDB.

--- a/content/influxdb/v1.8/administration/backup_and_restore.md
+++ b/content/influxdb/v1.8/administration/backup_and_restore.md
@@ -9,6 +9,7 @@ menu:
     name: Back up and restore
     weight: 60
     parent: Administration
+v2: /influxdb/v2.0/backup-restore/
 ---
 
 ## Overview

--- a/content/influxdb/v1.8/administration/config.md
+++ b/content/influxdb/v1.8/administration/config.md
@@ -7,6 +7,7 @@ menu:
     name: Configure InfluxDB
     weight: 10
     parent: Administration
+v2: /influxdb/v2.0/reference/config-options/
 ---
 
 The InfluxDB open source (OSS) configuration file contains configuration settings specific to a local node.
@@ -324,7 +325,7 @@ Environment variable: `INFLUXDB_DATA_COMPACT_THROUGHPUT`
 
 The maximum number of bytes per seconds TSM compactions write to disk during brief bursts. Default is `"48m"` (48 million).
 
-Environment variable: `INFLUXDB_DATA_COMPACT_THROUGHPUT_BURST` 
+Environment variable: `INFLUXDB_DATA_COMPACT_THROUGHPUT_BURST`
 
 #### `tsm-use-madv-willneed = false`
 

--- a/content/influxdb/v1.8/administration/https_setup.md
+++ b/content/influxdb/v1.8/administration/https_setup.md
@@ -7,6 +7,7 @@ menu:
     name: Enable HTTPS
     weight: 30
     parent: Administration
+v2: /influxdb/v2.0/security/enable-tls/
 ---
 
 Enabling HTTPS encrypts the communication between clients and the InfluxDB server.

--- a/content/influxdb/v1.8/administration/security.md
+++ b/content/influxdb/v1.8/administration/security.md
@@ -6,6 +6,7 @@ menu:
     name: Manage security
     weight: 70
     parent: Administration
+v2: /influxdb/v2.0/security/
 ---
 
 Some customers may choose to install InfluxDB with public internet access, however

--- a/content/influxdb/v1.8/concepts/_index.md
+++ b/content/influxdb/v1.8/concepts/_index.md
@@ -5,7 +5,7 @@ menu:
   influxdb_1_8:
     name: Concepts
     weight: 30
-
+v2: /influxdb/v2.0/reference/key-concepts/
 ---
 
 Understanding the following concepts will help you get the most out of InfluxDB.

--- a/content/influxdb/v1.8/concepts/glossary.md
+++ b/content/influxdb/v1.8/concepts/glossary.md
@@ -6,6 +6,7 @@ menu:
     name: Glossary
     weight: 20
     parent: Concepts
+v2: /influxdb/v2.0/reference/glossary/
 ---
 
 ## aggregation

--- a/content/influxdb/v1.8/concepts/insights_tradeoffs.md
+++ b/content/influxdb/v1.8/concepts/insights_tradeoffs.md
@@ -1,12 +1,13 @@
 ---
 title: InfluxDB design insights and tradeoffs
 description: >
-  Optimizing for time series use case entails some tradeoffs, primarily to increase performance at the cost of functionality. 
+  Optimizing for time series use case entails some tradeoffs, primarily to increase performance at the cost of functionality.
 menu:
   influxdb_1_8:
     name: InfluxDB design insights and tradeoffs
     weight: 40
     parent: Concepts
+v2: /influxdb/v2.0/reference/key-concepts/design-principles/
 ---
 
 InfluxDB is a time series database.

--- a/content/influxdb/v1.8/concepts/key_concepts.md
+++ b/content/influxdb/v1.8/concepts/key_concepts.md
@@ -6,6 +6,7 @@ menu:
     name: Key concepts
     weight: 10
     parent: Concepts
+v2: /influxdb/v2.0/reference/key-concepts/
 ---
 
 Before diving into InfluxDB it's good to get acquainted with some of the key concepts of the database.

--- a/content/influxdb/v1.8/concepts/storage_engine.md
+++ b/content/influxdb/v1.8/concepts/storage_engine.md
@@ -7,6 +7,7 @@ menu:
     name: In-memory indexing with TSM
     weight: 60
     parent: Concepts
+v2: /influxdb/v2.0/reference/internals/storage-engine/
 ---
 
 ## The InfluxDB storage engine and the Time-Structured Merge Tree (TSM)

--- a/content/influxdb/v1.8/flux/_index.md
+++ b/content/influxdb/v1.8/flux/_index.md
@@ -6,6 +6,7 @@ menu:
   influxdb_1_8:
     name: Flux
     weight: 80
+v2: /influxdb/v2.0/query-data/get-started/
 ---
 
 Flux is a functional data scripting language designed for querying, analyzing, and acting on time series data.

--- a/content/influxdb/v1.8/flux/get-started/_index.md
+++ b/content/influxdb/v1.8/flux/get-started/_index.md
@@ -12,6 +12,8 @@ menu:
 aliases:
   - /influxdb/v1.8/flux/getting-started/
   - /influxdb/v1.8/flux/introduction/getting-started/
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/get-started/
+v2: /influxdb/v2.0/query-data/get-started/
 ---
 
 Flux is InfluxData's new functional data scripting language designed for querying,

--- a/content/influxdb/v1.8/flux/get-started/query-influxdb.md
+++ b/content/influxdb/v1.8/flux/get-started/query-influxdb.md
@@ -8,6 +8,8 @@ menu:
     weight: 1
 aliases:
   - /influxdb/v1.8/flux/getting-started/query-influxdb/
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/get-started/query-influxdb/
+v2: /influxdb/v2.0/query-data/get-started/query-influxdb/
 ---
 
 This guide walks through the basics of using Flux to query data from InfluxDB.

--- a/content/influxdb/v1.8/flux/get-started/syntax-basics.md
+++ b/content/influxdb/v1.8/flux/get-started/syntax-basics.md
@@ -8,6 +8,8 @@ menu:
     weight: 3
 aliases:
   - /influxdb/v1.8/flux/getting-started/syntax-basics/
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/get-started/syntax-basics/
+v2: /influxdb/v2.0/query-data/get-started/syntax-basics/
 ---
 
 

--- a/content/influxdb/v1.8/flux/get-started/transform-data.md
+++ b/content/influxdb/v1.8/flux/get-started/transform-data.md
@@ -8,6 +8,8 @@ menu:
     weight: 2
 aliases:
   - /influxdb/v1.8/flux/getting-started/transform-data/
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/get-started/transform-data/
+v2: /influxdb/v2.0/query-data/get-started/transform-data/
 ---
 
 When [querying data from InfluxDB](/influxdb/v1.8/flux/get-started/query-influxdb),

--- a/content/influxdb/v1.8/flux/guides/_index.md
+++ b/content/influxdb/v1.8/flux/guides/_index.md
@@ -6,6 +6,8 @@ menu:
   influxdb_1_8:
     name: Query with Flux
     parent: Flux
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/
+v2: /influxdb/v2.0/query-data/flux/
 ---
 
 The following guides walk through both common and complex queries and use cases for Flux.

--- a/content/influxdb/v1.8/flux/guides/calculate-percentages.md
+++ b/content/influxdb/v1.8/flux/guides/calculate-percentages.md
@@ -10,6 +10,8 @@ menu:
     parent: Query with Flux
 weight: 6
 list_query_example: percentages
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/calculate-percentages/
+v2: /influxdb/v2.0/query-data/flux/calculate-percentages/
 ---
 
 Calculating percentages from queried data is a common use case for time series data.

--- a/content/influxdb/v1.8/flux/guides/conditional-logic.md
+++ b/content/influxdb/v1.8/flux/guides/conditional-logic.md
@@ -10,6 +10,8 @@ menu:
     name: Conditional logic
     parent: Query with Flux
 weight: 20
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/conditional-logic/
+v2: /influxdb/v2.0/query-data/flux/conditional-logic/
 list_code_example: |
   ```js
   if color == "green" then "008000" else "ffffff"

--- a/content/influxdb/v1.8/flux/guides/cumulativesum.md
+++ b/content/influxdb/v1.8/flux/guides/cumulativesum.md
@@ -10,6 +10,8 @@ menu:
     parent: Query with Flux
     name: Cumulative sum
 list_query_example: cumulative_sum
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/cumulativesum/
+v2: /influxdb/v2.0/query-data/flux/cumulativesum/
 ---
 
 Use the [`cumulativeSum()` function](/{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/built-in/transformations/cumulativesum/)

--- a/content/influxdb/v1.8/flux/guides/execute-queries.md
+++ b/content/influxdb/v1.8/flux/guides/execute-queries.md
@@ -8,6 +8,7 @@ menu:
 weight: 1
 aliases:
   - /influxdb/v1.8/flux/guides/executing-queries/
+v2: /influxdb/v2.0/query-data/execute-queries/
 ---
 
 There are multiple ways to execute Flux queries with InfluxDB and Chronograf v1.8+.

--- a/content/influxdb/v1.8/flux/guides/exists.md
+++ b/content/influxdb/v1.8/flux/guides/exists.md
@@ -10,6 +10,8 @@ menu:
     name: Exists
     parent: Query with Flux
 weight: 20
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/exists/
+v2: /influxdb/v2.0/query-data/flux/exists/
 list_code_example: |
   ##### Filter null values
   ```js

--- a/content/influxdb/v1.8/flux/guides/fill.md
+++ b/content/influxdb/v1.8/flux/guides/fill.md
@@ -10,6 +10,8 @@ menu:
     parent: Query with Flux
     name: Fill
 list_query_example: fill_null
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/fill/
+v2: /influxdb/v2.0/query-data/flux/fill/
 ---
 
 Use the [`fill()` function](/{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/built-in/transformations/fill/)

--- a/content/influxdb/v1.8/flux/guides/first-last.md
+++ b/content/influxdb/v1.8/flux/guides/first-last.md
@@ -10,6 +10,8 @@ menu:
     parent: Query with Flux
     name: First & last
 list_query_example: first_last
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/first-last/
+v2: /influxdb/v2.0/query-data/flux/first-last/
 ---
 
 Use the [`first()`](/{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/built-in/transformations/selectors/first/) or

--- a/content/influxdb/v1.8/flux/guides/flux-in-dashboards.md
+++ b/content/influxdb/v1.8/flux/guides/flux-in-dashboards.md
@@ -8,6 +8,8 @@ menu:
     name: Use Flux in dashboards
     parent: Query with Flux
 weight: 30
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/flux-in-dashboards/
+v2: /influxdb/v2.0/query-data/flux/flux-in-dashboards/
 ---
 
 [Chronograf](/{{< latest "chronograf" >}}/) is the web user interface for managing for the

--- a/content/influxdb/v1.8/flux/guides/geo/_index.md
+++ b/content/influxdb/v1.8/flux/guides/geo/_index.md
@@ -8,6 +8,8 @@ menu:
     name: Geo-temporal data
     parent: Query with Flux
 weight: 20
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/geo/
+v2: /influxdb/v2.0/query-data/flux/geo/
 list_code_example: |
   ```js
   import "experimental/geo"

--- a/content/influxdb/v1.8/flux/guides/geo/filter-by-region.md
+++ b/content/influxdb/v1.8/flux/guides/geo/filter-by-region.md
@@ -10,6 +10,8 @@ weight: 302
 related:
   - /{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/experimental/geo/
   - /{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/experimental/geo/filterrows/
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/geo/filter-by-region/
+v2: /influxdb/v2.0/query-data/flux/geo/filter-by-region/
 list_code_example: |
   ```js
   import "experimental/geo"

--- a/content/influxdb/v1.8/flux/guides/geo/group-geo-data.md
+++ b/content/influxdb/v1.8/flux/guides/geo/group-geo-data.md
@@ -11,6 +11,8 @@ related:
   - /{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/experimental/geo/
   - /{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/experimental/geo/groupbyarea/
   - /{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/experimental/geo/astracks/
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/geo/group-geo-data/
+v2: /influxdb/v2.0/query-data/flux/geo/group-geo-data/
 list_code_example: |
   ```js
   import "experimental/geo"

--- a/content/influxdb/v1.8/flux/guides/geo/shape-geo-data.md
+++ b/content/influxdb/v1.8/flux/guides/geo/shape-geo-data.md
@@ -12,6 +12,8 @@ related:
   - /{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/experimental/geo/
   - /{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/experimental/geo/shapedata/
   - /{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/experimental/geo/s2cellidtoken/
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/geo/shape-geo-data/
+v2: /influxdb/v2.0/query-data/flux/geo/shape-geo-data/
 list_code_example: |
   ```js
   import "experimental/geo"

--- a/content/influxdb/v1.8/flux/guides/group-data.md
+++ b/content/influxdb/v1.8/flux/guides/group-data.md
@@ -11,6 +11,8 @@ weight: 2
 aliases:
   - /influxdb/v1.8/flux/guides/grouping-data/
 list_query_example: group
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/group-data/
+v2: /influxdb/v2.0/query-data/flux/group-data/
 ---
 
 With Flux, you can group data by any column in your queried data set.

--- a/content/influxdb/v1.8/flux/guides/histograms.md
+++ b/content/influxdb/v1.8/flux/guides/histograms.md
@@ -9,6 +9,8 @@ menu:
     parent: Query with Flux
 weight: 10
 list_query_example: histogram
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/histograms/
+v2: /influxdb/v2.0/query-data/flux/histograms/
 ---
 
 Histograms provide valuable insight into the distribution of your data.

--- a/content/influxdb/v1.8/flux/guides/increase.md
+++ b/content/influxdb/v1.8/flux/guides/increase.md
@@ -12,6 +12,8 @@ menu:
     parent: Query with Flux
     name: Increase
 list_query_example: increase
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/increase/
+v2: /influxdb/v2.0/query-data/flux/increase/
 ---
 
 Use the [`increase()` function](/{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/built-in/transformations/aggregates/increase/)

--- a/content/influxdb/v1.8/flux/guides/join.md
+++ b/content/influxdb/v1.8/flux/guides/join.md
@@ -9,6 +9,8 @@ menu:
     parent: Query with Flux
 weight: 10
 list_query_example: join
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/join/
+v2: /influxdb/v2.0/query-data/flux/join/
 ---
 
 The [`join()` function](/{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/built-in/transformations/join) merges two or more

--- a/content/influxdb/v1.8/flux/guides/manipulate-timestamps.md
+++ b/content/influxdb/v1.8/flux/guides/manipulate-timestamps.md
@@ -8,6 +8,8 @@ menu:
     name: Manipulate timestamps
     parent: Query with Flux
 weight: 20
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/manipulate-timestamps/
+v2: /influxdb/v2.0/query-data/flux/manipulate-timestamps/
 ---
 
 Every point stored in InfluxDB has an associated timestamp.

--- a/content/influxdb/v1.8/flux/guides/mathematic-operations.md
+++ b/content/influxdb/v1.8/flux/guides/mathematic-operations.md
@@ -10,6 +10,8 @@ menu:
     parent: Query with Flux
 weight: 5
 list_query_example: map_math
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/mathematic-operations/
+v2: /influxdb/v2.0/query-data/flux/mathematic-operations/
 ---
 
 Flux supports mathematic expressions in data transformations.

--- a/content/influxdb/v1.8/flux/guides/median.md
+++ b/content/influxdb/v1.8/flux/guides/median.md
@@ -10,6 +10,8 @@ menu:
     parent: Query with Flux
     name: Median
 list_query_example: median
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/median/
+v2: /influxdb/v2.0/query-data/flux/median/
 ---
 
 Use the [`median()` function](/{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/built-in/transformations/aggregates/median/)

--- a/content/influxdb/v1.8/flux/guides/monitor-states.md
+++ b/content/influxdb/v1.8/flux/guides/monitor-states.md
@@ -7,6 +7,8 @@ menu:
     name: Monitor states
     parent: Query with Flux
 weight: 20
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/monitor-states/
+v2: /influxdb/v2.0/query-data/flux/monitor-states/
 ---
 
 Flux helps you monitor states in your metrics and events:

--- a/content/influxdb/v1.8/flux/guides/moving-average.md
+++ b/content/influxdb/v1.8/flux/guides/moving-average.md
@@ -10,6 +10,8 @@ menu:
     parent: Query with Flux
     name: Moving Average
 list_query_example: moving_average
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/moving-average/
+v2: /influxdb/v2.0/query-data/flux/moving-average/
 ---
 
 Use the [`movingAverage()`](/{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/built-in/transformations/aggregates/movingaverage/)

--- a/content/influxdb/v1.8/flux/guides/optimize-queries.md
+++ b/content/influxdb/v1.8/flux/guides/optimize-queries.md
@@ -7,6 +7,8 @@ menu:
   influxdb_1_8:
     name: Optimize queries
     parent: Query with Flux
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/optimize-queries/
+v2: /influxdb/v2.0/query-data/flux/optimize-queries/
 ---
 
 Optimize your Flux queries to reduce their memory and compute (CPU) requirements.

--- a/content/influxdb/v1.8/flux/guides/percentile-quantile.md
+++ b/content/influxdb/v1.8/flux/guides/percentile-quantile.md
@@ -11,6 +11,8 @@ menu:
     parent: Query with Flux
     name: Percentile & quantile
 list_query_example: quantile
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/percentile-quantile/
+v2: /influxdb/v2.0/query-data/flux/percentile-quantile/
 ---
 
 Use the [`quantile()` function](/{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/built-in/transformations/aggregates/quantile/)

--- a/content/influxdb/v1.8/flux/guides/query-fields.md
+++ b/content/influxdb/v1.8/flux/guides/query-fields.md
@@ -9,6 +9,8 @@ weight: 1
 menu:
   influxdb_1_8:
     parent: Query with Flux
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/query-fields/
+v2: /influxdb/v2.0/query-data/flux/query-fields/
 list_code_example: |
   ```js
   from(bucket: "db/rp")

--- a/content/influxdb/v1.8/flux/guides/rate.md
+++ b/content/influxdb/v1.8/flux/guides/rate.md
@@ -13,6 +13,8 @@ menu:
     parent: Query with Flux
     name: Rate
 list_query_example: rate_of_change
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/rate/
+v2: /influxdb/v2.0/query-data/flux/rate/
 ---
 
 

--- a/content/influxdb/v1.8/flux/guides/regular-expressions.md
+++ b/content/influxdb/v1.8/flux/guides/regular-expressions.md
@@ -8,6 +8,8 @@ menu:
     parent: Query with Flux
 weight: 20
 list_query_example: regular_expressions
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/regular-expressions/
+v2: /influxdb/v2.0/query-data/flux/regular-expressions/
 ---
 
 Regular expressions (regexes) are incredibly powerful when matching patterns in large collections of data.

--- a/content/influxdb/v1.8/flux/guides/scalar-values.md
+++ b/content/influxdb/v1.8/flux/guides/scalar-values.md
@@ -9,6 +9,8 @@ menu:
     name: Extract scalar values
     parent:  Query with Flux
 weight: 20
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/scalar-values/
+v2: /influxdb/v2.0/query-data/flux/scalar-values/
 list_code_example: |
   ```js
   scalarValue = {

--- a/content/influxdb/v1.8/flux/guides/sort-limit.md
+++ b/content/influxdb/v1.8/flux/guides/sort-limit.md
@@ -11,6 +11,8 @@ menu:
     parent: Query with Flux
 weight: 3
 list_query_example: sort_limit
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/sort-limit/
+v2: /influxdb/v2.0/query-data/flux/sort-limit/
 ---
 
 Use the [`sort()`function](/{{< latest "influxdb" "v2" >}}/reference/flux/stdlib/built-in/transformations/sort)

--- a/content/influxdb/v1.8/flux/guides/sql.md
+++ b/content/influxdb/v1.8/flux/guides/sql.md
@@ -10,6 +10,8 @@ menu:
     parent: Query with Flux
     list_title: SQL data
 weight: 20
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/sql/
+v2: /influxdb/v2.0/query-data/flux/sql/
 list_code_example: |
   ```js
   import "sql"

--- a/content/influxdb/v1.8/flux/guides/window-aggregate.md
+++ b/content/influxdb/v1.8/flux/guides/window-aggregate.md
@@ -11,6 +11,8 @@ menu:
     parent: Query with Flux
 weight: 4
 list_query_example: aggregate_window
+canonical: /{{< latest "influxdb" "v2" >}}/query-data/flux/window-aggregate/
+v2: /influxdb/v2.0/query-data/flux/window-aggregate/
 ---
 
 A common operation performed with time series data is grouping data into windows of time,

--- a/content/influxdb/v1.8/guides/calculate_percentages.md
+++ b/content/influxdb/v1.8/guides/calculate_percentages.md
@@ -10,6 +10,7 @@ menu:
     name: Calculate percentages
 aliases:
   - /influxdb/v1.8/guides/calculating_percentages/
+v2: /influxdb/v2.0/query-data/flux/calculate-percentages/
 ---
 
 Use Flux or InfluxQL to calculate percentages in a query.

--- a/content/influxdb/v1.8/guides/downsample_and_retain.md
+++ b/content/influxdb/v1.8/guides/downsample_and_retain.md
@@ -7,6 +7,7 @@ menu:
     parent: Guides
 aliases:
   - /influxdb/v1.8/guides/downsampling_and_retention/
+v2: /influxdb/v2.0/process-data/common-tasks/downsample-data/
 ---
 
 InfluxDB can handle hundreds of thousands of data points per second. Working with that much data over a long period of time can create storage concerns.

--- a/content/influxdb/v1.8/guides/query_data.md
+++ b/content/influxdb/v1.8/guides/query_data.md
@@ -9,6 +9,7 @@ menu:
     parent: Guides
 aliases:
   - /influxdb/v1.8/guides/querying_data/
+v2: /influxdb/v2.0/query-data/
 ---
 
 

--- a/content/influxdb/v1.8/guides/write_data.md
+++ b/content/influxdb/v1.8/guides/write_data.md
@@ -8,6 +8,7 @@ menu:
     parent: Guides
 aliases:
   - /influxdb/v1.8/guides/writing_data/
+v2: /influxdb/v2.0/write-data/
 ---
 
 Write data into InfluxDB using the [command line interface](/influxdb/v1.8/tools/shell/), [client libraries](/influxdb/v1.8/clients/api/), and plugins for common data formats such as [Graphite](/influxdb/v1.8/write_protocols/graphite/).

--- a/content/influxdb/v1.8/introduction/get-started.md
+++ b/content/influxdb/v1.8/introduction/get-started.md
@@ -9,6 +9,7 @@ menu:
     name: Get started with InfluxDB
     weight: 30
     parent: Introduction
+v2: /influxdb/v2.0/get-started/
 ---
 
 With InfluxDB open source (OSS) [installed](/influxdb/v1.8/introduction/installation), you're ready to start doing some awesome things.

--- a/content/influxdb/v1.8/introduction/install.md
+++ b/content/influxdb/v1.8/introduction/install.md
@@ -8,6 +8,7 @@ menu:
     parent: Introduction
 aliases:
   - /influxdb/v1.8/introduction/installation/
+v2: /influxdb/v2.0/get-started/
 ---
 
 This page provides directions for installing, starting, and configuring InfluxDB open source (OSS).

--- a/content/influxdb/v1.8/query_language/continuous_queries.md
+++ b/content/influxdb/v1.8/query_language/continuous_queries.md
@@ -7,6 +7,7 @@ menu:
     name: Continuous Queries
     weight: 50
     parent: InfluxQL
+v2: /influxdb/v2.0/process-data/
 ---
 
 ## Introduction

--- a/content/influxdb/v1.8/query_language/explore-data.md
+++ b/content/influxdb/v1.8/query_language/explore-data.md
@@ -9,6 +9,7 @@ menu:
     parent: InfluxQL
 aliases:
   - /influxdb/v1.8/query_language/data_exploration/
+v2: /influxdb/v2.0/query-data/flux/query-fields/
 ---
 
 InfluxQL is an SQL-like query language for interacting with data in InfluxDB.

--- a/content/influxdb/v1.8/query_language/explore-schema.md
+++ b/content/influxdb/v1.8/query_language/explore-schema.md
@@ -8,6 +8,7 @@ menu:
     parent: InfluxQL
 aliases:
   - /influxdb/v1.8/query_language/schema_exploration/
+v2: /influxdb/v2.0/query-data/flux/explore-schema/
 ---
 
 InfluxQL is an SQL-like query language for interacting with data in InfluxDB.

--- a/content/influxdb/v1.8/query_language/sample-data.md
+++ b/content/influxdb/v1.8/query_language/sample-data.md
@@ -8,6 +8,7 @@ menu:
 aliases:
   - /influxdb/v1.8/sample_data/data_download/
   - /influxdb/v1.8/query_language/data_download/
+v2: /influxdb/v2.0/reference/sample-data/
 ---
 
 In order to explore the query language further, these instructions help you create a database,

--- a/content/influxdb/v1.8/tools/_index.md
+++ b/content/influxdb/v1.8/tools/_index.md
@@ -8,7 +8,7 @@ menu:
   influxdb_1_8:
     name: Tools
     weight: 60
-
+v2: /influxdb/v2.0/tools/
 ---
 
 This section covers the available tools for interacting with InfluxDB.

--- a/content/influxdb/v1.8/tools/api.md
+++ b/content/influxdb/v1.8/tools/api.md
@@ -9,6 +9,7 @@ menu:
     name: InfluxDB API reference
     weight: 20
     parent: Tools
+v2: /influxdb/v2.0/reference/api/
 ---
 
 The InfluxDB API provides a simple way to interact with the database.

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -10,6 +10,7 @@ menu:
   influxdb_1_8:
     weight: 30
     parent: Tools
+v2: /influxdb/v2.0/tools/client-libraries/
 ---
 
 InfluxDB client libraries are language-specific packages that integrate with the InfluxDB 2.0 API and support both **InfluxDB 1.8+** and **InfluxDB 2.0**.

--- a/content/influxdb/v1.8/tools/grafana.md
+++ b/content/influxdb/v1.8/tools/grafana.md
@@ -7,6 +7,7 @@ menu:
     url: "https://grafana.com/docs/grafana/latest/features/datasources/influxdb/"
     weight: 60
     parent: Tools
+v2: /influxdb/v2.0/tools/grafana/
 ---
 
 Please see [Grafana's InfluxDB documentation](https://grafana.com/docs/grafana/latest/features/datasources/influxdb/).

--- a/content/influxdb/v1.8/tools/influx-cli/_index.md
+++ b/content/influxdb/v1.8/tools/influx-cli/_index.md
@@ -5,6 +5,7 @@ menu:
     name: influx
     weight: 10
     parent: Tools
+v2: /influxdb/v2.0/reference/cli/influx/
 ---
 
 The `influx` command line interface (CLI) includes commands to manage many aspects of InfluxDB, including databases, organizations, users, and tasks.

--- a/content/influxdb/v1.8/tools/influx_inspect.md
+++ b/content/influxdb/v1.8/tools/influx_inspect.md
@@ -6,6 +6,7 @@ menu:
   influxdb_1_8:
     weight: 50
     parent: Tools
+v2: /influxdb/v2.0/reference/cli/influxd/inspect/
 ---
 
 Influx Inspect is an InfluxDB disk utility that can be used to:

--- a/content/influxdb/v1.8/tools/influxd/_index.md
+++ b/content/influxdb/v1.8/tools/influxd/_index.md
@@ -7,6 +7,7 @@ menu:
     name: influxd
     weight: 10
     parent: Tools
+v2: /influxdb/v2.0/reference/cli/influxd/
 ---
 
 The `influxd` command starts and runs all the processes necessary for InfluxDB to function.

--- a/content/influxdb/v1.8/tools/influxd/backup.md
+++ b/content/influxdb/v1.8/tools/influxd/backup.md
@@ -7,6 +7,7 @@ menu:
     name: influxd backup
     weight: 10
     parent: influxd
+v2: /influxdb/v2.0/reference/cli/influx/backup/
 ---
 
 The `influxd backup` command crates a backup copy of specified InfluxDB OSS database(s) and saves the files in an Enterprise-compatible format to PATH (directory where backups are saved).

--- a/content/influxdb/v1.8/tools/influxd/restore.md
+++ b/content/influxdb/v1.8/tools/influxd/restore.md
@@ -7,6 +7,7 @@ menu:
     name: influxd restore
     weight: 10
     parent: influxd
+v2: /influxdb/v2.0/reference/cli/influxd/restore/
 ---
 The `influxd restore` command restores backup data and metadata from an InfluxDB backup directory.
 

--- a/content/influxdb/v1.8/tools/influxd/run.md
+++ b/content/influxdb/v1.8/tools/influxd/run.md
@@ -7,6 +7,7 @@ menu:
     name: influxd run
     weight: 10
     parent: influxd
+v2: /influxdb/v2.0/reference/cli/influxd/run/
 ---
 
 The `influxd run` command is the default command for `influxd`.

--- a/content/influxdb/v1.8/tools/influxd/version.md
+++ b/content/influxdb/v1.8/tools/influxd/version.md
@@ -7,6 +7,7 @@ menu:
     name: influxd version
     weight: 10
     parent: influxd
+v2: /influxdb/v2.0/reference/cli/influxd/version/
 ---
 
 

--- a/content/influxdb/v1.8/write_protocols/_index.md
+++ b/content/influxdb/v1.8/write_protocols/_index.md
@@ -6,6 +6,7 @@ menu:
   influxdb_1_8:
     name: Write protocols
     weight: 80
+v2: /influxdb/v2.0/reference/syntax/line-protocol/
 ---
 
 The InfluxDB line protocol is a text based format for writing points to InfluxDB databases.

--- a/content/influxdb/v1.8/write_protocols/line_protocol_reference.md
+++ b/content/influxdb/v1.8/write_protocols/line_protocol_reference.md
@@ -10,6 +10,7 @@ menu:
     weight: 10
     parent: Write protocols
 canonical: /{{< latest "influxdb" "v2" >}}/reference/syntax/line-protocol/
+v2: /influxdb/v2.0/reference/syntax/line-protocol/
 ---
 
 InfluxDB line protocol is a text-based format for writing points to InfluxDB.

--- a/content/influxdb/v1.8/write_protocols/line_protocol_tutorial.md
+++ b/content/influxdb/v1.8/write_protocols/line_protocol_tutorial.md
@@ -7,6 +7,7 @@ menu:
   influxdb_1_8:
     weight: 20
     parent: Write protocols
+v2: /influxdb/v2.0/reference/syntax/line-protocol/
 ---
 
 The InfluxDB line protocol is a text-based format for writing points to the

--- a/data/products.yml
+++ b/data/products.yml
@@ -4,7 +4,7 @@ influxdb:
   namespace: influxdb
   list_order: 1
   versions: [v1.3, v1.4, v1.5, v1.6, v1.7, v1.8, v2.0]
-  latest: v1.8
+  latest: v2.0
   latest_override: v2.0
 
   # Used in cloud-name and cloud-link shortcodes

--- a/data/products.yml
+++ b/data/products.yml
@@ -4,7 +4,7 @@ influxdb:
   namespace: influxdb
   list_order: 1
   versions: [v1.3, v1.4, v1.5, v1.6, v1.7, v1.8, v2.0]
-  latest: v2.0
+  latest: v1.8
   latest_override: v2.0
 
   # Used in cloud-name and cloud-link shortcodes

--- a/layouts/partials/article/stable-version.html
+++ b/layouts/partials/article/stable-version.html
@@ -7,6 +7,8 @@
 {{ $stableVersion := (index .Site.Data.products $product).latest }}
 {{ $stableVersionURL := replaceRE `v[1-2]\.[0-9]{1,2}` $stableVersion .RelPermalink }}
 {{ $v2EquivalentURL := replaceRE `v[1-2]\.[0-9]{1,2}` $latestV2 .Page.Params.v2 }}
+{{ $v2EquivalentPage := .GetPage (replaceRE `\/$` "" $v2EquivalentURL) }}
+{{ $v2PageExists := gt (len $v2EquivalentPage.Title) 0 }}
 
 {{ if lt $currentVersion $stableVersion }}
   <div class="warn block old-version">
@@ -16,7 +18,12 @@
       {{ if eq (findRE `v[1-2]` $currentVersion) (findRE `v[1-2]` $stableVersion) }}
         <a href="{{ $stableVersionURL }}">View this page in the {{ $stableVersion }} documentation</a>.
       {{ else if and (ne (findRE `v[1-2]` $currentVersion) (findRE `v[1-2]` $stableVersion)) (.Page.Params.v2) }}
-        <span style="margin-right:.25rem">See the equivalent <strong>InfluxDB {{ $latestV2 }}</strong> documentation:</span> <a href="{{ $v2EquivalentURL }}">{{ with .GetPage (replaceRE `\/$` "" $v2EquivalentURL) }}{{ .Title }}{{ end }}</a>
+        <!-- Check if the v2 equivalent page exists -->
+        {{ if $v2PageExists }}
+          <span style="margin-right:.25rem">See the equivalent <strong>InfluxDB {{ $latestV2 }}</strong> documentation:</span> <a href="{{ $v2EquivalentPage.RelPermalink }}">{{ $v2EquivalentPage.Title }}</a>.
+        {{ else }}
+          See the <a href="{{ $v2EquivalentURL }}">equivalent InfluxDB {{ $latestV2 }} documentation</a>.
+        {{ end }}
       {{ end }}
     </p>
   </div>
@@ -24,6 +31,12 @@
 
 {{ if and .Page.Params.v2 (eq (findRE `v[1-2]` $currentVersion) (findRE `v[1-2]` $stableVersion)) }}
   <div class="note block old-version">
-    <p><span style="margin-right:.25rem">See the <strong>InfluxDB {{ $latestV2 }}</strong> equivalent for this documentation:</span> <a href="{{ $v2EquivalentURL }}">{{ with .GetPage (replaceRE `\/$` "" $v2EquivalentURL) }}{{ .Title }}{{ end }}</a></p>
+    <p>
+      {{ if $v2PageExists }}
+        <span style="margin-right:.25rem">See the equivalent <strong>InfluxDB {{ $latestV2 }}</strong> documentation:</span> <a href="{{ $v2EquivalentPage.RelPermalink }}">{{ $v2EquivalentPage.Title }}</a>.
+      {{ else }}
+        See the <a href="{{ $v2EquivalentURL }}">equivalent InfluxDB {{ $latestV2 }} documentation</a>.
+      {{ end }}
+    </p>
   </div>
 {{ end }}

--- a/layouts/partials/article/stable-version.html
+++ b/layouts/partials/article/stable-version.html
@@ -2,18 +2,28 @@
 {{ $product := index $productPathData 0 }}
 {{ $productName := (index .Site.Data.products $product).name }}
 {{ $currentVersion := index $productPathData 1 }}
+{{ $latestV2 := index (last 1 .Site.Data.products.influxdb.versions) 0 }}
 
 {{ $stableVersion := (index .Site.Data.products $product).latest }}
 {{ $stableVersionURL := replaceRE `v[1-2]\.[0-9]{1,2}` $stableVersion .RelPermalink }}
+{{ $v2EquivalentURL := replaceRE `v[1-2]\.[0-9]{1,2}` $latestV2 .Page.Params.v2 }}
 
 {{ if lt $currentVersion $stableVersion }}
   <div class="warn block old-version">
     <p>
       This page documents an earlier version of {{ $productName }}.
-      <a href="/{{ $product }}/{{$stableVersion}}/">{{ $productName }} {{ $stableVersion }}</a> is the latest stable version.<br/>
+      <a href="/{{ $product }}/{{ $stableVersion }}/">{{ $productName }} {{ $stableVersion }}</a> is the latest stable version.
       {{ if eq (findRE `v[1-2]` $currentVersion) (findRE `v[1-2]` $stableVersion) }}
         <a href="{{ $stableVersionURL }}">View this page in the {{ $stableVersion }} documentation</a>.
+      {{ else if and (ne (findRE `v[1-2]` $currentVersion) (findRE `v[1-2]` $stableVersion)) (.Page.Params.v2) }}
+        <span style="margin-right:.25rem">See the equivalent <strong>InfluxDB {{ $latestV2 }}</strong> documentation:</span> <a href="{{ $v2EquivalentURL }}">{{ with .GetPage (replaceRE `\/$` "" $v2EquivalentURL) }}{{ .Title }}{{ end }}</a>
       {{ end }}
     </p>
+  </div>
+{{ end }}
+
+{{ if and .Page.Params.v2 (eq (findRE `v[1-2]` $currentVersion) (findRE `v[1-2]` $stableVersion)) }}
+  <div class="note block old-version">
+    <p><span style="margin-right:.25rem">See the <strong>InfluxDB {{ $latestV2 }}</strong> equivalent for this documentation:</span> <a href="{{ $v2EquivalentURL }}">{{ with .GetPage (replaceRE `\/$` "" $v2EquivalentURL) }}{{ .Title }}{{ end }}</a></p>
   </div>
 {{ end }}


### PR DESCRIPTION
Closes #1313

Specify equivalent v2 pages for 1.x docs using the `v2` front matter.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
