### PR TITLE
Fix some uses of the term "third-party"

### DIFF
--- a/content/influxdb/v2.0/monitor-alert/notification-endpoints/_index.md
+++ b/content/influxdb/v2.0/monitor-alert/notification-endpoints/_index.md
@@ -13,7 +13,7 @@ related:
   - /influxdb/v2.0/monitor-alert/notification-rules/
 ---
 
-Notification endpoints store information to connect to a third party service.
+Notification endpoints store information to connect to a third-party service.
 Create a connection to a HTTP, Slack, or PagerDuty endpoint.
 
 {{< children >}}

--- a/content/influxdb/v2.0/monitor-alert/notification-endpoints/create.md
+++ b/content/influxdb/v2.0/monitor-alert/notification-endpoints/create.md
@@ -12,7 +12,7 @@ related:
   - /influxdb/v2.0/monitor-alert/notification-rules/
 ---
 
-To send notifications about changes in your data, start by creating a notification endpoint to a third party service. After creating notification endpoints, [create notification rules](/influxdb/v2.0/monitor-alert/notification-rules/create) to send alerts to third party services on [check statuses](/influxdb/v2.0/monitor-alert/checks/create).
+To send notifications about changes in your data, start by creating a notification endpoint to a third-party service. After creating notification endpoints, [create notification rules](/influxdb/v2.0/monitor-alert/notification-rules/create) to send alerts to third-party services on [check statuses](/influxdb/v2.0/monitor-alert/checks/create).
 
 ## Create a notification endpoint in the UI
 

--- a/content/influxdb/v2.0/monitor-alert/send-email.md
+++ b/content/influxdb/v2.0/monitor-alert/send-email.md
@@ -11,7 +11,7 @@ related:
   - /influxdb/v2.0/monitor-alert/checks/
 ---
 
-Send an alert email using a third party service, such as [SendGrid](https://sendgrid.com/), [Amazon Simple Email Service (SES)](https://aws.amazon.com/ses/), [Mailjet](https://www.mailjet.com/), or [Mailgun](https://www.mailgun.com/). To send an alert email, complete the following steps:
+Send an alert email using a third-party service, such as [SendGrid](https://sendgrid.com/), [Amazon Simple Email Service (SES)](https://aws.amazon.com/ses/), [Mailjet](https://www.mailjet.com/), or [Mailgun](https://www.mailgun.com/). To send an alert email, complete the following steps:
 
 1. [Create a check](/influxdb/v2.0/monitor-alert/checks/create/#create-a-check-in-the-influxdb-ui) to identify the data to monitor and the status to alert on.
 2. Set up your preferred email service (sign up, retrieve API credentials, and send test email):

--- a/content/telegraf/v1.18/_index.md
+++ b/content/telegraf/v1.18/_index.md
@@ -11,7 +11,7 @@ weight: 1
 
 Telegraf is a plugin-driven server agent for collecting & reporting metrics,
 and is the first piece of the [TICK stack](https://influxdata.com/time-series-platform/).
-Telegraf has plugins to source a variety of metrics directly from the system it's running on, pull metrics from third party APIs, or even listen for metrics via a statsd and Kafka consumer services.
+Telegraf has plugins to source a variety of metrics directly from the system it's running on, pull metrics from third-party APIs, or even listen for metrics via a statsd and Kafka consumer services.
 It also has output plugins to send metrics to a variety of other datastores, services, and message queues, including InfluxDB, Graphite, OpenTSDB, Datadog, Librato, Kafka, MQTT, NSQ, and many others.
 
 ## Key features

--- a/content/telegraf/v1.18/about_the_project/_index.md
+++ b/content/telegraf/v1.18/about_the_project/_index.md
@@ -16,12 +16,12 @@ for important information about new versions of Telegraf.
 - [Contributor License Agreement (CLA)](https://influxdata.com/community/cla/)
 - [License](https://github.com/influxdata/telegraf/blob/master/LICENSE)
 
-## Third party software
-InfluxData products contain third party software, which means the copyrighted, patented, or otherwise legally protected
-software of third parties that is incorporated in InfluxData products.
+## Third-party software
+InfluxData products contain third-party software, which means the copyrighted, patented, or otherwise legally protected
+software of third-parties that is incorporated in InfluxData products.
 
-Third party suppliers make no representation nor warranty with respect to such third party software or any portion thereof.
-Third party suppliers assume no liability for any claim that might arise with respect to such third party software, nor for a
-customer’s use of or inability to use the third party software.
+Third-party suppliers make no representation nor warranty with respect to such third-party software or any portion thereof.
+Third-party suppliers assume no liability for any claim that might arise with respect to such third-party software, nor for a
+customer’s use of or inability to use the third-party software.
 
-The [list of third party software components, including references to associated licenses and other materials](https://github.com/influxdata/telegraf/blob/release-1.15/docs/LICENSE_OF_DEPENDENCIES.md), is maintained on a version by version basis.
+The [list of third-party software components, including references to associated licenses and other materials](https://github.com/influxdata/telegraf/blob/release-1.15/docs/LICENSE_OF_DEPENDENCIES.md), is maintained on a version by version basis.

--- a/content/telegraf/v1.18/plugins.md
+++ b/content/telegraf/v1.18/plugins.md
@@ -30,7 +30,7 @@ It supports four categories of plugins including input, output, aggregator, and 
 
 ## Input plugins
 Telegraf input plugins are used with the InfluxData time series platform to collect
-metrics from the system, services, or third party APIs.
+metrics from the system, services, or third-party APIs.
 
 {{< telegraf/plugins type="input" >}}
 


### PR DESCRIPTION
"Third-party" should be hyphenated when used as a modifier.

- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
