### PR TITLE
Add delete data with commented-out UI content

### DIFF
--- a/content/influxdb/v2.0/write-data/delete-data.md
+++ b/content/influxdb/v2.0/write-data/delete-data.md
@@ -53,7 +53,7 @@ Use the `influx` CLI or the InfluxDB API `/delete` endpoint to delete data.
 {{% note %}}
 The `-p, --predicate` flag is supported in **InfluxDB Cloud** and **InfluxDB OSS 2.0 beta 16 or earlier**.
 
-In InfluxDB OSS 2.0rc0, the `influx delete --predicate` flag has been disabled.
+In **InfluxDB OSS 2.0rc0**, the `influx delete --predicate` flag has been disabled.
 {{% /note %}}
 
 ## Delete data using the influx CLI
@@ -61,7 +61,7 @@ In InfluxDB OSS 2.0rc0, the `influx delete --predicate` flag has been disabled.
 1. Use the [`influx delete` command](/influxdb/v2.0/reference/cli/influx/delete/) to delete points from InfluxDB.
 2. Specify your organization, bucket, and authentication token.
 3. Define the time range to delete data from with the `--start` and `--stop` flags.
-4. (InfluxDB Cloud only) Specify which points to delete using the predicate parameter and [delete predicate syntax](/influxdb/v2.0/reference/syntax/delete-predicate/).
+4. (**InfluxDB Cloud** only) Specify which points to delete using the predicate parameter and [delete predicate syntax](/influxdb/v2.0/reference/syntax/delete-predicate/).
 
 ### Example delete commands
 
@@ -92,7 +92,7 @@ timestamps between the specified `--start` and `--stop` times in the specified b
 ## Delete data using the API
 
 {{% note %}}
