### PR TITLE
add task offset + now time

### DIFF
--- a/content/influxdb/v2.0/process-data/get-started.md
+++ b/content/influxdb/v2.0/process-data/get-started.md
@@ -21,6 +21,7 @@ This article walks through writing a basic InfluxDB task that downsamples
 data and stores it in a new bucket.
 
 ## Components of a task
+
 Every InfluxDB task needs the following four components.
 Their form and order can vary, but they are all essential parts of a task.
 
@@ -32,6 +33,7 @@ Their form and order can vary, but they are all essential parts of a task.
 _[Skip to the full example task script](#full-example-task-script)_
 
 ## Define task options
+
 Task options define specific information about the task.
 The example below illustrates how task options are defined in your Flux script:
 
@@ -53,6 +55,7 @@ When creating a task in the InfluxDB user interface (UI), task options are defin
 {{% /note %}}
 
 ## Define a data source
+
 Define a data source using Flux's [`from()` function](/influxdb/v2.0/reference/flux/stdlib/built-in/inputs/from/)
 or any other [Flux input functions](/influxdb/v2.0/reference/flux/stdlib/built-in/inputs/).
 
@@ -70,6 +73,7 @@ data = from(bucket: "telegraf/default")
 
 {{% note %}}
 #### Using task options in your Flux script
+
 Task options are passed as part of a `task` option record and can be referenced in your Flux script.
 In the example above, the time range is defined as `-task.every`.
 
@@ -80,9 +84,17 @@ Using task options to define values in your Flux script can make reusing your ta
 {{% /note %}}
 
 ## Process or transform your data
+
 The purpose of tasks is to process or transform data in some way.
 What exactly happens and what form the output data takes is up to you and your
 specific use case.
+
+{{% note %}}
+#### Account for latent data with an offset
+
+To account for latent data (for example, your edge devices), use an offset in your task. For example, set a task to run `every: 1h` and `offset: 5m`. The task executes 5 minutes late but the query [`now()`](/influxdb/v2.0/reference/flux/stdlib/built-in/misc/now/) time is on the exact hour.
+
+{{% /note %}}
 
 The example below illustrates a task that downsamples data by calculating the average of set intervals.
 It uses the `data` variable defined [above](#define-a-data-source) as the data source.
@@ -100,6 +112,7 @@ data
 _See [Common tasks](/influxdb/v2.0/process-data/common-tasks) for examples of tasks commonly used with InfluxDB._
 
 ## Define a destination
+
 In the vast majority of task use cases, once data is transformed, it needs to be sent and stored somewhere.
 This could be a separate bucket or another measurement.
 
@@ -116,6 +129,7 @@ In order to write data into InfluxDB, you must have `_time`, `_measurement`, `_f
 {{% /note %}}
 
 ## Full example task script
+
 Below is a task script that combines all of the components described above:
 
 ```js

--- a/content/influxdb/v2.0/process-data/get-started.md
+++ b/content/influxdb/v2.0/process-data/get-started.md
@@ -92,7 +92,7 @@ specific use case.
 {{% note %}}
 #### Account for latent data with an offset
 
-To account for latent data (for example, your edge devices), use an offset in your task. For example, set a task to run `every: 1h` and `offset: 5m`. The task executes 5 minutes late but the query [`now()`](/influxdb/v2.0/reference/flux/stdlib/built-in/misc/now/) time is on the exact hour.
+To account for latent data (like data streaming from your edge devices), use an offset in your task. For example, if you set a task interval on the hour with the options `every: 1h` and `offset: 5m`, a task executes 5 minutes after the task interval but the query [`now()`](/influxdb/v2.0/reference/flux/stdlib/built-in/misc/now/) time is on the exact hour.
 
 {{% /note %}}
 

--- a/content/influxdb/v2.0/process-data/task-options.md
+++ b/content/influxdb/v2.0/process-data/task-options.md
@@ -40,6 +40,7 @@ options task = {
 ```
 
 ## every
+
 The interval at which the task runs.
 
 _**Data type:** Duration_
@@ -70,6 +71,7 @@ options task = {
 ```
 
 ## offset
+
 Delays the execution of the task but preserves the original time range.
 For example, if a task is to run on the hour, a `10m` offset will delay it to 10
 minutes after the hour, but all time ranges defined in the task are relative to


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/1280

@lyondhill, I added a note to our tasks docs, but want to be sure I understand the change....the way our docs read, I thought the change you described was how scheduling the task interval, offsets, and `now()` already worked