### PR TITLE
InfluxDB OSS 1.8.4 release notes

### DIFF
--- a/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
@@ -9,18 +9,6 @@ menu:
     parent: About the project
 ---
 
-<!--  ## v1.8.4 [unreleased]
-
-The InfluxDB Enterprise 1.8.4 release builds on the InfluxDB OSS 1.8.4 release.
-For details on changes incorporated from the InfluxDB OSS release, see
-[InfluxDB OSS release notes](/influxdb/v1.8/about_the_project/releasenotes-changelog/#v1-8-4-unreleased).
-
-### Bugfixes
-
-- Fix "snapshot in progress" error that occurred during backup.
-
--->
-
 ## v1.8.3 [2020-09-30]
 
 The InfluxDB Enterprise 1.8.3 release builds on the InfluxDB OSS 1.8.3 release.

--- a/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
@@ -9,7 +9,7 @@ menu:
     parent: About the project
 ---
 
-## v1.8.4 [unreleased]
+<!--  ## v1.8.4 [unreleased]
 
 The InfluxDB Enterprise 1.8.4 release builds on the InfluxDB OSS 1.8.4 release.
 For details on changes incorporated from the InfluxDB OSS release, see
@@ -18,6 +18,8 @@ For details on changes incorporated from the InfluxDB OSS release, see
 ### Bugfixes
 
 - Fix "snapshot in progress" error that occurred during backup.
+
+-->
 
 ## v1.8.3 [2020-09-30]
 

--- a/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
@@ -9,6 +9,28 @@ menu:
     parent: About the project
 ---
 
+## v1.8.4 [unreleased]
+
+The InfluxDB Enterprise 1.8.4 release builds on the InfluxDB OSS 1.8.4 release.
+For details on changes incorporated from the InfluxDB OSS release, see
+[InfluxDB OSS release notes](/influxdb/v1.8/about_the_project/releasenotes-changelog/#v1-8-4-unreleased).
+
+### Bugfixes
+
+- Fix "snapshot in progress" error that occurred during backup.
+
+## v1.8.3 [2020-09-30]
+
+The InfluxDB Enterprise 1.8.3 release builds on the InfluxDB OSS 1.8.3 release.
+For details on changes incorporated from the InfluxDB OSS release, see
+[InfluxDB OSS release notes](/influxdb/v1.8/about_the_project/releasenotes-changelog/#v1-8-3-2020-09-30).
+
+### Bugfixes
+
+- Wrap TCP mux–based HTTP server with a function that adds custom headers.
+- Correct output for `influxd-ctl show shards`.
+- Properly encode/decode `control.Shard.Err`.
+
 ## v1.8.2 [2020-08-24]
 
 The InfluxDB Enterprise 1.8.2 release builds on the InfluxDB OSS 1.8.2 and 1.8.1 releases.

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -22,7 +22,7 @@ v2: /influxdb/v2.0/reference/release-notes/influxdb/
 - Add durations to Flux logging, including log compilation, execution, and total request duration.
 - Properly format JSON marshalling errors.
 - Close all `net.Listener` instances silently on error.
-- `regexp` handling complies with Prometheus Query Language (PromQL).
+- `regexp` handling in the prometheus converter complies with Prometheus Query Language (PromQL).
 - GROUP BY queries now correctly set the interval start time before calculating the time-zone offset.
 
 ## v1.8.3 [2020-09-30]

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -9,6 +9,22 @@ menu:
 v2: /influxdb/v2.0/reference/release-notes/influxdb/
 ---
 
+## v1.8.4 [unreleased]
+
+### Features
+
+- Optimize shard lookups in groups containing only one shard. Thanks @StoneYunZhao!
+- Add [`strict-error-handling` configuration option](/influxdb/v1.8/administration/config/#strict-error-handling-false). Previously, SELECT INTO queries attempting to insert an unsupported value failed silently. To preserve backwards compatibility, a new `strict-error-handling` option was added to the InfluxDB configuration file. Set this option to `true` to ensure a failed insert returns an error and no points are inserted.
+
+### Bug fixes
+
+- Ensure successful writes increment `WriteOK` write statistics correctly.
+- Add durations to Flux logging, including log compilation, execution, and total request duration.
+- Properly format JSON marshalling errors.
+- Close all `net.Listener` instances silently on error.
+- `regexp` handling complies with Prometheus Query Language (PromQL).
+- GROUP BY queries now correctly set the interval start time before calculating the time-zone offset.
+
 ## v1.8.3 [2020-09-30]
 
 ### Features

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -29,9 +29,6 @@ v2: /influxdb/v2.0/reference/release-notes/influxdb/
   - `stat_total_duration`
   - `stat_compile_duration`
   - `stat_execute_duration`
-  - `stat_queue_duration`
-  - `stat_plan_duration`
-  - `stat_requeue_duration`
  
     Now, these durations are logged correctly. 
 

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -30,8 +30,8 @@ v2: /influxdb/v2.0/reference/release-notes/influxdb/
   - `stat_compile_duration`
   - `stat_execute_duration`
  
-    Now, these durations are logged correctly. 
-
+    Now, these durations are logged correctly.
+    
 - ArrayFilterCursor truncation for multi-block data.
 - Multi-measurement queries now return all applicable series.
 - Lock map before writes.

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -11,19 +11,18 @@ v2: /influxdb/v2.0/reference/release-notes/influxdb/
 
 ## v1.8.4 [unreleased]
 
-### Features
-
-- Optimize shard lookups in groups containing only one shard. Thanks @StoneYunZhao!
-- Add [`strict-error-handling` configuration option](/influxdb/v1.8/administration/config/#strict-error-handling-false). Previously, SELECT INTO queries attempting to insert an unsupported value failed silently. To preserve backwards compatibility, a new `strict-error-handling` option was added to the InfluxDB configuration file. Set this option to `true` to ensure a failed insert returns an error and no points are inserted.
-
 ### Bug fixes
 
-- Ensure successful writes increment `WriteOK` write statistics correctly.
-- Add durations to Flux logging, including log compilation, execution, and total request duration.
-- Properly format JSON marshalling errors.
-- Close all `net.Listener` instances silently on error.
-- `regexp` handling in the prometheus converter complies with Prometheus Query Language (PromQL).
-- GROUP BY queries now correctly set the interval start time before calculating the time-zone offset.
+- Add durations to Flux logging, including the log compilation, execution, and total request duration. Previously, these stats were incorrectly logging `0.000ms`:
+
+  - `stat_total_duration`
+  - `stat_compile_duration`
+  - `stat_queue_duration`
+  - `stat_plan_duration`
+  - `stat_requeue_duration`
+  - `stat_execute_duration`
+
+ Now, these durations are logged correctly. Note, `flux-enabled` and `flux-log-enabled` must be set to `true` in the [InfluxDB configuration file](/influxdb/v1.8/administration/config). For more information about InfluxDB logging, see [Log and trace with InfluxDB](/influxdb/v1.8/administration/logs).
 
 ## v1.8.3 [2020-09-30]
 

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -9,31 +9,31 @@ menu:
 v2: /influxdb/v2.0/reference/release-notes/influxdb/
 ---
 
-## v1.8.4 [2020-01-27]
+## v1.8.4 [2020-02-01]
 
-### Bug fixes
-
-- Add durations to Flux logging, including the log compilation, execution, and total request duration. Previously, these stats were incorrectly logging `0.000ms`:
-
-  - `stat_total_duration`
-  - `stat_compile_duration`
-  - `stat_queue_duration`
-  - `stat_plan_duration`
-  - `stat_requeue_duration`
-  - `stat_execute_duration`
-
- Now, these durations are logged correctly. Note, `flux-enabled` and `flux-log-enabled` must be set to `true` in the [InfluxDB configuration file](/influxdb/v1.8/administration/config). For more information about InfluxDB logging, see [Log and trace with InfluxDB](/influxdb/v1.8/administration/logs).
-
-## v1.8.3 [2020-09-30]
+   > **Note:** InfluxDB 1.8.3 was not released. Features and bug fixes intended for 1.8.3 were rolled into InfluxDB 1.8.4.
 
 ### Features
 
-- Use latest version of InfluxQL package.
+- Use the latest version of InfluxQL package.
 - Add `-lponly` flag to [`influx export`](/influxdb/v2.0/reference/cli/influx/export/).
 - Add the ability to track number of values written via the [/debug/vars HTTP endpoint](/influxdb/v1.8/tools/api/#debug-vars-http-endpoint).
 - Update UUID library from [github.com/satori/go.uuid](https://github.com/satori/go.uuid) to [github.com/gofrs/uuid](https://github.com/gofrs/uuid).
+- Add `stat_total_allocated` to Flux logging.
+ To ensure Flux logging is enabled, set both `flux-enabled` and `flux-log-enabled` to `true` in the [InfluxDB configuration file](/influxdb/v1.8/administration/config). For more information about InfluxDB logging, see [Log and trace with InfluxDB](/influxdb/v1.8/administration/logs).
 
 ### Bug fixes
+
+- Add durations to Flux logging, including the log compilation, execution, and total request duration. Previously, the following stats were incorrectly logging `0.000ms`:
+
+  - `stat_total_duration`
+  - `stat_compile_duration`
+  - `stat_execute_duration`
+  - `stat_queue_duration`
+  - `stat_plan_duration`
+  - `stat_requeue_duration`
+ 
+    Now, these durations are logged correctly. 
 
 - ArrayFilterCursor truncation for multi-block data.
 - Multi-measurement queries now return all applicable series.

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -9,7 +9,7 @@ menu:
 v2: /influxdb/v2.0/reference/release-notes/influxdb/
 ---
 
-## v1.8.4 [unreleased]
+## v1.8.4 [2020-01-27]
 
 ### Bug fixes
 

--- a/content/influxdb/v1.8/administration/config.md
+++ b/content/influxdb/v1.8/administration/config.md
@@ -266,13 +266,15 @@ The query log can be useful for troubleshooting, but logs any sensitive data con
 
 Environment variable: `INFLUXDB_DATA_QUERY_LOG_ENABLED`
 
-#### `strict-error-handling = false`
+<!-- #### `strict-error-handling = false`
 
 When set to `false`, any query attempting to insert an unsupported value, for example `+/-Inf` or `NaN`, fails to insert the unsupported value silently and proceeds to insert any valid points in the query.
 
 Set to `true` to provide more error checking. For example, a SELECT INTO query attempting to insert an `+/-Inf` value, returns an error (rather than failing silently) and no points will be inserted.
 
 Environment variable: `INFLUXDB_DATA_STRICT_ERROR_HANDLING`
+
+-->
 
 #### `validate-keys = false`
 

--- a/content/influxdb/v1.8/administration/config.md
+++ b/content/influxdb/v1.8/administration/config.md
@@ -266,6 +266,14 @@ The query log can be useful for troubleshooting, but logs any sensitive data con
 
 Environment variable: `INFLUXDB_DATA_QUERY_LOG_ENABLED`
 
+#### `strict-error-handling = false`
+
+When set to `false`, any query attempting to insert an unsupported value, for example `+/-Inf` or `NaN`, fails to insert the unsupported value silently and proceeds to insert any valid points in the query.
+
+Set to `true` to provide more error checking. For example, a SELECT INTO query attempting to insert an `+/-Inf` value, returns an error (rather than failing silently) and no points will be inserted.
+
+Environment variable: `INFLUXDB_DATA_STRICT_ERROR_HANDLING`
+
 #### `validate-keys = false`
 
 Validates incoming writes to ensure keys only have valid Unicode characters.


### PR DESCRIPTION
Closes InfluxDB OSS 1.8.4 release notes:
- https://github.com/influxdata/docs-v2/issues/1909
