### PR TITLE
add telegraf 1.15.4 to release notes

### DIFF
--- a/content/telegraf/v1.15/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.15/about_the_project/release-notes-changelog.md
@@ -9,7 +9,7 @@ menu:
 ---
 
 
-## v1.16 [2020-09-11]
+## v1.16 [2020-10-21]
 
 ### Features
 - agent Send metrics in FIFO order
@@ -38,6 +38,13 @@ See EXTERNAL_PLUGINS.md for a full list of external plugins
 awsalarms - Simple plugin to gather/monitor alarms generated in AWS.
 youtube-telegraf-plugin - Gather view and subscriber stats from your youtube videos
 
+## v1.15.4 [2020-10-20]
+
+### Bug fixes
+- `agent` 
+  - Fix panic error on streaming processers
+- `common.shim` 
+  - Fix an issue with loading the processor configuration from `execd`
 
 ## v.1.15.3 [2020-09-11]
 

--- a/content/telegraf/v1.15/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.15/about_the_project/release-notes-changelog.md
@@ -41,10 +41,8 @@ youtube-telegraf-plugin - Gather view and subscriber stats from your youtube vid
 ## v1.15.4 [2020-10-20]
 
 ### Bug fixes
-- `agent` 
-  - Fix panic error on streaming processers
-- `common.shim` 
-  - Fix an issue with loading the processor configuration from `execd`
+- `agent`: Fix panic error on streaming processers.
+- `common.shim`: Fix an issue with loading the processor configuration from `execd`.
 
 ## v.1.15.3 [2020-09-11]
 


### PR DESCRIPTION
a 1.15.4 patch was technically released but only a few hours before 1.16 so didn't go through the normal process.

Closes #1709

_Describe your proposed changes here._