-The `influx` CLI is installed with InfluxDB OSS. If you're using InfluxDB Cloud and haven't already, download the [`influx` CLI](/influxdb/v2.0/get-started/#optional-download-install-and-use-the-influx-cli).
+The `influx` CLI is installed with **InfluxDB OSS**. If you're using **InfluxDB Cloud** and haven't already, download the [`influx` CLI](/influxdb/v2.0/get-started/#optional-download-install-and-use-the-influx-cli).
 {{% /note %}}
 
 1. Use the InfluxDB API `/delete` endpoint to delete points from InfluxDB.

--- a/content/influxdb/v2.0/write-data/delete-data.md
+++ b/content/influxdb/v2.0/write-data/delete-data.md
@@ -51,7 +51,7 @@ Delete data from buckets you've created. You cannot delete data from system buck
 Use the `influx` CLI or the InfluxDB API `/delete` endpoint to delete data.
 
 {{% note %}}
-The `-p, --predicate` flag is supported in InfluxDB Cloud and InfluxDB OSS 2.0 beta 16 or earlier.
+The `-p, --predicate` flag is supported in **InfluxDB Cloud** and **InfluxDB OSS 2.0 beta 16 or earlier**.
 
 In InfluxDB OSS 2.0rc0, the `influx delete --predicate` flag has been disabled.
 {{% /note %}}
@@ -61,15 +61,27 @@ In InfluxDB OSS 2.0rc0, the `influx delete --predicate` flag has been disabled.
 1. Use the [`influx delete` command](/influxdb/v2.0/reference/cli/influx/delete/) to delete points from InfluxDB.
 2. Specify your organization, bucket, and authentication token.
 3. Define the time range to delete data from with the `--start` and `--stop` flags.
-4. Specify which points to delete using the `--predicate` or `-p` flag and
-   [Delete predicate syntax](/influxdb/v2.0/reference/syntax/delete-predicate/).
+4. (InfluxDB Cloud only) Specify which points to delete using the predicate parameter and [delete predicate syntax](/influxdb/v2.0/reference/syntax/delete-predicate/).
 
-##### Example delete command
+### Example delete commands
+
+**InfluxDB OSS 2.0rc0** does not support the `predicate` parameter.
+
+#### Delete data in InfluxDB Cloud
+
 ```sh
 influx delete -o my-org -b my-bucket -t $INFLUX_TOKEN \
-  --start '1970-01-01T00:00:00.00Z' \
-  --stop '2020-01-01T00:00:00.00Z' \
-  --predicate '_measurement="sensors" and sensorID="abc123"'
+ --start '1970-01-01T00:00:00.00Z' \
+ --stop '2020-01-01T00:00:00.00Z' \
+ --predicate '_measurement="sensors" and sensorID="abc123"'
+```
+
+#### Delete data in InfluxDB OSS
+
+```sh
+influx delete -o my-org -b my-bucket -t $INFLUX_TOKEN \
+ --start '1970-01-01T00:00:00.00Z' \
+ --stop '2020-01-01T00:00:00.00Z' \
 ```
 
 {{% warn %}}
@@ -78,6 +90,11 @@ timestamps between the specified `--start` and `--stop` times in the specified b
 {{% /warn %}}
 
 ## Delete data using the API
+
+{{% note %}}
+The `influx` CLI is installed with InfluxDB OSS. If you're using InfluxDB Cloud and haven't already, download the [`influx` CLI](/influxdb/v2.0/get-started/#optional-download-install-and-use-the-influx-cli).
+{{% /note %}}
+
 1. Use the InfluxDB API `/delete` endpoint to delete points from InfluxDB.
 2. Include your organization and bucket as query parameters in the request URL.
 3. Use the `Authorization` header to provide your InfluxDB authentication token.
@@ -85,18 +102,34 @@ timestamps between the specified `--start` and `--stop` times in the specified b
    Specify which points to delete using the `predicate` and
    [Delete predicate syntax](/influxdb/v2.0/reference/syntax/delete-predicate/).
 
-##### Example delete request
+### Example delete requests
+
+**InfluxDB OSS 2.0rc0** does not support the `predicate` parameter.
+
+#### Delete data in InfluxDB Cloud
+
 ```sh
-curl -XPOST http://localhost:8086/api/v2/delete/?org=myOrg&bucket=myBucket \
-  -H 'Authorization: Token <YOURAUTHTOKEN>' \
-  -d '{
-        "start": "1970-01-01T00:00:00.00Z",
-        "stop": "2020-01-01T00:00:00.00Z",
-        "predicate": "_measurement=\"sensors\" and sensorID=\"abc123\""
-      }'
+curl -X POST 'https://us-west-2-1.aws.cloud2.influxdata.com/api/v2/delete?orgID=<ORGID>'
+-H 'Authorization: Token <TOKEN WITH WRITE PERMISSIONS'
+-H 'Content-Type: application/json'
+-d '{
+"predicate": "_measurement=\"<MEASUREMENT NAME>\" and _field=\"<FIELD>\"",
+"start": "2020-08-16T08:00:00Z",
+"stop": "2020-08-17T08:00:00Z"
+   }'
 ```
 
-_For more information, see the [`/delete` API documentation](/influxdb/v2.0/api/#/paths/~1delete/post)._
+#### Delete data in InfluxDB OSS
+
+```sh
+curl -XPOST http://localhost:8086/api/v2/delete/?org=myOrg&bucket=myBucket \
+-H 'Authorization: Token <YOURAUTHTOKEN>' \
+-d '{
+"start": "1970-01-01T00:00:00.00Z",
+"stop": "2020-01-01T00:00:00.00Z"
+}'
+```
+   _For more information, see the [`/delete` API documentation](/influxdb/v2.0/api/#/paths/~1delete/post)._
 
 {{% warn %}}
 Using the `/delete` endpoint without a `predicate` deletes all data with

--- a/content/influxdb/v2.0/write-data/delete-data.md
+++ b/content/influxdb/v2.0/write-data/delete-data.md
@@ -4,11 +4,11 @@ list_title: Delete data
 description: >
   Delete data in the InfluxDB CLI and API.
 menu:
-  v2_0:
+  influxdb_2_0:
     name: Delete data
     parent: Write data
 weight: 104
-influxdb/v2.0/tags:: [delete]
+influxdb/v2.0/tags: [delete]
 related:
   - /influxdb/v2.0/reference/syntax/delete-predicate/
   - /influxdb/v2.0/reference/cli/influx/delete/

--- a/content/influxdb/v2.0/write-data/delete-data.md
+++ b/content/influxdb/v2.0/write-data/delete-data.md
@@ -99,8 +99,7 @@ The `influx` CLI is installed with **InfluxDB OSS**. If you're using **InfluxDB 
 2. Include your organization and bucket as query parameters in the request URL.
 3. Use the `Authorization` header to provide your InfluxDB authentication token.
 4. In your request payload, define the time range to delete data from with `start` and `stop`.
-   Specify which points to delete using the `predicate` and
-   [Delete predicate syntax](/influxdb/v2.0/reference/syntax/delete-predicate/).
+5. (**InfluxDB Cloud** only): Specify which points to delete using the `predicate` parameter and [Delete predicate syntax](/influxdb/v2.0/reference/syntax/delete-predicate/).
 
 ### Example delete requests
 

--- a/content/v2.0/write-data/delete-data.md
+++ b/content/v2.0/write-data/delete-data.md
@@ -8,10 +8,10 @@ menu:
     name: Delete data
     parent: Write data
 weight: 104
-v2.0/tags: [delete]
+influxdb/v2.0/tags:: [delete]
 related:
-  - /v2.0/reference/syntax/delete-predicate/
-  - /v2.0/reference/cli/influx/delete/
+  - /influxdb/v2.0/reference/syntax/delete-predicate/
+  - /influxdb/v2.0/reference/cli/influx/delete/
 ---
 <!--
 ## Delete data in the InfluxDB UI

--- a/content/v2.0/write-data/delete-data.md
+++ b/content/v2.0/write-data/delete-data.md
@@ -1,0 +1,96 @@
+---
+title: Delete data
+list_title: Delete data
+description: >
+  Delete data in the InfluxDB CLI and API.
+menu:
+  v2_0:
+    name: Delete data
+    parent: Write data
+weight: 104
+v2.0/tags: [delete]
+related:
+  - /v2.0/reference/syntax/delete-predicate/
+  - /v2.0/reference/cli/influx/delete/
+---
+<!--
+## Delete data in the InfluxDB UI
+
+Delete data from buckets you've created. You cannot delete data from system buckets.
+
+### Delete data from buckets
+
+1. Click **Load Data** in the navigation bar.
+
+    {{< nav-icon "load data" >}}
+
+2. Select **Buckets**.
+3. Next to the bucket with data you want to delete, click **Delete Data by Filter**.
+4. In the **Delete Data** window that appears:
+  - Select a **Target Bucket** to delete data from.
+  - Enter a **Time Range** to delete data from.
+  - Click **+ Add Filter** to filter by tag key and value pair.
+  - Select **I understand that this cannot be undone**.
+5. Click **Confirm Delete** to delete the selected data.
+
+### Delete data from the Data Explorer
+
+1. Click the **Data Explorer** icon in the sidebar.
+
+    {{< nav-icon "data-explorer" >}}
+
+2. Click **Delete Data** in the top navigation bar.
+3. In the **Delete Data** window that appears:
+  - Select a **Target Bucket** to delete data from.
+  - Enter a **Time Range** to delete data from.
+  - Click **+ Add Filter** to filter by tag key-value pairs.
+  - Select **I understand that this cannot be undone**.
+4. Click **Confirm Delete** to delete the selected data.
+!-->
+
+## Delete data using the influx CLI
+
+1. Use the [`influx delete` command](/v2.0/reference/cli/influx/delete/) to delete points from InfluxDB.
+2. Specify your organization, bucket, and authentication token.
+3. Define the time range to delete data from with the `--start` and `--stop` flags.
+4. Specify which points to delete using the `--predicate` or `-p` flag and
+   [Delete predicate syntax](/v2.0/reference/syntax/delete-predicate/).
+
+##### Example delete command
+```sh
+influx delete -o my-org -b my-bucket -t $INFLUX_TOKEN \
+  --start '1970-01-01T00:00:00.00Z' \
+  --stop '2020-01-01T00:00:00.00Z' \
+  --predicate '_measurement="sensors" and sensorID="abc123"'
+```
+
+{{% warn %}}
+Running `influx delete` without the `-p` or `--predicate` flag deletes all data with
+timestamps between the specified `--start` and `--stop` times in the specified bucket.
+{{% /warn %}}
+
+## Delete data using the API
+1. Use the InfluxDB API `/delete` endpoint to delete points from InfluxDB.
+2. Include your organization and bucket as query parameters in the request URL.
+3. Use the `Authorization` header to provide your InfluxDB authentication token.
+4. In your request payload, define the time range to delete data from with `start` and `stop`.
+   Specify which points to delete using the `predicate` and
+   [Delete predicate syntax](/v2.0/reference/syntax/delete-predicate/).
+
+##### Example delete request
+```sh
+curl -XPOST http://localhost:9999/api/v2/delete/?org=myOrg&bucket=myBucket \
+  -H 'Authorization: Token <YOURAUTHTOKEN>' \
+  -d '{
+        "start": "1970-01-01T00:00:00.00Z",
+        "stop": "2020-01-01T00:00:00.00Z",
+        "predicate": "_measurement=\"sensors\" and sensorID=\"abc123\""
+      }'
+```
+
+_For more information, see the [`/delete` API documentation](/v2.0/api/#/paths/~1delete/post)._
+
+{{% warn %}}
+Using the `/delete` endpoint without a `predicate` deletes all data with
+timestamps between the specified `start` and `stop` times in the specified bucket.
+{{% /warn %}}

--- a/content/v2.0/write-data/delete-data.md
+++ b/content/v2.0/write-data/delete-data.md
@@ -48,13 +48,21 @@ Delete data from buckets you've created. You cannot delete data from system buck
 4. Click **Confirm Delete** to delete the selected data.
 !-->
 
+Use the `influx` CLI or the InfluxDB API `/delete` endpoint to delete data.
+
+{{% note %}}
+The `-p, --predicate` flag is supported in InfluxDB Cloud and InfluxDB OSS 2.0 beta 16 or earlier.
+
+In InfluxDB OSS 2.0rc0, the `influx delete --predicate` flag has been disabled.
+{{% /note %}}
+
 ## Delete data using the influx CLI
 
-1. Use the [`influx delete` command](/v2.0/reference/cli/influx/delete/) to delete points from InfluxDB.
+1. Use the [`influx delete` command](/influxdb/v2.0/reference/cli/influx/delete/) to delete points from InfluxDB.
 2. Specify your organization, bucket, and authentication token.
 3. Define the time range to delete data from with the `--start` and `--stop` flags.
 4. Specify which points to delete using the `--predicate` or `-p` flag and
-   [Delete predicate syntax](/v2.0/reference/syntax/delete-predicate/).
+   [Delete predicate syntax](/influxdb/v2.0/reference/syntax/delete-predicate/).
 
 ##### Example delete command
 ```sh
@@ -75,11 +83,11 @@ timestamps between the specified `--start` and `--stop` times in the specified b
 3. Use the `Authorization` header to provide your InfluxDB authentication token.
 4. In your request payload, define the time range to delete data from with `start` and `stop`.
    Specify which points to delete using the `predicate` and
-   [Delete predicate syntax](/v2.0/reference/syntax/delete-predicate/).
+   [Delete predicate syntax](/influxdb/v2.0/reference/syntax/delete-predicate/).
 
 ##### Example delete request
 ```sh
-curl -XPOST http://localhost:9999/api/v2/delete/?org=myOrg&bucket=myBucket \
+curl -XPOST http://localhost:8086/api/v2/delete/?org=myOrg&bucket=myBucket \
   -H 'Authorization: Token <YOURAUTHTOKEN>' \
   -d '{
         "start": "1970-01-01T00:00:00.00Z",
@@ -88,7 +96,7 @@ curl -XPOST http://localhost:9999/api/v2/delete/?org=myOrg&bucket=myBucket \
       }'
 ```
 
-_For more information, see the [`/delete` API documentation](/v2.0/api/#/paths/~1delete/post)._
+_For more information, see the [`/delete` API documentation](/influxdb/v2.0/api/#/paths/~1delete/post)._
 
 {{% warn %}}
 Using the `/delete` endpoint without a `predicate` deletes all data with


### PR DESCRIPTION
- Add how to delete date using the CLI and API. Currently, deleting data in the UI is not supported (in OSS or Cloud).
- Delete predicate syntax page updates:
   - Remove draft tag.
   - Add note that delete with predicate functionality has been disabled in the InfluxDB OSS 2.0rc0 release.
- influx delete page updates:
   - Add note that `-predicate`, `-p` flag is only supported in InfluxDB Cloud and InfluxDB OSS beta 16 or earlier. 
   - Add description of what happens when influx delete is run without the predicate flag.
   - Remove redirects.
