### PR TITLE
Kapa 1.5.8 release notes

### DIFF
--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -7,7 +7,7 @@ menu:
 ---
 
 
-## v1.5.8 [2020-01-11]
+## v1.5.8 [2020-01-27]
 
 ## Breaking changes
 
@@ -21,7 +21,7 @@ menu:
 - Add support for HTTP [sources](/kapacitor/v1.5/nodes/sideload_node/#source) in `SideloadNode` configuration, thanks @jregovic!
 - Add support for correlate in the [Alerta event handler](kapacitor/v1.5/event_handlers/alerta/), thanks @nermolaev!
 - Add `details` option to the [OpsGenie v2 event handler](/kapacitor/v1.5/event_handlers/opsgenie/v2/); set to `true` to use the Kapacitor alert details as OpsGenie description text, thanks @JamesClonk!
-- Send data to InfluxDB compressed as `gzip` by default.
+- Send data to InfluxDB compressed as `gzip` by default. Although, this default configuration does not appear in the Kapacitor configuration file, you can add `compression = "none"` to the [`[[influxdb]]` section](/kapacitor/v1.5/administration/configuration/#influxdb) of your Kapacitor configuration file.
 - Preallocate `GroupIDs` to increase performance by reducing allocations.
 
 ### Bug fixes

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -11,7 +11,8 @@ menu:
 
 ## Breaking changes
 
-- Remove support for darwin/386 builds (Go no longer supports), and add support for darwin/arm64 builds. 
+- Remove support for darwin/386 builds (Go no longer supports), and add support for darwin/arm64 builds.
+
 ## Features
 
 - Add InfluxDB `subscription-path` configuration option to allow Kapacitor to run behind a reverse proxy, thanks @aspring!

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -19,9 +19,9 @@ menu:
 - Add support for HTTP sources in `SideloadNode` configuration, thanks @jregovic!
 - Add support for correlate in the Alerta AlertNode, thanks @nermolaev!
 - Add `details` option to the OpsGenie v2 event handler; set to `true` to use the Kapacitor alert details as OpsGenie description text, thanks @JamesClonk!
-- Preallocate GroupIDs for increased performance by reducing allocations.
 - Send data to InfluxDB compressed as `gzip` by default.
 - Add `PrimaryProperty` and `SecondaryProperty` methods to BigPanda AlertNode.
+- Preallocate `GroupIDs` to increase performance by reducing allocations.
 
 ### Bug fixes
 

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -18,16 +18,15 @@ menu:
 - Add new [BigPanda event handler](/kapacitor/v1.5/event_handlers/bigpanda).
 - Add InfluxDB `subscription-path` configuration option to allow Kapacitor to run behind a reverse proxy, thanks @aspring!
   For more information, see the example in [Kapacitor to InfluxDB TLS configuration over HTTP API](/kapacitor/v1.5/administration/security/#secure-influxdb-and-kapacitor).
-- Add support for HTTP sources in `SideloadNode` configuration, thanks @jregovic!
-- Add support for correlate in the Alerta AlertNode, thanks @nermolaev!
+- Add support for HTTP [sources](/kapacitor/v1.5/nodes/sideload_node/#source) in `SideloadNode` configuration, thanks @jregovic!
+- Add support for correlate in the Alerta event handler, thanks @nermolaev!
 - Add `details` option to the OpsGenie v2 event handler; set to `true` to use the Kapacitor alert details as OpsGenie description text, thanks @JamesClonk!
 - Send data to InfluxDB compressed as `gzip` by default.
 - Preallocate `GroupIDs` to increase performance by reducing allocations.
 
 ### Bug fixes
 
-- Add error check when the system fails to read the replay file, thanks @johncming!
-- Add missing `.Details` to the alert template.
+- Rename the alert-handler match function `duration()` to `alertDuration()` to avoid name collision with the type conversion function of the same name.
 
 ## v1.5.7 [2020-10-26]
 

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -6,6 +6,26 @@ menu:
     parent: About the project
 ---
 
+
+## v1.5.8 [2020-1-6]
+
+## Breaking changes
+
+- Remove support for darwin/386 builds (Go no longer supports), and add support for darwin/arm64 builds. 
+## Features
+
+- Add InfluxDB `subscription-path` configuration option to allow Kapacitor to run behind a reverse proxy, thanks @aspring!
+- Add support for HTTP sources in `SideloadNode` configuration, thanks @jregovic!
+- Add support for correlate in the Alerta AlertNode, thanks @nermolaev!
+- Add `details` option to the OpsGenie v2 event handler; set to `true` to use the Kapacitor alert details as OpsGenie description text, thanks @JamesClonk!
+- Preallocate GroupIDs for increased performance by reducing allocations.
+- Send data to InfluxDB compressed as `gzip` by default.
+- Add `PrimaryProperty` and `SecondaryProperty` methods to BigPanda AlertNode.
+
+### Bug fixes
+
+- Add error check when the system fails to read the replay file, thanks @johncming!
+- Add missing `.Details` to the alert template.
 ## v1.5.7 [2020-10-26]
 
 ## Features

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -7,7 +7,7 @@ menu:
 ---
 
 
-## v1.5.8 [2020-1-7]
+## v1.5.8 [unreleased]
 
 ## Breaking changes
 

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -15,7 +15,8 @@ menu:
 
 ## Features
 
-- Add InfluxDB `subscription-path` configuration option to allow Kapacitor to run behind a reverse proxy, thanks @aspring!
+- Add the InfluxDB `subscription-path` configuration option to allow Kapacitor to run behind a reverse proxy, thanks @aspring!
+  For more information, see the example in [Kapacitor to InfluxDB TLS configuration over HTTP API](/kapacitor/v1.5/administration/security/#secure-influxdb-and-kapacitor).
 - Add support for HTTP sources in `SideloadNode` configuration, thanks @jregovic!
 - Add support for correlate in the Alerta AlertNode, thanks @nermolaev!
 - Add `details` option to the OpsGenie v2 event handler; set to `true` to use the Kapacitor alert details as OpsGenie description text, thanks @JamesClonk!

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -7,7 +7,7 @@ menu:
 ---
 
 
-## v1.5.8 [unreleased]
+## v1.5.8 [2020-01-11]
 
 ## Breaking changes
 
@@ -20,7 +20,7 @@ menu:
   For more information, see the example in [Kapacitor to InfluxDB TLS configuration over HTTP API](/kapacitor/v1.5/administration/security/#secure-influxdb-and-kapacitor).
 - Add support for HTTP [sources](/kapacitor/v1.5/nodes/sideload_node/#source) in `SideloadNode` configuration, thanks @jregovic!
 - Add support for correlate in the Alerta event handler, thanks @nermolaev!
-- Add `details` option to the OpsGenie v2 event handler; set to `true` to use the Kapacitor alert details as OpsGenie description text, thanks @JamesClonk!
+- Add `details` option to the [OpsGenie v2 event handler](/kapacitor/v1.5/event_handlers/opsgenie/v2/); set to `true` to use the Kapacitor alert details as OpsGenie description text, thanks @JamesClonk!
 - Send data to InfluxDB compressed as `gzip` by default.
 - Preallocate `GroupIDs` to increase performance by reducing allocations.
 

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -15,13 +15,13 @@ menu:
 
 ## Features
 
-- Add the InfluxDB `subscription-path` configuration option to allow Kapacitor to run behind a reverse proxy, thanks @aspring!
+- Add new [BigPanda event handler](/kapacitor/v1.5/event_handlers/bigpanda.md).
+- Add InfluxDB `subscription-path` configuration option to allow Kapacitor to run behind a reverse proxy, thanks @aspring!
   For more information, see the example in [Kapacitor to InfluxDB TLS configuration over HTTP API](/kapacitor/v1.5/administration/security/#secure-influxdb-and-kapacitor).
 - Add support for HTTP sources in `SideloadNode` configuration, thanks @jregovic!
 - Add support for correlate in the Alerta AlertNode, thanks @nermolaev!
 - Add `details` option to the OpsGenie v2 event handler; set to `true` to use the Kapacitor alert details as OpsGenie description text, thanks @JamesClonk!
 - Send data to InfluxDB compressed as `gzip` by default.
-- Add `PrimaryProperty` and `SecondaryProperty` methods to BigPanda AlertNode.
 - Preallocate `GroupIDs` to increase performance by reducing allocations.
 
 ### Bug fixes

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -15,7 +15,7 @@ menu:
 
 ## Features
 
-- Add new [BigPanda event handler](/kapacitor/v1.5/event_handlers/bigpanda.md).
+- Add new [BigPanda event handler](/kapacitor/v1.5/event_handlers/bigpanda).
 - Add InfluxDB `subscription-path` configuration option to allow Kapacitor to run behind a reverse proxy, thanks @aspring!
   For more information, see the example in [Kapacitor to InfluxDB TLS configuration over HTTP API](/kapacitor/v1.5/administration/security/#secure-influxdb-and-kapacitor).
 - Add support for HTTP sources in `SideloadNode` configuration, thanks @jregovic!

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -7,7 +7,7 @@ menu:
 ---
 
 
-## v1.5.8 [2020-1-6]
+## v1.5.8 [2020-1-7]
 
 ## Breaking changes
 
@@ -27,6 +27,7 @@ menu:
 
 - Add error check when the system fails to read the replay file, thanks @johncming!
 - Add missing `.Details` to the alert template.
+
 ## v1.5.7 [2020-10-26]
 
 ## Features

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -19,7 +19,7 @@ menu:
 - Add InfluxDB `subscription-path` configuration option to allow Kapacitor to run behind a reverse proxy, thanks @aspring!
   For more information, see the example in [Kapacitor to InfluxDB TLS configuration over HTTP API](/kapacitor/v1.5/administration/security/#secure-influxdb-and-kapacitor).
 - Add support for HTTP [sources](/kapacitor/v1.5/nodes/sideload_node/#source) in `SideloadNode` configuration, thanks @jregovic!
-- Add support for correlate in the Alerta event handler, thanks @nermolaev!
+- Add support for correlate in the [Alerta event handler](kapacitor/v1.5/event_handlers/alerta/), thanks @nermolaev!
 - Add `details` option to the [OpsGenie v2 event handler](/kapacitor/v1.5/event_handlers/opsgenie/v2/); set to `true` to use the Kapacitor alert details as OpsGenie description text, thanks @JamesClonk!
 - Send data to InfluxDB compressed as `gzip` by default.
 - Preallocate `GroupIDs` to increase performance by reducing allocations.


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/1910

Update Kapacitor 1.5.8 release notes.