### PR TITLE
Fix option syntax in Influx CLI example

### DIFF
--- a/content/influxdb/cloud/process-data/manage-tasks/create-task.md
+++ b/content/influxdb/cloud/process-data/manage-tasks/create-task.md
@@ -111,7 +111,7 @@ influx task create --org my-org -f /tasks/cq-mean-1h.flux
 ```sh
 influx task create --org my-org - # <return> to open stdin pipe
 
-options task = {
+option task = {
   name: "task-name",
   every: 6h
 }


### PR DESCRIPTION
The _Create a task using raw Flux_ example for [Create a task using the influx CLI](https://docs.influxdata.com/influxdb/cloud/process-data/manage-tasks/create-task/#create-a-task-using-the-influx-cli) shows `options` instead of the correct `option`.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
