### PR TITLE
Document `v1 auth` subcommands

### DIFF
--- a/content/influxdb/cloud/reference/cli/influx/v1/_index.md
+++ b/content/influxdb/cloud/reference/cli/influx/v1/_index.md
@@ -1,0 +1,12 @@
+---
+title: influx v1
+description: >
+  The `influx v1` command provides commands for working with the InfluxDB 1.x API in InfluxDB 2.0.
+menu:
+  influxdb_cloud_ref:
+    name: influx v1
+    parent: influx
+weight: 101
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/cloud/reference/cli/influx/v1/auth/_index.md
+++ b/content/influxdb/cloud/reference/cli/influx/v1/auth/_index.md
@@ -1,0 +1,13 @@
+---
+title: influx v1 auth
+description: >
+  The `influx v1 auth` subcommands provide authorization management for the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_cloud_ref:
+    name: influx v1 auth
+    parent: influx v1
+weight: 101
+influxdb/cloud/tags: [authorization]
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/cloud/reference/cli/influx/v1/auth/create.md
+++ b/content/influxdb/cloud/reference/cli/influx/v1/auth/create.md
@@ -1,0 +1,13 @@
+---
+title: influx v1 auth create
+description: >
+  The `influx v1 auth create` command creates an authorization in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_cloud_ref:
+    name: influx v1 auth create
+    parent: influx v1 auth
+weight: 101
+influxdb/cloud/tags: [authorization]
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/cloud/reference/cli/influx/v1/auth/delete.md
+++ b/content/influxdb/cloud/reference/cli/influx/v1/auth/delete.md
@@ -1,0 +1,13 @@
+---
+title: influx v1 auth delete
+description: >
+  The `influx v1 auth delete` command deletes an authorization in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_cloud_ref:
+    name: influx v1 auth delete
+    parent: influx v1 auth
+weight: 101
+influxdb/cloud/tags: [authorization]
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/cloud/reference/cli/influx/v1/auth/list.md
+++ b/content/influxdb/cloud/reference/cli/influx/v1/auth/list.md
@@ -1,0 +1,13 @@
+---
+title: influx v1 auth list
+description: >
+  The `influx v1 auth list` command lists and searches authorizations in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_cloud_ref:
+    name: influx v1 auth list
+    parent: influx v1 auth
+weight: 101
+influxdb/cloud/tags: [authorization]
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/cloud/reference/cli/influx/v1/auth/set-active.md
+++ b/content/influxdb/cloud/reference/cli/influx/v1/auth/set-active.md
@@ -1,0 +1,13 @@
+---
+title: influx v1 auth set-active
+description: >
+  The `influx v1 auth set-active` command activates an authorization in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_cloud_ref:
+    name: influx v1 auth set-active
+    parent: influx v1 auth
+weight: 101
+influxdb/cloud/tags: [authorization]
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/cloud/reference/cli/influx/v1/auth/set-inactive.md
+++ b/content/influxdb/cloud/reference/cli/influx/v1/auth/set-inactive.md
@@ -1,0 +1,13 @@
+---
+title: influx v1 auth set-inactive
+description: >
+  The `influx v1 auth set-inactive` command deactivates an authorization in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_cloud_ref:
+    name: influx v1 auth set-inactive
+    parent: influx v1 auth
+weight: 101
+influxdb/cloud/tags: [authorization]
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/cloud/reference/cli/influx/v1/auth/set-password.md
+++ b/content/influxdb/cloud/reference/cli/influx/v1/auth/set-password.md
@@ -1,0 +1,13 @@
+---
+title: influx v1 auth set-password
+description: >
+  The `influx v1 auth set-password` command sets a password for an existing authorization in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_cloud_ref:
+    name: influx v1 auth set-password
+    parent: influx v1 auth
+weight: 101
+influxdb/cloud/tags: [authorization]
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/v2.0/reference/cli/influx/v1/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/v1/_index.md
@@ -1,0 +1,29 @@
+---
+title: influx v1
+description: >
+  The `influx v1` command provides commands for working with the InfluxDB 1.x API in InfluxDB 2.0.
+menu:
+  influxdb_2_0_ref:
+    name: influx v1
+    parent: influx
+weight: 101
+influxdb/v2.0/tags: []
+---
+
+The `influx v1` command provides commands for working with the [InfluxDB 1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/) in InfluxDB 2.0.
+
+## Usage
+```
+influx v1 [flags]
+influx v1 [command]
+```
+
+## Subcommands
+| Subcommand                                           | Description                                   |
+|:-----------------------------------------------------|:----------------------------------------------|
+| [auth](/influxdb/v2.0/reference/cli/influx/v1/auth/) | Authorization management commands for v1 APIs |
+
+## Flags
+| Flag |          | Description               |
+|:-----|:---------|:--------------------------|
+| `-h` | `--help` | Help for the `v1` command |

