### PR TITLE
Link to DockerHub for upgrade instructions.

### DIFF
--- a/content/influxdb/v2.0/upgrade/v1-to-v2/_index.md
+++ b/content/influxdb/v2.0/upgrade/v1-to-v2/_index.md
@@ -17,8 +17,7 @@ The `upgrade` command provides an in-place upgrade from InfluxDB 1.x to InfluxDB
 {{% note %}}
 #### Docker users
 
-We have implemented as separate upgrade process to ensure a smooth transition from InfluxDB 1.x to InfluxDB 2.0 on Docker.
-See the "Upgrading from InfluxDB 1.x" section in the [DockerHub docs](https://hub.docker.com/_/influxdb) for instructions and examples.
+To upgrade from InfluxDB 1.x to InfluxDB 2.0 on Docker, see  "Upgrading from InfluxDB 1.x" in the [Docker Hub documentation](https://hub.docker.com/_/influxdb) for instructions and examples.
 {{% /note %}}
 
 Specifically, the upgrade process does the following:

--- a/content/influxdb/v2.0/upgrade/v1-to-v2/_index.md
+++ b/content/influxdb/v2.0/upgrade/v1-to-v2/_index.md
@@ -17,8 +17,8 @@ The `upgrade` command provides an in-place upgrade from InfluxDB 1.x to InfluxDB
 {{% note %}}
 #### Docker users
 
-We are working on the upgrade process to ensure a smooth upgrade from InfluxDB 1.x to InfluxDB 2.0 on Docker.
-If you're upgrading from InfluxDB 1.x on Docker, we recommend waiting to upgrade until we finalize an updated Docker release given the current process is undefined.
+We have implemented as separate upgrade process to ensure a smooth transition from InfluxDB 1.x to InfluxDB 2.0 on Docker.
+See the "Upgrading from InfluxDB 1.x" section in the [DockerHub docs](https://hub.docker.com/_/influxdb) for instructions and examples.
 {{% /note %}}
 
 Specifically, the upgrade process does the following:


### PR DESCRIPTION
Quick-fix to reflect that the upgrade process is now in place (might want to copy the info / examples directly into the site in the future, instead of ref-ing DockerHub). The notice box now looks like:
![image](https://user-images.githubusercontent.com/2755881/109342723-45d5ae00-783a-11eb-9899-dd4afdd63ce5.png)
After docker-library/docs#1882 merges, the info about upgrading to 1.x will be at the top of the content there. Unfortunately it doesn't seem possible to link directly to a header on a DockerHub page...

- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
