### PR TITLE
Add cloud note to schema package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,7 +173,7 @@ Use the `prepend` and `append` frontmatter to add content to the top or bottom o
 Each has the following fields:
 
 - **block:** _(Optional)_ block style to wrap content in (note, warn, cloud, or enterprise)
-- **content:** _**(Required)**_ markdown content to pre/append.
+- **content:** _**(Required)**_ markdown content to add.
 
 ```yaml
 append:
@@ -183,7 +183,7 @@ append:
     This is just an example note block that gets appended to the article.
 ```
 
-Use this frontmatter with [cascade](#cascade) to pre/append the same content to
+Use this frontmatter with [cascade](#cascade) to add the same content to
 all children pages as well.
 
 ```yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,9 +86,14 @@ list_note: # Used in children shortcode type="list" to add a small note next to 
 list_code_example: # Code example included with article descriptions in children type="articles" shortcode
 list_query_example: # Code examples included with article descriptions in children type="articles" shortcode,
   # References to examples in data/query_examples
-products: # List of products that the page specifically applies to: [oss, cloud, enterprise]
 canonical: # Path to canonical page, overrides auto-gen'd canonical URL
 v2: # Path to v2 equivalent page
+prepend: # Prepend markdown content to an article (especially powerful with cascade)
+  block: # (Optional) Wrap content in a block style (note, warn, cloud)
+  content: # Content to prepend to article
+append: # Append markdown content to an article (especially powerful with cascade)
+  block: # (Optional) Wrap content in a block style (note, warn, cloud)
+  content: # Content to append to article
 ```
 
 ### Title usage
@@ -155,12 +160,39 @@ canonical: /path/to/canonical/doc/
 canonical: /{{< latest "influxdb" "v2" >}}/path/to/canonical/doc/
 ```
 
-## v2 equivalent documentation
+### v2 equivalent documentation
 To display a notice on a 1.x page that links to an equivalent 2.0 page,
 add the following frontmatter to the 1.x page:
 
 ```yaml
 v2: /influxdb/v2.0/get-started/
+```
+
+### Prepend and append content to a page
+Use the `prepend` and `append` frontmatter to pre/append content to a page.
+Each has the following fields:
+
+- **block:** _(Optional)_ block style to wrap content in (note, warn, cloud, or enterprise)
+- **content:** _**(Required)**_ markdown content to pre/append.
+
+```yaml
+append:
+  block: note
+  content: |
+    #### This is example markdown content
+    This is just an example note block that gets appended to the article.
+```
+
+Use this frontmatter with [cascade](#cascade) to pre/append the same content to
+all children pages as well.
+
+```yaml
+cascade:
+  append:
+    block: note
+    content: |
+      #### This is example markdown content
+      This is just an example note block that gets appended to the article.
 ```
 
 ### Cascade
@@ -176,7 +208,7 @@ cascade:
 ```
 
 `cascade` applies the frontmatter to all children unless the child already includes
-those frontmatter keys. Frontmaatter defined on the page overrides fronmattered
+those frontmatter keys. Frontmatter defined on the page overrides frontmatter
 "cascaded" from a parent.
 
 ## Shortcodes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ v2: /influxdb/v2.0/get-started/
 ```
 
 ### Prepend and append content to a page
-Use the `prepend` and `append` frontmatter to pre/append content to a page.
+Use the `prepend` and `append` frontmatter to add content to the top or bottom of a page.
 Each has the following fields:
 
 - **block:** _(Optional)_ block style to wrap content in (note, warn, cloud, or enterprise)

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/_index.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/_index.md
@@ -18,11 +18,7 @@ cascade:
     block: cloud
     content: |
       #### Supported in the InfluxDB Cloud UI
-      The `schema` package can retrieve schema information from InfluxDB Cloud when
-      used in the InfluxDB Cloud user interface (UI), but it **cannot** when using
-      the [Flux REPL](/influxdb/cloud/tools/repl/).
-      In the REPL, there is no way to provide the host, organization, and token
-      required to authorize with InfluxDB Cloud.
+           The `schema` package can retrieve schema information from the InfluxDB Cloud user interface (UI), but **not** from the [Flux REPL](/influxdb/cloud/tools/repl/).
 ---
 
 The Flux InfluxDB schema package provides functions for exploring your InfluxDB data schema.

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/_index.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/_index.md
@@ -13,6 +13,16 @@ menu:
 weight: 202
 influxdb/v2.0/tags: [functions, schema, package]
 introduced: 0.88.0
+cascade:
+  append:
+    block: cloud
+    content: |
+      #### Supported in the InfluxDB Cloud UI
+      The `schema` package can retrieve schema information from InfluxDB Cloud when
+      used in the InfluxDB Cloud user interface (UI), but it **cannot** when using
+      the [Flux REPL](/influxdb/cloud/tools/repl/).
+      In the REPL, there is no way to provide the host, organization, and token
+      required to authorize with InfluxDB Cloud.
 ---
 
 The Flux InfluxDB schema package provides functions for exploring your InfluxDB data schema.

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/_index.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/_index.md
@@ -18,7 +18,8 @@ cascade:
     block: cloud
     content: |
       #### Supported in the InfluxDB Cloud UI
-           The `schema` package can retrieve schema information from the InfluxDB Cloud user interface (UI), but **not** from the [Flux REPL](/influxdb/cloud/tools/repl/).
+      The `schema` package can retrieve schema information from the InfluxDB
+      Cloud user interface (UI), but **not** from the [Flux REPL](/influxdb/cloud/tools/repl/).
 ---
 
 The Flux InfluxDB schema package provides functions for exploring your InfluxDB data schema.

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -4,7 +4,9 @@
     {{ partial "article/stable-version.html" . }}
     {{ partial "article/flux-experimental.html" . }}
     {{ partial "article/flux-contrib.html" . }}
+    {{ partial "article/prepend.html" . }}
     {{ .Content }}
+    {{ partial "article/append.html" . }}
     {{ partial "article/related.html" . }}
     {{ partial "article/tags.html" . }}
     {{ partial "article/feedback.html" . }}

--- a/layouts/partials/article/append.html
+++ b/layouts/partials/article/append.html
@@ -1,0 +1,11 @@
+{{ $p := .Page }}
+{{ $optBlock := dict "display" "block" }}
+{{ if .Params.append }}
+  {{ if .Params.append.block }}
+    <div class="block {{ .Params.append.block }}">
+      {{ .Params.append.content | $p.RenderString $optBlock }}
+    </div>
+  {{ else }}
+    {{ .Params.append.content | $p.RenderString $optBlock }}
+  {{ end }}
+{{ end }}

--- a/layouts/partials/article/prepend.html
+++ b/layouts/partials/article/prepend.html
@@ -1,0 +1,11 @@
+{{ $p := .Page }}
+{{ $optBlock := dict "display" "block" }}
+{{ if .Params.prepend }}
+  {{ if .Params.prepend.block }}
+    <div class="block {{ .Params.prepend.block }}">
+      {{ .Params.prepend.content | $p.RenderString $optBlock }}
+    </div>
+  {{ else }}
+    {{ .Params.prepend.content | $p.RenderString $optBlock }}
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
Closes influxdata/DAR#181

- Adds note about not being able to use the `schema` package with cloud from the REPL
- Adds new `prepend` and `append` frontmatter.

<!--  -->

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
