### PR TITLE
Add Enterprise 1.8.6 release notes

### DIFF
--- a/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
@@ -28,9 +28,9 @@ menu:
 
 ### Bug fixes
 
+- Use the proper TLS configuration when a meta node makes an remote procedure call (RPC) to a data node. Addresses RPC call issues using the following influxd-ctl commands: `copy-shard` `copy-shard-status` `kill-copy-shard` `remove-shard`
 - Previously, the Anti-Entropy service would loop trying to copy an empty shard to a data node missing that shard. Now, an empty shard is successfully created on a new node.
 - Check for previously ignored errors in `DiffIterator.Next()`. Update to check before possible function exit and ensure handles are closed on error in digest diffs.
-- Use the proper TLS configuration when a meta node makes an remote procedure call (RPC) to a data node. Addresses RPC call issues using the following influxd-ctl commands: `copy-shard` `copy-shard-status` `kill-copy-shard` `remove-shard`
 
 ## v1.8.5 [2020-04-20]
 

--- a/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
@@ -9,6 +9,23 @@ menu:
     parent: About the project
 ---
 
+## v1.8.6 [2021-05-21]
+
+{{% note %}}
+**Fine-grained authorization security update.** If you're on InfluxDB 1.8.5, we recommend immediately upgrading to this release. An issue was reported in 1.8.5 where grants with specified permissions for users were not enforced. Versions prior to InfluxDB 1.8.5 are not affected. This security update ensures that only users with sufficient permissions can read and write to a measurement.
+{{% /note %}}
+
+### Features
+
+- **Enhanced Anti-Entropy (AE) logging**: Add an optional `Engine.IsIdle()` trace logging to support debugging improvements in the Anti-Entropy service. Add an `IsLogged` parameter to `tsdb.Engine.IsIdle`. When trace logging is turned on, this option reports the reasons why a shard is not idle.
+- **Enhanced `copy-shard` logging**. Add information to log messages in `copy-shard` functions and additional error tests.
+
+### Bug fixes
+
+- Previously, the Anti-Entropy service would loop trying to copy an empty shard to a data node missing that shard. Now, an empty shard is successfully created on a new node.
+- Check for previously ignored errors in `DiffIterator.Next()`. Update to check before possible function exit and ensure handles are closed on error in digest diffs.
+- Use the proper TLS configuration when a meta node makes an remote procedure call (RPC) to a data node. Addresses RPC call issues using the following influxd-ctl commands: `copy-shard` `copy-shard-status` `kill-copy-shard` `remove-shard`
+
 ## v1.8.5 [2020-04-20]
 
 The InfluxDB Enterprise 1.8.5 release builds on the InfluxDB OSS 1.8.5 release.

--- a/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
@@ -12,7 +12,7 @@ menu:
 ## v1.8.6 [2021-05-21]
 
 {{% note %}}
-**Fine-grained authorization security update.** If you're on InfluxDB 1.8.5, we recommend immediately upgrading to this release. An issue was reported in 1.8.5 where grants with specified permissions for users were not enforced. Versions prior to InfluxDB 1.8.5 are not affected. This security update ensures that only users with sufficient permissions can read and write to a measurement.
+**Fine-grained authorization security update.** If you're on InfluxDB Enterprise 1.8.5, we recommend immediately upgrading to this release. An issue was reported in 1.8.5 where grants with specified permissions for users were not enforced. Versions prior to InfluxDB Enterprise 1.8.5 are not affected. This security update ensures that only users with sufficient permissions can read and write to a measurement.
 {{% /note %}}
 
 ### Features

--- a/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
@@ -17,7 +17,13 @@ menu:
 
 ### Features
 
