### PR TITLE
Upgrade from 1.x to Cloud

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -540,6 +540,17 @@ Markdown content associated with label 2.
 {{< /expand-wrapper >}}
 ```
 
+### Captions
+Use the `{{% caption %}}` shortcode to add captions to images and code blocks.
+Captions are styled with a smaller font size, italic text, slight transparency,
+and appear directly under the previous image or code block.
+
+```md
+{{% caption %}}
+Markdown content for the caption.
+{{% /caption %}}
+```
+
 ### Generate a list of children articles
 Section landing pages often contain just a list of articles with links and descriptions for each.
 This can be cumbersome to maintain as content is added.

--- a/assets/styles/layouts/_article.scss
+++ b/assets/styles/layouts/_article.scss
@@ -103,6 +103,7 @@
 
   @import "article/blocks",
           "article/buttons",
+          "article/captions",
           "article/children",
           "article/code",
           "article/cloud",

--- a/assets/styles/layouts/article/_captions.scss
+++ b/assets/styles/layouts/article/_captions.scss
@@ -1,0 +1,13 @@
+.caption {
+  margin: -2rem 0 2rem;
+  padding-left: .25rem;
+  font-size: .8rem;
+  font-style: italic;
+  opacity: .8;
+}
+
+.code-tabs-wrapper, .code-tab-content {
+  & + .caption {
+    margin-top: -2.75rem;
+  }
+}

--- a/content/influxdb/cloud/upgrade/from-v2.md
+++ b/content/influxdb/cloud/upgrade/from-v2.md
@@ -34,7 +34,7 @@ To upgrade from **InfluxDB OSS 2.x** to **InfluxDB Cloud**:
 {{% /note %}}
 
 ## Create an InfluxDB Cloud account
-To upgrade to InfluxDB Cloud, do one of the following to create an account:
+Do one of the following to create an InfluxDB Cloud account:
 
 - [Subscribe through InfluxData](/influxdb/cloud/get-started/#subscribe-through-influxdata) and
   [start for free](/influxdb/cloud/get-started/#start-for-free).

--- a/content/influxdb/cloud/upgrade/v1-to-cloud/_index.md
+++ b/content/influxdb/cloud/upgrade/v1-to-cloud/_index.md
@@ -46,7 +46,7 @@ _For more information about managing tokens and token types, see [Manage tokens]
 ## Download and install the influx CLI
 Visit the [InfluxDB downloads page](https://portal.influxdata.com/downloads/)
 and download the **InfluxDB Cloud CLI** (`influx`).
-Install the `influx` CLI in your system $PATH or execute the CLI commands from
+Place the `influx` binary in your system `PATH` or execute the CLI commands from
 the directory where the `influx` CLI exists.
 
 [Create a CLI connection configuration](/influxdb/cloud/reference/cli/influx/#provide-required-authentication-credentials)

--- a/content/influxdb/cloud/upgrade/v1-to-cloud/_index.md
+++ b/content/influxdb/cloud/upgrade/v1-to-cloud/_index.md
@@ -44,12 +44,12 @@ for the upgrade process.
 _For more information about managing tokens and token types, see [Manage tokens](/influxdb/cloud/security/tokens/)._
 
 ## Download and install the influx CLI
-Visit the [InfluxDB downloads page](https://portal.influxdata.com/downloads/)
+1. Visit the [InfluxDB downloads page](https://portal.influxdata.com/downloads/)
 and download the **InfluxDB Cloud CLI** (`influx`).
-Place the `influx` binary in your system `PATH` or execute the CLI commands from
+2. Place the `influx` binary in your system `PATH` or execute the CLI commands from
 the directory where the `influx` CLI exists.
 
-[Create a CLI connection configuration](/influxdb/cloud/reference/cli/influx/#provide-required-authentication-credentials)
+3. [Create a CLI connection configuration](/influxdb/cloud/reference/cli/influx/#provide-required-authentication-credentials)
 for your InfluxDB Cloud account.
 Include the following flags:
 
@@ -88,7 +88,7 @@ InfluxDB Cloud buckets while using the 1.x DBRP convention.
 _For more information about DBRP mapping, see
 [Database and retention policy mapping](/influxdb/cloud/reference/api/influxdb-1x/dbrp/)._
 
-**To map a DBRP combination to an InfluxDB Cloud bucket:**
+**To map a DBRP combination to an InfluxDB Cloud bucket**
 
 1.  **Create a bucket**  
     [Create an InfluxDB Cloud bucket](/influxdb/cloud/organizations/buckets/create-bucket/).
@@ -229,7 +229,7 @@ To migrate time series data from your InfluxDB 1.x instance to InfluxDB Cloud:
       --file /path/to/example-db_example-rp.lp
     ```
 
