### PR TITLE
Improve systemd installation docs for InfluxDB 2.0

### DIFF
--- a/content/influxdb/v2.0/get-started.md
+++ b/content/influxdb/v2.0/get-started.md
@@ -224,8 +224,10 @@ The following instructions have been tested on Ubuntu, and should work similarly
    ```sh
    sudo service influxdb start
    ```
-   Installing the InfluxDB package creates a service file at `/lib/systemd/services/influxdb.service`
-   to start InfluxDB as a background service on startup.
+   Installing the InfluxDB package creates a service file at to start InfluxDB as a background service on startup.
+   The localtion depends on your operating system:
+     - Ubuntu: `/lib/systemd/services/influxdb.service`
+     - Debian: `/lib/systemd/system/influxdb.service`
 3. Restart your system and verify that the service is running correctly:
    ```sh
    $  sudo service influxdb status

--- a/content/influxdb/v2.0/get-started.md
+++ b/content/influxdb/v2.0/get-started.md
@@ -209,25 +209,28 @@ If you rename the binaries, all references to `influx` and `influxd` in this doc
 
 ### Install InfluxDB as a service with systemd
 
-{{% note %}}
-The following instructions have been tested on Ubuntu, and should work similarly on other Linux distributions.
-{{% /note %}}
+{{< tabs-wrapper >}}
 
-1. Download and install the appropriate `.deb` file using a URL from the [InfluxData downloads page](https://portal.influxdata.com/downloads/)
+{{% tabs %}}
+[Ubuntu/Debian](#)
+[Red Hat](#)
+{{% /tabs %}}
+
+{{% tab-content %}}
+1. Download and install the appropriate `.deb` file
+   using a URL from the [InfluxData downloads page](https://portal.influxdata.com/downloads/)
    with the following commands:
    ```sh
    wget https://dl.influxdata.com/influxdb/releases/influxdb2_2.x.x_xxx
-   sudo dpkg -i influxdb2_2.x.x_xxx
+   sudo dpkg -i influxdb2_2.x.x_xxx.deb
    ```
    _Use the exact filename of the download of `.deb` package (for example, `influxdb2_2.0.3_amd64.deb`)._
 2. Start the InfluxDB service:
    ```sh
    sudo service influxdb start
    ```
-   Installing the InfluxDB package creates a service file at to start InfluxDB as a background service on startup.
-   The localtion depends on your operating system:
-     - Ubuntu: `/lib/systemd/services/influxdb.service`
-     - Debian: `/lib/systemd/system/influxdb.service`
+   Installing the InfluxDB package creates a service file at `/lib/systemd/services/influxdb.service`
+   to start InfluxDB as a background service on startup.
 3. Restart your system and verify that the service is running correctly:
    ```sh
    $  sudo service influxdb status
