### PR TITLE
Revert "Add video to automatically configure Telegraf"

### DIFF
--- a/content/influxdb/v2.0/write-data/no-code/use-telegraf/auto-config.md
+++ b/content/influxdb/v2.0/write-data/no-code/use-telegraf/auto-config.md
@@ -25,8 +25,6 @@ Only a subset of plugins are configurable using the InfluxDB UI.
 To use plugins other than those listed, you must [manually configure Telegraf](/influxdb/v2.0/write-data/no-code/use-telegraf/manual-config).
 {{% /note %}}
 
-{{< youtube M8KP7FAb2L0 >}}
-
 {{% note %}}
 _View the [requirements](/influxdb/v2.0/write-data/no-code/use-telegraf#requirements)
 for using Telegraf with InfluxDB v2.0._


### PR DESCRIPTION
Reverts influxdata/docs-v2#2122

This video is Cloud-specific. It should be added to the Cloud docs.