### PR TITLE
alter retention policy statement clarify

### DIFF
--- a/content/influxdb/v1.8/query_language/manage-database.md
+++ b/content/influxdb/v1.8/query_language/manage-database.md
@@ -327,7 +327,7 @@ See [Create a database with CREATE DATABASE](/influxdb/v1.8/query_language/manag
 
 The `ALTER RETENTION POLICY` query takes the following form, where you must declare at least one of the retention policy attributes `DURATION`, `REPLICATION`, `SHARD DURATION`, or `DEFAULT`:
 ```sql
-ALTER RETENTION POLICY <retention_policy_name> ON <database_name> DURATION <duration> REPLICATION <n> SHARD DURATION <duration> DEFAULT
+ALTER RETENTION POLICY <retention_policy_name> ON <database_name> [DURATION <duration>] [REPLICATION <n>] [SHARD DURATION <duration>] [DEFAULT]
 ```
 
 {{% warn %}} Replication factors do not serve a purpose with single node instances.


### PR DESCRIPTION
The precise statement of create retention policy is:
```
alter_retention_policy_stmt  = "ALTER RETENTION POLICY" policy_name on_clause
                               retention_policy_option
                               [ retention_policy_option ]
                               [ retention_policy_option ]
                               [ retention_policy_option ] .
```
But here is: 
```
ALTER RETENTION POLICY <retention_policy_name> ON <database_name> DURATION <duration> REPLICATION <n> SHARD DURATION <duration> DEFAULT
```

Actually, `ALTER RETENTION POLICY` only need to declare at least one of tokens DURATION, REPLICATION, SHARD DURATION, DEFAULT. But the second description means we should declare all of the token at the exactly same order. 

So I think the correct description is:
```
ALTER RETENTION POLICY <retention_policy_name> ON <database_name> [DURATION <duration>] [REPLICATION <n>] [SHARD DURATION <duration>] [DEFAULT]
```


- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
