### PR TITLE
Update commands in readme

### DIFF
--- a/content/influxdb/v2.0/get-started.md
+++ b/content/influxdb/v2.0/get-started.md
@@ -56,7 +56,7 @@ If `gpg` is not available, see the [GnuPG homepage](https://gnupg.org/download/)
 3. Verify the signature with `gpg --verify`:
 
     ```
-    gpg --verify influxdb-2.0.3_darwin_amd64.tar.gz.asc influxdb-2.0.3_darwin_amd64.tar.gz
+    gpg --verify influxdb2.0.3_darwin_amd64.tar.gz.asc influxdb2.0.3_darwin_amd64.tar.gz
     ```
 
     The output from this command should include the following:
@@ -83,7 +83,7 @@ prefix the executables with `./` to run then in place.
 
 ```sh
 # (Optional) Copy the influx and influxd binary to your $PATH
-sudo cp influxdb-2.0.3_darwin_amd64/{influx,influxd} /usr/local/bin/
+sudo cp influxdb2.0.3_darwin_amd64/{influx,influxd} /usr/local/bin/
 ```
 
 {{% note %}}


### PR DESCRIPTION
Updating the commands in the readme file so that the commands actually match the filenames. For some reason a hyphen was added in the file names of the influx-download and the .asc file.
for example these command fails
```
wget https://dl.influxdata.com/influxdb/releases/influxdb-2-2.0.3_darwin_amd64.tar.gz
wget https://dl.influxdata.com/influxdb/releases/influxdb-2-2.0.3_darwin_amd64.tar.gz.asc
```

but these work just fine.

```
wget https://dl.influxdata.com/influxdb/releases/influxdb2-2.0.3_darwin_amd64.tar.gz
wget https://dl.influxdata.com/influxdb/releases/influxdb2-2.0.3_darwin_amd64.tar.gz.asc
```

I simply updated the docs to reflect the correct files

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
