### PR TITLE
Fix typo in optimize-queries.md with `set()` function

### DIFF
--- a/content/influxdb/v2.0/query-data/optimize-queries.md
+++ b/content/influxdb/v2.0/query-data/optimize-queries.md
@@ -147,7 +147,7 @@ data
 
 // Recommended
 data
-  |> set(key: "foo", as: "bar" }))
+  |> set(key: "foo", value: "bar")
 ```
 
 #### Dynamically set a column value using existing row data


### PR DESCRIPTION
The `set()` function uses the kwarg `value`, not `as`. It's also a normal function and doesn't use braces.
