### PR TITLE
Update April 2021 InfluxDB Cloud release notes

### DIFF
--- a/content/influxdb/cloud/reference/release-notes/cloud-updates.md
+++ b/content/influxdb/cloud/reference/release-notes/cloud-updates.md
@@ -14,6 +14,12 @@ aliases:
 InfluxDB Cloud updates occur frequently. Find a compilation of recent updates below.
 To find information about the latest Flux updates in InfluxDB Cloud, see [Flux release notes](/influxdb/cloud/reference/release-notes/flux/).
 
+## April 2021
+
+- Add new [GCP Europe West (Belgium) region](/influxdb/cloud/reference/regions/#google-cloud-platform-gcp).
+- Add [mosaic visualization](/influxdb/cloud/visualize-data/visualization-types/mosaic/). Use this visualization to display state changes in your time series data.
+- Add [notebooks](/influxdb/cloud/notebooks/). Use notebooks to build and share ways to explore, visualize, and process your time series data. Learn how notebooks can help you [downsample](/influxdb/cloud/notebooks/downsample/) and [normalize](/influxdb/cloud/notebooks/clean-data/) your time series data.
+
 ## January 2021
 
 - [New AWS and Microsoft regions](#aws-and-microsoft-regions)


### PR DESCRIPTION
@bpalani added stuff we talked about today. @russorat, please lmk if we should hold off this InfluxDB Cloud release note update to include annotations (or add later). We do periodic release notes to highlight recent Cloud updates.