-- **Enhanced Anti-Entropy (AE) logging**: Add an optional `Engine.IsIdle()` trace logging to support debugging improvements in the Anti-Entropy service. Add an `IsLogged` parameter to `tsdb.Engine.IsIdle`. When trace logging is turned on, this option reports the reasons why a shard is not idle.
+- **Enhanced Anti-Entropy (AE) logging**: When the [debug logging level](/enterprise_influxdb/v1.8/administration/config-data-nodes/#logging-settings) is set (`level="debug"`) in the data node configuration, the Anti-Entropy service reports reasons a shard is not idle, including:
+  - active Cache compactions
+  - active Level (Zero, One, Two) compactions
+  - active Full compactions
+  - active TSM Optimization compactions
+  - cache size is nonzero
+  - shard is not fully compacted
 - **Enhanced `copy-shard` logging**. Add information to log messages in `copy-shard` functions and additional error tests.
 
 ### Bug fixes

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -9,20 +9,6 @@ menu:
 v2: /influxdb/v2.0/reference/release-notes/influxdb/
 ---
 
-## v1.8.6 [2021-05-21]
-
-{{% note %}}
-**Fine-grained authorization security update.** If you're on InfluxDB 1.8.5, we recommend immediately upgrading to this release. An issue was reported in 1.8.5 where grants with specified permissions for users were not enforced. Versions prior to InfluxDB 1.8.5 are not affected. This security update ensures that only users with sufficient permissions can read and write to a measurement.
-{{% /note %}}
-
-### Features
-
-- **Enhanced Anti-Entropy (AE) logging**: Add an optional `Engine.IsIdle()` trace logging to support debugging improvements in the Anti-Entropy service. Add an `IsLogged` parameter to `tsdb.Engine.IsIdle`. When trace logging is turned on, this option reports the reasons why a shard is not idle.
-
-### Bug fixes
-
-- Previously, the Anti-Entropy service would loop trying to copy an empty shard to a data node missing that shard. Now, an empty shard is successfully created on a new node.
-
 ## v1.8.5 [2021-04-20]
 ### Features
 

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -9,7 +9,12 @@ menu:
 v2: /influxdb/v2.0/reference/release-notes/influxdb/
 ---
 
+## v1.8.6 [2021-05-21]
+
+This release is for InfluxDB Enterprise 1.8.6 customers only. No OSS-specific changes were made for InfluxDB 1.8.6--updates were made to the code base to support [InfluxDB Enterprise 1.8.6](/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog/#v186-2021-05-21).
+
 ## v1.8.5 [2021-04-20]
+
 ### Features
 
 - Add the ability to find which measurements or shards are contributing to disk size with the new [`influx_inspect report-disk`](/influxdb/v1.8/tools/influx_inspect/#report-disk) command. Useful for capacity planning and managing storage requirements.

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -9,6 +9,20 @@ menu:
 v2: /influxdb/v2.0/reference/release-notes/influxdb/
 ---
 
+## v1.8.6 [2021-05-21]
+
+{{% note %}}
+**Fine-grained authorization security update.** If you're on InfluxDB 1.8.5, we recommend immediately upgrading to this release. An issue was reported in 1.8.5 where grants with specified permissions for users were not enforced. Versions prior to InfluxDB 1.8.5 are not affected. This security update ensures that only users with sufficient permissions can read and write to a measurement.
+{{% /note %}}
+
+### Features
+
+- **Enhanced Anti-Entropy (AE) logging**: Add an optional `Engine.IsIdle()` trace logging to support debugging improvements in the Anti-Entropy service. Add an `IsLogged` parameter to `tsdb.Engine.IsIdle`. When trace logging is turned on, this option reports the reasons why a shard is not idle.
+
+### Bug fixes
+
+- Previously, the Anti-Entropy service would loop trying to copy an empty shard to a data node missing that shard. Now, an empty shard is successfully created on a new node.
+
 ## v1.8.5 [2021-04-20]
 ### Features
 


### PR DESCRIPTION
**Update**: Will post, Monday morning, May 24th. 

Added OSS 1.8.6 release notes for good measure being we're posting a binary on the download page. From what I understand, OSS-only folks will not need to install this release. Please update text as needed--thank you, @timhallinflux @psteinbachs 

Addresses: https://github.com/influxdata/docs-v2/issues/2578