### PR TITLE
Clarify delete with predicate works w Cloud

### DIFF
--- a/content/influxdb/v2.0/reference/cli/influx/delete/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/delete/_index.md
@@ -31,7 +31,7 @@ Running `influx delete` without the `-p` or `--predicate` flag deletes all data 
 |      | `--host`            | HTTP address of InfluxDB (default `http://localhost:8086`)                                                | string     | `INFLUX_HOST`        |
 | `-o` | `--org`             | Organization name                                                                                         | string     | `INFLUX_ORG`         |
 |      | `--org-id`          | Organization ID                                                                                           | string     | `INFLUX_ORG_ID`      |
-| `-p` | `--predicate`       | Only supported in InfluxDB Cloud and InfluxDB OSS 2.0 beta 16 or earlier InfluxQL-like predicate string (see [Delete predicate](/v2.0/reference/syntax/delete-predicate)).  | string     |        |
+| `-p` | `--predicate`       | Only supported in InfluxDB Cloud and InfluxDB OSS 2.0 beta 16 or earlier InfluxQL-like predicate string (see [Delete predicate](/influxdb/v2.0/reference/syntax/delete-predicate)).  | string     |        |
 |      | `--skip-verify`     | Skip TLS certificate verification                                                                         |            |                      |
 |      | `--start`           | Start time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                                | string     |                      |
 |      | `--stop`            | Stop time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                                 | string     |                      |

--- a/content/influxdb/v2.0/reference/cli/influx/delete/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/delete/_index.md
@@ -31,8 +31,7 @@ Running `influx delete` without the `-p` or `--predicate` flag deletes all data 
 |      | `--host`            | HTTP address of InfluxDB (default `http://localhost:8086`)                                                | string     | `INFLUX_HOST`        |
 | `-o` | `--org`             | Organization name                                                                                         | string     | `INFLUX_ORG`         |
 |      | `--org-id`          | Organization ID                                                                                           | string     | `INFLUX_ORG_ID`      |
-| `-p` | `--predicate`       | Only supported in InfluxDB Cloud and InfluxDB OSS 2.0 beta 16 or earlier.
-                               InfluxQL-like predicate string (see [Delete predicate](/v2.0/reference/syntax/delete-predicate))          | string     |                      |
+| `-p` | `--predicate`       | Only supported in InfluxDB Cloud and InfluxDB OSS 2.0 beta 16 or earlier InfluxQL-like predicate string (see [Delete predicate](/v2.0/reference/syntax/delete-predicate)).  | string     |        |
 |      | `--skip-verify`     | Skip TLS certificate verification                                                                         |            |                      |
 |      | `--start`           | Start time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                                | string     |                      |
 |      | `--stop`            | Stop time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                                 | string     |                      |

--- a/content/influxdb/v2.0/reference/cli/influx/delete/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/delete/_index.md
@@ -1,8 +1,5 @@
 ---
 title: influx delete
-aliases:
-  - /influxdb/v2.0/tags/delete/
-  - /influxdb/v2.0/reference/syntax/delete-predicate/
 description: The `influx delete` command deletes points from an InfluxDB bucket.
 menu:
   influxdb_2_0_ref:
