### PR TITLE
Update external Telegraf plugins

### DIFF
--- a/assets/styles/layouts/article/_telegraf-plugins.scss
+++ b/assets/styles/layouts/article/_telegraf-plugins.scss
@@ -35,6 +35,15 @@
         color: $article-code-accent7;
       }
     }
+    &.external {
+      margin: 0 0 0 -.25rem;
+      display: inline-block;
+      padding: .1rem .75rem;
+      background-color: rgba($article-text, .1);
+      border-radius: 1rem;
+      font-size: .9rem;
+      font-weight: $medium;
+    }
   }
 
   & .info {

--- a/data/telegraf_plugin_filters.yml
+++ b/data/telegraf_plugin_filters.yml
@@ -5,6 +5,7 @@ filters:
       - Output
       - Aggregator
       - Processor
+      - External
   - category: Plugin category
     values:
       - Applications

--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -33,9 +33,11 @@ input:
   - name: Amazon CloudWatch Alarms
     id: awsalarms
     description: |
-      The Amazon CloudWatch Statistics input plugin pulls alarm statistics from Amazon CloudWatch.
+      The Amazon CloudWatch Alarms input plugin pulls alarm statistics from Amazon CloudWatch.
     introduced: 1.16.0
+    link: https://github.com/vipinvkmenon/awsalarms
     tags: [linux, macos, windows, cloud, external]
+    external: true
 
   - name: Amazon CloudWatch Statistics
     id: cloudwatch
@@ -567,7 +569,7 @@ input:
     description: |
       The HTTP Listener v2 input plugin listens for metrics sent via HTTP.
       Metrics may be sent in any supported [Telegraf input data format](/telegraf/latest/data_formats/input/influx).
-      Note the plugin previously known as `http_listener` has been renamed `influxdb_listener`. 
+      Note the plugin previously known as `http_listener` has been renamed `influxdb_listener`.
       To use Telegraf as a proxy/relay for InfluxDB, we recommend using [`influxdb_listener`](/telegraf/latest/plugins/#influxdb_listener).
     introduced: 1.9.0
     tags: [linux, macos, windows, servers, web]
@@ -1159,6 +1161,7 @@ input:
     description: |
       The Octoprint input plugin gathers metrics from the [Octoprint API](https://docs.octoprint.org/en/master/api/index.html).
     introduced: 1.16.0
+    link: https://github.com/BattleBas/octoprint-telegraf-plugin
     tags: [linux, macos, windows, external]
 
   - name: OPC UA
@@ -1542,6 +1545,14 @@ input:
     introduced: 0.1.6
     tags: [linux, macos, windows, systems]
 
+  - name: SystemD Timings
+    id: systemd_timings
+    description: |
+      The SystemD Timings plugin collects systemd boot timing metrics.
+    introduced: 1.16.0
+    tags: [linux, macos, windows, systems, external]
+    link: https://github.com/pdmorrow/telegraf-execd-systemd-timings
+
   - name: Systemd Units
     id: systemd_units
     description: |
@@ -1736,6 +1747,7 @@ input:
     description: |
       The YouTube input plugin gathers information from YouTube channels, including views, subscribers, and videos.
     introduced: 1.16.0
+    link: https://github.com/inabagumi/youtube-telegraf-plugin
     tags: [linux, macos, windows, external]
 
   - name: ZFS

--- a/layouts/shortcodes/telegraf/plugins.html
+++ b/layouts/shortcodes/telegraf/plugins.html
@@ -13,6 +13,7 @@
     <div class="plugin-card visible{{ if eq $minorVer $currentTelegrafVersion }} new{{ end }}" id="{{ .id }}" data-tags="{{ $type }} {{ lower $pluginTags }} {{ if eq $minorVer $currentTelegrafVersion }}new{{ end }} {{ if .deprecated }}deprecated{{ end }} ">
       <div class="info">
         <h3 id="{{ .id }}">{{ .name }}</h3>
+        {{ if in .tags "external"}}<p class="external">External</p>{{ end }}
         <p class="meta">
           Plugin ID: <code>{{ $type }}s.{{ .id }}</code><br/>
           Telegraf {{ if not .deprecated }}{{ .introduced }}+{{ else }}{{ .introduced }} - {{ .deprecated }} <span class="deprecated">Deprecated</span>{{ end }}


### PR DESCRIPTION
Closes influxdata/influxdata.com#280

- Provided links for external Telegraf plugins
- Added styles for external flag that appears on each external plugin card.

**Note:** There are existing external plugins that aren't included in Telegraf plugin list. I would've added the, but I wasn't sure if they were bound to a specific Telegraf version.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