-Repeat this process for each bucket.
+3. Repeat steps 1-2 for each bucket.
 
 {{% note %}}
 #### InfluxDB Cloud write rate limits

--- a/content/influxdb/cloud/upgrade/v1-to-cloud/_index.md
+++ b/content/influxdb/cloud/upgrade/v1-to-cloud/_index.md
@@ -16,7 +16,7 @@ To upgrade from **InfluxDB OSS 1.x** to **InfluxDB Cloud**:
 
 1. [Create an InfluxDB Cloud account](#create-an-influxdb-cloud-account)
 2. [Create an All-Access authentication token](#create-an-all-access-authentication-token)
-3. [Download and install the influx CLI](#download-and-install-the-influx-cli)
+3. [Download and install the `influx` CLI](#download-and-install-the-influx-cli)
 4. [Create DBRP mappings](#create-dbrp-mappings)
 5. [Dual write to InfluxDB 1.x and InfluxDB Cloud](#dual-write-to-influxdb-1x-and-influxdb-cloud)
 6. [Migrate time series data](#migrate-time-series-data)
@@ -50,7 +50,7 @@ Install the `influx` CLI in your system $PATH or execute the CLI commands from
 the directory where the `influx` CLI exists.
 
 [Create a CLI connection configuration](/influxdb/cloud/reference/cli/influx/#provide-required-authentication-credentials)
-for your InfluxDB Cloud instance.
+for your InfluxDB Cloud account.
 Include the following flags:
 
 - **-\-config-name**:
@@ -82,7 +82,7 @@ All `influx` CLI examples below assume the required InfluxDB Cloud **host**,
 ## Create DBRP mappings
 InfluxDB database and retention policy (DBRP) mappings associate database and
 retention policy combinations with InfluxDB cloud [buckets](/influxdb/cloud/reference/glossary/#bucket).
-These mappings allow InfluxDB 1.x clients to successfully query and write to
+These mappings allow InfluxDB 1.x clients to query and write to
 InfluxDB Cloud buckets while using the 1.x DBRP convention.
 
 _For more information about DBRP mapping, see

--- a/content/influxdb/cloud/upgrade/v1-to-cloud/_index.md
+++ b/content/influxdb/cloud/upgrade/v1-to-cloud/_index.md
@@ -44,33 +44,33 @@ for the upgrade process.
 _For more information about managing tokens and token types, see [Manage tokens](/influxdb/cloud/security/tokens/)._
 
 ## Download and install the influx CLI
-1. Visit the [InfluxDB downloads page](https://portal.influxdata.com/downloads/)
-and download the **InfluxDB Cloud CLI** (`influx`).
-2. Place the `influx` binary in your system `PATH` or execute the CLI commands from
-the directory where the `influx` CLI exists.
+1.  Visit the [InfluxDB downloads page](https://portal.influxdata.com/downloads/)
+    and download the **InfluxDB Cloud CLI** (`influx`).
+2.  Place the `influx` binary in your system `PATH` or execute the CLI commands from
+    the directory where the `influx` CLI exists.
 
 3. [Create a CLI connection configuration](/influxdb/cloud/reference/cli/influx/#provide-required-authentication-credentials)
-for your InfluxDB Cloud account.
-Include the following flags:
+    for your InfluxDB Cloud account.
+      Include the following flags:
 
-- **-\-config-name**:
-  Unique name for the connection configuration.
-- **-\-host-url**:
-  [InfluxDB Cloud region URL](/influxdb/cloud/reference/regions/).
-- **-\-org**:
-  InfluxDB Cloud organization name.
-  The default organization name is the email address associated with your account.
-- **-\-token**:
-  InfluxDB Cloud **All-Access** token.
+    - **-\-config-name**:
+      Unique name for the connection configuration.
+    - **-\-host-url**:
+      [InfluxDB Cloud region URL](/influxdb/cloud/reference/regions/).
+    - **-\-org**:
+      InfluxDB Cloud organization name.
+      The default organization name is the email address associated with your account.
+    - **-\-token**:
+      InfluxDB Cloud **All-Access** token.
 
-```sh
-influx config create \
-  --config-name cloud \
-  --host-url https://cloud2.influxdata.com \
-  --org your.email@example.com \
-  --token mY5uP3rS3cRe7Cl0uDt0K3n \
-  --active
-```
+    ```sh
+    influx config create \
+      --config-name cloud \
+      --host-url https://cloud2.influxdata.com \
+      --org your.email@example.com \
+      --token mY5uP3rS3cRe7Cl0uDt0K3n \
+      --active
+    ```
 
 {{% note %}}
 #### Required InfluxDB Cloud credentials
@@ -149,6 +149,9 @@ influx v1 dbrp create \
 ```
     {{% /code-tab-content %}}
     {{< /code-tabs-wrapper >}}
+    {{% caption %}}
+See [Required InfluxDB Cloud credentials](#required-influxdb-cloud-credentials)
+    {{% /caption %}}
 
 ## Dual write to InfluxDB 1.x and InfluxDB Cloud
 Update external clients to write to your InfluxDB Cloud instance.
@@ -228,6 +231,9 @@ To migrate time series data from your InfluxDB 1.x instance to InfluxDB Cloud:
       --bucket example-db/example-rp \
       --file /path/to/example-db_example-rp.lp
     ```
+    {{% caption %}}
+See [Required InfluxDB Cloud credentials](#required-influxdb-cloud-credentials)
+    {{% /caption %}}
 
 3. Repeat steps 1-2 for each bucket.
 
@@ -244,6 +250,9 @@ influx write \
   --file /path/to/example-db_example-rp.lp \
   --rate-limit "5 MB / 5 min"
 ```
+{{% caption %}}
+See [Required InfluxDB Cloud credentials](#required-influxdb-cloud-credentials)
+{{% /caption %}}
 
 To minimize network bandwidth usage, we recommend using gzip to compress exported line protocol.
 However, when writing to InfluxDB Cloud, **Data In** and **Ingest batch size**

--- a/content/influxdb/cloud/upgrade/v1-to-cloud/_index.md
+++ b/content/influxdb/cloud/upgrade/v1-to-cloud/_index.md
@@ -1,0 +1,259 @@
+---
+title: Upgrade from InfluxDB 1.x to InfluxDB Cloud
+description: >
+  To upgrade from InfluxDB 1.x to InfluxDB Cloud, migrate data, and then create
+  database and retention policy (DBRP) mappings.
+menu:
+  influxdb_cloud:
+    parent: Upgrade to Cloud
+    name: 1.x to Cloud
+weight: 11
+related:
+  - /influxdb/cloud/upgrade/v1-to-cloud/migrate-cqs/
+---
+
+To upgrade from **InfluxDB OSS 1.x** to **InfluxDB Cloud**:
+
+1. [Create an InfluxDB Cloud account](#create-an-influxdb-cloud-account)
+2. [Create an All-Access authentication token](#create-an-all-access-authentication-token)
+3. [Download and install the influx CLI](#download-and-install-the-influx-cli)
+4. [Create DBRP mappings](#create-dbrp-mappings)
+5. [Dual write to InfluxDB 1.x and InfluxDB Cloud](#dual-write-to-influxdb-1x-and-influxdb-cloud)
+6. [Migrate time series data](#migrate-time-series-data)
+7. [Migrate continuous queries](#migrate-continuous-queries)
+8. [Collaborate with other users](#collaborate-with-other-users)
+
+## Create an InfluxDB Cloud account
+Do one of the following to create an InfluxDB Cloud account:
+
+- [Subscribe through InfluxData](/influxdb/cloud/get-started/#subscribe-through-influxdata) and
+  [start for free](/influxdb/cloud/get-started/#start-for-free).
+- [Subscribe through your cloud provider](/influxdb/cloud/get-started/#subscribe-through-a-cloud-provider).
+
+## Create an All-Access authentication token
+InfluxDB Cloud requires all requests to be authenticated with **token authentication**.
+Create an **All-Access** token in your InfluxDB Cloud user interface (UI) to use
+for the upgrade process.
+
+1. Click **Data (Load Data) > Tokens** in the left navigation bar.
+
+    {{< nav-icon "data" >}}
+2. Click **{{< icon "plus" >}} Generate**, and then select **All-Access Token**.
+3. Enter a description for the token, and then click **{{< icon "check" >}} Save**.
+
+_For more information about managing tokens and token types, see [Manage tokens](/influxdb/cloud/security/tokens/)._
+
+## Download and install the influx CLI
+Visit the [InfluxDB downloads page](https://portal.influxdata.com/downloads/)
+and download the **InfluxDB Cloud CLI** (`influx`).
+Install the `influx` CLI in your system $PATH or execute the CLI commands from
+the directory where the `influx` CLI exists.
+
+[Create a CLI connection configuration](/influxdb/cloud/reference/cli/influx/#provide-required-authentication-credentials)
+for your InfluxDB Cloud instance.
+Include the following flags:
+
+- **-\-config-name**:
+  Unique name for the connection configuration.
+- **-\-host-url**:
+  [InfluxDB Cloud region URL](/influxdb/cloud/reference/regions/).
+- **-\-org**:
+  InfluxDB Cloud organization name.
+  The default organization name is the email address associated with your account.
+- **-\-token**:
+  InfluxDB Cloud **All-Access** token.
+
+```sh
+influx config create \
+  --config-name cloud \
+  --host-url https://cloud2.influxdata.com \
+  --org your.email@example.com \
+  --token mY5uP3rS3cRe7Cl0uDt0K3n \
+  --active
+```
+
+{{% note %}}
+#### Required InfluxDB Cloud credentials
+All `influx` CLI examples below assume the required InfluxDB Cloud **host**,
+**organization**, and **authentication token** credentials are provided by your
+[`influx` CLI configuration](/influxdb/cloud/reference/cli/influx/#provide-required-authentication-credentials).
+{{% /note %}}
+
+## Create DBRP mappings
+InfluxDB database and retention policy (DBRP) mappings associate database and
+retention policy combinations with InfluxDB cloud [buckets](/influxdb/cloud/reference/glossary/#bucket).
+These mappings allow InfluxDB 1.x clients to successfully query and write to
+InfluxDB Cloud buckets while using the 1.x DBRP convention.
+
+_For more information about DBRP mapping, see
+[Database and retention policy mapping](/influxdb/cloud/reference/api/influxdb-1x/dbrp/)._
+
+**To map a DBRP combination to an InfluxDB Cloud bucket:**
+
+1.  **Create a bucket**  
+    [Create an InfluxDB Cloud bucket](/influxdb/cloud/organizations/buckets/create-bucket/).
+    We recommend creating a bucket for each unique 1.x database and retention
+    policy combination using the following naming convention:
+
+    ```sh
+    # Naming convention
+    db-name/rp-name
+
+    # Example
+    telegraf/autogen
+    ```
+
+2.  **Create a DBRP mapping**  
+    Use the [`influx v1 dbrp create` command](/influxdb/cloud/reference/cli/influx/v1/dbrp/create/)
+    to create a DBRP mapping.
+    Provide the following:
+
+    - database name
+    - retention policy name _(not retention period)_
+    - [bucket ID](/influxdb/cloud/organizations/buckets/view-buckets/)
+    - _(optional)_ `--default` flag if you want the retention policy to be the default retention
+      policy for the specified database
+
+    {{< code-tabs-wrapper >}}
+    {{% code-tabs %}}
+[DB with one RP](#)
+[DB with multiple RPs](#)
+    {{% /code-tabs %}}
+    {{% code-tab-content %}}
+```sh
+influx v1 dbrp create \
+  --db example-db \
+  --rp example-rp \
+  --bucket-id 00xX00o0X001 \
+  --default
+```
+    {{% /code-tab-content %}}
+    {{% code-tab-content %}}
+```sh
+# Create telegraf/autogen DBRP mapping with autogen
+# as the default RP for the telegraf DB
+
+influx v1 dbrp create \
+  --db telegraf \
+  --rp autogen \
+  --bucket-id 00xX00o0X001 \
+  --default
+
+# Create telegraf/downsampled-daily DBRP mapping that
+# writes to a different bucket
+
+influx v1 dbrp create \
+  --db telegraf \
+  --rp downsampled-daily \
+  --bucket-id 00xX00o0X002
+```
+    {{% /code-tab-content %}}
+    {{< /code-tabs-wrapper >}}
+
+## Dual write to InfluxDB 1.x and InfluxDB Cloud
+Update external clients to write to your InfluxDB Cloud instance.
+**We recommend writing data to both InfluxDB 1.x and InfluxDB Cloud until you
+finish [migrating your existing time series data](#migrate-time-series-data)**.
+
+Configure external clients with your InfluxDB Cloud **host**, **organization**,
+and **authentication token**.
+
+### Update Telegraf configurations
+If using Telegraf to collect and write metrics to InfluxDB 1.x, update your
+Telegraf configuration to write to both InfluxDB 1.x and InfluxDB Cloud:
+
+1.  Update your Telegraf configuration with a `influxdb_v2` output to write to
+    your InfluxDB Cloud instance.
+
+    ##### Example dual-write Telegraf configuration
+    ```toml
+    # Write metrics to InfluxDB 1.x
+    [[outputs.influxdb]]
+      urls = ["https://localhost:8086"]
+      database = "example-db"
+      retention_policy = "example-rp"
+
+    # Write metrics to InfluxDB Cloud
+    [[outputs.influxdb_v2]]
+      urls = ["https://cloud2.influxdata.com"]
+      token = "$INFLUX_TOKEN"
+      organization = "your.email@example.com"
+      bucket = "example-db/example-rp"
+    ```
+
+2.  Add the `INFLUX_TOKEN` environment variable to your Telegraf environment(s)
+    and set the value to your InfluxDB Cloud authentication token.
+
+3.  Restart Telegraf with the updated configuration and begin writing to both
+    InfluxDB 1.x and InfluxDB Cloud.
+
+## Migrate time series data
+To migrate time series data from your InfluxDB 1.x instance to InfluxDB Cloud:
+
+1. Use the **InfluxDB 1.x** [`influx_inspect export` command](/{{< latest "influxdb" "v1" >}}/tools/influx_inspect/#export)
+   to export time series data as line protocol.
+   Include the `-lponly` flag to exclude comments and the data definition
+   language (DDL) from the output file.
+
+   _We recommend exporting each DBRP combination separately to easily write data
+   to a corresponding InfluxDB Cloud bucket._
+
+    ```sh
+    # Syntax
+    influx_inspect export \
+      -database <database-name> \
+      -retention <retention-policy-name> \
+      -out <output-file-path> \
+      -lponly
+
+    # Example
+    influx_inspect export \
+      -database example-db \
+      -retention example-rp \
+      -out /path/to/example-db_example-rp.lp \
+      -lponly
+    ```
+
+2. Use the **InfluxDB Cloud** [`influx write` command](/influxdb/cloud/reference/cli/influx/write/)
+   to write the exported line protocol to InfluxDB Cloud.
+
+    ```sh
+    # Syntax
+    influx write \
+      --bucket <bucket-name> \
+      --file <path-to-line-protocol-file>
+
+    # Example
+    influx write \
+      --bucket example-db/example-rp \
+      --file /path/to/example-db_example-rp.lp
+    ```
+
+Repeat this process for each bucket.
+
+{{% note %}}
+#### InfluxDB Cloud write rate limits
+Write requests are subject to rate limits associated with your
+[InfluxDB Cloud pricing plan](/influxdb/cloud/account-management/pricing-plans/).
+If your exported line protocol size potentially exceeds your rate limits,
+include the `--rate-limit` flag with `influx write` to rate limit written data.
+
+```sh
+influx write \
+  --bucket example-bucket \
+  --file /path/to/example-db_example-rp.lp \
+  --rate-limit "5 MB / 5 min"
+```
+
+To minimize network bandwidth usage, we recommend using gzip to compress exported line protocol.
+However, when writing to InfluxDB Cloud, **Data In** and **Ingest batch size**
+rate limits track the payload size of the **uncompressed** line protocol.
+{{% /note %}}
+
+## Migrate continuous queries
+For information about migrating InfluxDB 1.x continuous queries to InfluxDB Cloud tasks,
+see [Migrate continuous queries to tasks](/influxdb/cloud/upgrade/v1-to-cloud/migrate-cqs/).
+
+## Collaborate with other users
+To collaborate with other users in your InfluxDB Cloud organization,
+[invite users to join your organization](/influxdb/cloud/account-management/multi-user/invite-user/).

--- a/content/influxdb/cloud/upgrade/v1-to-cloud/migrate-cqs.md
+++ b/content/influxdb/cloud/upgrade/v1-to-cloud/migrate-cqs.md
@@ -1,41 +1,30 @@
 ---
 title: Migrate continuous queries to tasks
 description: >
-  InfluxDB OSS 2.0 replaces 1.x continuous queries (CQs) with **InfluxDB tasks**.
-  To migrate continuous queries to InfluxDB 2.0, convert InfluxDB 1.x CQs into Flux and create new
-  InfluxDB 2.0 tasks.
+  InfluxDB Cloud replaces 1.x continuous queries (CQs) with **InfluxDB tasks**.
+  To migrate continuous queries to InfluxDB Cloud, convert InfluxDB 1.x CQs into
+  Flux and create new InfluxDB Cloud tasks.
 menu:
-  influxdb_2_0:
-    parent: InfluxDB 1.x to 2.0
+  influxdb_cloud:
+    parent: 1.x to Cloud
     name: Migrate CQs
 weight: 102
 related:
-  - /influxdb/v2.0/query-data/get-started/
-  - /influxdb/v2.0/query-data/flux/
-  - /influxdb/v2.0/process-data/
-  - /influxdb/v2.0/process-data/common-tasks/
-  - /influxdb/v2.0/reference/flux/flux-vs-influxql/
+  - /influxdb/cloud/query-data/get-started/
+  - /influxdb/cloud/query-data/flux/
+  - /influxdb/cloud/process-data/
+  - /influxdb/cloud/process-data/common-tasks/
+  - /influxdb/cloud/reference/flux/flux-vs-influxql/
 ---
 
-InfluxDB OSS 2.0 replaces 1.x continuous queries (CQs) with **InfluxDB tasks**.
-To migrate continuous queries to InfluxDB 2.0 tasks, do the following:
+InfluxDB Cloud replaces 1.x continuous queries (CQs) with **InfluxDB tasks**.
+To migrate continuous queries to InfluxDB Cloud tasks, do the following:
 
 1. [Output all InfluxDB 1.x continuous queries](#output-all-influxdb-1x-continuous-queries)
 2. [Convert continuous queries to Flux queries](#convert-continuous-queries-to-flux-queries)
 3. [Create new InfluxDB tasks](#create-new-influxdb-tasks)
 
 ## Output all InfluxDB 1.x continuous queries
-
-If using the `influxd upgrade` command, by default, all continuous queries are
-output to `~/continuous_queries.txt` during the upgrade process.
-To customize the destination path of the continuous queries file,
-use the `--continuous-query-export-path` flag with the `influxd upgrade` command.
-
-```sh
-influxd upgrade --continuous-query-export-path /path/to/continuous_queries.txt
-```
-
-**To manually output continuous queries:**
 
 1. Use the **InfluxDB 1.x `influx` interactive shell** to run `SHOW CONTINUOUS QUERIES`:
 
@@ -51,9 +40,9 @@ influxd upgrade --continuous-query-export-path /path/to/continuous_queries.txt
 
 ## Convert continuous queries to Flux queries
 
-To migrate InfluxDB 1.x continuous queries to InfluxDB 2.0 tasks, convert the InfluxQL query syntax to Flux.
+To migrate InfluxDB 1.x continuous queries to InfluxDB Cloud tasks, convert the InfluxQL query syntax to Flux.
 The majority of continuous queries are simple downsampling queries and can be converted quickly
-using the [`aggregateWindow()` function](/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/aggregatewindow/).
+using the [`aggregateWindow()` function](/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/aggregatewindow/).
 For example:
 
 ##### Example continuous query
@@ -100,10 +89,10 @@ Review the following statements and clauses to see how to convert your CQs to Fl
 
 #### ON clause
 The `ON` clause defines the database to query.
-In InfluxDB OSS 2.0, database and retention policy combinations are mapped to specific buckets
-(for more information, see [Database and retention policy mapping](/influxdb/v2.0/reference/api/influxdb-1x/dbrp/)).
+In InfluxDB Cloud, database and retention policy combinations are mapped to specific buckets
+(for more information, see [Database and retention policy mapping](/influxdb/cloud/reference/api/influxdb-1x/dbrp/)).
 
-Use the [`from()` function](/influxdb/v2.0/reference/flux/stdlib/built-in/inputs/from)
+Use the [`from()` function](/influxdb/cloud/reference/flux/stdlib/built-in/inputs/from)
 to specify the bucket to query:
 
 ###### InfluxQL
@@ -122,18 +111,18 @@ from(bucket: "my-db/")
 The `SELECT` statement queries data by field, tag, and time from a specific measurement.
 `SELECT` statements can take many different forms and converting them to Flux depends
 on your use case. For information about Flux and InfluxQL function parity, see
-[Flux vs InfluxQL](/influxdb/v2.0/reference/flux/flux-vs-influxql/#influxql-and-flux-parity).
+[Flux vs InfluxQL](/influxdb/cloud/reference/flux/flux-vs-influxql/#influxql-and-flux-parity).
 See [other resources available to help](#other-helpful-resources).
 
 #### INTO clause
 The `INTO` clause defines the measurement to write results to.
 `INTO` also supports fully-qualified measurements that include the database and retention policy.
-In InfluxDB OSS 2.0, database and retention policy combinations are mapped to specific buckets
-(for more information, see [Database and retention policy mapping](/influxdb/v2.0/reference/api/influxdb-1x/dbrp/)).
+In InfluxDB Cloud, database and retention policy combinations are mapped to specific buckets
+(for more information, see [Database and retention policy mapping](/influxdb/cloud/reference/api/influxdb-1x/dbrp/)).
 
 To write to a measurement different than the measurement queried, use
-[`set()`](/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/set/) or
-[`map()`](/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/map/)
+[`set()`](/influxdb/cloud/reference/flux/stdlib/built-in/transformations/set/) or
+[`map()`](/influxdb/cloud/reference/flux/stdlib/built-in/transformations/map/)
 to change the measurement name.
 Use the `to()` function to specify the bucket to write results to.
 
@@ -168,13 +157,13 @@ INTO "example-db"."example-rp"."example-measurement"
 
 ##### Write pivoted data to InfluxDB
 InfluxDB 1.x query results include a column for each field.
-InfluxDB 2.0 does not do this by default, but it is possible with
-[`pivot()`](/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/pivot)
-or [`schema.fieldsAsCols()`](/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/fieldsascols/).
+InfluxDB Cloud does not do this by default, but it is possible with
+[`pivot()`](/influxdb/cloud/reference/flux/stdlib/built-in/transformations/pivot)
+or [`schema.fieldsAsCols()`](/influxdb/cloud/reference/flux/stdlib/influxdb-schema/fieldsascols/).
 
-If you use `to()` to write _pivoted data_ back to InfluxDB 2.0, each field column is stored as a tag.
+If you use `to()` to write _pivoted data_ back to InfluxDB Cloud, each field column is stored as a tag.
 To write pivoted fields back to InfluxDB as fields, import the `experimental` package
-and use the [`experimental.to()` function](/influxdb/v2.0/reference/flux/stdlib/experimental/to/).
+and use the [`experimental.to()` function](/influxdb/cloud/reference/flux/stdlib/experimental/to/).
 
 ###### InfluxQL
 ```sql
@@ -202,7 +191,7 @@ from(bucket: "my-db/")
 
 #### FROM clause
 The from clause defines the measurement to query.
-Use the [`filter()` function](/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/filter/)
+Use the [`filter()` function](/influxdb/cloud/reference/flux/stdlib/built-in/transformations/filter/)
 to specify the measurement to query.
 
 ###### InfluxQL
@@ -220,8 +209,8 @@ FROM "example-measurement"
 
 #### AS clause
 The `AS` clause changes the name of the field when writing data back to InfluxDB.
-Use [`set()`](/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/set/)
-or [`map()`](/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/map/)
+Use [`set()`](/influxdb/cloud/reference/flux/stdlib/built-in/transformations/set/)
+or [`map()`](/influxdb/cloud/reference/flux/stdlib/built-in/transformations/map/)
 to change the field name.
 
 ###### InfluxQL
@@ -253,10 +242,10 @@ AS newfield
 
 #### WHERE clause
 The `WHERE` clause uses predicate logic to filter results based on fields, tags, or timestamps.
-Use the [`filter()` function](/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/filter/)
-and Flux [comparison operators](/influxdb/v2.0/reference/flux/language/operators/#comparison-operators)
+Use the [`filter()` function](/influxdb/cloud/reference/flux/stdlib/built-in/transformations/filter/)
+and Flux [comparison operators](/influxdb/cloud/reference/flux/language/operators/#comparison-operators)
 to filter results based on fields and tags.
-Use the [`range()` function](/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/range/) to filter results based on timestamps.
+Use the [`range()` function](/influxdb/cloud/reference/flux/stdlib/built-in/transformations/range/) to filter results based on timestamps.
 
 ###### InfluxQL
 ```sql
@@ -275,8 +264,8 @@ WHERE "example-tag" = "foo" AND time > now() - 7d
 The InfluxQL `GROUP BY` clause groups data by specific tags or by time (typically to calculate an aggregate value for windows of time).
 
 ##### Group by tags
-Use the [`group()` function](/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/group/)
-to modify the [group key](/influxdb/v2.0/reference/glossary/#group-key) and change how data is grouped.
+Use the [`group()` function](/influxdb/cloud/reference/flux/stdlib/built-in/transformations/group/)
+to modify the [group key](/influxdb/cloud/reference/glossary/#group-key) and change how data is grouped.
 
 ###### InfluxQL
 ```sql
@@ -291,7 +280,7 @@ GROUP BY "location"
 ```
 
 ##### Group by time
-Use the [`aggregateWindow()` function](/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/aggregatewindow/)
+Use the [`aggregateWindow()` function](/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/aggregatewindow/)
 to group data into time windows and perform an aggregation on each window.
 In CQs, the interval specified in the `GROUP BY time()` clause determines the CQ execution interval.
 Use the `GROUP BY time()` interval to set the `every` task option.
@@ -365,16 +354,16 @@ from(bucket: "my-db/")
 
 ## Create new InfluxDB tasks
 After converting your continuous query to Flux, use the Flux query to
-[create a new task](/influxdb/v2.0/process-data/manage-tasks/create-task/).
+[create a new task](/influxdb/cloud/process-data/manage-tasks/create-task/).
 
 ## Other helpful resources
 The following resources are available and may be helpful when converting
 continuous queries to Flux tasks.
 
 ##### Documentation
-- [Get started with Flux](/influxdb/v2.0/query-data/get-started/)
-- [Query data with Flux](/influxdb/v2.0/query-data/flux/)
-- [Common tasks](/influxdb/v2.0/process-data/common-tasks/#downsample-data-with-influxdb)
+- [Get started with Flux](/influxdb/cloud/query-data/get-started/)
+- [Query data with Flux](/influxdb/cloud/query-data/flux/)
+- [Common tasks](/influxdb/cloud/process-data/common-tasks/#downsample-data-with-influxdb)
 
 ##### Community
 - Post in the [InfluxData Community](https://community.influxdata.com/)

--- a/content/influxdb/v2.0/upgrade/v1-to-v2/manual-upgrade.md
+++ b/content/influxdb/v2.0/upgrade/v1-to-v2/manual-upgrade.md
@@ -160,7 +160,7 @@ _For more information about DBRP mapping, see
 
 2.  **Create a DBRP mapping**  
     Use the [`influx v1 dbrp create` command](/influxdb/v2.0/reference/cli/influx/v1/dbrp/create/)
-    command to create a DBRP mapping.
+    to create a DBRP mapping.
     Provide the following:
 
     - database name

--- a/layouts/shortcodes/caption.html
+++ b/layouts/shortcodes/caption.html
@@ -1,0 +1,2 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
+<div class="caption">{{ .Inner }}</div>


### PR DESCRIPTION
Related to #2332

- Adds a 1.x to Cloud migration guide
- Ports the OSS Migrate CQs doc to Cloud

<!-- -->
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
