### PR TITLE
Update external-monitor-setup.md

### DIFF
--- a/content/platform/monitoring/influxdata-platform/external-monitor-setup.md
+++ b/content/platform/monitoring/influxdata-platform/external-monitor-setup.md
@@ -98,7 +98,7 @@ from the local Kapacitor `/debug/vars` endpoint.
 ```toml
 # ...
 
-[[inputs.influxdb]]
+[[inputs.kapacitor]]
   # ...
   ## Multiple URLs from which to read Kapacitor-formatted JSON
   ## Default is "http://localhost:9092/kapacitor/v1/debug/vars".


### PR DESCRIPTION
Fixed typo in configuration example of **Monitor Kapacitor performance metrics**

- [X] Tests pass (no build errors)
- [X] Rebased/mergeable