--- a/content/influxdb/v2.0/reference/cli/influx/v1/auth/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/v1/auth/_index.md
@@ -1,0 +1,38 @@
+---
+title: influx v1 auth
+description: >
+  The `influx v1 auth` subcommands provide authorization management for the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_2_0_ref:
+    name: influx v1 auth
+    parent: influx v1
+weight: 101
+influxdb/v2.0/tags: [authorization]
+---
+
+The `influx v1 auth` subcommands provide authorization management for the [InfluxDB 1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/).
+
+## Usage
+```
+influx v1 auth [flags]
+influx v1 auth [command]
+```
+
+#### Aliases
+`auth`, `authorization`
+
+## Commands
+
+| Command                                                                     | Description                                  |
+|:----------------------------------------------------------------------------|----------------------------------------------|
+| [`create`](/influxdb/v2.0/reference/cli/influx/v1/auth/create/)             | Create authorization                         |
+| [`delete`](/influxdb/v2.0/reference/cli/influx/v1/auth/delete/)             | Delete authorization                         |
+| [`list`](/influxdb/v2.0/reference/cli/influx/v1/auth/list/)                 | List authorizations                          |
+| [`set-active`](/influxdb/v2.0/reference/cli/influx/v1/auth/set-active/)     | Activate an authorization                    |
+| [`set-inactive`](/influxdb/v2.0/reference/cli/influx/v1/auth/set-inactive/) | Deactivate an authorization                  |
+| [`set-password`](/influxdb/v2.0/reference/cli/influx/v1/auth/set-password/) | Set a password for an existing authorization |
+
+## Flags
+| Flag |          | Description                     |
+|:-----|:---------|:--------------------------------|
+| `-h` | `--help` | Help for the `v1 auth ` command |

--- a/content/influxdb/v2.0/reference/cli/influx/v1/auth/create.md
+++ b/content/influxdb/v2.0/reference/cli/influx/v1/auth/create.md
@@ -1,0 +1,50 @@
+---
+title: influx v1 auth create
+description: >
+  The `influx v1 auth create` command creates an authorization in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_2_0_ref:
+    name: influx v1 auth create
+    parent: influx v1 auth
+weight: 101
+influxdb/v2.0/tags: [authorization]
+---
+
+The `influx v1 auth create` command creates a legacy authorization with the [InfluxDB 1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/).
+
+## Usage
+```
+influx v1 auth create [flags]
+```
+
+## Flags
+| Flag |                   | Description                                                                                            | Input type  | {{< cli/mapped >}}      |
+|:-----|:------------------|:-------------------------------------------------------------------------------------------------------|:-----------:|:------------------------|
+| `-c` | `--active-config` | Config name to use for command                                                                         | string      | `$INFLUX_ACTIVE_CONFIG` |
+|      | `--configs-path`  | Path to the influx CLI configurations (default: `~/.influxdbv2/configs`)                               | string      | `$INFLUX_CONFIGS_PATH`  |
+| `-d` | `--description`   | Token description                                                                                      | string      |                         |
+| `-h` | `--help`          | Help for the `create` command                                                                          |             |                         |
+|      | `--hide-headers`  | Hide the table headers (default: `false`)                                                              |             | `$INFLUX_HIDE_HEADERS`  |
+|      | `--host`          | HTTP address of InfluxDB                                                                               | string      | `$INFLUX_HOST`          |
+|      | `--json`          | Output data as JSON (default: `false`)                                                                 |             | `$INFLUX_OUTPUT_JSON`   |
+|      | `--no-password`   | Don't prompt for a password. (You must use the `v1 auth set-password` command before using the token.) |             |                         |
+| `-o` | `--org`           | Organization name                                                                                      | string      | `$INFLUX_ORG`           |
+|      | `--org-id`        | Organization ID                                                                                        | string      | `$INFLUX_ORG_ID`        |
+|      | `--read-bucket`   | Bucket ID to assign read permissions to                                                                |             |                         |
+|      | `--skip-verify`   | Skip TLS certificate verification                                                                      |             |                         |
+| `-t` | `--token`         | Authentication token                                                                                   | string      | `$INFLUX_TOKEN`         |
+|      | `--username`      | (Required) Token username                                                                              | string      |                         |
+|      | `--write-bucket`  | Bucket ID(s) to assign write permissions to                                                            | stringArray |                         |
+
+## Examples
+
+##### Create a new authorization with read and write permissions
+```sh
+// Create an authorization with read and write access to bucket 00xX00o0X001
+// but only read access to bucket 00xX00o0X002
+influx v1 auth create \
+  --read-bucket 00xX00o0X001 \
+  --read-bucket 00xX00o0X002 \
+  --write-bucket 00xX00o0X001 \
+  --username example-user
+```

