### PR TITLE
fix: update usage for `influx restore`

### DIFF
--- a/content/influxdb/v2.0/backup-restore/restore.md
+++ b/content/influxdb/v2.0/backup-restore/restore.md
@@ -52,26 +52,25 @@ To restore all time series data from a backup directory, provide the following:
 - backup directory path
 
 ```sh
-influx restore \
-  --input /backups/2020-01-20_12-00/
+influx restore /backups/2020-01-20_12-00/
 ```
 
 ### Restore data from a specific bucket
 To restore data from a specific backup bucket, provide the following:
 
-- backup directory path
 - bucket name or ID
+- backup directory path
 
 ```sh
 influx restore \
-  --input /backups/2020-01-20_12-00/ \
-  --bucket example-bucket
+  --bucket example-bucket \
+  /backups/2020-01-20_12-00/
 
 # OR
 
 influx restore \
-  --input /backups/2020-01-20_12-00/ \
-  --bucket-id 000000000000
+  --bucket-id 000000000000 \
+  /backups/2020-01-20_12-00/
 ```
 
 If a bucket with the same name as the backed up bucket already exists in InfluxDB,
@@ -80,9 +79,9 @@ restore data into it.
 
 ```sh
 influx restore \
-  --input /backups/2020-01-20_12-00/ \
   --bucket example-bucket \
-  --new-bucket new-example-bucket
+  --new-bucket new-example-bucket \
+  /backups/2020-01-20_12-00/
 ```
 
 ### Restore and replace all InfluxDB data
@@ -94,8 +93,8 @@ tokens, users, dashboards, etc., include the following:
 
 ```sh
 influx restore \
-  --input /backups/2020-01-20_12-00/ \
-  --full
+  --full \
+  /backups/2020-01-20_12-00/
 ```
 
 {{% note %}}
@@ -113,8 +112,8 @@ If using a backup to populate a new InfluxDB server:
 
     ```sh
     influx restore \
-      --input /backups/2020-01-20_12-00/ \
-      --full
+      --full \
+      /backups/2020-01-20_12-00/
     ```
 
 If you do not provide the admin token from your source InfluxDB instance as the

--- a/content/influxdb/v2.0/reference/cli/influx/restore/index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/restore/index.md
@@ -37,7 +37,7 @@ and then begin the restore process.
 ## Usage
 
 ```
-influx restore [flags]
+influx restore [flags] path
 ```
 
 ## Flags
@@ -52,7 +52,6 @@ influx restore [flags]
 | `-h` | `--help`          | Help for the `restore` command                                        |             |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |             | `INFLUX_HIDE_HEADERS` |
 |      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string      | `INFLUX_HOST`         |
-|      | `--input`         | ({{< req >}}) Path to local backup directory                          | string      |                       |
 |      | `--json`          | Output data as JSON (default `false`)                                 |             | `INFLUX_OUTPUT_JSON`  |
 |      | `--new-bucket`    | Name of the bucket to restore to                                      | string      |                       |
 |      | `--new-org`       | Name of the organization to restore to                                | string      |                       |
@@ -71,8 +70,7 @@ influx restore [flags]
 
 ##### Restore backup data
 ```sh
-influx restore \
-  --input /path/to/backup/dir/
+influx restore /path/to/backup/dir/
 ```
 
 ##### Restore backup data for a specific bucket into a new bucket
@@ -80,7 +78,7 @@ influx restore \
 influx restore \
   --bucket example-bucket \
   --new-bucket new-example-bucket \
-  --input /path/to/backup/dir/
+  /path/to/backup/dir/
 ```
 
 ##### Restore and replace all data
@@ -90,5 +88,5 @@ data such as tokens, dashboards, users, etc.
 {{% /note %}}
 
 ```sh
-influx restore --full --input /path/to/backup/dir/
+influx restore --full /path/to/backup/dir/
 ```


### PR DESCRIPTION
Found this while responding to a community question about how to do a restore - the docs show a flag of `--input`, but that's not actually a flag (anymore?) and is now actually the argument.