### PR TITLE
Add Working with the API page

### DIFF
--- a/content/influxdb/cloud/tools/api/_index.md
+++ b/content/influxdb/cloud/tools/api/_index.md
@@ -4,7 +4,7 @@ seotitle: Use the InfluxDB API
 description: Interact with InfluxDB using a rich API for writing and querying data and more.
 weight: 103
 menu:
-  influxdb_2_0:
+  influxdb_cloud:
     name: Working with the API
     parent: Tools & integrations
 ---

--- a/content/influxdb/cloud/tools/api/_index.md
+++ b/content/influxdb/cloud/tools/api/_index.md
@@ -1,0 +1,12 @@
+---
+title: Working with the InfluxDB API
+seotitle: Use the InfluxDB API
+description: Interact with InfluxDB using a rich API for writing and querying data and more.
+weight: 103
+menu:
+  influxdb_2_0:
+    name: Working with the API
+    parent: Tools & integrations
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/v2.0/tools/api/_index.md
+++ b/content/influxdb/v2.0/tools/api/_index.md
@@ -1,22 +1,24 @@
 ---
 title: Working with the InfluxDB API
 seotitle: Use the InfluxDB API
-description: Interact with InfluxDB using a rich API for writing and querying data and more.
-weight: 3
+description: Interact with InfluxDB 2.0 using a rich API for writing and querying data and more.
+weight: 103
 menu:
   influxdb_2_0:
     name: Working with the API
     parent: Tools & integrations
 ---
 
-InfluxDB offers a rich API that developers can use to create applications.
+InfluxDB offers a rich API that you can use to create applications.
 The following pages offer general guides to the most commonly used API methods.
 
-For detailed documentation on the entire API, see [InfluxDBv2 API Documentation](/influxdb/v2.0/reference/api/#influxdb-v2-api-documentation)
+For detailed documentation on the entire API, see [InfluxDBv2 API Documentation](/influxdb/v2.0/reference/api/#influxdb-v2-api-documentation).
 
 {{% note %}}
 If you are interacting with InfluxDB 1.x, see the [1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/).
 {{% /note %}}
+
+Use the following API endpoints to write and query data:
 
 ## Write API
 

--- a/content/influxdb/v2.0/tools/api/_index.md
+++ b/content/influxdb/v2.0/tools/api/_index.md
@@ -1,0 +1,27 @@
+---
+title: Working with the InfluxDB API
+seotitle: Use the InfluxDB API
+description: Interact with InfluxDB using a rich API for writing and querying data and more.
+weight: 3
+menu:
+  influxdb_2_0:
+    name: Working with the API
+    parent: Tools & integrations
+---
+
+InfluxDB offers a rich API that developers can use to create applications.
+The following pages offer general guides to the most commonly used API methods.
+
+For detailed documentation on the entire API, see [InfluxDBv2 API Documentation](/influxdb/v2.0/reference/api/#influxdb-v2-api-documentation)
+
+{{% note %}}
+If you are interacting with InfluxDB 1.x, see the [1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/).
+{{% /note %}}
+
+## Write API
+
+[Write data to InfluxDB](/influxdb/v2.0/write-data/developer-tools/api/) using an HTTP request to the InfluxDB API `/write` endpoint.
+
+## Query API
+
+[Query from InfluxDB](/influxdb/v2.0/query-data/execute-queries/influx-api/) using an HTTP request to the `/query` endpoint.


### PR DESCRIPTION
Closes #1688

Add a "Working with the API" page under Tools & integrations. Populate this page with some basic info and links to write and query task docs.

As we continue to build out developer-facing docs for the API, this page will serve as a landing page for a whole subsection under "Working with the API".

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
