### PR TITLE
One Newline seperated is rendered as a single line

### DIFF
--- a/content/telegraf/v1.17/introduction/installation.md
+++ b/content/telegraf/v1.17/introduction/installation.md
@@ -88,10 +88,15 @@ sudo apt-get update && sudo apt-get install apt-transport-https
 # Add the InfluxData key
 
 wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+
 source /etc/os-release
+
 test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+
 test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+
 test $VERSION_ID = "9" && echo "deb https://repos.influxdata.com/debian stretch stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+
 test $VERSION_ID = "10" && echo "deb https://repos.influxdata.com/debian buster stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
 {{% /code-tab-content %}}


### PR DESCRIPTION
See https://docs.influxdata.com/telegraf/v1.17/introduction/installation/ in the section about debian.

Closes #

As seen in the documentation, if the markdown is just seperated by a single newline it is rendered as a single line, which results in the first `source` not being interpreted as a command.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors) (pretty sure the newlines wont break the tests :^) )
- [x] Rebased/mergeable
