### PR TITLE
remove starlark storage state from release notes

### DIFF
--- a/content/telegraf/v1.16/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.16/about_the_project/release-notes-changelog.md
@@ -32,7 +32,6 @@ menu:
   - Allow the processor to manage errors that occur in the `apply` function.
   - Add support for logging.
   - Add capability to return multiple metrics.
-  - Add the shared state to the global scope to retrieve previous data.
 
 ## v1.16.2 [2020-11-13]
 


### PR DESCRIPTION
missed this - i'll need to improve this process for next time
