### PR TITLE
Update link to influx-cxx

### DIFF
--- a/content/influxdb/v1.7/tools/api_client_libraries.md
+++ b/content/influxdb/v1.7/tools/api_client_libraries.md
@@ -1,6 +1,6 @@
 ---
 title: InfluxDB client libraries
-description: InfluxDB client libraries include support for Elixir, Go, Haskell, Java, JavaScript/Node.js, Lisp, MATLAB, .Net, Perl, PHP, Python, R, Ruby, Rust, Scala, Sensu, and the SNMP agent.
+description: InfluxDB client libraries include support for Elixir, C++, Go, Haskell, Java, JavaScript/Node.js, Lisp, MATLAB, .Net, Perl, PHP, Python, R, Ruby, Rust, Scala, Sensu, and the SNMP agent.
 aliases:
     - /influxdb/v1.7/clients/api_client_libraries/
     - /influxdb/v1.7/clients/

--- a/content/influxdb/v1.7/tools/api_client_libraries.md
+++ b/content/influxdb/v1.7/tools/api_client_libraries.md
@@ -19,8 +19,8 @@ InfluxDB client libraries are developed by the open source community. These clie
 Thanks to the open source community for your contributions, commitment, and effort!
 
 ## C++
-* [influxdb-cxx](https://github.com/awegrzyn/influxdb-cxx.git)
-  * Maintained by [Adam Wegrzynek (awegrzyn)](https://github.com/awegrzyn)
+* [influxdb-cxx](https://github.com/offa/influxdb-cxx)
+  * Maintained by [offa](https://github.com/offa)
 
 ## Elixir
 

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -1,7 +1,7 @@
 ---
 title: InfluxDB client libraries
 description: >
-  InfluxDB client libraries includes support for Arduino, C#, Go, Java, JavaScript, PHP, Python, and Ruby.
+  InfluxDB client libraries includes support for Arduino, C#, C++, Go, Java, JavaScript, PHP, Python, and Ruby.
 aliases:
     - /influxdb/v1.8/clients/api_client_libraries/
     - /influxdb/v1.8/clients/
@@ -30,6 +30,10 @@ Functionality varies between client libraries. Refer to client libraries on GitH
 
 - [influxdb-client-csharp](https://github.com/influxdata/influxdb-client-csharp)
   - Maintained by [InfluxData](https://github.com/influxdata)
+
+## C++
+* [influxdb-cxx](https://github.com/offa/influxdb-cxx)
+  * Maintained by [offa](https://github.com/offa)
 
 ### Go
 


### PR DESCRIPTION
Originally linked project is unmaintained, new link goes to active fork

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
