### PR TITLE
Document compatability API limits

### DIFF
--- a/content/influxdb/v2.0/query-data/influxql.md
+++ b/content/influxdb/v2.0/query-data/influxql.md
@@ -51,19 +51,23 @@ policies are mapped to buckets using the **database and retention policy (DBRP) 
 _See [DBRP mapping](/influxdb/v2.0/reference/api/influxdb-1x/dbrp/) for more information._
 
 ## InfluxQL support
-InfluxQL in InfluxDB 2.0 supports **read-only** queries.
+InfluxQL in InfluxDB 2.0 supports **read-only** queries (with two exceptions shown below).
 
 {{< flex >}}
 {{< flex-content >}}
 {{% note %}}
 ##### Supported InfluxQL queries
 
+- `DELETE`*
+- `DROP MEASUREMENT`*
 - `SELECT` _(read-only)_
 - `SHOW DATABASES`
 - `SHOW MEASUREMENTS`
 - `SHOW TAG KEYS`
 - `SHOW TAG VALUES`
 - `SHOW FIELD KEYS`
+
+\* These commands delete data.
 {{% /note %}}
 {{< /flex-content >}}
 {{< flex-content >}}
@@ -73,8 +77,8 @@ InfluxQL in InfluxDB 2.0 supports **read-only** queries.
 - `SELECT INTO`
 - `ALTER`
 - `CREATE`
-- `DELETE`
-- `DROP`
+<!-- - `DELETE` -->
+- `DROP` (see above)
 - `GRANT`
 - `KILL`
 - `REVOKE`

--- a/content/influxdb/v2.0/reference/api/influxdb-1x/_index.md
+++ b/content/influxdb/v2.0/reference/api/influxdb-1x/_index.md
@@ -57,6 +57,13 @@ Authorization: Token <token>
 Authorization: Token mYSuP3rs3cREtT0k3N
 ```
 
+##### InfluxQL support
+
+The compatability API supports InfluxQL, with the following caveats:
+
+- The `INTO` clause (e.g. `SELECT ... INTO ...`) is not supported.
+- With the exception of `DELETE` and `DROP MEASUREMENT` queries, which are still allowed, InfluxQL database management commands are not supported.
+
 ## Compatibility endpoints
 
 {{< children readmore=true >}}

--- a/content/influxdb/v2.0/reference/api/influxdb-1x/_index.md
+++ b/content/influxdb/v2.0/reference/api/influxdb-1x/_index.md
@@ -62,7 +62,9 @@ Authorization: Token mYSuP3rs3cREtT0k3N
 The compatability API supports InfluxQL, with the following caveats:
 
 - The `INTO` clause (e.g. `SELECT ... INTO ...`) is not supported.
-- With the exception of `DELETE` and `DROP MEASUREMENT` queries, which are still allowed, InfluxQL database management commands are not supported.
+- With the exception of [`DELETE`](/influxdb/v1.8/query_language/manage-database/#delete-series-with-delete) and 
+  [`DROP MEASUREMENT`](/influxdb/v1.8/query_language/manage-database/#delete-measurements-with-drop-measurement) queries, which are still allowed,
+  InfluxQL database management commands are not supported.
 
 ## Compatibility endpoints
 


### PR DESCRIPTION
Clarify compatibility API support for InfluxQL.

Closes #1424.

- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
