### PR TITLE
fix(grafana): fix grafana config page

### DIFF
--- a/content/influxdb/v2.0/tools/grafana.md
+++ b/content/influxdb/v2.0/tools/grafana.md
@@ -53,7 +53,7 @@ configure your InfluxDB connection:
     - **URL**: Your [InfluxDB URL](/influxdb/v2.0/reference/urls/).
 
         ```sh
-        http://localhost:8086/api/v2
+        http://localhost:8086/
         ```
 
     - **Organization**: Your InfluxDB [organization name **or** ID](/influxdb/v2.0/organizations/view-orgs/).
@@ -71,10 +71,6 @@ configure your InfluxDB connection:
 {{% tab-content %}}
 ## Configure Grafana to use InfluxQL
 
-{{% cloud %}}
-**{{< cloud-name "short" >}}** supports InfluxQL, but **InfluxDB 2.0 OSS** does not.
-{{% /cloud %}}
-
 With **InfluxQL** selected as the query language in your InfluxDB data source,
 configure your InfluxDB connection:
 
@@ -83,7 +79,7 @@ configure your InfluxDB connection:
     - **URL**: Your [InfluxDB URL](/influxdb/v2.0/reference/urls/).
 
         ```sh
-        https://cloud2.influxdata.com
+        http://localhost:8086/
         ```
     - **Access**: Server (default)
 


### PR DESCRIPTION
Fixing the docs for grafana to cloud config. the url was wrong and OSS now supports InfluxQL:

![image](https://user-images.githubusercontent.com/4805997/96155402-c071e280-0ec4-11eb-8787-a1c9446d26ef.png)


Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
