### PR TITLE
Debian/Ubuntu installation: use separate keyring for InfluxDB key

### DIFF
--- a/content/influxdb/v1.8/introduction/install.md
+++ b/content/influxdb/v1.8/introduction/install.md
@@ -59,7 +59,7 @@ please see the
 Debian and Ubuntu users can install the latest stable version of InfluxDB using the
 `apt-get` package manager.
 
-For Ubuntu users, add the InfluxData repository with the following commands:
+For Ubuntu/Debian users, add the InfluxData repository with the following commands:
 
 {{< code-tabs-wrapper >}}
 {{% code-tabs %}}
@@ -67,50 +67,21 @@ For Ubuntu users, add the InfluxData repository with the following commands:
 [curl](#)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
-```bash
-sudo mkdir -p /etc/apt/keyrings
-wget -qO- https://repos.influxdata.com/influxdb.key | gpg --dearmor | sudo tee /etc/apt/keyrings/influxdb.gpg > /dev/null
-source /etc/lsb-release
-echo "deb [signed-by=/etc/apt/keyrings/influxdb.gpg] https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+```sh
+wget -qO- https://repos.influxdata.com/influxdb.key | gpg --dearmor > /etc/apt/trusted.gpg.d/influxdb.gpg
+export DISTRIB_ID=$(lsb_release -si); export DISTRIB_CODENAME=$(lsb_release -sc)
+echo "deb [signed-by=/etc/apt/trusted.gpg.d/influxdb.gpg] https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" > /etc/apt/sources.list.d/influxdb.list
 ```
 {{% /code-tab-content %}}
 
 {{% code-tab-content %}}
-```bash
-sudo mkdir -p /etc/apt/keyrings
-wget -qO- https://repos.influxdata.com/influxdb.key | gpg --dearmor | sudo tee /etc/apt/keyrings/influxdb.gpg > /dev/null
-source /etc/lsb-release
-echo "deb [signed-by=/etc/apt/keyrings/influxdb.gpg] https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+```sh
+curl -s https://repos.influxdata.com/influxdb.key | gpg --dearmor > /etc/apt/trusted.gpg.d/influxdb.gpg
+export DISTRIB_ID=$(lsb_release -si); export DISTRIB_CODENAME=$(lsb_release -sc)
+echo "deb [signed-by=/etc/apt/trusted.gpg.d/influxdb.gpg] https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" > /etc/apt/sources.list.d/influxdb.list
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
-
-For Debian users, add the InfluxData repository:
-
-{{< code-tabs-wrapper >}}
-{{% code-tabs %}}
-[wget](#)
-[curl](#)
-{{% /code-tabs %}}
-{{% code-tab-content %}}
-```bash
-sudo mkdir -p /etc/apt/keyrings
-wget -qO- https://repos.influxdata.com/influxdb.key | gpg --dearmor | sudo tee /etc/apt/keyrings/influxdb.gpg > /dev/null
-source /etc/os-release
-echo "deb https://repos.influxdata.com/debian $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
-```
-{{% /code-tab-content %}}
-
-{{% code-tab-content %}}
-```bash
-sudo mkdir -p /etc/apt/keyrings
-wget -qO- https://repos.influxdata.com/influxdb.key | gpg --dearmor | sudo tee /etc/apt/keyrings/influxdb.gpg > /dev/null
-source /etc/os-release
-echo "deb https://repos.influxdata.com/debian $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
-```
-{{% /code-tab-content %}}
-{{< /code-tabs-wrapper >}}
-
 
 Then, install and start the InfluxDB service:
 

--- a/content/influxdb/v1.8/introduction/install.md
+++ b/content/influxdb/v1.8/introduction/install.md
@@ -68,17 +68,19 @@ For Ubuntu users, add the InfluxData repository with the following commands:
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```bash
-wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+sudo mkdir -p /etc/apt/keyrings
+wget -qO- https://repos.influxdata.com/influxdb.key | gpg --dearmor | sudo tee /etc/apt/keyrings/influxdb.gpg > /dev/null
 source /etc/lsb-release
-echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+echo "deb [signed-by=/etc/apt/keyrings/influxdb.gpg] https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
 {{% /code-tab-content %}}
 
 {{% code-tab-content %}}
 ```bash
-curl -s https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+sudo mkdir -p /etc/apt/keyrings
+wget -qO- https://repos.influxdata.com/influxdb.key | gpg --dearmor | sudo tee /etc/apt/keyrings/influxdb.gpg > /dev/null
 source /etc/lsb-release
-echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+echo "deb [signed-by=/etc/apt/keyrings/influxdb.gpg] https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
@@ -92,7 +94,8 @@ For Debian users, add the InfluxData repository:
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```bash
-wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+sudo mkdir -p /etc/apt/keyrings
+wget -qO- https://repos.influxdata.com/influxdb.key | gpg --dearmor | sudo tee /etc/apt/keyrings/influxdb.gpg > /dev/null
 source /etc/os-release
 echo "deb https://repos.influxdata.com/debian $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
@@ -100,7 +103,8 @@ echo "deb https://repos.influxdata.com/debian $(lsb_release -cs) stable" | sudo 
 
 {{% code-tab-content %}}
 ```bash
-curl -s https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+sudo mkdir -p /etc/apt/keyrings
+wget -qO- https://repos.influxdata.com/influxdb.key | gpg --dearmor | sudo tee /etc/apt/keyrings/influxdb.gpg > /dev/null
 source /etc/os-release
 echo "deb https://repos.influxdata.com/debian $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```


### PR DESCRIPTION
See #2286.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
