### PR TITLE
Clarify TICKscript lambda docs

### DIFF
--- a/content/kapacitor/v1.5/tick/expr.md
+++ b/content/kapacitor/v1.5/tick/expr.md
@@ -250,7 +250,8 @@ lambda: "expiration" < unixNano(now())
 #### Math functions
 
 The following mathematical functions are available.
-Each function is implemented via the equivalent Go function.
+Each function is implemented via the equivalent Go function
+(linked in the table below for reference only).
 
 | Function                                                          | Description                                                                                                                      |
 | ----------                                                        | -------------                                                                                                                    |
@@ -300,7 +301,8 @@ Each function is implemented via the equivalent Go function.
 #### String functions
 
 The following string manipulation functions are available.
-Each function is implemented via the equivalent Go function.
+Each function is implemented via the equivalent Go function
+(linked in the table below for reference only).
 
 | Function                                                                                                  | Description                                                                                                                                                                                                                            |
 | ----------                                                                                                | -------------                                                                                                                                                                                                                          |

--- a/content/kapacitor/v1.5/tick/expr.md
+++ b/content/kapacitor/v1.5/tick/expr.md
@@ -328,7 +328,11 @@ Each function is implemented via the equivalent Go function
 | [strTrimSuffix(s,&nbsp;suffix&nbsp;string)&nbsp;string)](https://golang.org/pkg/strings/#TrimSuffix)                     | StrTrimSuffix returns s without the provided trailing suffix string. If s doesn't end with suffix, s is returned unchanged.                                                                                                            |
 | [regexReplace(r&nbsp;regex,&nbsp;s,&nbsp;pattern&nbsp;string)&nbsp;string](https://golang.org/pkg/regexp/#Regexp.ReplaceAllString) | RegexReplace replaces matches of the regular expression in the input string with the output string. For example regexReplace(/a(b*)c/, 'abbbc', 'group is $1') -> 'group is bbb'. The original string is returned if no matches are found. |
 
+**Example:**
 
+```js
+.where(lambda: !strContains("fstype", 'nfs') OR !strContains("fstype", 'cifs'))
+```
 
 #### Human string functions
 


### PR DESCRIPTION
Add note that the links to Golang docs are for reference. Add example `strContains` use.

Closes https://github.com/influxdata/DAR/issues/137.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