--- a/content/influxdb/v2.0/reference/cli/influx/v1/auth/delete.md
+++ b/content/influxdb/v2.0/reference/cli/influx/v1/auth/delete.md
@@ -1,0 +1,39 @@
+---
+title: influx v1 auth delete
+description: >
+  The `influx v1 auth delete` command deletes an authorization in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_2_0_ref:
+    name: influx v1 auth delete
+    parent: influx v1 auth
+weight: 101
+influxdb/v2.0/tags: [authorization]
+---
+
+The `influx v1 auth delete` command deletes an authorization in the [InfluxDB 1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/).
+
+## Usage
+```
+influx v1 auth delete [flags]
+```
+
+## Flags
+| Flag |                   | Description                                                              | Input type | {{< cli/mapped >}}      |
+|:-----|:------------------|:-------------------------------------------------------------------------|:----------:|:------------------------|
+| `-c` | `--active-config` | Config name to use for command                                           | string     | `$INFLUX_ACTIVE_CONFIG` |
+|      | `--configs-path`  | Path to the influx CLI configurations (default: `~/.influxdbv2/configs`) | string     | `$INFLUX_CONFIGS_PATH`  |
+| `-h` | `--help`          | Help for the `delete` command                                            |            |                         |
+|      | `--hide-headers`  | Hide the table headers (default: `false`)                                |            | `$INFLUX_HIDE_HEADERS`  |
+|      | `--host`          | HTTP address of InfluxDB                                                 | string     | `$INFLUX_HOST`          |
+| `-i` | `--id`            | Authorization ID (required)                                              | string     |                         |
+|      | `--json`          | Output data as JSON (default: `false`)                                   |            | `$INFLUX_OUTPUT_JSON`   |
+|      | `--skip-verify`   | Skip TLS certificate verification                                        |            |                         |
+| `-t` | `--token`         | Authentication token                                                     | string     | `$INFLUX_TOKEN`         |
+|      | `--username`      | Authorization username                                                   | string     | `$INFLUX_USERNAME`      |
+
+## Examples
+
+##### Delete a v1 authorization
+```sh
+influx v1 auth delete --id 00xX00o0X001
+```

