### PR TITLE
Update k8s "Get started" docs

### DIFF
--- a/content/influxdb/v2.0/get-started.md
+++ b/content/influxdb/v2.0/get-started.md
@@ -326,7 +326,7 @@ docker exec -it influxdb /bin/bash
 The instructions below use minikube or kind, but the steps should be similar in any Kubernetes cluster.
 InfluxData also makes [Helm charts](https://github.com/influxdata/helm-charts) available.
 
-1. [Install minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) or
+1. Install [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) or
    [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation).
 
 2. Start a local cluster:

--- a/content/influxdb/v2.0/get-started.md
+++ b/content/influxdb/v2.0/get-started.md
@@ -323,15 +323,20 @@ docker exec -it influxdb /bin/bash
 
 ### Install InfluxDB in a Kubernetes cluster
 
-The instructions below use Minikube, but the steps should be similar in any Kubernetes cluster.
+The instructions below use minikube or kind, but the steps should be similar in any Kubernetes cluster.
 InfluxData also makes [Helm charts](https://github.com/influxdata/helm-charts) available.
 
-1. [Install Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/).
+1. [Install minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) or
+   [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation).
 
-2. Start Minikube:
+2. Start a local cluster:
 
     ```sh
+    # with minikube
     minikube start
+
+    # with kind
+    kind create cluster
     ```
 
 3. Apply the [sample InfluxDB configuration](https://github.com/influxdata/docs-v2/blob/master/static/downloads/influxdb-k8-minikube.yaml) by running:

--- a/content/influxdb/v2.0/get-started.md
+++ b/content/influxdb/v2.0/get-started.md
@@ -323,7 +323,7 @@ docker exec -it influxdb /bin/bash
 
 ### Install InfluxDB in a Kubernetes cluster
 
-The instructions below use minikube or kind, but the steps should be similar in any Kubernetes cluster.
+The instructions below use **minikube** or **kind**, but the steps should be similar in any Kubernetes cluster.
 InfluxData also makes [Helm charts](https://github.com/influxdata/helm-charts) available.
 
 1. Install [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) or

--- a/static/downloads/influxdb-k8-minikube.yaml
+++ b/static/downloads/influxdb-k8-minikube.yaml
@@ -23,7 +23,7 @@ spec:
                 app: influxdb
         spec:
             containers:
-              - image: quay.io/influxdb/influxdb:v2.0.1
+              - image: quay.io/influxdb/influxdb:v2.0.3
                 name: influxdb
                 ports:
                   - containerPort: 8086


### PR DESCRIPTION
Noticed some easy improvements to the Kubernetes section of the InfluxDB "Get started" doc:

- Add instructions for using kind
- Bump version to 2.0.3

---

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
