### PR TITLE
Context maintainer

### DIFF
--- a/layouts/partials/topnav/product-selector.html
+++ b/layouts/partials/topnav/product-selector.html
@@ -1,7 +1,9 @@
+{{ $scratch := newScratch }}
 {{ $productPathData := findRE "[^/]+.*?" .RelPermalink }}
 {{ $product := index $productPathData 0 }}
 {{ $currentVersion := index $productPathData 1 }}
 {{ $isCloud := eq "influxdb/cloud" (print $product "/" $currentVersion )}}
+{{ $isOSSv2 := in (print $product "/" $currentVersion ) "influxdb/v2."}}
 
 <div class="dropdown">
   {{ if or (eq $product nil) (eq $product "platform") }}
@@ -14,8 +16,21 @@
   {{ end }}
   <ul class="item-list">
     {{ range sort .Site.Data.products "list_order" "desc" }}
+      {{ $scratch.Set "link" (print "/" .namespace "/" .latest "/") }}
+      {{ if and $isCloud (eq .altname "InfluxDB OSS")}}
+        {{ $altOSSPage := $.GetPage (replaceRE "influxdb/cloud" (print "influxdb/" $.Site.Data.products.influxdb.latest) $.Page.RelPermalink) }}
+        {{ if gt (len $altOSSPage.Title) 0 }}
+          {{ $scratch.Set "link" $altOSSPage.RelPermalink }}
+        {{ end }}
+      {{ else if and $isOSSv2 (eq .altname "InfluxDB Cloud") }}
+        {{ $altCloudPage := $.GetPage (replaceRE $currentVersion "cloud" $.Page.RelPermalink) }}
+        {{ if gt (len $altCloudPage.Title) 0 }}
+          {{ $scratch.Set "link" $altCloudPage.RelPermalink }}
+        {{ end }}
+      {{ end }}
+      {{ $link := $scratch.Get "link" }}
       <li>
-        <a href='/{{ .namespace }}/{{ cond (isset . "latest_override") .latest_override .latest }}/' {{ if and (eq .namespace $product) (in .versions $currentVersion) }}class="active"{{ end }}>{{ cond (isset . "altname") .altname .name }}</a>
+        <a href='{{ $link }}' {{ if and (eq .namespace $product) (in .versions $currentVersion) }}class="active"{{ end }}>{{ cond (isset . "altname") .altname .name }}</a>
       </li>
     {{ end }}
   </ul>

--- a/layouts/partials/topnav/product-selector.html
+++ b/layouts/partials/topnav/product-selector.html
@@ -18,12 +18,12 @@
     {{ range sort .Site.Data.products "list_order" "desc" }}
       {{ $scratch.Set "link" (print "/" .namespace "/" .latest "/") }}
       {{ if and $isCloud (eq .altname "InfluxDB OSS")}}
-        {{ $altOSSPage := $.GetPage (replaceRE "influxdb/cloud" (print "influxdb/" $.Site.Data.products.influxdb.latest) $.Page.RelPermalink) }}
+        {{ $altOSSPage := $.GetPage ((replaceRE "influxdb/cloud" (print "influxdb/" $.Site.Data.products.influxdb.latest) $.Page.RelPermalink) | replaceRE `\/$` "") }}
         {{ if gt (len $altOSSPage.Title) 0 }}
           {{ $scratch.Set "link" $altOSSPage.RelPermalink }}
         {{ end }}
       {{ else if and $isOSSv2 (eq .altname "InfluxDB Cloud") }}
-        {{ $altCloudPage := $.GetPage (replaceRE $currentVersion "cloud" $.Page.RelPermalink) }}
+        {{ $altCloudPage := $.GetPage ((replaceRE $currentVersion "cloud" $.Page.RelPermalink) | replaceRE `\/$` "") }}
         {{ if gt (len $altCloudPage.Title) 0 }}
           {{ $scratch.Set "link" $altCloudPage.RelPermalink }}
         {{ end }}

--- a/layouts/partials/topnav/version-selector.html
+++ b/layouts/partials/topnav/version-selector.html
@@ -1,3 +1,4 @@
+{{ $scratch := newScratch }}
 {{ $productPathData := findRE "[^/]+.*?" .RelPermalink }}
 {{ $product := index $productPathData 0 }}
 {{ $currentVersion := index $productPathData 1 }}
@@ -9,8 +10,14 @@
   <ul class="item-list">
     <li><a href="https://archive.docs.influxdata.com/{{ $product }}/" class="legacy" target="_blank">older</a></li>
     {{ range (index .Site.Data.products $product).versions }}
+      {{ $scratch.Set "link" (print "/" $product "/" . "/") }}
+      {{ $altVersionPage := $.GetPage ((replaceRE $currentVersion . $.Page.RelPermalink) | replaceRE `\/$` "") }}
+      {{ if gt (len $altVersionPage.Title) 0 }}
+        {{ $scratch.Set "link" $altVersionPage.RelPermalink }}
+      {{ end }}
+      {{ $link := $scratch.Get "link" }}
       <li>
-        <a href="/{{ $product }}/{{ . }}/" {{ if eq . $currentVersion }}class="active"{{ end }}>{{ cond (in . "v") . (title .) }}</a>
+        <a href="{{ $link }}" {{ if eq . $currentVersion }}class="active"{{ end }}>{{ cond (in . "v") . (title .) }}</a>
       </li>
     {{ end }}
   </ul>


### PR DESCRIPTION
Updated the product and version dropdowns to link to the equivalent page for the current page if it exists in the specific product/version. Users will be able to switch between OSS and Cloud sections and stay on the same page. In the 1.x docs (and in the 2.0 docs when we add the next minor version), users can switch between versions but stay on the "same" page.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
