### PR TITLE
Added Coveo search meta data

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,12 +16,12 @@
     <link rel="shortcut icon" href="/img/favicon.png" type="image/png" sizes="32x32">
 
     {{ partial "header/canonical.html" . }}
-    {{ partial "header/coveo-meta-data.html" . }}
     {{ partial "header/stylesheets.html" }}
     {{ partial "header/google-fonts.html" }}
     {{ partial "header/marketing.html" }}
     {{ partial "header/javascript.html" }}
     {{ partial "header/search-attributes.html" . }}
+    {{ partial "header/coveo-meta-data.html" . }}
 
     <meta name="Copyright" content="InfluxData Inc." />
   </head>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,6 +16,7 @@
     <link rel="shortcut icon" href="/img/favicon.png" type="image/png" sizes="32x32">
 
     {{ partial "header/canonical.html" . }}
+    {{ partial "header/coveo-meta-data.html" . }}
     {{ partial "header/stylesheets.html" }}
     {{ partial "header/google-fonts.html" }}
     {{ partial "header/marketing.html" }}

--- a/layouts/partials/header/coveo-meta-data.html
+++ b/layouts/partials/header/coveo-meta-data.html
@@ -1,0 +1,9 @@
+{{ $productPathData := findRE "[^/]+.*?" .RelPermalink }}
+{{ $product := index $productPathData 0 | default "none" }}
+{{ $currentVersion := index $productPathData 1 | default "none" }}
+{{ $isLatest := cond (eq .Kind "home") true (or (eq $currentVersion (index $.Site.Data.products $product).latest) (eq $currentVersion "cloud") (eq $product "platform")) }}
+
+<meta name="coveo-search-data" content="InfluxData Documentation"
+  data-latest="{{ cond $isLatest true false }}"
+  data-last-modified="{{ .Lastmod }}"
+/>

--- a/layouts/partials/header/coveo-meta-data.html
+++ b/layouts/partials/header/coveo-meta-data.html
@@ -3,7 +3,5 @@
 {{ $currentVersion := index $productPathData 1 | default "none" }}
 {{ $isLatest := cond (eq .Kind "home") true (or (eq $currentVersion (index $.Site.Data.products $product).latest) (eq $currentVersion "cloud") (eq $product "platform")) }}
 
-<meta name="coveo-search-data" content="InfluxData Documentation"
-  data-latest="{{ cond $isLatest true false }}"
-  data-last-modified="{{ .Lastmod }}"
-/>
+<meta name="latest" content="{{ cond $isLatest true false }}">
+<meta name="last-modified" content="{{ .Lastmod }}">


### PR DESCRIPTION
This adds meta data to every page that Coveo can use to prioritize documentation search results.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