--- a/content/influxdb/v2.0/reference/cli/influx/v1/auth/list.md
+++ b/content/influxdb/v2.0/reference/cli/influx/v1/auth/list.md
@@ -1,0 +1,39 @@
+---
+title: influx v1 auth list
+description: >
+  The `influx v1 auth list` command lists and searches authorizations in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_2_0_ref:
+    name: influx v1 auth list
+    parent: influx v1 auth
+weight: 101
+influxdb/v2.0/tags: [authorization]
+---
+
+The `influx v1 auth list` command lists and searches authorizations in the [InfluxDB 1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/).
+
+## Usage
+```
+influx v1 auth list [flags]
+```
+
+#### Aliases
+`list`, `ls`, `find`
+
+## Flags
+| Flag |                   | Description                                                              | Input type | {{< cli/mapped >}}      |
+|:-----|:------------------|:-------------------------------------------------------------------------|:----------:|:------------------------|
+| `-c` | `--active-config` | Config name to use for command                                           | string     | `$INFLUX_ACTIVE_CONFIG` |
+|      | `--configs-path`  | Path to the influx CLI configurations (default: `~/.influxdbv2/configs`) | string     | `$INFLUX_CONFIGS_PATH`  |
+| `-h` | `--help`          | Help for the `list` command                                              |            |                         |
+|      | `--hide-headers`  | Hide the table headers (default: `false`)                                |            | `$INFLUX_HIDE_HEADERS`  |
+|      | `--host`          | HTTP address of InfluxDB                                                 | string     | `$INFLUX_HOST`          |
+| `-i` | `--id`            | Authorization ID                                                         | string     |                         |
+|      | `--json`          | Output data as JSON (default: `false`)                                   |            | `$INFLUX_OUTPUT_JSON`   |
+| `-o` | `--org`           | Organization name                                                        | string     | `$INFLUX_ORG`           |
+|      | `--org-id`        | Organization ID                                                          | string     | `$INFLUX_ORG_ID`        |
+|      | `--skip-verify`   | Skip TLS certificate verification                                        |            |                         |
+| `-t` | `--token`         | Authentication token                                                     | string     | `$INFLUX_TOKEN`         |
+| `-u` | `--user`          | InfluxDB user                                                            | string     |                         |
+|      | `--user-id`       | InfluxDB user ID                                                         | string     |                         |
+|      | `--username`      | Authorization username                                                   | string     | `$INFLUX_USERNAME`      |

--- a/content/influxdb/v2.0/reference/cli/influx/v1/auth/set-active.md
+++ b/content/influxdb/v2.0/reference/cli/influx/v1/auth/set-active.md
@@ -1,0 +1,32 @@
+---
+title: influx v1 auth set-active
+description: >
+  The `influx v1 auth set-active` command activates an authorization in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_2_0_ref:
+    name: influx v1 auth set-active
+    parent: influx v1 auth
+weight: 101
+influxdb/v2.0/tags: [authorization]
+---
+
+The `influx v1 auth set-active` command activates an authorization in the [InfluxDB 1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/).
+
+## Usage
+```
+influx v1 auth set-active [flags]
+```
+
+## Flags
+| Flag |                   | Description                                                              | Input type | {{< cli/mapped >}}      |
+|:-----|:------------------|:-------------------------------------------------------------------------|:----------:|:------------------------|
+| `-c` | `--active-config` | Config name to use for command                                           | string     | `$INFLUX_ACTIVE_CONFIG` |
+|      | `--configs-path`  | Path to the influx CLI configurations (default: `~/.influxdbv2/configs`) | string     | `$INFLUX_CONFIGS_PATH`  |
+| `-h` | `--help`          | Help for the `set-active` command                                        |            |                         |
+|      | `--hide-headers`  | Hide the table headers (default: `false`)                                |            | `$INFLUX_HIDE_HEADERS`  |
+|      | `--host`          | HTTP address of InfluxDB                                                 | string     | `$INFLUX_HOST`          |
+| `-i` | `--id`            | Authorization ID (required)                                              | string     |                         |
+|      | `--json`          | Output data as JSON (default: `false`)                                   |            | `$INFLUX_OUTPUT_JSON`   |
+|      | `--skip-verify`   | Skip TLS certificate verification                                        |            |                         |
+| `-t` | `--token`         | Authentication token                                                     | string     | `$INFLUX_TOKEN`         |
+|      | `--username`      | Authorization username                                                   | string     | `$INFLUX_USERNAME`      |