@@ -235,6 +238,31 @@ The following instructions have been tested on Ubuntu, and should work similarly
      Loaded: loaded (/lib/systemd/system/influxdb.service; enabled; vendor preset: enable>
      Active: active (running)
    ```
+{{% /tab-content %}}
+{{% tab-content %}}
+1. Download and install the appropriate `.rpm` file
+   using a URL from the [InfluxData downloads page](https://portal.influxdata.com/downloads/)
+   with the following commands:
+   ```sh
+   wget https://dl.influxdata.com/influxdb/releases/influxdb2_2.x.x_xxx
+   sudo yum localinstall influxdb2_2.x.x_xxx.rpm
+   ```
+   _Use the exact filename of the download of `.rpm` package (for example, `influxdb2_2.0.3_amd64.rpm`)._
+2. Start the InfluxDB service:
+   ```sh
+   sudo service influxdb start
+   ```
+   Installing the InfluxDB package creates a service file at `/lib/systemd/services/influxdb.service`
+   to start InfluxDB as a background service on startup.
+3. Restart your system and verify that the service is running correctly:
+   ```sh
+   $  sudo service influxdb status
+   ● influxdb.service - InfluxDB is an open-source, distributed, time series database
+     Loaded: loaded (/lib/systemd/system/influxdb.service; enabled; vendor preset: enable>
+     Active: active (running)
+   ```
+{{% /tab-content %}}
+{{< /tabs-wrapper >}}
 
 ### Networking ports
 

--- a/content/influxdb/v2.0/get-started.md
+++ b/content/influxdb/v2.0/get-started.md
@@ -209,29 +209,18 @@ If you rename the binaries, all references to `influx` and `influxd` in this doc
 
 ### Install InfluxDB as a service with systemd
 
-1. Download and install the appropriate `.deb` or `.rpm` file
-   using a URL from the [InfluxData downloads page](https://portal.influxdata.com/downloads/)
-   with the following commands:
-   {{< code-tabs-wrapper >}}
-   {{% code-tabs %}}
-   [Ubuntu/Debian](#)
-   [Red Hat/CentOS/Fedora](#)
-   {{% /code-tabs %}}
-   {{% code-tab-content %}} <!-- `.deb` -->
-   ```bash
-   wget https://dl.influxdata.com/influxdb/releases/influxdb2_2.x.x_xxx.deb
-   sudo dpkg -i influxdb2_2.x.x_xxx.deb
-   ```
-   _Use the exact filename of the download of `.deb` package (for example, `influxdb2_2.0.3_amd64.deb`)._
-   {{% /code-tab-content %}}
-   {{% code-tab-content %}} <!-- `.rpm` -->
-   ```bash
-   wget https://dl.influxdata.com/influxdb/releases/influxdb2_2.x.x_xxx.rpm
-   sudo yum localinstall influxdb2_2.x.x_xxx.deb.rpm
-   ```
-   _Use the exact filename of the download of `.rpm` package (for example, `influxdb2_2.0.3_amd64.rpm`)._
-   {{% /code-tab-content %}}
-   {{< /code-tabs-wrapper >}}
+1.  Download and install the appropriate `.deb` or `.rpm` file using a URL from the
+    [InfluxData downloads page](https://portal.influxdata.com/downloads/)
+    with the following commands:
+    ```sh
+    # Ubuntu/Debian
+    wget https://dl.influxdata.com/influxdb/releases/influxdb2_2.x.x_xxx.deb
+    sudo dpkg -i influxdb2_2.x.x_xxx.deb
+    # Red Hat/CentOS/Fedora
+    wget https://dl.influxdata.com/influxdb/releases/influxdb2_2.x.x_xxx.rpm
+    sudo yum localinstall influxdb2_2.x.x_xxx.deb.rpm
+    ```
+    _Use the exact filename of the download of `.rpm` package (for example, `influxdb2_2.0.3_amd64.rpm`)._
 2. Start the InfluxDB service:
    ```sh
    sudo service influxdb start

--- a/content/influxdb/v2.0/get-started.md
+++ b/content/influxdb/v2.0/get-started.md
@@ -209,45 +209,29 @@ If you rename the binaries, all references to `influx` and `influxd` in this doc
 
 ### Install InfluxDB as a service with systemd
 
-{{< tabs-wrapper >}}
-
-{{% tabs %}}
-[Ubuntu/Debian](#)
-[Red Hat](#)
-{{% /tabs %}}
-
-{{% tab-content %}}
-1. Download and install the appropriate `.deb` file
+1. Download and install the appropriate `.deb` or `.rpm` file
    using a URL from the [InfluxData downloads page](https://portal.influxdata.com/downloads/)
    with the following commands:
-   ```sh
-   wget https://dl.influxdata.com/influxdb/releases/influxdb2_2.x.x_xxx
+   {{< code-tabs-wrapper >}}
+   {{% code-tabs %}}
+   [Ubuntu/Debian](#)
+   [Red Hat/CentOS/Fedora](#)
+   {{% /code-tabs %}}
+   {{% code-tab-content %}} <!-- `.deb` -->
+   ```bash
+   wget https://dl.influxdata.com/influxdb/releases/influxdb2_2.x.x_xxx.deb
    sudo dpkg -i influxdb2_2.x.x_xxx.deb
    ```
    _Use the exact filename of the download of `.deb` package (for example, `influxdb2_2.0.3_amd64.deb`)._
-2. Start the InfluxDB service:
-   ```sh
-   sudo service influxdb start
-   ```
-   Installing the InfluxDB package creates a service file at `/lib/systemd/services/influxdb.service`
-   to start InfluxDB as a background service on startup.
-3. Restart your system and verify that the service is running correctly:
-   ```sh
-   $  sudo service influxdb status
-   ● influxdb.service - InfluxDB is an open-source, distributed, time series database
-     Loaded: loaded (/lib/systemd/system/influxdb.service; enabled; vendor preset: enable>
-     Active: active (running)
-   ```
-{{% /tab-content %}}
-{{% tab-content %}}
-1. Download and install the appropriate `.rpm` file
-   using a URL from the [InfluxData downloads page](https://portal.influxdata.com/downloads/)
-   with the following commands:
-   ```sh
-   wget https://dl.influxdata.com/influxdb/releases/influxdb2_2.x.x_xxx
-   sudo yum localinstall influxdb2_2.x.x_xxx.rpm
+   {{% /code-tab-content %}}
+   {{% code-tab-content %}} <!-- `.rpm` -->
+   ```bash
+   wget https://dl.influxdata.com/influxdb/releases/influxdb2_2.x.x_xxx.rpm
+   sudo yum localinstall influxdb2_2.x.x_xxx.deb.rpm
    ```
    _Use the exact filename of the download of `.rpm` package (for example, `influxdb2_2.0.3_amd64.rpm`)._
+   {{% /code-tab-content %}}
+   {{< /code-tabs-wrapper >}}
 2. Start the InfluxDB service:
    ```sh
    sudo service influxdb start
@@ -261,8 +245,6 @@ If you rename the binaries, all references to `influx` and `influxd` in this doc
      Loaded: loaded (/lib/systemd/system/influxdb.service; enabled; vendor preset: enable>
      Active: active (running)
    ```
-{{% /tab-content %}}
-{{< /tabs-wrapper >}}
 
 ### Networking ports
 


### PR DESCRIPTION
Edits following review of systemd installation docs for InfluxDB 2.0. `.deb` and `.rpm` are both covered now. (Tested locally on Ubuntu 20 and Fedora 30.)

~### Note~

~Currently clicking the tabs for this content leads to strange behavior, moving to wrong parts of the page, content seemingly disappearing...~

This is work toward #2136.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
