### PR TITLE
Add "Use tokens" documentation

### DIFF
--- a/content/influxdb/cloud/security/tokens/use-tokens.md
+++ b/content/influxdb/cloud/security/tokens/use-tokens.md
@@ -1,0 +1,12 @@
+---
+title: Use tokens
+seotitle: Use an authentication token in InfluxDB
+description: Use an authentication token in InfluxDB using the InfluxDB UI, `influx` CLI, or InfluxDB API
+menu:
+  influxdb_cloud:
+    name: Use tokens
+    parent: Manage tokens
+weight: 203
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/cloud/security/tokens/use-tokens.md
+++ b/content/influxdb/cloud/security/tokens/use-tokens.md
@@ -6,7 +6,7 @@ menu:
   influxdb_cloud:
     name: Use tokens
     parent: Manage tokens
-weight: 203
+weight: 204
 ---
 
 {{< duplicate-oss >}}

--- a/content/influxdb/v2.0/security/tokens/use-tokens.md
+++ b/content/influxdb/v2.0/security/tokens/use-tokens.md
@@ -8,7 +8,7 @@ menu:
   influxdb_2_0:
     name: Use tokens
     parent: Manage tokens
-weight: 201
+weight: 204
 ---
 
 ## Use tokens
@@ -29,6 +29,9 @@ influx write -t <token> -b BUCKET -o org-name <DATA>
 export INFLUX_TOKEN=my-token
 influx write -b my-bucket -org my-org "meaurement field=1"
 ```
+
+_See [here](/influxdb/v2.0/write-data/no-code/use-telegraf/auto-config/#configure-your-token-as-an-environment-variable).
+to configure environment variables on Windows._
 
 ## More examples
 - Use tokens in [API requests](https://docs.influxdata.com/influxdb/v2.0/write-data/developer-tools/api/)

--- a/content/influxdb/v2.0/security/tokens/use-tokens.md
+++ b/content/influxdb/v2.0/security/tokens/use-tokens.md
@@ -1,0 +1,36 @@
+---
+title: Use tokens
+seotitle: Use an authentication token in InfluxDB
+description: Use an authentication token in InfluxDB using the InfluxDB UI, `influx` CLI, or InfluxDB API.
+aliases:
+  - /influxdb/v2.0/users/tokens/use-tokens
+menu:
+  influxdb_2_0:
+    name: Use tokens
+    parent: Manage tokens
+weight: 201
+---
+
+## Use tokens
+
+Tokens are used to authenticate all requests to InfluxDB, whether writing, querying, or managing data and resources.
+This includes requests made with using the `influx` command line as well as API requests made with client libraries and
+tools like `curl`.
+
+### Example with token on command line
+
+```sh
+influx write -t <token> -b BUCKET -o org-name <DATA>
+```
+
+### Example with token in environment variable
+
+```
+export INFLUX_TOKEN=my-token
+influx write -b my-bucket -org my-org "meaurement field=1"
+```
+
+## More examples
+- Use tokens in [API requests](https://docs.influxdata.com/influxdb/v2.0/write-data/developer-tools/api/)
+- Automatically manage and use tokens from the CLI using [`influx config`](/influxdb/v2.0/reference/cli/influx/config/).
+- Make authenticated requests with tokens [using Postman](https://docs.influxdata.com/influxdb/v2.0/tools/postman/)

--- a/content/influxdb/v2.0/security/tokens/use-tokens.md
+++ b/content/influxdb/v2.0/security/tokens/use-tokens.md
@@ -11,29 +11,38 @@ menu:
 weight: 204
 ---
 
-## Use tokens
-
 Use tokens to authenticate requests to InfluxDB, including requests to write, query, and manage data and resources.
-Authenticate requests using the `influx` command line, API requests made with client libraries, and
-tools like `curl`.
+Authenticate requests using the [`influx` CLI](/influxdb/v2.0/reference/cli/influx/), API requests made with client libraries, and tools like `curl`.
 
-### Example with token on command line
+## Add a token to a CLI request
+
+### Example: token on command line
 
 ```sh
 influx write -t <token> -b BUCKET -o org-name <DATA>
 ```
 
-### Example with token in environment variable
+### Example: token in environment variable
 
 ```
 export INFLUX_TOKEN=my-token
 influx write -b my-bucket -org my-org "meaurement field=1"
 ```
 
-_See [here](/influxdb/v2.0/write-data/no-code/use-telegraf/auto-config/#configure-your-token-as-an-environment-variable).
-to configure environment variables on Windows._
+{{% note %}}
+See [here](/influxdb/v2.0/write-data/no-code/use-telegraf/auto-config/#configure-your-token-as-an-environment-variable)
+to configure environment variables on Windows.
+(Click on the **Windows** tab.)
+{{% /note %}}
 
-## More examples
-- Use tokens in [API requests](https://docs.influxdata.com/influxdb/v2.0/write-data/developer-tools/api/)
-- Automatically manage and use tokens from the CLI using [`influx config`](/influxdb/v2.0/reference/cli/influx/config/).
-- Make authenticated requests with tokens [using Postman](https://docs.influxdata.com/influxdb/v2.0/tools/postman/)
+### Use CLI configurations
+
+Automatically manage and use tokens from the CLI using [`influx config`](/influxdb/v2.0/reference/cli/influx/config/).
+
+## Use a token in an API request
+
+Use tokens in [API requests](https://docs.influxdata.com/influxdb/v2.0/write-data/developer-tools/api/).
+
+## Add a token to Postman
+
+Make authenticated requests with tokens [using Postman](https://docs.influxdata.com/influxdb/v2.0/tools/postman/).

--- a/content/influxdb/v2.0/security/tokens/use-tokens.md
+++ b/content/influxdb/v2.0/security/tokens/use-tokens.md
@@ -14,7 +14,7 @@ weight: 201
 ## Use tokens
 
 Use tokens to authenticate requests to InfluxDB, including requests to write, query, and manage data and resources.
-This includes requests made with using the `influx` command line as well as API requests made with client libraries and
+Authenticate requests using the `influx` command line, API requests made with client libraries, and
 tools like `curl`.
 
 ### Example with token on command line

--- a/content/influxdb/v2.0/security/tokens/use-tokens.md
+++ b/content/influxdb/v2.0/security/tokens/use-tokens.md
@@ -14,15 +14,11 @@ weight: 204
 Use tokens to authenticate requests to InfluxDB, including requests to write, query, and manage data and resources.
 Authenticate requests using the [`influx` CLI](/influxdb/v2.0/reference/cli/influx/), API requests made with client libraries, and tools like `curl`.
 
-## Add a token to a CLI request
-
-### Example: token on command line
+### Add a token to a CLI request
 
 ```sh
