### PR TITLE
typo: wrong flag

### DIFF
--- a/content/influxdb/v2.0/security/tokens/create-token.md
+++ b/content/influxdb/v2.0/security/tokens/create-token.md
@@ -42,7 +42,7 @@ influx auth create -o <org-name> [permission-flags]
 
 # Example
 influx auth create -o my-org \
-  --read-buckets 03a2bbf46309a000 03ace3a87c269000 \
+  --read-bucket 03a2bbf46309a000 03ace3a87c269000 \
   --read-dashboards \
   --read-tasks \
   --read-telegrafs \


### PR DESCRIPTION
Using `--read-buckets 03a2bbf46309a000 03ace3a87c269000` instead of `--read-bucket 03a2bbf46309a000 03ace3a87c269000` will allow read on all buckets instead of those specify

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
