### PR TITLE
Change wrong ordID in example

### DIFF
--- a/content/influxdb/v2.0/reference/flux/stdlib/built-in/inputs/from.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/built-in/inputs/from.md
@@ -34,7 +34,7 @@ from(
 from(
   bucketID: "0261d8287f4d6000",
   host: "https://example.com",
-  orgID: "example-org",
+  orgID: "867f3fcf1846f11f",
   token: "MySuP3rSecr3Tt0k3n"
 )
 ```


### PR DESCRIPTION
Param `orgID` in the second part of the example was wrongly set as organization label instead of numerical ID.


