### PR TITLE
fix: wrong file name in get-started.md

### DIFF
--- a/content/influxdb/v2.0/get-started.md
+++ b/content/influxdb/v2.0/get-started.md
@@ -56,7 +56,7 @@ If `gpg` is not available, see the [GnuPG homepage](https://gnupg.org/download/)
 3. Verify the signature with `gpg --verify`:
 
     ```
-    gpg --verify influxdb2.0.3_darwin_amd64.tar.gz.asc influxdb2.0.3_darwin_amd64.tar.gz
+    gpg --verify influxdb2-2.0.3_darwin_amd64.tar.gz.asc influxdb2.0.3_darwin_amd64.tar.gz
     ```
 
     The output from this command should include the following:
@@ -83,7 +83,7 @@ prefix the executables with `./` to run then in place.
 
 ```sh
 # (Optional) Copy the influx and influxd binary to your $PATH
-sudo cp influxdb2.0.3_darwin_amd64/{influx,influxd} /usr/local/bin/
+sudo cp influxdb2-2.0.3_darwin_amd64/{influx,influxd} /usr/local/bin/
 ```
 
 {{% note %}}


### PR DESCRIPTION
Closes #2092

Fix wrong file name in get-started.md

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
