### PR TITLE
Add missing TLS configuration options

### DIFF
--- a/content/enterprise_influxdb/v1.8/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.8/guides/https_setup.md
@@ -117,6 +117,11 @@ Consult your CA if you are unsure about how to use these files.
 
       # If using a self-signed certificate:
       https-insecure-tls = true
+
+      # Use TLS when communicating with data notes
+      data-use-tls = true
+      data-insecure-tls = true
+
     ```
 
 5. **Enable HTTPS within the configuration file for each data node**


### PR DESCRIPTION
`data-use-tls = true` and `data-insecure-tls = true` allow the meta notes to communicate with the data notes using TLS (with self-signed certificates).

Closes https://github.com/influxdata/DAR/issues/140.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
