### PR TITLE
fix: remove semicolons from Flux examples #2490

### DIFF
--- a/content/influxdb/v2.0/write-data/developer-tools/csv.md
+++ b/content/influxdb/v2.0/write-data/developer-tools/csv.md
@@ -1,7 +1,7 @@
 ---
 title: Write CSV data to InfluxDB
 description: >
-  Write CSV data with the [`influx write` command](#influx-write-command) or Flux.
+  Write CSV data with the [`influx write` command](/influxdb/cloud/reference/cli/influx/write/) or Flux.
   Include annotations with the CSV data to determine how the data translates into
   [line protocol](/influxdb/v2.0/reference/syntax/line-protocol/).
 menu:
@@ -422,6 +422,7 @@ in the `double`, `long`, and `unsignedLong` datatype annotations.
 If your **numeric format separators** include a comma (`,`), wrap the column annotation in double
 quotes (`""`) to prevent the comma from being parsed as a column separator or delimiter.
 You can also [define a custom column separator](##################).
+You can also [define a custom column separator](/influxdb/v2.0/reference/syntax/annotated-csv/extended/#define-custom-column-separator).
 {{% /note %}}
 
 {{< tabs-wrapper >}}


### PR DESCRIPTION
Closes #2490

Fixup for previous merge.

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [x] Rebased/mergeable
