### PR TITLE
Fix minor typo in "Group keys"

### DIFF
--- a/content/influxdb/v2.0/query-data/flux/group-data.md
+++ b/content/influxdb/v2.0/query-data/flux/group-data.md
@@ -28,7 +28,7 @@ If you're just getting started with Flux queries, check out the following:
 - [Execute queries](/influxdb/v2.0/query-data/execute-queries/) to discover a variety of ways to run your queries.
 
 ## Group keys
-Every table has a **group key** – a list of columns which for which every row in the table has the same value.
+Every table has a **group key** – a list of columns for which every row in the table has the same value.
 
 ###### Example group key
 ```js


### PR DESCRIPTION
As the description says.
> Every table has a group key – a list of columns ~~which~~ for which every row in the table has the same value.

- [x] Typos do not require signing the CLA
- [x] Rebased/mergeable