### PR TITLE
fix: fixing some issues on the pagerduty.endpoint page

### DIFF
--- a/content/influxdb/v2.0/reference/flux/stdlib/pagerduty/endpoint.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/pagerduty/endpoint.md
@@ -12,29 +12,29 @@ weight: 202
 influxdb/v2.0/tags: [endpoints]
 ---
 
-The `pagerduty.endpoint()` function sends a message to PagerDuty that includes output data.
+The `pagerduty.endpoint()` returns a function that can be used to send a message to PagerDuty that includes output data.
 
 _**Function type:** Output_
 
 ```js
 import "pagerduty"
 
-pagerduty.endpoint(
+toPagerDuty = pagerduty.endpoint(
   url: "https://events.pagerduty.com/v2/enqueue"
 )
 ```
 
 ## Parameters
 
-### pagerdutyURL
-The PagerDuty API URL.
+### url
+The PagerDuty v2 Events API URL.
 Defaults to `https://events.pagerduty.com/v2/enqueue`.
 
 _**Data type:** String_
 
 ## Usage
 `pagerduty.endpoint` is a factory function that outputs another function.
-The output function requires a `mapFn` parameter.
+The output function requires a `mapFn` parameter. See the [PagerDuty v2 Events API documentation](https://developer.pagerduty.com/api-reference/reference/events-v2/openapiv3.json) for more information about these parameters.
 
 ### mapFn
 ({{< req >}}) A function that builds the record used to generate the POST request.
@@ -65,8 +65,8 @@ _For more information, see [`pagerduty.sendEvent()`](/influxdb/v2.0/reference/fl
 import "pagerduty"
 import "influxdata/influxdb/secrets"
 
-token = secrets.get(key: "PAGERDUTY_TOKEN")
-toPagerDuty = pagerduty.endpoint(token: token)
+routingKey = secrets.get(key: "PAGERDUTY_ROUTING_KEY")
+toPagerDuty = pagerduty.endpoint()
 
 crit_statuses = from(bucket: "example-bucket")
   |> range(start: -1m)
@@ -74,7 +74,7 @@ crit_statuses = from(bucket: "example-bucket")
 
 crit_statuses
   |> toPagerDuty(mapFn: (r) => ({ r with
-      routingKey: r.routingKey,
+      routingKey: routingKey,
       client: r.client,
       clientURL: r.clientURL,
       class: r.class,


### PR DESCRIPTION
Closes #

noticed some issues with the pagerduty endpoint page.
 - the parameter name was wrong
 - the token should be the routing key
 - the routing key isn't passed into the endpoint function
 - added a link to the pagerduty v2 docs

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
