### PR TITLE
update: mention that max-select-point frequency only checks every second.

### DIFF
--- a/content/influxdb/v1.4/troubleshooting/query_management.md
+++ b/content/influxdb/v1.4/troubleshooting/query_management.md
@@ -141,6 +141,8 @@ the following error:
 ```
 ERR: max number of points reached
 ```
+InfluxDB checks the point count every second (so queries exceeding the maximum aren’t immediately aborted).
+
 
 ### max-select-series
 

--- a/content/influxdb/v1.5/troubleshooting/query_management.md
+++ b/content/influxdb/v1.5/troubleshooting/query_management.md
@@ -142,6 +142,8 @@ the following error:
 ```
 ERR: max number of points reached
 ```
+InfluxDB checks the point count every second (so queries exceeding the maximum aren’t immediately aborted).
+
 
 ### max-select-series
 

--- a/content/influxdb/v1.6/troubleshooting/query_management.md
+++ b/content/influxdb/v1.6/troubleshooting/query_management.md
@@ -142,6 +142,8 @@ the following error:
 ```
 ERR: max number of points reached
 ```
+InfluxDB checks the point count every second (so queries exceeding the maximum aren’t immediately aborted).
+
 
 ### max-select-series
 

--- a/content/influxdb/v1.7/troubleshooting/query_management.md
+++ b/content/influxdb/v1.7/troubleshooting/query_management.md
@@ -152,6 +152,9 @@ the following error:
 ERR: max number of points reached
 ```
 
+InfluxDB checks the point count every second (so queries exceeding the maximum aren’t immediately aborted).
+
+
 ### `max-select-series`
 
 The maximum number of [series](/influxdb/v1.7/concepts/glossary/#series) that a

--- a/content/influxdb/v1.8/troubleshooting/query_management.md
+++ b/content/influxdb/v1.8/troubleshooting/query_management.md
@@ -151,6 +151,8 @@ the following error:
 ```
 ERR: max number of points reached
 ```
+InfluxDB checks the point count every second (so queries exceeding the maximum aren’t immediately aborted).
+
 
 ### `max-select-series`
 

--- a/content/influxdb/v2.0/reference/config-options.md
+++ b/content/influxdb/v2.0/reference/config-options.md
@@ -652,7 +652,7 @@ influxql-max-select-buckets = 0
 ### influxql-max-select-point
 Maximum number of points a `SELECT` statement can process.
 `0` allows an unlimited number of points.
-This is only checked every second so queries will not be aborted immediately when hitting the limit.
+InfluxDB checks the point count every second (so queries exceeding the maximum aren’t immediately aborted).
 
 **Default:** `0`
 


### PR DESCRIPTION
Closes #1498 

The code comment isn't clear, but I'm assuming here that the count, not the config, is checked every second. I haven't verified it.