### PR TITLE
Prom histograms in Flux draft-in-progress

### DIFF
--- a/content/influxdb/v2.0/query-data/flux/histograms.md
+++ b/content/influxdb/v2.0/query-data/flux/histograms.md
@@ -247,7 +247,7 @@ argument `upperBoundColumn` (by default, `le`).
 but the `10s` bucket had a count of 10, the following error would occur: "histogram records counts are not monotonic".
 Given Prometheus increments the counts in each bucket continually as the process runs, whatever is most recently scraped from `/metrics` is a histogram of all the requests (events, etc) since the process started (maybe days, weeks, or longer). To be more useful, Telegraf scrapes at regular intervals, and we can subtract adjacent samples from the same bucket to discover the number of new items in that bucket for a given interval.
 
-Transform a set of cumulative histograms collected over time and visualize that as some quantile, such as the 50th percentile or 99th percentile) to show change over time. Complete the following high-level transformations:
+To transform a set of cumulative histograms collected over time and visualize that as some quantile (such as the 50th percentile or 99th percentile) and show change over time, complete the following high-level transformations:
 
 1. Downsample the data to a specified time resolution (for example, to see how the 50th percentile changes over a month), downsample to a resolution of `1h` to improve query performance).
 2. Subtract adjacent samples so that buckets contain only the new counts for each period.

--- a/content/influxdb/v2.0/query-data/flux/histograms.md
+++ b/content/influxdb/v2.0/query-data/flux/histograms.md
@@ -193,7 +193,7 @@ and `severity` as the **Group By** option:
 
 ### Use Prometheus histograms in Flux
 
-Monitor a service instrumented with a `/metrics` endpoint with InfluxDB and Telegraf. This example demonstrates how to use Telegraf to scrape `/metrics` at regular intervals (10s by default), and then send metrics to an InfluxDB instance.
+Use InfluxDB and Telegraf to monitor a service instrumented with an endpoint that outputs [prometheus-formatted metrics](/influxdb/v2.0/write-data/no-code/scrape-data/scrapable-endpoints/). This example demonstrates how to use Telegraf to scrape metrics from the InfluxDB 2.0 OSS `/metrics` endpoint at regular intervals (10s by default), and then store those metrics in InfluxDB.
 
 Use Prometheus histograms to measure the distribution of a variable, for example, the time it takes a server to respond to a request. This example applies to this use case, but can be adapted to others.
 

--- a/content/influxdb/v2.0/query-data/flux/histograms.md
+++ b/content/influxdb/v2.0/query-data/flux/histograms.md
@@ -313,4 +313,4 @@ union(tables: [
 ])
 ```
 
-The tables flowing into the call to `histogramQuantile` should look similar to this. Note, that rows are sorted by `le` to be clear that the counts increase for larger upper bounds):
+The tables piped-forward into `histogramQuantile()` should look similar to those returned by the `histograms` variable in the example above. Note, that rows are sorted by `le` to be clear that the counts increase for larger upper bounds.

--- a/content/influxdb/v2.0/query-data/flux/histograms.md
+++ b/content/influxdb/v2.0/query-data/flux/histograms.md
@@ -195,11 +195,10 @@ and `severity` as the **Group By** option:
 
 Use InfluxDB and Telegraf to monitor a service instrumented with an endpoint that outputs [prometheus-formatted metrics](/influxdb/v2.0/write-data/no-code/scrape-data/scrapable-endpoints/). This example demonstrates how to use Telegraf to scrape metrics from the InfluxDB 2.0 OSS `/metrics` endpoint at regular intervals (10s by default), and then store those metrics in InfluxDB.
 
-Use Prometheus histograms to measure the distribution of a variable, for example, the time it takes a server to respond to a request. This example applies to this use case, but can be adapted to others.
-
-Prometheus represents histograms as many sets of buckets (notably, different from an InfluxDB bucket).
+Use Prometheus histograms to measure the distribution of a variable, for example, the time it takes a server to respond to a request. Prometheus represents histograms as many sets of buckets (notably, different from an InfluxDB bucket).
 Each unique set of labels corresponds to one set of buckets; within that set, each bucket is labeled with an upper bound.
-You'll notice in this example, the upper bound label is `le`, which stands for *less than or equal to*. Notice the example output from `/metrics` below, there is a bucket for requests that take less-than-or-equal-to 0.005s, 0.01s, and so on, up to 10s and then +Inf. Note that the buckets are cumulative, so if a request takes 7.5s, Prometheus will increment the counters in the buckets for 10s as well as +Inf.
+In this example, the upper bound label is `le`, which stands for *less than or equal to*.
+In the example `/metrics` endpoint output below, there is a bucket for requests that take less-than-or-equal-to 0.005s, 0.01s, and so on, up to 10s and then +Inf. Note that the buckets are cumulative, so if a request takes 7.5s, Prometheus increments the counters in the buckets for 10s as well as +Inf.
 
 Sample output from a `/metrics` endpoint on an instance of InfluxDB OSS 2.0, including two histograms for requests served by the `/api/v2/write` and `/api/v2/query` endpoints.
 

--- a/content/influxdb/v2.0/query-data/flux/histograms.md
+++ b/content/influxdb/v2.0/query-data/flux/histograms.md
@@ -249,7 +249,12 @@ Given Prometheus increments the counts in each bucket continually as the process
 
 To transform a set of cumulative histograms collected over time and visualize that as some quantile (such as the 50th percentile or 99th percentile) and show change over time, complete the following high-level transformations:
 
-1. Downsample the data to a specified time resolution (for example, to see how the 50th percentile changes over a month), downsample to a resolution of `1h` to improve query performance).
+1. Use `aggregateWindow()` to downsample the data to a specified time resolution to improve query performance. For example, to see how the 50th percentile changes over a month, downsample to a resolution of `1h`.
+
+    ```js
+    // ...
+      |> aggregateWindow(every: 1h, fn: last)
+    ```
 2. Subtract adjacent samples so that buckets contain only the new counts for each period.
 3. Sum data across the dimensions that we aren't interested in. For example, in the Prometheus data from above, there is a label for path, but we may not care to break out http requests by path. If this is the case, we would ungroup the path dimension, and then add corresponding buckets together.
 4. Reshape the data so all duration buckets for the same period are in their own tables, with an upper bound column that describes the bucket represented by each row.

--- a/content/influxdb/v2.0/query-data/flux/histograms.md
+++ b/content/influxdb/v2.0/query-data/flux/histograms.md
@@ -237,7 +237,7 @@ http_api_request_duration_seconds_count{handler="platform",method="POST",path="/
 {{% /expand %}}
 {{< /expand-wrapper >}}
 
-Use the [histogramQuantile()](https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/histogramquantile/) function to convert a Prometheus histogram to the quantile requested by the caller.
+Use the [histogramQuantile()](/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/histogramquantile/) function to convert a Prometheus histogram to a specified quantile.
 This function expects a stream of input tables where each table has the following form:
 
 - Each row represents one bucket of a histogram, where the upper bound of the bucket is defined by the

--- a/content/influxdb/v2.0/query-data/flux/histograms.md
+++ b/content/influxdb/v2.0/query-data/flux/histograms.md
@@ -255,7 +255,7 @@ To transform a set of cumulative histograms collected over time and visualize th
     // ...
       |> aggregateWindow(every: 1h, fn: last)
     ```
