### PR TITLE
Remove trailing / from API

### DIFF
--- a/content/influxdb/cloud/tools/postman.md
+++ b/content/influxdb/cloud/tools/postman.md
@@ -45,5 +45,5 @@ To test the authentication, enter the root API endpoint of an InfluxDB Cloud URL
 
 ###### InfluxDB API endpoint
 ```
-https://cloud2.influxdata.com/api/v2/
+https://cloud2.influxdata.com/api/v2
 ```

--- a/content/influxdb/v2.0/tools/postman.md
+++ b/content/influxdb/v2.0/tools/postman.md
@@ -44,5 +44,5 @@ To test the authentication, enter the root endpoint of an InfluxDB OSS instance 
 
 ###### InfluxDB API endpoint
 ```sh
-http://localhost:8086/api/v2/
+http://localhost:8086/api/v2
 ```


### PR DESCRIPTION

Customer support case feedback:
I got past my issue accessing our cloud with Postman, simply by removing the trailing slash from the endpoint URL shown in [your documentation](https://docs.influxdata.com/influxdb/cloud/tools/postman/)  - - that was an easy one.


