### PR TITLE
InfluxDB 2.0.7 cleanup

### DIFF
--- a/content/influxdb/v2.0/reference/config-options.md
+++ b/content/influxdb/v2.0/reference/config-options.md
@@ -120,7 +120,6 @@ To configure InfluxDB, use the following configuration options when starting the
 - [secret-store](#secret-store)
 - [session-length](#session-length)
 - [session-renew-disabled](#session-renew-disabled)
-- [sqlite-path](#sqlite-path)
 - [storage-cache-max-memory-size](#storage-cache-max-memory-size)
 - [storage-cache-snapshot-memory-size](#storage-cache-snapshot-memory-size)
 - [storage-cache-snapshot-write-cold-duration](#storage-cache-snapshot-write-cold-duration)
@@ -1471,6 +1470,7 @@ session-renew-disabled = true
 ---
 
 
+<!--
 ### sqlite-path
 
 Path to the SQLite database file.
@@ -1519,6 +1519,7 @@ sqlite_path = "/users/user/.influxdbv2/influxd.sqlite"
 {{< /code-tabs-wrapper >}}
 
 ---
+-->
 
 ### storage-cache-max-memory-size
 Maximum size (in bytes) a shard's cache can reach before it starts rejecting writes.

--- a/content/influxdb/v2.0/reference/release-notes/influxdb.md
+++ b/content/influxdb/v2.0/reference/release-notes/influxdb.md
@@ -13,7 +13,7 @@ weight: 101
 ### Features
 
 - Upgrade Flux to [v0.117.0](/influxdb/v2.0/reference/release-notes/flux/#v01171-2021-06-01)
-- Optimize [table.fill()](https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/table/fill/) execution within Flux aggregate windows.
+- Optimize [`table.fill()`](https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/table/fill/) execution within Flux aggregate windows.
 - Upgrade UI to v2.0.7.
 
 ### Bug Fixes

--- a/content/influxdb/v2.0/reference/release-notes/influxdb.md
+++ b/content/influxdb/v2.0/reference/release-notes/influxdb.md
@@ -12,13 +12,13 @@ weight: 101
 
 ### Features
 
-- Upgrade Flux to v0.117.0 <!-- https://github.com/influxdata/influxdb/pull/21519 -->
+- Upgrade Flux to [v0.117.0](/influxdb/v2.0/reference/release-notes/flux/#v01171-2021-06-01)
 - Optimize [table.fill()] execution within Flux aggregate windows. <!-- https://github.com/influxdata/influxdb/pull/21519 -->
 - Upgrade UI to v2.0.7 <!-- https://github.com/influxdata/influxdb/pull/21564 -->
 
 ### Bug Fixes
 
-- Fix off-by-one error in query range calculation over partially compacted data. <!-- https://github.com/influxdata/influxdb/pull/21349 -->
+- Fix query range calculation (off by one) over partially compacted data.
 - Deprecate the unsupported `PostSetupUser` API. <!-- https://github.com/influxdata/influxdb/pull/21350 -->
 - Add limits to the `/api/v2/delete` endpoint for start and stop times with error messages. <!-- https://github.com/influxdata/influxdb/pull/21376 -->
 - Add logging to NATS streaming server to help debug startup failures. <!-- https://github.com/influxdata/influxdb/pull/21379 -->

--- a/content/influxdb/v2.0/reference/release-notes/influxdb.md
+++ b/content/influxdb/v2.0/reference/release-notes/influxdb.md
@@ -13,22 +13,22 @@ weight: 101
 ### Features
 
 - Upgrade Flux to [v0.117.0](/influxdb/v2.0/reference/release-notes/flux/#v01171-2021-06-01)
-- Optimize [table.fill()] execution within Flux aggregate windows. <!-- https://github.com/influxdata/influxdb/pull/21519 -->
-- Upgrade UI to v2.0.7 <!-- https://github.com/influxdata/influxdb/pull/21564 -->
+- Optimize [table.fill()](https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/table/fill/) execution within Flux aggregate windows.
+- Upgrade UI to v2.0.7.
 
 ### Bug Fixes
 
 - Fix query range calculation (off by one) over partially compacted data.
-- Deprecate the unsupported `PostSetupUser` API. <!-- https://github.com/influxdata/influxdb/pull/21350 -->
-- Add limits to the `/api/v2/delete` endpoint for start and stop times with error messages. <!-- https://github.com/influxdata/influxdb/pull/21376 -->
-- Add logging to NATS streaming server to help debug startup failures. <!-- https://github.com/influxdata/influxdb/pull/21379 -->
-- Accept `--input` instead of a positional argument in `influx restore`. <!-- https://github.com/influxdata/influxdb/pull/21479 -->
-- Print error instead of panicking when `influx restore` fails to find backup manifests. <!-- https://github.com/influxdata/influxdb/pull/21479 -->
-- Set last-modified time of empty shard directory to the directory's last-modified time, instead of the Unix epoch. <!-- https://github.com/influxdata/influxdb/pull/21485 -->
-- Remove deadlock in `influx org members list` when an organization has greater than 10 members. <!-- https://github.com/influxdata/influxdb/pull/21501 -->
-- Replace telemetry file name with slug for `ttf`, `woff`, and `eot` files. <!-- https://github.com/influxdata/influxdb/pull/21524 -->
-- Enable use of absolute path for `--upgrade-log` when running `influxd upgrade` on Windows. <!-- https://github.com/influxdata/influxdb/pull/21549 -->
-- Make InfluxQL meta queries respect query timeouts. <!-- https://github.com/influxdata/influxdb/pull/21548 -->
+- Deprecate the unsupported `PostSetupUser` API.
+- Add limits to the `/api/v2/delete` endpoint for start and stop times with error messages.
+- Add logging to NATS streaming server to help debug startup failures.
+- Accept `--input` instead of a positional argument in `influx restore`.
+- Print error instead of panicking when `influx restore` fails to find backup manifests.
+- Set last-modified time of empty shard directory to the directory's last-modified time, instead of the Unix epoch.
+- Remove deadlock in `influx org members list` when an organization has greater than 10 members.
+- Replace telemetry file name with slug for `ttf`, `woff`, and `eot` files.
+- Enable use of absolute path for `--upgrade-log` when running `influxd upgrade` on Windows.
+- Make InfluxQL meta queries respect query timeouts.
 
 ---
 

--- a/content/influxdb/v2.0/reference/release-notes/influxdb.md
+++ b/content/influxdb/v2.0/reference/release-notes/influxdb.md
@@ -22,11 +22,6 @@ for storing metadata required by the latest UI features like notebooks and annot
   `axisTicksGenerator`, `legendOrientation`, `mosaicGraphType`, and `bandPlotType`.
 - Allow hiding the tooltip independently of the static legend. <!-- https://github.com/influxdata/influxdb/pull/21547:  -->
 - Support pagination when listing users via the API. <!-- https://github.com/influxdata/influxdb/pull/21367:  -->
-- Add `influxd` configuration flag [`--sqlite-path`](/influxdb/v2.0/reference/config-options/#sqlite-path).
-  for specifying a user-defined path to the SQLite database file. <!-- https://github.com/influxdata/influxdb/pull/21543:  -->
-- Update `influxd` configuration flag `--store` to work with string values `disk` or `memory`.
-  `memory` continues to store metadata in-memory for testing;
-  `disk` persists metadata to disk via bolt and SQLite. <!-- https://github.com/influxdata/influxdb/pull/21543:  -->
 
 ### Bug Fixes
 - Deprecate the `PostSetupUser` API. <!-- https://github.com/influxdata/influxdb/pull/21345: --> 

--- a/content/influxdb/v2.0/reference/release-notes/influxdb.md
+++ b/content/influxdb/v2.0/reference/release-notes/influxdb.md
@@ -10,30 +10,25 @@ weight: 101
 
 ## v2.0.7 [2021-TK]
 
-### SQLite Metadata Store
-
-This release adds an embedded SQLite database
-for storing metadata required by the latest UI features like notebooks and annotations.
-
 ### Features
-- Add Geo graph type to be able to store in Dashboard cells. <!-- https://github.com/influxdata/influxdb/pull/19811:  -->
-- Add the properties of a static legend for line graphs and band plots. <!-- https://github.com/influxdata/influxdb/pull/21218:  -->
-- Remove feature flags for permanent UI features: <!-- https://github.com/influxdata/influxdb/pull/21531:  -->
-  `axisTicksGenerator`, `legendOrientation`, `mosaicGraphType`, and `bandPlotType`.
-- Allow hiding the tooltip independently of the static legend. <!-- https://github.com/influxdata/influxdb/pull/21547:  -->
-- Support pagination when listing users via the API. <!-- https://github.com/influxdata/influxdb/pull/21367:  -->
+
+- Upgrade Flux to v0.117.0 <!-- https://github.com/influxdata/influxdb/pull/21519 -->
+- Optimize [table.fill()] execution within Flux aggregate windows. <!-- https://github.com/influxdata/influxdb/pull/21519 -->
+- Upgrade UI to v2.0.7 <!-- https://github.com/influxdata/influxdb/pull/21564 -->
 
 ### Bug Fixes
-- Deprecate the `PostSetupUser` API. <!-- https://github.com/influxdata/influxdb/pull/21345: --> 
-- Disable `MergeFiltersRule` until it is more stable. <!-- https://github.com/influxdata/influxdb/pull/21356: --> 
-- Add limits to the `/api/v2/delete` endpoint for start and stop times with error messages. <!-- https://github.com/influxdata/influxdb/pull/21369: --> 
-- Add logging to NATS streaming server to help debug startup failures. <!-- https://github.com/influxdata/influxdb/pull/21375: --> 
-- Accept `--input` flag instead of a positional argument in `influx restore`. <!-- https://github.com/influxdata/influxdb/pull/21477: --> 
-- Print error instead of panicking when `influx restore` fails to find backup manifests. <!-- https://github.com/influxdata/influxdb/pull/21477: --> 
-- Set last modified time of empty shard directory to the directory's last modified time, instead of the Unix epoch. <!-- https://github.com/influxdata/influxdb/pull/21481: --> 
-- Replace telemetry file name with slug for `ttf`, `woff`, and `eot` files. <!-- https://github.com/influxdata/influxdb/pull/21522: --> 
-- Enable use of absolute path for `--upgrade-log` when running `influxd upgrade` on Windows. <!-- https://github.com/influxdata/influxdb/pull/21540: --> 
-- Make InfluxQL meta queries respect query timeouts. <!-- https://github.com/influxdata/influxdb/pull/21545: --> 
+
+- Fix off-by-one error in query range calculation over partially compacted data. <!-- https://github.com/influxdata/influxdb/pull/21349 -->
+- Deprecate the unsupported `PostSetupUser` API. <!-- https://github.com/influxdata/influxdb/pull/21350 -->
+- Add limits to the `/api/v2/delete` endpoint for start and stop times with error messages. <!-- https://github.com/influxdata/influxdb/pull/21376 -->
+- Add logging to NATS streaming server to help debug startup failures. <!-- https://github.com/influxdata/influxdb/pull/21379 -->
+- Accept `--input` instead of a positional argument in `influx restore`. <!-- https://github.com/influxdata/influxdb/pull/21479 -->
+- Print error instead of panicking when `influx restore` fails to find backup manifests. <!-- https://github.com/influxdata/influxdb/pull/21479 -->
+- Set last-modified time of empty shard directory to the directory's last-modified time, instead of the Unix epoch. <!-- https://github.com/influxdata/influxdb/pull/21485 -->
+- Remove deadlock in `influx org members list` when an organization has greater than 10 members. <!-- https://github.com/influxdata/influxdb/pull/21501 -->
+- Replace telemetry file name with slug for `ttf`, `woff`, and `eot` files. <!-- https://github.com/influxdata/influxdb/pull/21524 -->
+- Enable use of absolute path for `--upgrade-log` when running `influxd upgrade` on Windows. <!-- https://github.com/influxdata/influxdb/pull/21549 -->
+- Make InfluxQL meta queries respect query timeouts. <!-- https://github.com/influxdata/influxdb/pull/21548 -->
 
 ---
 

--- a/layouts/shortcodes/cli/influxd-flags.md
+++ b/layouts/shortcodes/cli/influxd-flags.md
@@ -26,7 +26,6 @@
 - [\--secret-store](/influxdb/v2.0/reference/config-options/#secret-store)
 - [\--session-length](/influxdb/v2.0/reference/config-options/#session-length)
 - [\--session-renew-disabled](/influxdb/v2.0/reference/config-options/#session-renew-disabled)
-- [\--sqlite-path](/influxdb/v2.0/reference/config-options/#sqlite-path)
 - [\--storage-cache-max-memory-size](/influxdb/v2.0/reference/config-options/#storage-cache-max-memory-size)
 - [\--storage-cache-snapshot-memory-size](/influxdb/v2.0/reference/config-options/#storage-cache-snapshot-memory-size)
 - [\--storage-cache-snapshot-write-cold-duration](/influxdb/v2.0/reference/config-options/#storage-cache-snapshot-write-cold-duration)


### PR DESCRIPTION
Fixes release notes to reflect https://github.com/influxdata/influxdb/blob/2.0/CHANGELOG.md.

Comments out documentation added regarding `--sql-path`, since this will be useful in the future.

Closes #2663.
Closes #2664.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