@@ -13,24 +10,30 @@ influxdb/v2.0/tags: [delete]
 ---
 
 The `influx delete` command deletes [points](/influxdb/v2.0/reference/glossary/#point)
-from an InfluxDB bucket.
+from an InfluxDB bucket. Identify points to delete using [delete predicate syntax](/influxdb/v2.0/reference/syntax/delete-predicate).
 
 {{% note %}}
-In this release, the delete with predicate API (`/api/v2/delete`) has been disabled. This API now returns a 501 Not implemented message.
+In **InfluxDB OSS 2.0rc0**, the `influx delete --predicate` flag has been disabled.
+The `-p`, `--predicate` flag is supported in **InfluxDB Cloud** and **InfluxDB OSS 2.0 beta 16 or earlier**.
+
+Running `influx delete` without the `-p` or `--predicate` flag deletes all data with timestamps between the specified
+`--start` and `--stop` times in the specified bucket.
 {{% /note %}}
 
 ## Flags
-| Flag |                   | Description                                                                                               | Input type | {{< cli/mapped >}}   |
-|:---- |:---               |:-----------                                                                                               |:----------:|:------------------   |
-| `-c` | `--active-config` | CLI configuration to use for command                                                                      | string     |                      |
-| `-b` | `--bucket`        | Name of bucket to remove data from                                                                        | string     | `INFLUX_BUCKET_NAME` |
-|      | `--bucket-id`     | Bucket ID                                                                                                 | string     | `INFLUX_BUCKET_ID`   |
-|      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`)                                     | string     |`INFLUX_CONFIGS_PATH` |
-| `-h` | `--help`          | Help for the `delete` command                                                                             |            |                      |
-|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)                                                | string     | `INFLUX_HOST`        |
-| `-o` | `--org`           | Organization name                                                                                         | string     | `INFLUX_ORG`         |
-|      | `--org-id`        | Organization ID                                                                                           | string     | `INFLUX_ORG_ID`      |
-|      | `--skip-verify`   | Skip TLS certificate verification                                                                         |            |                      |
-|      | `--start`         | Start time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                                | string     |                      |
-|      | `--stop`          | Stop time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                                 | string     |                      |
-| `-t` | `--token`         | Authentication token                                                                                      | string     | `INFLUX_TOKEN`       |
+| Flag |                     | Description                                                                                               | Input type | {{< cli/mapped >}}   |
+|:---- |:---                 |:-----------                                                                                               |:----------:|:------------------   |
+| `-c` | `--active-config`   | CLI configuration to use for command                                                                      | string     |                      |
+| `-b` | `--bucket`          | Name of bucket to remove data from                                                                        | string     | `INFLUX_BUCKET_NAME` |
+|      | `--bucket-id`       | Bucket ID                                                                                                 | string     | `INFLUX_BUCKET_ID`   |
+|      | `--configs-path`    | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`)                                     | string     |`INFLUX_CONFIGS_PATH` |
+| `-h` | `--help`            | Help for the `delete` command                                                                             |            |                      |
+|      | `--host`            | HTTP address of InfluxDB (default `http://localhost:8086`)                                                | string     | `INFLUX_HOST`        |
+| `-o` | `--org`             | Organization name                                                                                         | string     | `INFLUX_ORG`         |
+|      | `--org-id`          | Organization ID                                                                                           | string     | `INFLUX_ORG_ID`      |
+| `-p` | `--predicate`       | Only supported in InfluxDB Cloud and InfluxDB OSS 2.0 beta 16 or earlier.
+                               InfluxQL-like predicate string (see [Delete predicate](/v2.0/reference/syntax/delete-predicate))          | string     |                      |
+|      | `--skip-verify`     | Skip TLS certificate verification                                                                         |            |                      |
+|      | `--start`           | Start time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                                | string     |                      |
+|      | `--stop`            | Stop time in RFC3339 format (i.e. `2009-01-02T23:00:00Z`)                                                 | string     |                      |
+| `-t` | `--token`           | Authentication token                                                                                      | string     | `INFLUX_TOKEN`       |

--- a/content/influxdb/v2.0/reference/syntax/delete-predicate.md
+++ b/content/influxdb/v2.0/reference/syntax/delete-predicate.md
@@ -9,11 +9,16 @@ menu:
     parent: Syntax
     name: Delete predicate
 weight: 104
-draft: true
 influxdb/v2.0/tags: [syntax, delete]
 related:
   - /influxdb/v2.0/reference/cli/influx/delete/
 ---
+
+{{% note %}}
+In InfluxDB OSS 2.0rc0, the delete with predicate API (`/api/v2/delete`) has been disabled and returns a 501 Not implemented message.
+
+Use the InfluxDB `/delete` endpoint with InfluxDB Cloud and InfluxDB OSS 2.0 beta 16 or earlier.
+{{% /note %}}
 
 The InfluxDB `/delete` endpoint uses an InfluxQL-like predicate syntax to determine
 what data [points](/influxdb/v2.0/reference/glossary/#point) to delete.

--- a/content/influxdb/v2.0/reference/syntax/delete-predicate.md
+++ b/content/influxdb/v2.0/reference/syntax/delete-predicate.md
@@ -15,9 +15,9 @@ related:
 ---
 
 {{% note %}}
-In InfluxDB OSS 2.0rc0, the delete with predicate API (`/api/v2/delete`) has been disabled and returns a 501 Not implemented message.
+In **InfluxDB OSS 2.0rc0**, the delete with predicate API (`/api/v2/delete`) has been disabled and returns a 501 Not implemented message.
 
-Use the InfluxDB `/delete` endpoint with InfluxDB Cloud and InfluxDB OSS 2.0 beta 16 or earlier.
+Use the InfluxDB `/delete` endpoint with **InfluxDB Cloud** and **InfluxDB OSS 2.0 beta 16 or earlier**.
 {{% /note %}}
 
 The InfluxDB `/delete` endpoint uses an InfluxQL-like predicate syntax to determine


### PR DESCRIPTION
- Remove draft on Delete predicate syntax page and add note that functionality has been disabled in the InfluxDB OSS 2.0rc0 release.
- On `influx delete` page, add note that `-predicate` flag is only supported in InfluxDB Cloud and InfluxDB OSS beta 16 or earlier. Add description of what happens when `influx delete` is run without the predicate flag. 
- Remove redirects.

