### PR TITLE
Add robots.txt and staging config file

### DIFF
--- a/config.staging.toml
+++ b/config.staging.toml
@@ -1,4 +1,4 @@
-baseURL = "https://docs.influxdata.com/"
+baseURL = "https://test2.docs.influxdata.com/"
 languageCode = "en-us"
 title = "InfluxDB Documentation"
 

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,1 @@
+User-agent: *{{ if ne .Site.BaseURL "https://docs.influxdata.com/" }} Disallow: /{{ end }}


### PR DESCRIPTION
This change is to prevent google and other search engines from indexing the staging site.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
