### PR TITLE
fix example for json.parse

### DIFF
--- a/content/influxdb/v2.0/reference/flux/stdlib/experimental/json/parse.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/experimental/json/parse.md
@@ -19,7 +19,7 @@ _**Function type:** Type conversion_
 import "experimental/json"
 
 json.parse(
-  data: bytes(v: "{\"\"a\"\":1,\"\"b\"\":2,\"\"c\"\":3}")
+  data: bytes(v: "{\"a\":1,\"b\":2,\"c\":3}")
 )
 ```
 


### PR DESCRIPTION
Closes #

_Describe your proposed changes here._

The example was wrong

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
