### PR TITLE
Add `influxd upgrade` guide (1.x to 2.0)

### DIFF
--- a/content/influxdb/v2.0/get-started.md
+++ b/content/influxdb/v2.0/get-started.md
@@ -244,7 +244,9 @@ Get started with InfluxDB OSS v2.0 by downloading InfluxDB, installing the neces
 executables, and running the initial setup process.
 
 {{% note %}}
-To upgrade from InfluxDB 2.0 beta 16 or earlier to the latest version, see [Upgrade to InfluxDB OSS 2.0rc0](/influxdb/v2.0/reference/rc0-upgrade-guide/).
+To upgrade from InfluxDB 2.0 beta 16 or earlier to the latest version, see [Upgrade from InfluxDB 2.0 beta to InfluxDB 2.0rc1](/influxdb/v2.0/reference/rc1-upgrade-guide/).
+
+To upgrade to InfluxDB 2.0rc1 from InfluxDB 1.x, see [Upgrade from InfluxDB 1.x to InfluxDB 2.0](/influxdb/v2.0/reference/influxd-upgrade-guide/).
 {{% /note %}}
 
 {{< tabs-wrapper >}}

--- a/content/influxdb/v2.0/reference/upgrading/_index.md
+++ b/content/influxdb/v2.0/reference/upgrading/_index.md
@@ -1,0 +1,10 @@
+---
+title: Upgrade InfluxDB
+description: >
+  Upgrade your version of InfluxDB
+menu: influxdb_2_0_ref
+weight: 20
+influxdb/v2.0/tags: []
+---
+
+{{< children >}}

--- a/content/influxdb/v2.0/reference/upgrading/beta2rc1-upgrade-guide.md
+++ b/content/influxdb/v2.0/reference/upgrading/beta2rc1-upgrade-guide.md
@@ -9,7 +9,7 @@ menu:
 aliases:
   - /influxdb/v2.0/reference/rc0-upgrade-guide/
   - /influxdb/v2.0/reference/rc1-upgrade-guide/
-weight: 9
+weight: 7
 ---
 
 To upgrade from InfluxDB 2.0 beta 16 or earlier to InfluxDB 2.0rc1, you must manually upgrade all resources and data to the latest version by completing the following steps:

--- a/content/influxdb/v2.0/reference/upgrading/beta2rc1-upgrade-guide.md
+++ b/content/influxdb/v2.0/reference/upgrading/beta2rc1-upgrade-guide.md
@@ -1,12 +1,14 @@
 ---
-title: Upgrade to InfluxDB OSS 2.0rc1
+title: Upgrade from InfluxDB 2.0 beta to InfluxDB 2.0rc1
 description: >
-  Upgrade to InfluxDB OSS 2.0rc1.
+  Upgrade from InfluxDB 2.0 beta to InfluxDB 2.0rc1.
 menu:
   influxdb_2_0_ref:
-    name: Upgrade to InfluxDB OSS 2.0rc1
+    parent: Upgrade InfluxDB
+    name: Upgrade from InfluxDB 2.0 beta to InfluxDB 2.0rc1
 aliases:
   - /influxdb/v2.0/reference/rc0-upgrade-guide/
+  - /influxdb/v2.0/reference/rc1-upgrade-guide/
 weight: 9
 ---
 

--- a/content/influxdb/v2.0/reference/upgrading/influxd-upgrade-guide.md
+++ b/content/influxdb/v2.0/reference/upgrading/influxd-upgrade-guide.md
@@ -10,16 +10,16 @@ weight: 9
 ---
 
 Use the `influxd upgrade` command to upgrade InfluxDB 1.x to InfluxDB 2.0.
-This command copies all data stored in [databases](/influxdb/v1.8/concepts/glossary/#database) and 
-[retention policies](/influxdb/v1.8/concepts/glossary/#retention-policy-rp) (used in 1.x)
-over to [buckets](/influxdb/v2.0/reference/glossary/#bucket) (used in 2.0).
+This command copies all data stored in 1.x [databases](/influxdb/v1.8/concepts/glossary/#database) and
+[retention policies](/influxdb/v1.8/concepts/glossary/#retention-policy-rp)
+to 2.0 [buckets](/influxdb/v2.0/reference/glossary/#bucket).
 
 {{% warn %}}
-Be sure to back up all data before upgrading with `influx upgrade`.
+Back up all data before upgrading with `influx upgrade`.
 {{% /warn %}}
 
-1. If you haven't already, [download the InfluxDB OSS 2.0rc1](https://portal.influxdata.com/downloads/).
-   Follow the install instructions for `influxd` and `influx`.
+1. [Download the InfluxDB OSS 2.0rc1](https://portal.influxdata.com/downloads/),
+   unpackage the InfluxDB binaries, and then place them in your `$PATH`.
 2. Stop your running InfluxDB 1.x instance.
 3. If your configuration file is at the default location (`~/.influxdbv2/configs`), run:
 
@@ -28,6 +28,7 @@ Be sure to back up all data before upgrading with `influx upgrade`.
    ```
 
    Otherwise, run:
+
    ```sh
    influxd upgrade --config <path to config file>
    ```

--- a/content/influxdb/v2.0/reference/upgrading/influxd-upgrade-guide.md
+++ b/content/influxdb/v2.0/reference/upgrading/influxd-upgrade-guide.md
@@ -1,0 +1,34 @@
+---
+title: Upgrade from InfluxDB 1.x to InfluxDB 2.0
+description: >
+  Upgrade from InfluxDB 1.x to InfluxDB 2.0.
+menu:
+  influxdb_2_0_ref:
+    parent: Upgrade InfluxDB
+    name: Upgrade from InfluxDB 1.x to InfluxDB 2.0
+weight: 9
+---
+
+Use the `influxd upgrade` command to upgrade InfluxDB 1.x to InfluxDB 2.0.
+This command copies all data stored in [databases](/influxdb/v1.8/concepts/glossary/#database) and 
+[retention policies](/influxdb/v1.8/concepts/glossary/#retention-policy-rp) (used in 1.x)
+over to [buckets](/influxdb/v2.0/reference/glossary/#bucket) (used in 2.0).
+
+{{% warn %}}
+Be sure to back up all data before upgrading with `influx upgrade`.
+{{% /warn %}}
+
+1. If you haven't already, [download the InfluxDB OSS 2.0rc1](https://portal.influxdata.com/downloads/).
+   Follow the install instructions for `influxd` and `influx`.
+2. Stop your running InfluxDB 1.x instance.
+3. If your configuration file is at the default location (`~/.influxdbv2/configs`), run:
+
+   ```sh
+   influxd upgrade
+   ```
+
+   Otherwise, run:
+   ```sh
+   influxd upgrade --config <path to config file>
+   ```
+4. Follow the prompts to set up a new InfluxDB 2.0 instance.


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/1659.

Adds a guide to using `influxd upgrade`.

Collects the two upgrade guides (from 1.x and from 2.0 beta) into an "Upgrading InfluxDB" section.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
