### PR TITLE
Fixed minor typo in python library getting started documentation

### DIFF
--- a/content/influxdb/v2.0/tools/client-libraries/python.md
+++ b/content/influxdb/v2.0/tools/client-libraries/python.md
@@ -56,7 +56,7 @@ We are going to write some data in [line protocol](/influxdb/v2.0/reference/synt
 3. Instantiate the client. The `InfluxDBClient` object takes three named parameters: `url`, `org`, and `token`. Pass in the named parameters.
 
    ```python
-   client = InfluxDBClient(
+   client = influxdb_client.InfluxDBClient(
       url=url,
       token=token,
       org=org


### PR DESCRIPTION
If you follow the code example line by line, you end up using InfluxDBClient which has not been imported yet.  The complete example clearly show us referencing it through the module, so I edited the step-by-step instructions to do the same.

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [x] Rebased/mergeable
