### PR TITLE
Kapacitor 1.5.9 release notes

### DIFF
--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -10,30 +10,6 @@ menu:
 
 ## Features
 
-- Send full event payload on pagerduty resolve, thanks @asvinours!
-- Add default color theme to teams alerts, thanks @NoamShaish!
-- Add barrier handling to `FlattenNode`.
-- Fix TICKscript AST for BigPanda.
-
-### Bug fixes
-
-- Ensure large batch writes with `influx` gzip are completely written to InfluxDB.
-- Update function node name `ServiceNow` handler to camelcase.
-- Fix memory leaks in `JoinNode` and `UnionNode`.
-- Avoid infinite hang when closing Kafka writer and prevent the timeout error that occurred when updating the Kafka configuration file (`kapacitor.conf`) via http.
-
-## v1.5.8 [2020-01-27]
-
-{{% warn %}}
-If you’ve installed this release, please roll back to v1.5.7 as soon as possible. This release introduced a defect wherein large batch tasks will not completely write all points back to InfluxDB. This primarily affects downsampling tasks where information is written to another retention policy. If the source retention policy is short there is the potential for the source data to age out and the downsample to have never been fully written.
-{{% /warn %}}
-
-<!--## Breaking changes
-
-- Remove support for `darwin/386` builds (Go no longer supports), and add support for `darwin/arm64` builds.
-
-## Features
-
 #### New event handler
 
 - Add new [BigPanda event handler](/kapacitor/v1.5/event_handlers/bigpanda).
