### PR TITLE
update: help Mac users resolve ulimit errors when writing CSV (#2491).

### DIFF
--- a/content/influxdb/v2.0/write-data/developer-tools/csv.md
+++ b/content/influxdb/v2.0/write-data/developer-tools/csv.md
@@ -94,7 +94,7 @@ When attempting to write large amounts of CSV data into InfluxDB, you might see 
 Error: Failed to write data: unexpected error writing points to database: [shard <#>] fcntl: too many open files.
 ```
 
-To fix this error on Linux or Mac OS, run the following command to increase the number of open files allowed:
+To fix this error on Linux or macOS, run the following command to increase the number of open files allowed:
 
   ```
   ulimit -n 10000

--- a/content/influxdb/v2.0/write-data/developer-tools/csv.md
+++ b/content/influxdb/v2.0/write-data/developer-tools/csv.md
@@ -94,11 +94,14 @@ When attempting to write large amounts of CSV data into InfluxDB, you might see 
 Error: Failed to write data: unexpected error writing points to database: [shard <#>] fcntl: too many open files.
 ```
 
-To fix this error, run the following command to increase the number of open files allowed by the OS (works on both Linux and MacOS):
+To fix this error on Linux or Mac OS, run the following command to increase the number of open files allowed:
 
-```
-ulimit -n 10000
-```
+  ```
+  ulimit -n 10000
+  ```
+
+Mac OS users, to persist the `ulimit` setting, follow the [recommended steps](https://unix.stackexchange.com/a/221988/471569) for your OS version.
+
 {{% /note %}}
 
 ## CSV Annotations

--- a/content/influxdb/v2.0/write-data/developer-tools/csv.md
+++ b/content/influxdb/v2.0/write-data/developer-tools/csv.md
@@ -100,7 +100,7 @@ To fix this error on Linux or Mac OS, run the following command to increase the 
   ulimit -n 10000
   ```
 
-Mac OS users, to persist the `ulimit` setting, follow the [recommended steps](https://unix.stackexchange.com/a/221988/471569) for your OS version.
+macOS users, to persist the `ulimit` setting, follow the [recommended steps](https://unix.stackexchange.com/a/221988/471569) for your operating system version.
 
 {{% /note %}}
 


### PR DESCRIPTION
Closes #2491 

LInked to the stackexchange answer since it's likely to be the most durable and updated - and provides references to Apple docs.