-2. Subtract adjacent samples so that buckets contain only the new counts for each period.
+2. Use `difference()` to subtract adjacent samples so that buckets contain only the new counts for each period.
 3. Sum data across the dimensions that we aren't interested in. For example, in the Prometheus data from above, there is a label for path, but we may not care to break out http requests by path. If this is the case, we would ungroup the path dimension, and then add corresponding buckets together.
 4. Reshape the data so all duration buckets for the same period are in their own tables, with an upper bound column that describes the bucket represented by each row.
 5. Transform each table from a histogram to a quantile with the `histogramQuantile()` function.

--- a/content/influxdb/v2.0/query-data/flux/histograms.md
+++ b/content/influxdb/v2.0/query-data/flux/histograms.md
@@ -308,8 +308,8 @@ histograms =
 
 // Compute the 50th and 95th percentile for duration of http requests.
 union(tables: [
-  histos |> doQuantile(q:  0.95),
-  histos |> doQuantile(q:  0.5)
+  histograms |> doQuantile(q:  0.95),
+  histograms |> doQuantile(q:  0.5)
 ])
 ```
 

--- a/content/influxdb/v2.0/query-data/flux/histograms.md
+++ b/content/influxdb/v2.0/query-data/flux/histograms.md
@@ -278,7 +278,7 @@ doQuantile = (tables=<-, q) => tables
   |> map(fn: (r) => ({r with _measurement: "quantile", _field: string(v: q)}))
   |> experimental.group(mode: "extend", columns: ["_measurement", "_field"])
 
-histos =
+histograms =
   from(bucket: "telegraf")
   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
   |> filter(fn: (r) => r._measurement == "http_api_request_duration_seconds"

--- a/content/influxdb/v2.0/query-data/flux/histograms.md
+++ b/content/influxdb/v2.0/query-data/flux/histograms.md
@@ -200,9 +200,11 @@ Each unique set of labels corresponds to one set of buckets; within that set, ea
 In this example, the upper bound label is `le`, which stands for *less than or equal to*.
 In the example `/metrics` endpoint output below, there is a bucket for requests that take less-than-or-equal-to 0.005s, 0.01s, and so on, up to 10s and then +Inf. Note that the buckets are cumulative, so if a request takes 7.5s, Prometheus increments the counters in the buckets for 10s as well as +Inf.
 
-Sample output from a `/metrics` endpoint on an instance of InfluxDB OSS 2.0, including two histograms for requests served by the `/api/v2/write` and `/api/v2/query` endpoints.
+{{< expand-wrapper >}}
+{{% expand "View sample histogram data from the /metrics endpoint" %}}
+Sample histogram metrics from the `/metrics` endpoint on an instance of InfluxDB OSS 2.0, including two histograms for requests served by the `/api/v2/write` and `/api/v2/query` endpoints.
 
-```sh
+```js
 http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/write",response_code="204",status="2XX",user_agent="Telegraf",le="0.005"} 0
 http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/write",response_code="204",status="2XX",user_agent="Telegraf",le="0.01"} 1
 http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/write",response_code="204",status="2XX",user_agent="Telegraf",le="0.025"} 13
@@ -232,6 +234,8 @@ http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="
 http_api_request_duration_seconds_sum{handler="platform",method="POST",path="/api/v2/query",response_code="200",status="2XX",user_agent="Chrome"} 1.4840353630000003
 http_api_request_duration_seconds_count{handler="platform",method="POST",path="/api/v2/query",response_code="200",status="2XX",user_agent="Chrome"} 71
 ```
+{{% /expand %}}
+{{< /expand-wrapper >}}
 
 Use the [histogramQuantile()](https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/histogramquantile/) function to convert a Prometheus histogram to the quantile requested by the caller.
 This function expects a stream of input tables where each table has the following form:


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/2287. Incorporated content from Chris; @sanderson review and updates.

@wolffcm, we added this content to the "Create histograms with Flux" doc. You referred to the `histogramquantile()` function specifically. Is there a distinction to be made between this function and the `histogram()` function in the context of creating histograms for Flux? 

Does it make sense to include links on docs for both of these functions to this new content? Lmk your thoughts-thanks!