@@ -54,11 +30,26 @@ If you’ve installed this release, please roll back to v1.5.7 as soon as possib
 - Send data to InfluxDB compressed as `gzip` by default. Although, this default configuration does not appear in the Kapacitor configuration file, you can add `compression = "none"` to the [InfluxDB section](/kapacitor/v1.5/administration/configuration/#influxdb) of your Kapacitor configuration file.
 - Preallocate `GroupIDs` to increase performance by reducing allocations.
 
+#### Miscellaneous event updates
+
+- Send the full event payload to [Pagerduty](/influxdb/v2.0/reference/flux/stdlib/pagerduty/sendevent) when the `eventAction` is `resolve`, thanks @asvinours!
+- Add the default color theme to [Microsoft Teams](/kapacitor/v1.5/event_handlers/microsoftteams/) alerts, thanks @NoamShaish!
+- Add barrier handling to [FlattenNode](/kapacitor/v1.5/nodes/flatten_node/) to ensure points are successfully emitted.
+
 ### Bug fixes
 
+- Ensure large batch writes with `influx` gzip are completely written to InfluxDB.
+- Update function node name `ServiceNow` handler to camelcase.
+- Fix memory leaks in `JoinNode` and `UnionNode`.
+- Avoid infinite hang when closing Kafka writer and prevent the timeout error that occurred when updating the Kafka configuration file (`kapacitor.conf`) via http.
+- Remove support for `darwin/386` builds (Go no longer supports), and add support for `darwin/arm64` builds.
 - Rename the alert-handler match function `duration()` to `alertDuration()` to avoid name collision with the type conversion function of the same name.
 
--->
+## v1.5.8 [2020-01-27]
+
+{{% warn %}}
+If you’ve installed this release, please roll back to v1.5.7 as soon as possible. This release introduced a defect wherein large batch tasks will not completely write all points back to InfluxDB. This primarily affects downsampling tasks where information is written to another retention policy. If the source retention policy is short there is the potential for the source data to age out and the downsample to have never been fully written.
+{{% /warn %}}
 
 ## v1.5.7 [2020-10-26]
 
@@ -67,7 +58,7 @@ If you’ve installed this release, please roll back to v1.5.7 as soon as possib
 - Add the `.recoveryaction()` method to support overriding the OpsGenieV2 alert recovery action in a TICKscript, thanks @zabullet!
 - Add support for templating URLs in the [`httpPost` node](/kapacitor/v1.5/nodes/http_post_node/) and [`alert` node](/kapacitor/v1.5/nodes/alert_node/). To set up an template:
   - For the `alert` node, see [alert templates](/kapacitor/v1.5/event_handlers/post/#alert-templates).
-  - For the `http post` node, see [row templates](/kapacitor/v1.5/event_handlers/post/#row-templates).
+  - For the `http post` node, see [row, a templates](/kapacitor/v1.5/event_handlers/post/#row-templates).
 - Upgrade `github.com/gorhill/cronexpr`, thanks @wuguanyu!
 - Add the [ServiceNow event handler](/kapacitor/v1.5/event_handlers/servicenow/) to support ServiceNow integration and provide proxy support.
 

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -6,7 +6,7 @@ menu:
     parent: About the project
 ---
 
-## v1.5.9 [TBD]
+## v1.5.9 [2021-04-01]
 
 ## Features
 

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -58,7 +58,7 @@ If you’ve installed this release, please roll back to v1.5.7 as soon as possib
 - Add the `.recoveryaction()` method to support overriding the OpsGenieV2 alert recovery action in a TICKscript, thanks @zabullet!
 - Add support for templating URLs in the [`httpPost` node](/kapacitor/v1.5/nodes/http_post_node/) and [`alert` node](/kapacitor/v1.5/nodes/alert_node/). To set up an template:
   - For the `alert` node, see [alert templates](/kapacitor/v1.5/event_handlers/post/#alert-templates).
-  - For the `http post` node, see [row, a templates](/kapacitor/v1.5/event_handlers/post/#row-templates).
+  - For the `http post` node, see [row templates](/kapacitor/v1.5/event_handlers/post/#row-templates).
 - Upgrade `github.com/gorhill/cronexpr`, thanks @wuguanyu!
 - Add the [ServiceNow event handler](/kapacitor/v1.5/event_handlers/servicenow/) to support ServiceNow integration and provide proxy support.
 

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -13,7 +13,7 @@ menu:
 - Send full event payload on pagerduty resolve, thanks @asvinours!
 - Add default color theme to teams alerts, thanks @NoamShaish!
 - Add barrier handling to `FlattenNode`.
-- Fix TICKScript AST for BigPanda.
+- Fix TICKscript AST for BigPanda.
 
 ### Bug fixes
 

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -42,7 +42,7 @@ menu:
 - Update function node name `ServiceNow` handler to camelcase.
 - Fix memory leaks in `JoinNode` and `UnionNode`.
 - Avoid infinite hang when closing Kafka writer and prevent the timeout error that occurred when updating the Kafka configuration file (`kapacitor.conf`) via http.
-- Remove support for `darwin/386` builds (Go no longer supports), and add support for `darwin/arm64` builds.
+- Remove support for `darwin/386` builds (Go no longer supports).
 - Rename the alert-handler match function `duration()` to `alertDuration()` to avoid name collision with the type conversion function of the same name.
 
 ## v1.5.8 [2020-01-27]

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -6,6 +6,22 @@ menu:
     parent: About the project
 ---
 
+## v1.5.9 [TBD]
+
+## Features
+
+- Send full event payload on pagerduty resolve, thanks @asvinours!
+- Add default color theme to teams alerts, thanks @NoamShaish!
+- Add barrier handling to `FlattenNode`.
+- Fix TICKScript AST for BigPanda.
+
+### Bug fixes
+
+- Ensure large batch writes with `influx` gzip are completely written to InfluxDB.
+- Update function node name `ServiceNow` handler to camelcase.
+- Fix memory leaks in `JoinNode` and `UnionNode`.
+- Avoid infinite hang when closing Kafka writer and prevent the timeout error that occurred when updating the Kafka configuration file (`kapacitor.conf`) via http.
+
 ## v1.5.8 [2020-01-27]
 
 {{% warn %}}


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/2331

Do we want to add more contextual info about how the 1.5.8 release was pulled in the changelog?, and/or add contextual info to the release notes on which feature/functionality were originally in 1.5.8 and then rolled back into 1.5.9 in the change log/release notes?

Including @veereshhosakere...recall support and edge teams working with us on verbiage when we pulled down 1.5.8. 