### PR TITLE
Re-order LDAP instructions

### DIFF
--- a/content/enterprise_influxdb/v1.8/administration/ldap.md
+++ b/content/enterprise_influxdb/v1.8/administration/ldap.md
@@ -78,60 +78,59 @@ For more detail on authentication, see [Authentication and authorization in Infl
     For more information, see [Fine-grained authorization in InfluxDB Enterprise](/enterprise_influxdb/v1.8/guides/fine-grained-authorization/).
     The InfluxDB admin user doesn't include permissions for InfluxDB Enterprise roles.
 
-3. To verify your LDAP configuration, run:
+3. Restart all meta and data nodes in your InfluxDB Enterprise cluster to load your updated configuration.
+
+   On each **meta** node, run:
+
+   {{< code-tabs-wrapper >}}
+   {{% code-tabs %}}
+   [sysvinit](#)
+   [systemd](#)
+   {{% /code-tabs %}}
+   {{% code-tab-content %}}
+   ```sh
+   service influxdb-meta restart
+   ```
+   {{% /code-tab-content %}}
+   {{% code-tab-content %}}
+   ```sh
+   sudo systemctl restart influxdb-meta
+   ```
+   {{% /code-tab-content %}}
+   {{< /code-tabs-wrapper >}}
+
+   On each **data** node, run:
+
+   {{< code-tabs-wrapper >}}
+   {{% code-tabs %}}
+   [sysvinit](#)
+   [systemd](#)
+   {{% /code-tabs %}}
+   {{% code-tab-content %}}
+   ```sh
+   service influxdb restart
+   ```
+   {{% /code-tab-content %}}
+   {{% code-tab-content %}}
+   ```sh
+   sudo systemctl restart influxdb
+   ```
+   {{% /code-tab-content %}}
+   {{< /code-tabs-wrapper >}}
+
+
+4. To verify your LDAP configuration, run:
 
     ```bash
     influxd-ctl ldap verify -ldap-config /path/to/ldap.toml
     ```
 
-4. To load your LDAP configuration file, run the following command:
+5. To load your LDAP configuration file, run the following command:
 
     ```bash
     influxd-ctl ldap set-config /path/to/ldap.toml
     ```
 
-###  Restart meta and data nodes
-
-Restart all meta and data nodes in your InfluxDB Enterprise cluster to load your
-updated configuration.
-
-On each **meta** node, run:
-
-{{< code-tabs-wrapper >}}
-{{% code-tabs %}}
-[sysvinit](#)
-[systemd](#)
-{{% /code-tabs %}}
-{{% code-tab-content %}}
-```sh
-service influxdb-meta restart
-```
-{{% /code-tab-content %}}
-{{% code-tab-content %}}
-```sh
-sudo systemctl restart influxdb-meta
-```
-{{% /code-tab-content %}}
-{{< /code-tabs-wrapper >}}
-
-On each **data** node, run:
-
-{{< code-tabs-wrapper >}}
-{{% code-tabs %}}
-[sysvinit](#)
-[systemd](#)
-{{% /code-tabs %}}
-{{% code-tab-content %}}
-```sh
-service influxdb restart
-```
-{{% /code-tab-content %}}
-{{% code-tab-content %}}
-```sh
-sudo systemctl restart influxdb
-```
-{{% /code-tab-content %}}
-{{< /code-tabs-wrapper >}}
 
 ## Sample LDAP configuration
 


### PR DESCRIPTION
Instruct users to restart the service before verifying LDAP configuration.

Fixes #2021

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