-influx write -t <token> -b BUCKET -o org-name <DATA>
+influx write -t <token> -b BUCKET -o org-name <LINE PROTOCOL>
 ```
-
-### Example: token in environment variable
 
 ```
 export INFLUX_TOKEN=my-token
@@ -39,10 +35,10 @@ to configure environment variables on Windows.
 
 Automatically manage and use tokens from the CLI using [`influx config`](/influxdb/v2.0/reference/cli/influx/config/).
 
-## Use a token in an API request
+### Use a token in an API request
 
 Use tokens in [API requests](https://docs.influxdata.com/influxdb/v2.0/write-data/developer-tools/api/).
 
-## Add a token to Postman
+### Use a token in Postman
 
 Make authenticated requests with tokens [using Postman](https://docs.influxdata.com/influxdb/v2.0/tools/postman/).

--- a/content/influxdb/v2.0/security/tokens/use-tokens.md
+++ b/content/influxdb/v2.0/security/tokens/use-tokens.md
@@ -13,7 +13,7 @@ weight: 201
 
 ## Use tokens
 
-Tokens are used to authenticate all requests to InfluxDB, whether writing, querying, or managing data and resources.
+Use tokens to authenticate requests to InfluxDB, including requests to write, query, and manage data and resources.
 This includes requests made with using the `influx` command line as well as API requests made with client libraries and
 tools like `curl`.
 


### PR DESCRIPTION
Add a page called "Use tokens" to "Manage tokens". This gives two minimal examples using the CLI and links to other existing documentation.

Closes #2054

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
