### PR TITLE
InfluxDB OSS 1.8.4 updates

### DIFF
--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -17,7 +17,7 @@ v2: /influxdb/v2.0/reference/release-notes/influxdb/
 
 - Use the latest version of InfluxQL package.
 - Add `-lponly` flag to [`influx_inspect export`](/influxdb/v1.8/tools/influx_inspect/#export).
-- Add the ability to track number of values (fields) written via the [/debug/vars HTTP endpoint](/influxdb/v1.8/tools/api/#debug-vars-http-endpoint).
+- Add the ability to [track number of values](/platform/monitoring/influxdata-platform/tools/measurements-internal/#valueswrittenok) written via the [/debug/vars HTTP endpoint](/influxdb/v1.8/tools/api/#debug-vars-http-endpoint).
 - Update UUID library from [github.com/satori/go.uuid](https://github.com/satori/go.uuid) to [github.com/gofrs/uuid](https://github.com/gofrs/uuid).
 - Add `stat_total_allocated` to Flux logging.
  To ensure Flux logging is enabled, set both `flux-enabled` and `flux-log-enabled` to `true` in the [InfluxDB configuration file](/influxdb/v1.8/administration/config). For more information about InfluxDB logging, see [Log and trace with InfluxDB](/influxdb/v1.8/administration/logs).

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -16,8 +16,8 @@ v2: /influxdb/v2.0/reference/release-notes/influxdb/
 ### Features
 
 - Use the latest version of InfluxQL package.
-- Add `-lponly` flag to [`influx export`](/influxdb/v2.0/reference/cli/influx/export/).
-- Add the ability to track number of values written via the [/debug/vars HTTP endpoint](/influxdb/v1.8/tools/api/#debug-vars-http-endpoint).
+- Add `-lponly` flag to [`influx_inspect export`](/influxdb/v1.8/tools/influx_inspect/#export).
+- Add the ability to track number of values (fields) written via the [/debug/vars HTTP endpoint](/influxdb/v1.8/tools/api/#debug-vars-http-endpoint).
 - Update UUID library from [github.com/satori/go.uuid](https://github.com/satori/go.uuid) to [github.com/gofrs/uuid](https://github.com/gofrs/uuid).
 - Add `stat_total_allocated` to Flux logging.
  To ensure Flux logging is enabled, set both `flux-enabled` and `flux-log-enabled` to `true` in the [InfluxDB configuration file](/influxdb/v1.8/administration/config). For more information about InfluxDB logging, see [Log and trace with InfluxDB](/influxdb/v1.8/administration/logs).

--- a/content/influxdb/v1.8/tools/api.md
+++ b/content/influxdb/v1.8/tools/api.md
@@ -288,6 +288,7 @@ curl http://localhost:8086/debug/vars
 ```
 
 Server statistics and information are displayed in JSON format.
+For information about InfluxDB HTTP server metrics, see the [`httpd` measurement](/platform/monitoring/influxdata-platform/tools/measurements-internal/#httpd).
 
 >**Note:** The [InfluxDB input plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/influxdb) is available to collect metrics (using the `/debug/vars` endpoint) from specified Kapacitor instances. For a list of the measurements and fields, see the [InfluxDB input plugin README](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/influxdb#readme).
 

--- a/content/platform/monitoring/influxdata-platform/tools/measurements-internal.md
+++ b/content/platform/monitoring/influxdata-platform/tools/measurements-internal.md
@@ -524,7 +524,7 @@ The number of points dropped by the storage engine.
 The number of points accepted by the HTTP `/write` endpoint, but unable to be persisted.
 
 #### pointsWrittenOK
-The number of points accepted by the HTTP `/write` endpoint and persisted successfully.
+The number of points successfully accepted and persisted by the HTTP `/write` endpoint.
 
 #### promReadReq
 The number of read requests to the Prometheus `/read` endpoint.
@@ -560,7 +560,7 @@ The number of HTTP responses due to server errors.
 The number of status requests served using the HTTP `/status` endpoint.
 
 #### valuesWrittenOK
-The number of values (fields) accepted by the HTTP `/write` endpoint that persisted successfully.
+The number of values (fields) successfully accepted and persisted by the HTTP `/write` endpoint.
 #### writeReq
 The number of write requests served using the HTTP `/write` endpoint.
 

--- a/content/platform/monitoring/influxdata-platform/tools/measurements-internal.md
+++ b/content/platform/monitoring/influxdata-platform/tools/measurements-internal.md
@@ -559,6 +559,8 @@ The number of HTTP responses due to server errors.
 #### statusReq
 The number of status requests served using the HTTP `/status` endpoint.
 
+#### valuesWrittenOK
+The number of values (fields) accepted by the HTTP `/write` endpoint that persisted successfully.
 #### writeReq
 The number of write requests served using the HTTP `/write` endpoint.
 


### PR DESCRIPTION
Edits from Tim:
- Update release notes to show the`lponly` flag was added to `influx_inspect export` command
- Add `valuesWrittenOK` to the `httpd` measurement
- Update InfluxDB 1.x `/debug/vars` HTTP endpoint to include a link to the `httpd` measurement
