### PR TITLE
Update DBRP examples

### DIFF
--- a/content/influxdb/cloud/query-data/influxql.md
+++ b/content/influxdb/cloud/query-data/influxql.md
@@ -30,7 +30,7 @@ Because InfluxQL uses the 1.x data model, before querying in InfluxQL, a bucket 
 
 {{% note %}}
 When writing to an InfluxDB Cloud bucket using the `/write` 1.x compatibility API,
-InfluxDB Cloud automatically creates a DBRP mapping for the bucket.
+InfluxDB Cloud automatically creates a DBRP mapping for the bucket that matches the `db/rp` naming convention.
 For more information, see [Database and retention policy mapping](/influxdb/cloud/reference/api/influxdb-1x/dbrp/).
 If you're not sure how data was written into a bucket, verify the bucket has a mapping.
 {{% /note %}}
@@ -40,10 +40,9 @@ Include the following:
 
 - **Request method:** `GET`
 - **Headers:**
-  - **Authorization:** `Token` schema with your InfluxDB [autorization token](/influxdb/cloud/security/tokens/)
-  - **Content-type:** `application/json`
+  - **Authorization:** `Token` schema with your InfluxDB [authentication token](/influxdb/cloud/security/tokens/)
 - **Query parameters:**
-  - **organization_id:** [organization ID](/influxdb/cloud/organizations/view-orgs/#view-your-organization-id) <span class="req">Required</span>
+  - (<span class="req">Required</span>) **organization_id:** [organization ID](/influxdb/cloud/organizations/view-orgs/#view-your-organization-id)
   - **bucket_id:** [bucket ID](/influxdb/cloud/organizations/buckets/view-buckets/) _(to list DBRP mappings for a specific bucket)_
   - **database:** database name _(to list DBRP mappings with a specific database name)_
   - **retention_policy:** retention policy name _(to list DBRP mappings with a specific retention policy name)_
@@ -52,36 +51,42 @@ Include the following:
 ##### View all DBRP mappings
 ```sh
 curl --request GET \
-  https://cloud2.influxdata.com/api/v2/dbrps?organization_id=example-org-id \
-  --header "Authorization: Token YourAuthToken" \
-  --header "Content-type: application/json"
+  https://cloud2.influxdata.com/api/v2/dbrps?organization_id=00oxo0oXx000x0Xo \
+  --header "Authorization: Token YourAuthToken"
 ```
 
 ##### Filter DBRP mappings by database
 ```sh
 curl --request GET \
-  https://cloud2.influxdata.com/api/v2/dbrps?organization_id=example-org-id&database=example-db \
-  --header "Authorization: Token YourAuthToken" \
-  --header "Content-type: application/json"
+  https://cloud2.influxdata.com/api/v2/dbrps?organization_id=00oxo0oXx000x0Xo&database=example-db \
+  --header "Authorization: Token YourAuthToken"
+```
+
+##### Filter DBRP mappings by bucket ID
+```sh
+curl --request GET \
+  https://cloud2.influxdata.com/api/v2/dbrps?organization_id=00oxo0oXx000x0Xo&bucket_id=00oxo0oXx000x0Xo \
+  --header "Authorization: Token YourAuthToken"
 ```
 
 If you **do not find a DBRP mapping for a bucket**, complete the next procedure to map the unmapped bucket.
 _For more information on the DBRP mapping API, see the [`/api/v2/dbrps` endpoint documentation](/influxdb/cloud/api/#tag/DBRPs)._
 
 ## Map unmapped buckets
-Use the [`/api/v2/dbrps` API endpoint](/influxdb/cloud/api/#operation/PostDBRP) to create a new DBRP mapping.
+Use the [`/api/v2/dbrps` API endpoint](/influxdb/cloud/api/#operation/PostDBRP)
+to create a new DBRP mapping for a bucket.
 Include the following:
 
 - **Request method:** `POST`
 - **Headers:**
-  - **Authorization:** `Token` schema with your InfluxDB [autorization token](/influxdb/cloud/security/tokens/)
+  - **Authorization:** `Token` schema with your InfluxDB [authentication token](/influxdb/cloud/security/tokens/)
   - **Content-type:** `application/json`
 - **Request body:** JSON object with the following fields:
-  - **bucket_id:** [bucket ID](/influxdb/cloud/organizations/buckets/view-buckets/) <span class="req">Required</span>
-  - **database:** database name <span class="req">Required</span>
+  - (<span class="req">Required</span>) **bucket_id:** [bucket ID](/influxdb/cloud/organizations/buckets/view-buckets/)
+  - (<span class="req">Required</span>) **database:** database name
   - **default:** set the provided retention policy as the default retention policy for the database
-  - **organization** or **organization_id:** organization name or [organization ID](/influxdb/cloud/organizations/view-orgs/#view-your-organization-id) <span class="req">Required</span>
-  - **retention_policy:** retention policy name <span class="req">Required</span>
+  - (<span class="req">Required</span>) **organization** or **organization_id:** organization name or [organization ID](/influxdb/cloud/organizations/view-orgs/#view-your-organization-id)
+  - (<span class="req">Required</span>) **retention_policy:** retention policy name
 
 <!--  -->
 ```sh
@@ -102,7 +107,7 @@ After you've verified the bucket is mapped, query the bucket using the `query` 1
 ## Query a mapped bucket with InfluxQL
 
 The [InfluxDB 1.x compatibility API](/influxdb/cloud/reference/api/influxdb-1x/) supports
-all InfluxDB 1.x client libraries and integrations in InfluxDB Cloud and InfluxDB OSS 2.0.
+all InfluxDB 1.x client libraries and integrations in InfluxDB Cloud.
 
 To query a mapped bucket with InfluxQL, use the [`/query` 1.x compatibility endpoint](/influxdb/cloud/reference/api/influxdb-1x/query/).
 Include the following in your request:
@@ -130,7 +135,7 @@ To return results as **CSV**, include the `Accept: application/csv` header.
 
 ## InfluxQL support
 
-InfluxDB Cloud and InfluxDB OSS 2.0 support InfluxQL **read-only** queries. See supported and unsupported queries below.
+InfluxDB Cloud support InfluxQL **read-only** queries. See supported and unsupported queries below.
 To learn more about InfluxQL, see [Influx Query Language (InfluxQL)](/{{< latest "influxdb" "v1" >}}/query_language/).
 
 {{< flex >}}

--- a/content/influxdb/cloud/query-data/influxql.md
+++ b/content/influxdb/cloud/query-data/influxql.md
@@ -17,7 +17,7 @@ related:
 
 In InfluxDB 1.x, data is stored in [databases](/{{< latest "influxdb" "v1" >}}/concepts/glossary/#database)
 and [retention policies](/{{< latest "influxdb" "v1" >}}/concepts/glossary/#retention-policy-rp).
-In InfluxDB Cloud, data is stored in [buckets](/influxdb/v2.0/reference/glossary/#bucket).
+In InfluxDB Cloud, data is stored in [buckets](/influxdb/cloud/reference/glossary/#bucket).
 Because InfluxQL uses the 1.x data model, before querying in InfluxQL, a bucket must be mapped to a database and retention policy (DBRP).
 
 **Complete the following steps:**
@@ -28,24 +28,31 @@ Because InfluxQL uses the 1.x data model, before querying in InfluxQL, a bucket 
 
 ## Verify buckets have a mapping
 
-Use the [`/api/v2/dbrps` API endpoint](/influxdb/v2.0/api/#operation/GetDBRPs) to list DBRP mappings.
+{{% note %}}
+When writing to an InfluxDB Cloud bucket using the `/write` 1.x compatibility API,
+InfluxDB Cloud automatically creates a DBRP mapping for the bucket.
+For more information, see [Database and retention policy mapping](/influxdb/cloud/reference/api/influxdb-1x/dbrp/).
+If you're not sure how data was written into a bucket, verify the bucket has a mapping.
+{{% /note %}}
+
+Use the [`/api/v2/dbrps` API endpoint](/influxdb/cloud/api/#operation/GetDBRPs) to list DBRP mappings.
 Include the following:
 
 - **Request method:** `GET`
 - **Headers:**
-  - **Authorization:** `Token` schema with your InfluxDB [autorization token](/influxdb/v2.0/security/tokens/)
+  - **Authorization:** `Token` schema with your InfluxDB [autorization token](/influxdb/cloud/security/tokens/)
   - **Content-type:** `application/json`
 - **Query parameters:**
-  - **organization_id:** [organization ID](/influxdb/v2.0/organizations/view-orgs/#view-your-organization-id) <span class="req">Required</span>
-  - **bucket_id:** [bucket ID](/influxdb/v2.0/organizations/buckets/view-buckets/) _(to list DBRP mappings for a specific bucket)_
+  - **organization_id:** [organization ID](/influxdb/cloud/organizations/view-orgs/#view-your-organization-id) <span class="req">Required</span>
+  - **bucket_id:** [bucket ID](/influxdb/cloud/organizations/buckets/view-buckets/) _(to list DBRP mappings for a specific bucket)_
   - **database:** database name _(to list DBRP mappings with a specific database name)_
-  - **retention_policy:** database name _(to list DBRP mappings with a specific retention policy name)_
+  - **retention_policy:** retention policy name _(to list DBRP mappings with a specific retention policy name)_
   - **id:** DBRP mapping ID _(to list a specific DBRP mapping)_
 
 ##### View all DBRP mappings
 ```sh
 curl --request GET \
-  http://localhost:8086/api/v2/dbrps?organization_id=example-org-id \
+  https://cloud2.influxdata.com/api/v2/dbrps?organization_id=example-org-id \
   --header "Authorization: Token YourAuthToken" \
   --header "Content-type: application/json"
 ```
@@ -53,32 +60,32 @@ curl --request GET \
 ##### Filter DBRP mappings by database
 ```sh
 curl --request GET \
-  http://localhost:8086/api/v2/dbrps?organization_id=example-org-id&database=example-db \
+  https://cloud2.influxdata.com/api/v2/dbrps?organization_id=example-org-id&database=example-db \
   --header "Authorization: Token YourAuthToken" \
   --header "Content-type: application/json"
 ```
 
-If you **do not find a mapping ID (`id`) for a bucket**, complete the next procedure to map the unmapped bucket.
-_For more information on the DBRP mapping API, see the [`/api/v2/dbrps` endpoint documentation](/influxdb/v2.0/api/#tag/DBRPs)._
+If you **do not find a DBRP mapping for a bucket**, complete the next procedure to map the unmapped bucket.
+_For more information on the DBRP mapping API, see the [`/api/v2/dbrps` endpoint documentation](/influxdb/cloud/api/#tag/DBRPs)._
 
 ## Map unmapped buckets
-Use the [`/api/v2/dbrps` API endpoint](/influxdb/v2.0/api/#operation/PostDBRP) to create a new DBRP mapping.
+Use the [`/api/v2/dbrps` API endpoint](/influxdb/cloud/api/#operation/PostDBRP) to create a new DBRP mapping.
 Include the following:
 
 - **Request method:** `POST`
 - **Headers:**
-  - **Authorization:** `Token` schema with your InfluxDB [autorization token](/influxdb/v2.0/security/tokens/)
+  - **Authorization:** `Token` schema with your InfluxDB [autorization token](/influxdb/cloud/security/tokens/)
   - **Content-type:** `application/json`
 - **Request body:** JSON object with the following fields:
-  - **bucket_id:** [bucket ID](/influxdb/v2.0/organizations/buckets/view-buckets/) <span class="req">Required</span>
+  - **bucket_id:** [bucket ID](/influxdb/cloud/organizations/buckets/view-buckets/) <span class="req">Required</span>
   - **database:** database name <span class="req">Required</span>
-  - **default:** set DBRP mapping to default
-  - **organization** or **organization_id:** organization name or [organization ID](/influxdb/v2.0/organizations/view-orgs/#view-your-organization-id) <span class="req">Required</span>
+  - **default:** set the provided retention policy as the default retention policy for the database
+  - **organization** or **organization_id:** organization name or [organization ID](/influxdb/cloud/organizations/view-orgs/#view-your-organization-id) <span class="req">Required</span>
   - **retention_policy:** retention policy name <span class="req">Required</span>
 
 <!--  -->
 ```sh
-curl --request POST http://localhost:8086/api/v2/dbrps \
+curl --request POST https://cloud2.influxdata.com/api/v2/dbrps \
   --header "Authorization: Token YourAuthToken" \
   --header 'Content-type: application/json' \
   --data '{
@@ -86,7 +93,7 @@ curl --request POST http://localhost:8086/api/v2/dbrps \
         "database": "example-db",
         "default": true,
         "organization_id": "00oxo0oXx000x0Xo",
-        "retention_policy": "example-rp",
+        "retention_policy": "example-rp"
       }'
 ```
 
@@ -94,15 +101,15 @@ After you've verified the bucket is mapped, query the bucket using the `query` 1
 
 ## Query a mapped bucket with InfluxQL
 
-The [InfluxDB 1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/) supports
+The [InfluxDB 1.x compatibility API](/influxdb/cloud/reference/api/influxdb-1x/) supports
 all InfluxDB 1.x client libraries and integrations in InfluxDB Cloud and InfluxDB OSS 2.0.
 
-To query a mapped bucket with InfluxQL, use the [`/query` 1.x compatibility endpoint](/influxdb/v2.0/reference/api/influxdb-1x/query/).
+To query a mapped bucket with InfluxQL, use the [`/query` 1.x compatibility endpoint](/influxdb/cloud/reference/api/influxdb-1x/query/).
 Include the following in your request:
 
 - **Request method:** `GET`
 - **Headers:**
-  - **Authorization:** _See [compatibility API authentication](/influxdb/v2.0/reference/api/influxdb-1x/#authentication)
+  - **Authorization:** _See [compatibility API authentication](/influxdb/cloud/reference/api/influxdb-1x/#authentication)_
 - **Query parameters:**
   - **db**: 1.x database to query
   - **rp**: 1.x retention policy to query _(if no retention policy is specified, InfluxDB uses the default retention policy for the specified database)_
@@ -113,7 +120,7 @@ Include the following in your request:
 {{% /note %}}
 
 ```sh
-curl --request GET http://localhost:8086/query?db=example-db \
+curl --request GET https://cloud2.influxdata.com/query?db=example-db \
   --header "Authorization: Token YourAuthToken" \
   --data-urlencode "q=SELECT used_percent FROM example-db.example-rp.example-measurement WHERE host=host1"
 ```

--- a/content/influxdb/cloud/query-data/influxql.md
+++ b/content/influxdb/cloud/query-data/influxql.md
@@ -15,4 +15,146 @@ related:
   - /influxdb/cloud/reference/api/influxdb-1x/dbrp
 ---
 
-{{< duplicate-oss >}}
+In InfluxDB 1.x, data is stored in [databases](/{{< latest "influxdb" "v1" >}}/concepts/glossary/#database)
+and [retention policies](/{{< latest "influxdb" "v1" >}}/concepts/glossary/#retention-policy-rp).
+In InfluxDB Cloud, data is stored in [buckets](/influxdb/v2.0/reference/glossary/#bucket).
+Because InfluxQL uses the 1.x data model, before querying in InfluxQL, a bucket must be mapped to a database and retention policy (DBRP).
+
+**Complete the following steps:**
+
+1. [Verify buckets have a mapping](#verify-buckets-have-a-mapping).
+2. [Map unmapped buckets](#map-unmapped-buckets).
+3. [Query a mapped bucket with InfluxQL](#query-a-mapped-bucket-with-influxql).
+
+## Verify buckets have a mapping
+
+Use the [`/api/v2/dbrps` API endpoint](/influxdb/v2.0/api/#operation/GetDBRPs) to list DBRP mappings.
+Include the following:
+
+- **Request method:** `GET`
+- **Headers:**
+  - **Authorization:** `Token` schema with your InfluxDB [autorization token](/influxdb/v2.0/security/tokens/)
+  - **Content-type:** `application/json`
+- **Query parameters:**
+  - **organization_id:** [organization ID](/influxdb/v2.0/organizations/view-orgs/#view-your-organization-id) <span class="req">Required</span>
+  - **bucket_id:** [bucket ID](/influxdb/v2.0/organizations/buckets/view-buckets/) _(to list DBRP mappings for a specific bucket)_
+  - **database:** database name _(to list DBRP mappings with a specific database name)_
+  - **retention_policy:** database name _(to list DBRP mappings with a specific retention policy name)_
+  - **id:** DBRP mapping ID _(to list a specific DBRP mapping)_
+
+##### View all DBRP mappings
+```sh
+curl --request GET \
+  http://localhost:8086/api/v2/dbrps?organization_id=example-org-id \
+  --header "Authorization: Token YourAuthToken" \
+  --header "Content-type: application/json"
+```
+
+##### Filter DBRP mappings by database
+```sh
+curl --request GET \
+  http://localhost:8086/api/v2/dbrps?organization_id=example-org-id&database=example-db \
+  --header "Authorization: Token YourAuthToken" \
+  --header "Content-type: application/json"
+```
+
+If you **do not find a mapping ID (`id`) for a bucket**, complete the next procedure to map the unmapped bucket.
+_For more information on the DBRP mapping API, see the [`/api/v2/dbrps` endpoint documentation](/influxdb/v2.0/api/#tag/DBRPs)._
+
+## Map unmapped buckets
+Use the [`/api/v2/dbrps` API endpoint](/influxdb/v2.0/api/#operation/PostDBRP) to create a new DBRP mapping.
+Include the following:
+
+- **Request method:** `POST`
+- **Headers:**
+  - **Authorization:** `Token` schema with your InfluxDB [autorization token](/influxdb/v2.0/security/tokens/)
+  - **Content-type:** `application/json`
+- **Request body:** JSON object with the following fields:
+  - **bucket_id:** [bucket ID](/influxdb/v2.0/organizations/buckets/view-buckets/) <span class="req">Required</span>
+  - **database:** database name <span class="req">Required</span>
+  - **default:** set DBRP mapping to default
+  - **organization** or **organization_id:** organization name or [organization ID](/influxdb/v2.0/organizations/view-orgs/#view-your-organization-id) <span class="req">Required</span>
+  - **retention_policy:** retention policy name <span class="req">Required</span>
+
+<!--  -->
+```sh
+curl --request POST http://localhost:8086/api/v2/dbrps \
+  --header "Authorization: Token YourAuthToken" \
+  --header 'Content-type: application/json' \
+  --data '{
+        "bucket_id": "00oxo0oXx000x0Xo",
+        "database": "example-db",
+        "default": true,
+        "organization_id": "00oxo0oXx000x0Xo",
+        "retention_policy": "example-rp",
+      }'
+```
+
+After you've verified the bucket is mapped, query the bucket using the `query` 1.x compatibility endpoint.
+
+## Query a mapped bucket with InfluxQL
+
+The [InfluxDB 1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/) supports
+all InfluxDB 1.x client libraries and integrations in InfluxDB Cloud and InfluxDB OSS 2.0.
+
+To query a mapped bucket with InfluxQL, use the [`/query` 1.x compatibility endpoint](/influxdb/v2.0/reference/api/influxdb-1x/query/).
+Include the following in your request:
+
+- **Request method:** `GET`
+- **Headers:**
+  - **Authorization:** _See [compatibility API authentication](/influxdb/v2.0/reference/api/influxdb-1x/#authentication)
+- **Query parameters:**
+  - **db**: 1.x database to query
+  - **rp**: 1.x retention policy to query _(if no retention policy is specified, InfluxDB uses the default retention policy for the specified database)_
+  - **q**: InfluxQL query
+
+{{% note %}}
+**URL-encode** the InfluxQL query to ensure it's formatted correctly when submitted to InfluxDB.
+{{% /note %}}
+
+```sh
+curl --request GET http://localhost:8086/query?db=example-db \
+  --header "Authorization: Token YourAuthToken" \
+  --data-urlencode "q=SELECT used_percent FROM example-db.example-rp.example-measurement WHERE host=host1"
+```
+
+By default, the `/query` compatibility endpoint returns results in **JSON**.
+To return results as **CSV**, include the `Accept: application/csv` header.
+
+## InfluxQL support
+
+InfluxDB Cloud and InfluxDB OSS 2.0 support InfluxQL **read-only** queries. See supported and unsupported queries below.
+To learn more about InfluxQL, see [Influx Query Language (InfluxQL)](/{{< latest "influxdb" "v1" >}}/query_language/).
+
+{{< flex >}}
+{{< flex-content >}}
+{{% note %}}
+##### Supported InfluxQL queries
+
+- `DELETE`*
+- `DROP MEASUREMENT`*
+- `SELECT` _(read-only)_
+- `SHOW DATABASES`
+- `SHOW MEASUREMENTS`
+- `SHOW TAG KEYS`
+- `SHOW TAG VALUES`
+- `SHOW FIELD KEYS`
+
+\* These commands delete data.
+{{% /note %}}
+{{< /flex-content >}}
+{{< flex-content >}}
+{{% warn %}}
+
+##### Unsupported InfluxQL queries
+
+- `SELECT INTO`
+- `ALTER`
+- `CREATE`
+- `DROP` _(limited support)_
+- `GRANT`
+- `KILL`
+- `REVOKE`
+{{% /warn %}}
+{{< /flex-content >}}
+{{< /flex >}}

--- a/content/influxdb/cloud/reference/api/influxdb-1x/dbrp.md
+++ b/content/influxdb/cloud/reference/api/influxdb-1x/dbrp.md
@@ -14,4 +14,47 @@ related:
   - /influxdb/cloud/api/#tag/DBRPs, InfluxDB v2 API /dbrps endpoint
 ---
 
-{{< duplicate-oss >}}
+The InfluxDB 1.x data model includes [databases](/influxdb/v1.8/concepts/glossary/#database)
+and [retention policies](/influxdb/v1.8/concepts/glossary/#retention-policy-rp).
+InfluxDB Cloud replaces both with [buckets](/influxdb/v2.0/reference/glossary/#bucket).
+To support InfluxDB 1.x query and write patterns in InfluxDB Cloud, databases and retention
+policies are mapped to buckets using the **database and retention policy (DBRP) mapping service**.
+
+The DBRP mapping service uses the **database** and **retention policy** specified in
+[1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/) requests to route operations to a bucket.
+
+{{% note %}}
+For more information, see [Map unmapped buckets](/influxdb/v2.0/query-data/influxql/#map-unmapped-buckets).
+{{% /note %}}
+
+### Default retention policies
+
+A database can have multiple retention policies with one set as default.
+If no retention policy is specified in a query or write request, InfluxDB uses
+the default retention policy for the specified database.
+
+### When writing data
+
+When writing data using the
+[`/write` compatibility endpoint](/influxdb/v2.0/reference/api/influxdb-1x/write/),
+the DBRP mapping service checks for a bucket mapped to the database and retention policy:
+
+- If a mapped bucket is found, data is written to the bucket.
+- If an unmapped bucket with a name matching:
+    - **database/retention policy** exists, a DBRP mapping is added to the bucket,
+      and data is written to the bucket.
+    - **database** exists (without a specified retention policy), the default
+      database retention policy is used, a DBRP mapping is added to the bucket,
+      and data is written to the bucket.
+
+### When querying data
+
+When querying data from InfluxDB Cloud and InfluxDB OSS 2.0 using the
+[`/query` compatibility endpoint](/influxdb/v2.0/reference/api/influxdb-1x/query/),
+the DBRP mapping service checks for the specified database and retention policy
+(if no retention policy is specified, the database's default retention policy is used):
+
+- If a mapped bucket exists, data is queried from the mapped bucket.
+- If no mapped bucket exists, InfluxDB returns an error. See how to [Map unmapped buckets](/influxdb/v2.0/query-data/influxql/#map-unmapped-buckets).
+
+_For more information on the DBRP mapping API, see the [`/api/v2/dbrps` endpoint documentation](/influxdb/v2.0/api/#tag/DBRPs)._

--- a/content/influxdb/cloud/reference/cli/influx/v1/dbrp/_index.md
+++ b/content/influxdb/cloud/reference/cli/influx/v1/dbrp/_index.md
@@ -1,0 +1,13 @@
+---
+title: influx v1 dbrp
+description: >
+  The `influx v1 dbrp` subcommands provide database retention policy (DBRP) mapping management for the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_cloud_ref:
+    name: influx v1 dbrp
+    parent: influx v1
+weight: 101
+influxdb/cloud/tags: [DBRP]
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/cloud/reference/cli/influx/v1/dbrp/create.md
+++ b/content/influxdb/cloud/reference/cli/influx/v1/dbrp/create.md
@@ -1,0 +1,13 @@
+---
+title: influx v1 dbrp create
+description: >
+  The `influx v1 dbrp create` command creates a DBRP mapping in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_cloud_ref:
+    name: influx v1 dbrp create
+    parent: influx v1 dbrp
+weight: 101
+influxdb/cloud/tags: [DBRP]
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/cloud/reference/cli/influx/v1/dbrp/delete.md
+++ b/content/influxdb/cloud/reference/cli/influx/v1/dbrp/delete.md
@@ -1,0 +1,13 @@
+---
+title: influx v1 dbrp delete
+description: >
+  The `influx v1 dbrp delete` command deletes a DBRP mapping in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_cloud_ref:
+    name: influx v1 dbrp delete
+    parent: influx v1 dbrp
+weight: 101
+influxdb/cloud/tags: [DBRP]
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/cloud/reference/cli/influx/v1/dbrp/list.md
+++ b/content/influxdb/cloud/reference/cli/influx/v1/dbrp/list.md
@@ -1,0 +1,13 @@
+---
+title: influx v1 dbrp list
+description: >
+  The `influx v1 dbrp list` command lists and searches DBRP mappings in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_cloud_ref:
+    name: influx v1 dbrp list
+    parent: influx v1 dbrp
+weight: 101
+influxdb/cloud/tags: [dbrp]
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/cloud/reference/cli/influx/v1/dbrp/update.md
+++ b/content/influxdb/cloud/reference/cli/influx/v1/dbrp/update.md
@@ -1,0 +1,13 @@
+---
+title: influx v1 dbrp update
+description: >
+  The `influx v1 dbrp update` command updates a DBRP mapping in the InfluxDB 1.x compatibility API.
+menu:
+  influxdb_cloud_ref:
+    name: influx v1 dbrp update
+    parent: influx v1 dbrp
+weight: 101
+influxdb/cloud/tags: [DBRP]
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/v2.0/organizations/buckets/view-buckets.md
+++ b/content/influxdb/v2.0/organizations/buckets/view-buckets.md
@@ -18,7 +18,7 @@ weight: 202
     A list of buckets with their retention policies and IDs appears.
 
 2. Click a bucket to open it in the **Data Explorer**.
-3. Click the bucket ID to copy it to the clipboard.
+3. Click the **bucket ID** to copy it to the clipboard.
 
 ## View buckets using the influx CLI
 

--- a/content/influxdb/v2.0/query-data/influxql.md
+++ b/content/influxdb/v2.0/query-data/influxql.md
@@ -17,7 +17,7 @@ related:
 
 In InfluxDB 1.x, data is stored in [databases](/{{< latest "influxdb" "v1" >}}/concepts/glossary/#database)
 and [retention policies](/{{< latest "influxdb" "v1" >}}/concepts/glossary/#retention-policy-rp).
-In InfluxDB Cloud and InfluxDB OSS 2.0, data is stored in [buckets](/influxdb/v2.0/reference/glossary/#bucket).
+In InfluxDB OSS 2.0, data is stored in [buckets](/influxdb/v2.0/reference/glossary/#bucket).
 Because InfluxQL uses the 1.x data model, before querying in InfluxQL, a bucket must be mapped to a database and retention policy (DBRP).
 
 **Complete the following steps:**
@@ -48,6 +48,12 @@ to verify the buckets you want to query are mapped to a database and retention p
 
 Use the [`influx v1 dbrp list` command](/influxdb/v2.0/reference/cli/influx/v1/dbrp/list/) to list DBRP mappings.
 
+{{% note %}}
+The examples below assume that your organization and authentication token are
+provided by the active [InfluxDB connection configuration](/influxdb/v2.0/reference/cli/influx/config/) in the `influx` CLI.
+If not, include your organization (`--org`) and authentication token (`--token`) with each command.
+{{% /note %}}
+
 ##### View all DBRP mappings
 ```sh
 influx v1 dbrp list
@@ -57,6 +63,11 @@ influx v1 dbrp list
 ```sh
 influx v1 dbrp list --db example-db
 ```
+
+##### Filter DBRP mappings by bucket ID
+```sh
+influx v1 dbrp list --bucket-id 00oxo0oXx000x0Xo
+```
 {{% /tab-content %}}
 {{% tab-content %}}
 Use the [`/api/v2/dbrps` API endpoint](/influxdb/v2.0/api/#operation/GetDBRPs) to list DBRP mappings.
@@ -64,10 +75,9 @@ Include the following:
 
 - **Request method:** `GET`
 - **Headers:**
-  - **Authorization:** `Token` schema with your InfluxDB [autorization token](/influxdb/v2.0/security/tokens/)
-  - **Content-type:** `application/json`
+  - **Authorization:** `Token` schema with your InfluxDB [authentication token](/influxdb/v2.0/security/tokens/)
 - **Query parameters:**
-  - **orgID:** [organization ID](/influxdb/v2.0/organizations/view-orgs/#view-your-organization-id) <span class="req">Required</span>
+  - (<span class="req">Required</span>) **orgID:** [organization ID](/influxdb/v2.0/organizations/view-orgs/#view-your-organization-id)
   - **bucketID:** [bucket ID](/influxdb/v2.0/organizations/buckets/view-buckets/) _(to list DBRP mappings for a specific bucket)_
   - **database:** database name _(to list DBRP mappings with a specific database name)_
   - **rp:** retention policy name _(to list DBRP mappings with a specific retention policy name)_
@@ -76,17 +86,22 @@ Include the following:
 ##### View all DBRP mappings
 ```sh
 curl --request GET \
-  http://localhost:8086/api/v2/dbrps?orgID=example-org-id \
-  --header "Authorization: Token YourAuthToken" \
-  --header "Content-type: application/json"
+  http://localhost:8086/api/v2/dbrps?orgID=00oxo0oXx000x0Xo \
+  --header "Authorization: Token YourAuthToken"
 ```
 
 ##### Filter DBRP mappings by database
 ```sh
 curl --request GET \
-  http://localhost:8086/api/v2/dbrps?orgID=example-org-id&db=example-db \
-  --header "Authorization: Token YourAuthToken" \
-  --header "Content-type: application/json"
+  http://localhost:8086/api/v2/dbrps?orgID=00oxo0oXx000x0Xo&db=example-db \
+  --header "Authorization: Token YourAuthToken"
+```
+
+##### Filter DBRP mappings by bucket ID
+```sh
+curl --request GET \
+  https://cloud2.influxdata.com/api/v2/dbrps?organization_id=00oxo0oXx000x0Xo&bucketID=00oxo0oXx000x0Xo \
+  --header "Authorization: Token YourAuthToken"
 ```
 {{% /tab-content %}}
 {{% /tabs-wrapper %}}
@@ -106,12 +121,12 @@ to manually create DBRP mappings for unmapped buckets.
 {{% tab-content %}}
 
 Use the [`influx v1 dbrp create` command](/influxdb/v2.0/reference/cli/influx/v1/dbrp/create/)
-To map an unmapped bucket to a database and retention policy.
+to map an unmapped bucket to a database and retention policy.
 Include the following:
 
-- **Database name** to map <span class="req">Required</span>
-- **Retention policy** name to map <span class="req">Required</span>
-- [Bucket ID](/influxdb/v2.0/organizations/buckets/view-buckets/#view-buckets-in-the-influxdb-ui) to map to <span class="req">Required</span>
+- (<span class="req">Required</span>) **database name** to map
+- (<span class="req">Required</span>) **retention policy** name to map
+- (<span class="req">Required</span>) [Bucket ID](/influxdb/v2.0/organizations/buckets/view-buckets/#view-buckets-in-the-influxdb-ui) to map to
 - Default flag to set the provided retention policy as the default retention policy for the database
 
 ```sh
@@ -130,14 +145,14 @@ Include the following:
 
 - **Request method:** `POST`
 - **Headers:**
-  - **Authorization:** `Token` schema with your InfluxDB [autorization token](/influxdb/v2.0/security/tokens/)
+  - **Authorization:** `Token` schema with your InfluxDB [authentication token](/influxdb/v2.0/security/tokens/)
   - **Content-type:** `application/json`
 - **Request body:** JSON object with the following fields:
-  - **bucketID:** [bucket ID](/influxdb/v2.0/organizations/buckets/view-buckets/) <span class="req">Required</span>
-  - **database:** database name <span class="req">Required</span>
+  - (<span class="req">Required</span>) **bucketID:** [bucket ID](/influxdb/v2.0/organizations/buckets/view-buckets/)
+  - (<span class="req">Required</span>) **database:** database name
   - **default:** set the provided retention policy as the default retention policy for the database
-  - **org** or **orgID:** organization name or [organization ID](/influxdb/v2.0/organizations/view-orgs/#view-your-organization-id) <span class="req">Required</span>
-  - **retention_policy:** retention policy name <span class="req">Required</span>
+  - (<span class="req">Required</span>) **org** or **orgID:** organization name or [organization ID](/influxdb/v2.0/organizations/view-orgs/#view-your-organization-id)
+  - (<span class="req">Required</span>) **retention_policy:** retention policy name
 
 <!--  -->
 ```sh
@@ -161,14 +176,14 @@ After you've verified the bucket is mapped, query the bucket using the `query` 1
 ## Query a mapped bucket with InfluxQL
 
 The [InfluxDB 1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/) supports
-all InfluxDB 1.x client libraries and integrations in InfluxDB Cloud and InfluxDB OSS 2.0.
+all InfluxDB 1.x client libraries and integrations in InfluxDB OSS 2.0.
 
 To query a mapped bucket with InfluxQL, use the [`/query` 1.x compatibility endpoint](/influxdb/v2.0/reference/api/influxdb-1x/query/).
 Include the following in your request:
 
 - **Request method:** `GET`
 - **Headers:**
-  - **Authorization:** _See [compatibility API authentication](/influxdb/v2.0/reference/api/influxdb-1x/#authentication)
+  - **Authorization:** _See [compatibility API authentication](/influxdb/v2.0/reference/api/influxdb-1x/#authentication)_
 - **Query parameters:**
   - **db**: 1.x database to query
   - **rp**: 1.x retention policy to query _(if no retention policy is specified, InfluxDB uses the default retention policy for the specified database)_
@@ -189,7 +204,7 @@ To return results as **CSV**, include the `Accept: application/csv` header.
 
 ## InfluxQL support
 
-InfluxDB Cloud and InfluxDB OSS 2.0 support InfluxQL **read-only** queries. See supported and unsupported queries below.
+InfluxDB OSS 2.0 support InfluxQL **read-only** queries. See supported and unsupported queries below.
 To learn more about InfluxQL, see [Influx Query Language (InfluxQL)](/{{< latest "influxdb" "v1" >}}/query_language/).
 
 {{< flex >}}

--- a/content/influxdb/v2.0/query-data/influxql.md
+++ b/content/influxdb/v2.0/query-data/influxql.md
@@ -127,7 +127,7 @@ Include the following:
 - (<span class="req">Required</span>) **database name** to map
 - (<span class="req">Required</span>) **retention policy** name to map
 - (<span class="req">Required</span>) [Bucket ID](/influxdb/v2.0/organizations/buckets/view-buckets/#view-buckets-in-the-influxdb-ui) to map to
-- Default flag to set the provided retention policy as the default retention policy for the database
+- **Default flag** to set the provided retention policy as the default retention policy for the database
 
 ```sh
 influx v1 dbrp create \

--- a/content/influxdb/v2.0/query-data/influxql.md
+++ b/content/influxdb/v2.0/query-data/influxql.md
@@ -55,8 +55,7 @@ influx v1 dbrp list
 
 ##### Filter DBRP mappings by database
 ```sh
-influx v1 dbrp list \
-  --db example-db
+influx v1 dbrp list --db example-db
 ```
 {{% /tab-content %}}
 {{% tab-content %}}
@@ -71,7 +70,7 @@ Include the following:
   - **orgID:** [organization ID](/influxdb/v2.0/organizations/view-orgs/#view-your-organization-id) <span class="req">Required</span>
   - **bucketID:** [bucket ID](/influxdb/v2.0/organizations/buckets/view-buckets/) _(to list DBRP mappings for a specific bucket)_
   - **database:** database name _(to list DBRP mappings with a specific database name)_
-  - **rp:** database name _(to list DBRP mappings with a specific retention policy name)_
+  - **rp:** retention policy name _(to list DBRP mappings with a specific retention policy name)_
   - **id:** DBRP mapping ID _(to list a specific DBRP mapping)_
 
 ##### View all DBRP mappings
@@ -92,7 +91,7 @@ curl --request GET \
 {{% /tab-content %}}
 {{% /tabs-wrapper %}}
 
-If you **do not find a mapping ID (`id`) for a bucket**, complete the next procedure to map the unmapped bucket.
+If you **do not find a DBRP mapping for a bucket**, complete the next procedure to map the unmapped bucket.
 _For more information on the DBRP mapping API, see the [`/api/v2/dbrps` endpoint documentation](/influxdb/v2.0/api/#tag/DBRPs)._
 
 ## Map unmapped buckets
@@ -113,10 +112,10 @@ Include the following:
 - **Database name** to map <span class="req">Required</span>
 - **Retention policy** name to map <span class="req">Required</span>
 - [Bucket ID](/influxdb/v2.0/organizations/buckets/view-buckets/#view-buckets-in-the-influxdb-ui) to map to <span class="req">Required</span>
-- Default flag to set the DBRP mapping as default
+- Default flag to set the provided retention policy as the default retention policy for the database
 
 ```sh
-influx v1 dbrp create
+influx v1 dbrp create \
   --db example-db \
   --rp example-rp \
   --bucket-id 00oxo0oXx000x0Xo \
@@ -136,18 +135,9 @@ Include the following:
 - **Request body:** JSON object with the following fields:
   - **bucketID:** [bucket ID](/influxdb/v2.0/organizations/buckets/view-buckets/) <span class="req">Required</span>
   - **database:** database name <span class="req">Required</span>
-  - **default:** set DBRP mapping to default
+  - **default:** set the provided retention policy as the default retention policy for the database
   - **org** or **orgID:** organization name or [organization ID](/influxdb/v2.0/organizations/view-orgs/#view-your-organization-id) <span class="req">Required</span>
   - **retention_policy:** retention policy name <span class="req">Required</span>
-
-{{% cloud %}}
-Include an **authorization token** with [basic or token authentication](/influxdb/v2.0/reference/api/influxdb-1x/#authentication)
-in your request header and the following **required parameters** in your request body:
-
-- organization (`organization` or `organization_id`)
-- target bucket (`bucket_id`)
-- database and retention policy to map to bucket (`database` and `retention_policy`)
-{{% /cloud %}}
 
 <!--  -->
 ```sh
@@ -159,7 +149,7 @@ curl --request POST http://localhost:8086/api/v2/dbrps \
         "database": "example-db",
         "default": true,
         "orgID": "00oxo0oXx000x0Xo",
-        "retention_policy": "example-rp",
+        "retention_policy": "example-rp"
       }'
 ```
 

--- a/content/influxdb/v2.0/reference/api/influxdb-1x/dbrp.md
+++ b/content/influxdb/v2.0/reference/api/influxdb-1x/dbrp.md
@@ -16,15 +16,16 @@ related:
 
 The InfluxDB 1.x data model includes [databases](/influxdb/v1.8/concepts/glossary/#database)
 and [retention policies](/influxdb/v1.8/concepts/glossary/#retention-policy-rp).
-InfluxDB Cloud and InfluxDB OSS 2.0 replace both with [buckets](/influxdb/v2.0/reference/glossary/#bucket).
-To support InfluxDB 1.x query and write patterns in InfluxDB Cloud and InfluxDB OSS 2.0, databases and retention
+InfluxDB OSS 2.0 replaces both with [buckets](/influxdb/v2.0/reference/glossary/#bucket).
+To support InfluxDB 1.x query and write patterns in InfluxDB OSS 2.0, databases and retention
 policies are mapped to buckets using the **database and retention policy (DBRP) mapping service**.
 
 The DBRP mapping service uses the **database** and **retention policy** specified in
 [1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/) requests to route operations to a bucket.
 
 {{% note %}}
-To query data in InfluxQL that was written using the 2.x `/write` API, you must manually create a DBRP mapping to map a bucket to a database and retention policy.
+To query data in InfluxQL that was written using the 2.x `/write` API,
+you must **manually create a DBRP mapping** to map a bucket to a database and retention policy.
 For more information, see [Map unmapped buckets](/influxdb/v2.0/query-data/influxql/#map-unmapped-buckets).
 {{% /note %}}
 
@@ -41,12 +42,8 @@ When writing data using the
 the DBRP mapping service checks for a bucket mapped to the database and retention policy:
 
 - If a mapped bucket is found, data is written to the bucket.
-- If an unmapped bucket with a name matching:
-    - **database/retention policy** exists, a DBRP mapping is added to the bucket,
-      and data is written to the bucket.
-    - **database** exists (without a specified retention policy), the default
-      database retention policy is used, a DBRP mapping is added to the bucket,
-      and data is written to the bucket.
+- If an unmapped bucket, InfluxDB returns an error.
+  See how to [Map unmapped buckets](/influxdb/v2.0/query-data/influxql/#map-unmapped-buckets).
 
 ### When querying data
 

--- a/content/influxdb/v2.0/reference/cli/influx/v1/dbrp/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/v1/dbrp/_index.md
@@ -18,15 +18,14 @@ influx v1 dbrp [flags]
 influx v1 dbrp [command]
 ```
 
-
 ## Commands
 
-| Command                                                                     | Description                                  |
-|:----------------------------------------------------------------------------|----------------------------------------------|
-| [`create`](/influxdb/v2.0/reference/cli/influx/v1/dbrp/create/)             | Create a DBRP mapping                       |
-| [`delete`](/influxdb/v2.0/reference/cli/influx/v1/dbrp/delete/)             | Delete a DBRP mapping                                 |
-| [`list`](/influxdb/v2.0/reference/cli/influx/v1/dbrp/list/)                 | List DBRP mappings                                   |
-| [`update`](/influxdb/v2.0/reference/cli/influx/v1/dbrp/update/)             | Update a DBRP mapping                               |
+| Command                                                       | Description           |
+|:------------------------------------------------------------- |:--------------------- |
+| [create](/influxdb/v2.0/reference/cli/influx/v1/dbrp/create/) | Create a DBRP mapping |
+| [delete](/influxdb/v2.0/reference/cli/influx/v1/dbrp/delete/) | Delete a DBRP mapping |
+| [list](/influxdb/v2.0/reference/cli/influx/v1/dbrp/list/)     | List DBRP mappings    |
+| [update](/influxdb/v2.0/reference/cli/influx/v1/dbrp/update/) | Update a DBRP mapping |
 
 ## Flags
 | Flag |          | Description                     |

--- a/content/influxdb/v2.0/reference/cli/influx/v1/dbrp/create.md
+++ b/content/influxdb/v2.0/reference/cli/influx/v1/dbrp/create.md
@@ -18,28 +18,28 @@ influx v1 dbrp create [flags]
 ```
 
 ## Flags
-| Flag  |                   | Description                                                                                | Input type | {{< cli/mapped >}}      |
-|-------|-------------------|--------------------------------------------------------------------------------------------|------------|-------------------------|
-| `-c`  | `--active-config` | Config name to use for command                                                             | string     | `$INFLUX_ACTIVE_CONFIG` |
-|       | `--bucket-id`     | Bucket ID to map to                                                                                 |            |                         |
-|       | `--configs-path`  | Path to the influx CLI configurations (default: `~/.influxdbv2/configs`)                   | string     | `$INFLUX_CONFIGS_PATH`  |
-|       | `--db`            | InfluxDB v1 database to map from                                                                    |            |                         |
-|       | `--default`       | Set DBRP mapping's retention policy as default   |            |                         |
-| `-h`  | `--help`          | Help for the `create` command                                                              |            |                         |
-|       | `--hide-headers`  | Hide table headers (default: `false`)                                                  |            | `$INFLUX_HIDE_HEADERS`  |
-|       | `--host`          | HTTP address of InfluxDB                                                                   | string     | `$INFLUX_HOST`          |
-|       | `--json`          | Output data as JSON (default: `false`)                                                     |            | `$INFLUX_OUTPUT_JSON`   |
-| `-o`  | `--org`           | Organization name                                                                          | string     | `$INFLUX_ORG`           |
-|       | `--org-id`        | Organization ID                                                                            | string     | `$INFLUX_ORG_ID`        |
-|       | `--rp`            | InfluxDB v1 retention policy to map from                                                               |            |                         |
-|       | `--skip-verify`   | Skip TLS certificate verification                                                          |            |                         |
-| `-t`  | `--token`         | Authentication token                                                                       | string     | `$INFLUX_TOKEN`         |
+| Flag  |                   | Description                                                              | Input type | {{< cli/mapped >}}      |
+|:------|:------------------|:-------------------------------------------------------------------------|:----------:|:------------------------|
+| `-c`  | `--active-config` | Config name to use for command                                           | string     | `$INFLUX_ACTIVE_CONFIG` |
+|       | `--bucket-id`     | Bucket ID to map to                                                      |            |                         |
+|       | `--configs-path`  | Path to the influx CLI configurations (default: `~/.influxdbv2/configs`) | string     | `$INFLUX_CONFIGS_PATH`  |
+|       | `--db`            | InfluxDB v1 database to map from                                         |            |                         |
+|       | `--default`       | Set DBRP mapping's retention policy as default                           |            |                         |
+| `-h`  | `--help`          | Help for the `create` command                                            |            |                         |
+|       | `--hide-headers`  | Hide table headers (default: `false`)                                    |            | `$INFLUX_HIDE_HEADERS`  |
+|       | `--host`          | HTTP address of InfluxDB                                                 | string     | `$INFLUX_HOST`          |
+|       | `--json`          | Output data as JSON (default: `false`)                                   |            | `$INFLUX_OUTPUT_JSON`   |
+| `-o`  | `--org`           | Organization name                                                        | string     | `$INFLUX_ORG`           |
+|       | `--org-id`        | Organization ID                                                          | string     | `$INFLUX_ORG_ID`        |
+|       | `--rp`            | InfluxDB v1 retention policy to map from                                 |            |                         |
+|       | `--skip-verify`   | Skip TLS certificate verification                                        |            |                         |
+| `-t`  | `--token`         | Authentication token                                                     | string     | `$INFLUX_TOKEN`         |
 
 
 ## Examples
 
 ##### Create a DBRP mapping
-```
+```sh
 influx v1 dbrp create \
   --bucket-id 12ab34cd56ef \
   --database example-db \

--- a/content/influxdb/v2.0/reference/cli/influx/v1/dbrp/list.md
+++ b/content/influxdb/v2.0/reference/cli/influx/v1/dbrp/list.md
@@ -19,20 +19,44 @@ influx v1 dbrp list [flags]
 
 ## Flags
 
-| Flag |                   | Description                                                                                | Input type | {{< cli/mapped >}}      |
-|------|-------------------|--------------------------------------------------------------------------------------------|------------|-------------------------|
-| `-c` | `--active-config` | Config name to use for command                                                             | string     | `$INFLUX_ACTIVE_CONFIG` |
-|      | `--bucket-id`     | Bucket ID                                                                                  |            |                         |
-|      | `--configs-path`  | Path to the influx CLI configurations (default: `~/.influxdbv2/configs`)                   | string     | `$INFLUX_CONFIGS_PATH`  |
-|      | `--db`            | Filter DBRP mappings by database                                                           |            |                         |
-|      | `--default`       | Limit results to default mapping |            |                         |
-| `-h` | `--help`          | Help for the `list` command                                                              |            |                         |
-|      | `--hide-headers`  | Hide the table headers (default: `false`)                                                  |            | `$INFLUX_HIDE_HEADERS`  |
-|      | `--host`          | HTTP address of InfluxDB                                                                   | string     | `$INFLUX_HOST`          |
-|      | `--id`            | Limit results to a specified mapping                                                     | string     |                         |
-|      | `--json`          | Output data as JSON (default: `false`)                                                     |            | `$INFLUX_OUTPUT_JSON`   |
+| Flag |                   | Description                                                              | Input type | {{< cli/mapped >}}      |
+|------|-------------------|--------------------------------------------------------------------------|------------|-------------------------|
+| `-c` | `--active-config` | Config name to use for command                                           | string     | `$INFLUX_ACTIVE_CONFIG` |
+|      | `--bucket-id`     | Bucket ID                                                                |            |                         |
+|      | `--configs-path`  | Path to the influx CLI configurations (default: `~/.influxdbv2/configs`) | string     | `$INFLUX_CONFIGS_PATH`  |
+|      | `--db`            | Filter DBRP mappings by database                                         |            |                         |
+|      | `--default`       | Limit results to default mapping                                         |            |                         |
+| `-h` | `--help`          | Help for the `list` command                                              |            |                         |
+|      | `--hide-headers`  | Hide the table headers (default: `false`)                                |            | `$INFLUX_HIDE_HEADERS`  |
+|      | `--host`          | HTTP address of InfluxDB                                                 | string     | `$INFLUX_HOST`          |
+|      | `--id`            | Limit results to a specified mapping                                     | string     |                         |
+|      | `--json`          | Output data as JSON (default: `false`)                                   |            | `$INFLUX_OUTPUT_JSON`   |
 | `-o` | `--org`           | Organization name                                                        | string     | `$INFLUX_ORG`           |
 |      | `--org-id`        | Organization ID                                                          | string     | `$INFLUX_ORG_ID`        |
-|      | `--rp`            | Filter DBRP mappings by InfluxDB v1 retention policy                                                         | string     | `$INFLUX_ORG`           |
-|      | `--skip-verify`   | Skip TLS certificate verification                                                          |            |                         |
-| `-t` | `--token`         | Authentication token                                                                       | string     | `$INFLUX_TOKEN`         |
+|      | `--rp`            | Filter DBRP mappings by InfluxDB v1 retention policy                     | string     | `$INFLUX_ORG`           |
+|      | `--skip-verify`   | Skip TLS certificate verification                                        |            |                         |
+| `-t` | `--token`         | Authentication token                                                     | string     | `$INFLUX_TOKEN`         |
+
+## Examples
+
+##### List all DBRP mappings in your organization
+```sh
+influx v1 dbrp list
+```
+
+##### List DBRP mappings for specific buckets
+```sh
+influx v1 dbrp list \
+  --bucket-id 12ab34cd56ef78 \
+  --bucket-id 09zy87xw65vu43
+```
+
+##### List DBRP mappings with a specific database
+```sh
+influx v1 dbrp list --db example-db
+```
+
+##### List DBRP mappings with a specific retention policy
+```sh
+influx v1 dbrp list --rp example-rp
+```

--- a/content/influxdb/v2.0/reference/cli/influx/v1/dbrp/update.md
+++ b/content/influxdb/v2.0/reference/cli/influx/v1/dbrp/update.md
@@ -4,7 +4,7 @@ description: >
   The `influx v1 dbrp update` command updates a DBRP mapping in the InfluxDB 1.x compatibility API.
 menu:
   influxdb_2_0_ref:
-    name: influx v1 dbrp set-active
+    name: influx v1 dbrp update
     parent: influx v1 dbrp
 weight: 101
 influxdb/v2.0/tags: [DBRP]
@@ -18,18 +18,34 @@ influx v1 dbrp update [flags]
 ```
 
 ## Flags
-| Flag |                   | Description                                                                                | Input type | {{< cli/mapped >}}      |
-|------|-------------------|--------------------------------------------------------------------------------------------|------------|-------------------------|
-| `-c` | `--active-config` | Config name to use for command                                                             | string     | `$INFLUX_ACTIVE_CONFIG` |
-|      | `--configs-path`  | Path to the influx CLI configurations (default: `~/.influxdbv2/configs`)                   | string     | `$INFLUX_CONFIGS_PATH`  |
-|      | `--default`       | Set DBRP mapping's retention policy as default   |            |                         |
-| `-h` | `--help`          | Help for the `update` command                                                              |            |                         |
-|      | `--hide-headers`  | Hide the table headers (default: `false`)                                                  |            | `$INFLUX_HIDE_HEADERS`  |
-|      | `--host`          | HTTP address of InfluxDB                                                                   | string     | `$INFLUX_HOST`          |
-|      | `--id`            | DBRP ID (required)                                                                         | string     |                         |
-|      | `--json`          | Output data as JSON (default: `false`)                                                     |            | `$INFLUX_OUTPUT_JSON`   |
-| `-o` | `--org`           | Organization name                                                                          | string     | `$INFLUX_ORG`           |
-|      | `--org-id`        | Organization ID                                                                            | string     | `$INFLUX_ORG_ID`        |
-| `-r` | `--rp`            | InfluxDB v1 retention policy to map from                                                               |            |                         |
-|      | `--skip-verify`   | Skip TLS certificate verification                                                          |            |                         |
-| `-t` | `--token`         | Authentication token                                                                       | string     | `$INFLUX_TOKEN`         |
+| Flag |                   | Description                                                              | Input type | {{< cli/mapped >}}      |
+|:-----|:------------------|:-------------------------------------------------------------------------|:----------:|:------------------------|
+| `-c` | `--active-config` | Config name to use for command                                           | string     | `$INFLUX_ACTIVE_CONFIG` |
+|      | `--configs-path`  | Path to the influx CLI configurations (default: `~/.influxdbv2/configs`) | string     | `$INFLUX_CONFIGS_PATH`  |
+|      | `--default`       | Set DBRP mapping's retention policy as default                           |            |                         |
+| `-h` | `--help`          | Help for the `update` command                                            |            |                         |
+|      | `--hide-headers`  | Hide the table headers (default: `false`)                                |            | `$INFLUX_HIDE_HEADERS`  |
+|      | `--host`          | HTTP address of InfluxDB                                                 | string     | `$INFLUX_HOST`          |
+|      | `--id`            | DBRP ID <span class="req">Required</span>                                | string     |                         |
+|      | `--json`          | Output data as JSON (default: `false`)                                   |            | `$INFLUX_OUTPUT_JSON`   |
+| `-o` | `--org`           | Organization name                                                        | string     | `$INFLUX_ORG`           |
+|      | `--org-id`        | Organization ID                                                          | string     | `$INFLUX_ORG_ID`        |
+| `-r` | `--rp`            | InfluxDB v1 retention policy to map from                                 |            |                         |
+|      | `--skip-verify`   | Skip TLS certificate verification                                        |            |                         |
+| `-t` | `--token`         | Authentication token                                                     | string     | `$INFLUX_TOKEN`         |
+
+## Examples
+
+##### Set a DBRP mapping as default
+```sh
+influx v1 dbrp update \
+  --id 12ab34cd56ef78 \
+  --default
+```
+
+##### Update the retention policy of a DBRP mapping
+```sh
+influx v1 dbrp update \
+  --id 12ab34cd56ef78 \
+  --rp new-rp-name
+```


### PR DESCRIPTION
Closes #1851 
Closes #1883 

This is a stop-gap change. The DBRP API implementations are currently different. Because of the differences, the `influx v1 dbrp` CLI will not work with cloud. This PR adds CLI examples to the DBRP mapping sections of the **Query with InfluxQL** doc **in OSS**. This updates the `curl` examples in the Cloud version of this doc to accurately reflect the Cloud implementation of the DBRP API.

Once the Cloud DBRP API is fixed and aligned with OSS, we can just use `{{< duplicate-oss >}}` to populate the Cloud content. That work is being tracked here: https://github.com/influxdata/idpe/issues/9267.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
