### PR TITLE
Simple annotations

### DIFF
--- a/content/influxdb/cloud/visualize-data/annotations.md
+++ b/content/influxdb/cloud/visualize-data/annotations.md
@@ -27,17 +27,17 @@ Annotations may be useful to highlight operations or anomalies for your team to 
 
     {{< nav-icon "dashboards" >}}
 
-2. Select an existing dashboard to add the annotation to, or [create a new dashboard](/influxdb/v2.0/visualize-data/dashboards/create-dashboard/).
-3. Click **Annotations**. The **Show Annotations** and **Enable 1-Click Annotations** options appear selected. To add an annotation, the **Enable 1-Click Annotations** option must be selected.
-4. In any dashboard cell, click the point in time (within the selected graph range) to add the annotation.
+2. Select an existing dashboard to add the annotation to, or [create a new dashboard](/influxdb/cloud/visualize-data/dashboards/create-dashboard/).
+3. Click **Annotations**. The **Show Annotations** option is selected by default.
+4. Select the **Enable 1-Click Annotations** option, and then in any dashboard cell, click the point in time to add the annotation.
   {{% note %}}
-**Tip:** To move the annotation outside of the selected graph time range, you must first create the annotation, and then edit the annotation to update the timestamp as needed.
-{{% /note %}}
+**Tip:** To move the annotation outside of the selected graph time range, you must first create the annotation, and then [edit the annotation](#edit-an-annotation) to update the timestamp as needed.
+  {{% /note %}}
 5. On the **Add Annotation** page:
-   - Verify the start time, and update if needed.
-   - Enter a message (maximum of 255 characters) to associate with the selected start time.
 
-5. Click **Save Annotation** (or press **Enter**). The annotation appears as a line at the specified start time in all dashboard cells.
+   1. Verify the start time, and update if needed.
+   2. Enter a message (maximum of 255 characters) to associate with the selected start time.
+   3. Click **Save Annotation**. The annotation appears as a dotted line at the specified start time and includes details associated with the selected point.
 
 ## Edit an annotation
 
@@ -46,7 +46,7 @@ Annotations may be useful to highlight operations or anomalies for your team to 
     {{< nav-icon "dashboards" >}}
 
 2. Open the dashboard with the annotation to edit, and then click the annotation to open it.
-3. Update the text (maximum of 255 characters) or timestamp, and then click **Save Annotation** (or press **Enter**).
+3. Update the text (maximum of 255 characters) or timestamp, and then click **Save Annotation**.
 
 ## View or hide annotations
 
@@ -66,5 +66,4 @@ Select or clear the **Show Annotations** option to hide or show annotations.
 1.  In the navigation menu on the left, select **Boards** (**Dashboards**).
 
     {{< nav-icon "dashboards" >}}
-2. Open a dashboard with the annotation to delete, click **Annotations**, and select the **Show Annotations** option.
-3. Click the annotation line to delete, and then click **Delete**.
+2. Open a dashboard with the annotation to delete, click the dotted annotation line, and then click **Delete Annotation**.

--- a/content/influxdb/cloud/visualize-data/annotations.md
+++ b/content/influxdb/cloud/visualize-data/annotations.md
@@ -21,7 +21,7 @@ Add annotations to your dashboards to provide useful, contextual information abo
 Annotations may be useful to highlight operations or anomalies for your team to reference.
 {{% /note %}}
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/5NEplCesNAc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+{{< youtube 5NEplCesNAc >}}
 
 ## Create an annotation
 

--- a/content/influxdb/cloud/visualize-data/annotations.md
+++ b/content/influxdb/cloud/visualize-data/annotations.md
@@ -1,7 +1,7 @@
 ---
 title: Use annotations in dashboards
 description: >
-  Add annotations to your dashboards to provide useful, contextual information about single points in time.
+  Add annotations to your InfluxDB dashboards to provide useful, contextual information about single points in time.
 influxdb/cloud/tags: [labels]
 menu:
   influxdb_cloud:

--- a/content/influxdb/cloud/visualize-data/annotations.md
+++ b/content/influxdb/cloud/visualize-data/annotations.md
@@ -2,7 +2,7 @@
 title: Use annotations in dashboards
 description: >
   Add annotations to your InfluxDB dashboards to provide useful, contextual information about single points in time.
-influxdb/cloud/tags: [labels]
+influxdb/cloud/tags: [labels, annotations]
 menu:
   influxdb_cloud:
     name: Use annotations

--- a/content/influxdb/cloud/visualize-data/annotations.md
+++ b/content/influxdb/cloud/visualize-data/annotations.md
@@ -14,6 +14,7 @@ Add annotations to your dashboards to provide useful, contextual information abo
 
 - [Create an annotation](#create-an-annotation)
 - [Edit an annotation](#edit-an-annotation)
+- [View or hide annotations](#view-or-hide-annotations)
 - [Delete an annotation](#delete-an-annotation)
 
 ## Create an annotation

--- a/content/influxdb/cloud/visualize-data/annotations.md
+++ b/content/influxdb/cloud/visualize-data/annotations.md
@@ -2,15 +2,19 @@
 title: Use annotations in dashboards
 description: >
   Add annotations to your dashboards to provide useful, contextual information about single points in time.
-influxdb/v2.0/tags: [labels]
+influxdb/cloud/tags: [labels]
 menu:
-  influxdb_2_0:
+  influxdb_cloud:
     name: Use annotations
     parent: Visualize data
 weight: 104
 ---
 
-Add annotations to your dashboards to provide useful, contextual information about single points in time. Edit annotations to change information, including the text or timestamp.
+Add annotations to your dashboards to provide useful, contextual information about single points in time. For example, highlight maintenance, such as sensor calibrations, or other operations for your team to reference. After an annotation is created, edit the annotation by updating the text or timestamp, or delete the annotation.
+
+[Create an annotation](#create-an-annotation)
+[Edit an annotation](#edit-an-annotation)
+[Delete an annotation](#delete-an-annotation)
 
 #### Create an annotation
 

--- a/content/influxdb/cloud/visualize-data/annotations.md
+++ b/content/influxdb/cloud/visualize-data/annotations.md
@@ -12,9 +12,9 @@ weight: 104
 
 Add annotations to your dashboards to provide useful, contextual information about single points in time. For example, highlight maintenance, such as sensor calibrations, or other operations for your team to reference. After an annotation is created, edit the annotation by updating the text or timestamp, or delete the annotation.
 
-[Create an annotation](#create-an-annotation)
-[Edit an annotation](#edit-an-annotation)
-[Delete an annotation](#delete-an-annotation)
+- [Create an annotation](#create-an-annotation)
+- [Edit an annotation](#edit-an-annotation)
+- [Delete an annotation](#delete-an-annotation)
 
 #### Create an annotation
 

--- a/content/influxdb/cloud/visualize-data/annotations.md
+++ b/content/influxdb/cloud/visualize-data/annotations.md
@@ -16,7 +16,7 @@ Add annotations to your dashboards to provide useful, contextual information abo
 - [Edit an annotation](#edit-an-annotation)
 - [Delete an annotation](#delete-an-annotation)
 
-#### Create an annotation
+## Create an annotation
 
 1. In the navigation menu on the left, select **Boards** (**Dashboards**).
 
@@ -34,7 +34,7 @@ Add annotations to your dashboards to provide useful, contextual information abo
 
 5. Click **Save Annotation** (or press **Enter**). The annotation appears as a line at the specified start time in all dashboard cells.
 
-#### Edit an annotation
+## Edit an annotation
 
 1.  In the navigation menu on the left, select **Boards** (**Dashboards**).
 
@@ -43,7 +43,7 @@ Add annotations to your dashboards to provide useful, contextual information abo
 2. Open the dashboard with the annotation to edit, and then click the annotation to open it.
 3. Update the text (maximum of 255 characters) or timestamp, and then click **Save Annotation** (or press **Enter**).
 
-#### View or hide annotations
+## View or hide annotations
 
 By default, annotations are visible.
 Select or clear the **Show Annotations** option to hide or show annotations.
@@ -56,7 +56,7 @@ Select or clear the **Show Annotations** option to hide or show annotations.
    - To hide annotations, clear the **Show Annotations** option.
    - To show annotations, select the **Show Annotations** option.
 
-#### Delete an annotation
+## Delete an annotation
 
 1.  In the navigation menu on the left, select **Boards** (**Dashboards**).
 

--- a/content/influxdb/cloud/visualize-data/annotations.md
+++ b/content/influxdb/cloud/visualize-data/annotations.md
@@ -33,7 +33,7 @@ Annotations may be useful to highlight operations or anomalies for your team to 
 3. Click **Annotations**. The **Show Annotations** option is selected by default.
 4. Select the **Enable 1-Click Annotations** option, and then in any dashboard cell, click the point in time to add the annotation.
   {{% note %}}
-**Tip:** To move the annotation outside of the selected graph time range, you must first create the annotation, and then [edit the annotation](#edit-an-annotation) to update the timestamp as needed.
+**Tip:** To move the annotation outside of the selected graph time range, first create the annotation, and then [edit the annotation](#edit-an-annotation) to update the timestamp as needed.
   {{% /note %}}
 5. On the **Add Annotation** page:
 

--- a/content/influxdb/cloud/visualize-data/annotations.md
+++ b/content/influxdb/cloud/visualize-data/annotations.md
@@ -10,7 +10,11 @@ menu:
 weight: 104
 ---
 
-Add annotations to your dashboards to provide useful, contextual information about single points in time. For example, highlight maintenance, such as sensor calibrations, or other operations for your team to reference. After an annotation is created, edit the annotation by updating the text or timestamp, or delete the annotation.
+Add annotations to your dashboards to provide useful, contextual information about single points in time. After an annotation is created, edit the annotation by updating the text or timestamp, or delete the annotation.
+
+{{% note %}}
+Annotations may be useful to highlight operations or anomalies for your team to reference.
+{{% /note %}}
 
 - [Create an annotation](#create-an-annotation)
 - [Edit an annotation](#edit-an-annotation)

--- a/content/influxdb/cloud/visualize-data/annotations.md
+++ b/content/influxdb/cloud/visualize-data/annotations.md
@@ -12,14 +12,16 @@ weight: 104
 
 Add annotations to your dashboards to provide useful, contextual information about single points in time. After an annotation is created, edit the annotation by updating the text or timestamp, or delete the annotation.
 
-{{% note %}}
-Annotations may be useful to highlight operations or anomalies for your team to reference.
-{{% /note %}}
-
 - [Create an annotation](#create-an-annotation)
 - [Edit an annotation](#edit-an-annotation)
 - [View or hide annotations](#view-or-hide-annotations)
 - [Delete an annotation](#delete-an-annotation)
+
+{{% note %}}
+Annotations may be useful to highlight operations or anomalies for your team to reference.
+{{% /note %}}
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/5NEplCesNAc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Create an annotation
 

--- a/content/influxdb/cloud/visualize-data/dashboards/control-dashboard.md
+++ b/content/influxdb/cloud/visualize-data/dashboards/control-dashboard.md
@@ -10,7 +10,6 @@ menu:
 weight: 203
 ---
 
-## Control at the dashboard level
 
 Use dashboard controls in the upper left to update your dashboard.
 

--- a/content/influxdb/cloud/visualize-data/dashboards/control-dashboard.md
+++ b/content/influxdb/cloud/visualize-data/dashboards/control-dashboard.md
@@ -10,7 +10,6 @@ menu:
 weight: 203
 ---
 
-
 Use dashboard controls in the upper left to update your dashboard.
 
 ### Add a cell

--- a/content/influxdb/cloud/visualize-data/dashboards/create-dashboard.md
+++ b/content/influxdb/cloud/visualize-data/dashboards/create-dashboard.md
@@ -54,8 +54,8 @@ weight: 201
 
 2. Select the **Templates** tab.
 
-  - In the **Static Templates** tab, a list of pre-created templates appears.
-  - In the **User Templates** tab, a list of custom user-created templates appears.
+   - In the **Static Templates** tab, a list of pre-created templates appears.
+   - In the **User Templates** tab, a list of custom user-created templates appears.
 
 3. Hover over the name of the template you want to create a dashboard from, then click **Create**.
 

--- a/content/influxdb/cloud/visualize-data/dashboards/create-dashboard.md
+++ b/content/influxdb/cloud/visualize-data/dashboards/create-dashboard.md
@@ -12,7 +12,6 @@ menu:
 weight: 201
 ---
 
-## Create a new dashboard
 
 1. In the navigation menu on the left, select **Boards** (**Dashboards**).
 

--- a/content/influxdb/cloud/visualize-data/dashboards/create-dashboard.md
+++ b/content/influxdb/cloud/visualize-data/dashboards/create-dashboard.md
@@ -20,7 +20,6 @@ weight: 201
 2. Click the **{{< icon "plus" >}} Create Dashboard** menu in the upper right and select **New Dashboard**.
 3. Enter a name for your dashboard in the **Name this dashboard** field in the upper left.
 
-
 **To import an existing dashboard**:
 
 1. In the navigation menu on the left, select **Boards** (**Dashboards**).
@@ -29,8 +28,10 @@ weight: 201
 
 2. Click the **Create Dashboard** menu in the upper right and select **Import Dashboard**.
 3. In the window that appears:
-  * Select **Upload File** to drag-and-drop or select a file.
-  * Select **Paste JSON** to paste in JSON.
+
+   - Select **Upload File** to drag-and-drop or select a file.
+   - Select **Paste JSON** to paste in JSON.
+   
 4. Click **Import JSON as Dashboard**.
 
 ## Create dashboards with templates

--- a/content/influxdb/v2.0/query-data/flux/sql.md
+++ b/content/influxdb/v2.0/query-data/flux/sql.md
@@ -391,4 +391,4 @@ Download and import the Air Sensors dashboard to visualize the generated data:
 
 <a class="btn download" href="/downloads/air-sensors-dashboard.json" download>Download Air Sensors dashboard</a>
 
-_For information about importing a dashboard, see [Create a dashboard](/influxdb/v2.0/visualize-data/dashboards/create-dashboard/#create-a-new-dashboard)._
+_For information about importing a dashboard, see [Create a dashboard](/influxdb/v2.0/visualize-data/dashboards/create-dashboard)._

--- a/content/influxdb/v2.0/visualize-data/annotations.md
+++ b/content/influxdb/v2.0/visualize-data/annotations.md
@@ -1,0 +1,54 @@
+---
+title: Use annotations in dashboards
+description: >
+  Add annotations to your dashboards to provide useful, contextual information about single points in time or time intervals. Use annotations to correlate the effects of important events, such as system changes or outages across multiple metrics.
+influxdb/v2.0/tags: [labels]
+menu:
+  influxdb_2_0:
+    name: Use annotations
+    parent: Visualize data
+weight: 104
+---
+
+Add annotations to your dashboards to provide useful, contextual information about single points in time or time intervals. Use annotations to correlate the effects of important events, such as system changes or outages across multiple metrics.
+
+#### Create an annotation
+
+1. In the navigation menu on the left, select **Boards** (**Dashboards**).
+
+    {{< nav-icon "dashboards" >}}
+
+2. Select the dashboard to add the annotation to. Or [create a new dashboard](/influxdb/v2.0/visualize-data/dashboards/create-dashboard/).
+3. Click **Annotations**, and then search for an annotation stream (find out more/clarify).
+3. _(Optional)_ Select **Enable 1-Click Annotations** to (find out more/clarify).
+4. Click the gear <insert graphic> to open the Annotations tab on the Settings page.
+5. Click **Create Label**.
+
+#### Edit an annotation
+
+1. In the label list view, click the name of the label you would like to edit.
+   The **Edit Label** overlay will appear.
+2. Make the desired changes to the label.
+3. Click **Save Changes**.
+
+#### View annotations
+
+1. In the navigation menu on the left, select **Settings** > **Annotations**.
+Click **{{< icon "plus" >}} Create Label**.
+2. Enter a **Name** for the label.
+3. Enter a description for the label _(Optional)_.
+4. Select a **Color** for the label.
+5. Click **Create Label**.
+
+#### Delete an annotation
+
+1. In the label list view, hover over the label you would like to delete and click **{{< icon "trash" >}}**.
+2. Click **Delete**.
+
+### Add annotations to a dashboard
+
+1. In the list view of dashboards, tasks, or other assets, hover over the item to which you would like to add a label.
+2. Click the {{< icon "add-label" >}} icon that appears below the name.
+   The **Add Labels** overlay will appear.
+3. Type the name of the label you would like to add to filter the list of available labels.
+   Click the label you would like to add.

--- a/content/influxdb/v2.0/visualize-data/annotations.md
+++ b/content/influxdb/v2.0/visualize-data/annotations.md
@@ -27,8 +27,6 @@ Add annotations to your dashboards to provide useful, contextual information abo
 
 5. Click **Save Annotation**. The annotation appears as a line at the specified start time in all dashboard cells.
 
-<!-->
-TBD not yet implemented
 #### Edit an annotation
 
 1.  In the navigation menu on the left, select **Boards** (**Dashboards**).
@@ -37,7 +35,6 @@ TBD not yet implemented
 
 2. Open the dashboard with the annotation to edit, and then click the annotation to open it.
 3. Update the text (or timestamp?), and then click **Save Annotation**.
--->
 
 #### View or hide annotations
 
@@ -52,9 +49,6 @@ Select or clear the **Show Annotations** option to hide or show annotations.
    - To hide annotations, clear the **Show Annotations** option.
    - To show annotations, select the **Show Annotations** option.
 
-<!-->
-
-TBD not yet implemented
 #### Delete an annotation
 
 1.  In the navigation menu on the left, select **Boards** (**Dashboards**).
@@ -63,4 +57,3 @@ TBD not yet implemented
 2. Open a dashboard with the annotation to delete, click **Annotations**, and select the **Show Annotations** option.
 3. Click the annotation line to delete, and then click **Delete**.
 
--->

--- a/content/influxdb/v2.0/visualize-data/annotations.md
+++ b/content/influxdb/v2.0/visualize-data/annotations.md
@@ -1,7 +1,7 @@
 ---
 title: Use annotations in dashboards
 description: >
-  Add annotations to your dashboards to provide useful, contextual information about single points in time or time intervals. Use annotations to correlate the effects of important events, such as system changes or outages across multiple metrics.
+  Add annotations to your dashboards to provide useful, contextual information about single points in time.
 influxdb/v2.0/tags: [labels]
 menu:
   influxdb_2_0:
@@ -10,7 +10,9 @@ menu:
 weight: 104
 ---
 
-Add annotations to your dashboards to provide useful, contextual information about single points in time or time intervals. Use annotations to correlate the effects of important events, such as system changes or outages across multiple metrics.
+Add annotations to your dashboards to provide useful, contextual information about single points in time.
+
+<!-- On the Settings page, Annotation not implemented. 404. -->
 
 #### Create an annotation
 
@@ -18,37 +20,49 @@ Add annotations to your dashboards to provide useful, contextual information abo
 
     {{< nav-icon "dashboards" >}}
 
-2. Select the dashboard to add the annotation to. Or [create a new dashboard](/influxdb/v2.0/visualize-data/dashboards/create-dashboard/).
-3. Click **Annotations**, and then search for an annotation stream (find out more/clarify).
-3. _(Optional)_ Select **Enable 1-Click Annotations** to (find out more/clarify).
-4. Click the gear <insert graphic> to open the Annotations tab on the Settings page.
-5. Click **Create Label**.
+2. Select an existing dashboard to add the annotation to, or [create a new dashboard](/influxdb/v2.0/visualize-data/dashboards/create-dashboard/).
+3. Click **Annotations**. The **Show Annotations** and **Enable 1-Click Annotations** options appear selected. To add an annotation, the **Enable 1-Click Annotations** option must be selected.
+4. In any dashboard cell, click the point in time to add the annotation.
+5. On the **Add Annotation** page:
+   - Verify the start time, and update if needed.
+   - Enter a message to associate with the selected start time.
 
+5. Click **Save Annotation**. The annotation appears as a line at the specified start time in all dashboard cells.
+
+<!-->
+TBD not yet implemented
 #### Edit an annotation
 
-1. In the label list view, click the name of the label you would like to edit.
-   The **Edit Label** overlay will appear.
-2. Make the desired changes to the label.
-3. Click **Save Changes**.
+1.  In the navigation menu on the left, select **Boards** (**Dashboards**).
 
-#### View annotations
+    {{< nav-icon "dashboards" >}}
 
-1. In the navigation menu on the left, select **Settings** > **Annotations**.
-Click **{{< icon "plus" >}} Create Label**.
-2. Enter a **Name** for the label.
-3. Enter a description for the label _(Optional)_.
-4. Select a **Color** for the label.
-5. Click **Create Label**.
+2. Open the dashboard with the annotation to edit, and then click the annotation to open it.
+3. Update the text (or timestamp?), and then click **Save Annotation**.
+-->
 
+#### View or hide annotations
+
+By default, annotations are visible.
+Select or clear the **Show Annotations** option to hide or show annotations.
+
+1.  In the navigation menu on the left, select **Boards** (**Dashboards**).
+
+    {{< nav-icon "dashboards" >}}
+
+2. Open a dashboard with annotations, click **Annotations**, and then do one of the following:
+   - To hide annotations, clear the **Show Annotations** option.
+   - To show annotations, select the **Show Annotations** option.
+
+<!-->
+
+TBD not yet implemented
 #### Delete an annotation
 
-1. In the label list view, hover over the label you would like to delete and click **{{< icon "trash" >}}**.
-2. Click **Delete**.
+1.  In the navigation menu on the left, select **Boards** (**Dashboards**).
 
-### Add annotations to a dashboard
+    {{< nav-icon "dashboards" >}}
+2. Open a dashboard with the annotation to delete, click **Annotations**, and select the **Show Annotations** option.
+3. Click the annotation line to delete, and then click **Delete**.
 
-1. In the list view of dashboards, tasks, or other assets, hover over the item to which you would like to add a label.
-2. Click the {{< icon "add-label" >}} icon that appears below the name.
-   The **Add Labels** overlay will appear.
-3. Type the name of the label you would like to add to filter the list of available labels.
-   Click the label you would like to add.
+-->

--- a/content/influxdb/v2.0/visualize-data/annotations.md
+++ b/content/influxdb/v2.0/visualize-data/annotations.md
@@ -10,7 +10,7 @@ menu:
 weight: 104
 ---
 
-Add annotations to your dashboards to provide useful, contextual information about single points in time.
+Add annotations to your dashboards to provide useful, contextual information about single points in time. Edit annotations to change information, including the text or timestamp.
 
 #### Create an annotation
 
@@ -20,12 +20,15 @@ Add annotations to your dashboards to provide useful, contextual information abo
 
 2. Select an existing dashboard to add the annotation to, or [create a new dashboard](/influxdb/v2.0/visualize-data/dashboards/create-dashboard/).
 3. Click **Annotations**. The **Show Annotations** and **Enable 1-Click Annotations** options appear selected. To add an annotation, the **Enable 1-Click Annotations** option must be selected.
-4. In any dashboard cell, click the point in time to add the annotation.
+4. In any dashboard cell, click the point in time (within the selected graph range) to add the annotation.
+  {{% note %}}
+**Tip:** To move the annotation outside of the selected graph time range, you must first create the annotation, and then edit the annotation to update the timestamp as needed.
+{{% /note %}}
 5. On the **Add Annotation** page:
    - Verify the start time, and update if needed.
-   - Enter a message to associate with the selected start time.
+   - Enter a message (maximum of 255 characters) to associate with the selected start time.
 
-5. Click **Save Annotation**. The annotation appears as a line at the specified start time in all dashboard cells.
+5. Click **Save Annotation** (or press **Enter**). The annotation appears as a line at the specified start time in all dashboard cells.
 
 #### Edit an annotation
 
@@ -34,7 +37,7 @@ Add annotations to your dashboards to provide useful, contextual information abo
     {{< nav-icon "dashboards" >}}
 
 2. Open the dashboard with the annotation to edit, and then click the annotation to open it.
-3. Update the text (or timestamp?), and then click **Save Annotation**.
+3. Update the text (maximum of 255 characters) or timestamp, and then click **Save Annotation** (or press **Enter**).
 
 #### View or hide annotations
 
@@ -56,4 +59,3 @@ Select or clear the **Show Annotations** option to hide or show annotations.
     {{< nav-icon "dashboards" >}}
 2. Open a dashboard with the annotation to delete, click **Annotations**, and select the **Show Annotations** option.
 3. Click the annotation line to delete, and then click **Delete**.
-

--- a/content/influxdb/v2.0/visualize-data/annotations.md
+++ b/content/influxdb/v2.0/visualize-data/annotations.md
@@ -12,8 +12,6 @@ weight: 104
 
 Add annotations to your dashboards to provide useful, contextual information about single points in time.
 
-<!-- On the Settings page, Annotation not implemented. 404. -->
-
 #### Create an annotation
 
 1. In the navigation menu on the left, select **Boards** (**Dashboards**).


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/1972

@russorat, think this is ready for your review. 

I reviewed the channel discussion and tools cluster, and made the following doc updates:

- Uncommented edit and delete procedures.
- Removed annotations on Settings.
- Updated UI elements with new names in Tools.
- Added tip about moving annotation outside of graph range by editing. 
- Updated text to reflect Annotations no longer needs to be selected for annotations to be visible.
- Moved annotations to Cloud only.
- Noted 255 char limit for both new and edit annotation texts.
- Added overview links in doc.
- Noted annotation may be useful for highlighting operations and anomalies to teams to reference.

fwiw, saw discussion about pressing Enter (Return) to save/update annotation, but that doesn't appear to be working on Tools, so left that out. 