--- a/content/influxdb/v2.0/reference/cli/influx/v1/auth/set-inactive.md
+++ b/content/influxdb/v2.0/reference/cli/influx/v1/auth/set-inactive.md
@@ -1,0 +1,32 @@
+---
+title: influx v1 auth set-inactive
+description: >
+  The `influx v1 auth set-inactive` command deactivates an authorization in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_2_0_ref:
+    name: influx v1 auth set-inactive
+    parent: influx v1 auth
+weight: 101
+influxdb/v2.0/tags: [authorization]
+---
+
+The `influx v1 auth set-inactive` command deactivates an authorization in the [InfluxDB 1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/).
+
+## Usage
+```
+influx v1 auth set-inactive [flags]
+```
+
+## Flags
+| Flag |                   | Description                                                              | Input type | {{< cli/mapped >}}      |
+|:-----|:------------------|:-------------------------------------------------------------------------|:----------:|:------------------------|
+| `-c` | `--active-config` | Config name to use for command                                           | string     | `$INFLUX_ACTIVE_CONFIG` |
+|      | `--configs-path`  | Path to the influx CLI configurations (default: `~/.influxdbv2/configs`) | string     | `$INFLUX_CONFIGS_PATH`  |
+| `-h` | `--help`          | Help for the `set-inactive` command                                      |            |                         |
+|      | `--hide-headers`  | Hide the table headers (default: `false`)                                |            | `$INFLUX_HIDE_HEADERS`  |
+|      | `--host`          | HTTP address of InfluxDB                                                 | string     | `$INFLUX_HOST`          |
+| `-i` | `--id`            | Authorization ID (required)                                              | string     |                         |
+|      | `--json`          | Output data as JSON (default: `false`)                                   |            | `$INFLUX_OUTPUT_JSON`   |
+|      | `--skip-verify`   | Skip TLS certificate verification                                        |            |                         |
+| `-t` | `--token`         | Authentication token                                                     | string     | `$INFLUX_TOKEN`         |
+|      | `--username`      | Authorization username                                                   | string     | `$INFLUX_USERNAME`      |

--- a/content/influxdb/v2.0/reference/cli/influx/v1/auth/set-password.md
+++ b/content/influxdb/v2.0/reference/cli/influx/v1/auth/set-password.md
@@ -1,0 +1,30 @@
+---
+title: influx v1 auth set-password
+description: >
+  The `influx v1 auth set-password` command sets a password for an existing authorization in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_2_0_ref:
+    name: influx v1 auth set-password
+    parent: influx v1 auth
+weight: 101
+influxdb/v2.0/tags: [authorization]
+---
+
+The `influx v1 auth set-password` command sets a password for an existing authorization in the [InfluxDB 1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/).
+
+## Usage
+```
+influx v1 auth set-password [flags]
+```
+
+## Flags
+| Flag |                   | Description                                                              | Input type | {{< cli/mapped >}}      |
+|:-----|:------------------|:-------------------------------------------------------------------------|:----------:|:------------------------|
+| `-c` | `--active-config` | Config name to use for command                                           | string     | `$INFLUX_ACTIVE_CONFIG` |
+|      | `--configs-path`  | Path to the influx CLI configurations (default: `~/.influxdbv2/configs`) | string     | `$INFLUX_CONFIGS_PATH`  |
+| `-h` | `--help`          | Help for the `set-password` command                                      |            |                         |
+|      | `--host`          | HTTP address of InfluxDB                                                 | string     | `$INFLUX_HOST`          |
+| `-i` | `--id`            | Authorization ID                                                         | string     |                         |
+|      | `--skip-verify`   | Skip TLS certificate verification                                        |            |                         |
+| `-t` | `--token`         | Authentication token                                                     | string     | `$INFLUX_TOKEN`         |
+|      | `--username`      | Authorization username                                                   | string     | `$INFLUX_USERNAME`      |


### PR DESCRIPTION
Based on https://github.com/influxdata/docs-v2/pull/1768. This is a new PR due to merge conflicts.

Adds the new `influx v1` command, and documents the following `v1 auth` commands:
`create`, `delete`, `list`, `set-active`, `set-inactive`, and `set-password`.

Closes #1736.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable