### PR TITLE
Fix paths to docker volume mounts

### DIFF
--- a/content/influxdb/v2.0/get-started.md
+++ b/content/influxdb/v2.0/get-started.md
@@ -419,7 +419,7 @@ _To run InfluxDB in [detached mode](https://docs.docker.com/engine/reference/run
    docker run \
        --name influxdb \
        -p 8086:8086 \
-       --volume $PWD:/root/.influxdbv2 \
+       --volume $PWD:/var/lib/influxdb2 \
        influxdb:2.0.6
    ```
 

--- a/static/downloads/influxdb-k8-minikube.yaml
+++ b/static/downloads/influxdb-k8-minikube.yaml
@@ -23,13 +23,13 @@ spec:
                 app: influxdb
         spec:
             containers:
-              - image: influxdb:2.0.4
+              - image: influxdb:2.0.6
                 name: influxdb
                 ports:
                   - containerPort: 8086
                     name: influxdb
                 volumeMounts:
-                  - mountPath: /root/.influxdbv2
+                  - mountPath: /var/lib/influxdb2
                     name: data
     volumeClaimTemplates:
       - metadata:


### PR DESCRIPTION
Also bump InfluxDB version in k8s example.

Closes #2463, #2385, #2324.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
