### PR TITLE
Update Grafana auth steps for InfluxQL against Influx2.0

### DIFF
--- a/content/influxdb/v2.0/tools/grafana.md
+++ b/content/influxdb/v2.0/tools/grafana.md
@@ -81,11 +81,10 @@ configure your InfluxDB connection:
         ```
     - **Access**: Server (default)
 
-2. Under **Custom HTTP Headers**, select **Add Header**.
-3. Provide your InfluxDB authentication credentials:
+2. Under **Custom HTTP Headers**, select **Add Header**. Provide your InfluxDB authentication credentials:
 
     - **Header**: "Authorization"
-    - **Value**: In the form of "Token <your InfluxDB [authentication token](/influxdb/v2.0/security/tokens/)>"
+    - **Value**: use the `Token` schema and provide your [InfluxDB authentication token](/influxdb/v2.0/security/tokens/) (for example: `Token y0uR5uP3rSecr3tT0k3n`)
 
 4. Under **InfluxDB Details**, do the following:
 

--- a/content/influxdb/v2.0/tools/grafana.md
+++ b/content/influxdb/v2.0/tools/grafana.md
@@ -81,11 +81,11 @@ configure your InfluxDB connection:
         ```
     - **Access**: Server (default)
 
-2. Under **Auth**, enable **Basic Auth**.
-3. Under **Basic Auth Details**, provide your InfluxDB authentication credentials:
+2. Under **Custom HTTP Headers**, select **Add Header**.
+3. Provide your InfluxDB authentication credentials:
 
-    - **User**: InfluxDB username
-    - **Password**: InfluxDB [authentication token](/influxdb/v2.0/security/tokens/)
+    - **Header**: "Authorization"
+    - **Value**: In the form of "Token <your InfluxDB [authentication token](/influxdb/v2.0/security/tokens/)>"
 
 4. Under **InfluxDB Details**, do the following:
 

--- a/content/influxdb/v2.0/tools/grafana.md
+++ b/content/influxdb/v2.0/tools/grafana.md
@@ -86,7 +86,7 @@ configure your InfluxDB connection:
     - **Header**: "Authorization"
     - **Value**: use the `Token` schema and provide your [InfluxDB authentication token](/influxdb/v2.0/security/tokens/) (for example: `Token y0uR5uP3rSecr3tT0k3n`)
 
-4. Under **InfluxDB Details**, do the following:
+3. Under **InfluxDB Details**, do the following:
 
     - **Database**: Enter the ID of the bucket to query in InfluxDB 2.0. To retrieve your bucket ID, see how to [view buckets](/influxdb/v2.0/organizations/buckets/view-buckets/).
     - **User**: Enter the username to sign into InfluxDB.
@@ -95,7 +95,7 @@ configure your InfluxDB connection:
 
     {{< img-hd src="/img/influxdb/2-0-visualize-grafana-influxql.png" />}}
 
-5. Click **Save & Test**. Grafana attempts to connect to the InfluxDB 2.0 datasource
+4. Click **Save & Test**. Grafana attempts to connect to the InfluxDB 2.0 datasource
    and returns the results of the test.
 {{% /tab-content %}}
 <!--------------------------- END INFLUXQL CONTENT --------------------------->


### PR DESCRIPTION
Addresses https://github.com/influxdata/docs-v2/issues/1942

Closes #1942

The current documentation is misleading with respect to using Grafana with InfluxQL with Influx2.0. This change seeks to correct this.

You do not need basic authentication, you need only add a custom HTTP header with your token. 

See:
https://github.com/influxdata/docs-v2/issues/1942
https://github.com/grafana/grafana/issues/29372

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
