### PR TITLE
Remove use of `influx restore --input` flag

### DIFF
--- a/content/influxdb/cloud/reference/cli/influx/restore/index.md
+++ b/content/influxdb/cloud/reference/cli/influx/restore/index.md
@@ -48,7 +48,6 @@ influx restore [flags]
 | `-h` | `--help`          | Help for the `restore` command                                        |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
 |      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
-|      | `--input`         | ({{< req >}}) Path to local backup directory                          | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 |      | `--new-bucket`    | Name of the bucket to restore to                                      | string      |                       |
 |      | `--new-org`       | Name of the organization to restore to                                | string      |                       |
@@ -67,20 +66,20 @@ influx restore [flags]
 
 ##### Restore and replace all data
 ```sh
-influx restore --full --input /path/to/backup/dir/
+influx restore --full /path/to/backup/dir/
 ```
 
 ##### Restore backup data to an existing bucket
 ```sh
 influx restore \
   --bucket example-bucket \
-  --input /path/to/backup/dir/
+  /path/to/backup/dir/
 ```
 
 ##### Create a bucket and restore data to it
 ```sh
 influx restore \
   --new-bucket new-example-bucket \
-  --input /path/to/backup/dir/
+  /path/to/backup/dir/
 ```
 

--- a/content/influxdb/v2.0/backup-restore/restore.md
+++ b/content/influxdb/v2.0/backup-restore/restore.md
@@ -52,8 +52,7 @@ To restore all time series data from a backup directory, provide the following:
 - backup directory path
 
 ```sh
-influx restore \
-  --input /backups/2020-01-20_12-00/
+influx restore /backups/2020-01-20_12-00/
 ```
 
 ### Restore data from a specific bucket
@@ -64,13 +63,13 @@ To restore data from a specific backup bucket, provide the following:
 
 ```sh
 influx restore \
-  --input /backups/2020-01-20_12-00/ \
+  /backups/2020-01-20_12-00/ \
   --bucket example-bucket
 
 # OR
 
 influx restore \
-  --input /backups/2020-01-20_12-00/ \
+  /backups/2020-01-20_12-00/ \
   --bucket-id 000000000000
 ```
 
@@ -80,7 +79,7 @@ restore data into it.
 
 ```sh
 influx restore \
-  --input /backups/2020-01-20_12-00/ \
+  /backups/2020-01-20_12-00/ \
   --bucket example-bucket \
   --new-bucket new-example-bucket
 ```
@@ -94,7 +93,7 @@ tokens, users, dashboards, etc., include the following:
 
 ```sh
 influx restore \
-  --input /backups/2020-01-20_12-00/ \
+  /backups/2020-01-20_12-00/ \
   --full
 ```
 
@@ -113,7 +112,7 @@ If using a backup to populate a new InfluxDB server:
 
     ```sh
     influx restore \
-      --input /backups/2020-01-20_12-00/ \
+      /backups/2020-01-20_12-00/ \
       --full
     ```
 

--- a/content/influxdb/v2.0/reference/cli/influx/restore/index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/restore/index.md
@@ -52,7 +52,6 @@ influx restore [flags]
 | `-h` | `--help`          | Help for the `restore` command                                        |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
 |      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
-|      | `--input`         | ({{< req >}}) Path to local backup directory                          | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 |      | `--new-bucket`    | Name of the bucket to restore to                                      | string      |                       |
 |      | `--new-org`       | Name of the organization to restore to                                | string      |                       |
@@ -71,8 +70,7 @@ influx restore [flags]
 
 ##### Restore backup data
 ```sh
-influx restore \
-  --input /path/to/backup/dir/
+influx restore /path/to/backup/dir/
 ```
 
 ##### Restore backup data for a specific bucket into a new bucket
@@ -80,7 +78,7 @@ influx restore \
 influx restore \
   --bucket example-bucket \
   --new-bucket new-example-bucket \
-  --input /path/to/backup/dir/
+  /path/to/backup/dir/
 ```
 
 ##### Restore and replace all data
@@ -90,5 +88,5 @@ data such as tokens, dashboards, users, etc.
 {{% /note %}}
 
 ```sh
-influx restore --full --input /path/to/backup/dir/
+influx restore --full /path/to/backup/dir/
 ```


### PR DESCRIPTION
Examples now use the new method with a positional argument.

Closes #2635.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
