### PR TITLE
Update toduration.md

### DIFF
--- a/content/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/toduration.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/toduration.md
@@ -27,7 +27,7 @@ _**Supported data types:** Integer | String | Uinteger_
 
 {{% note %}}
 `duration()` assumes **numeric** input values are **nanoseconds**.
-**String** input values must use [duration literal representation](#/v2.0/reference/flux/language/lexical-elements/#duration-literals).
+**String** input values must use [duration literal representation](/influxdb/v2.0/reference/flux/language/lexical-elements/#duration-literals).
 {{% /note %}}
 
 {{% note %}}


### PR DESCRIPTION
The link to "duration literal representation" was wrong. Updated.

Closes #

_Describe your proposed changes here._

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
