### PR TITLE
Kapacitor 1.6.0 release notes

### DIFF
--- a/content/kapacitor/v1.6/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.6/about_the_project/releasenotes-changelog.md
@@ -8,7 +8,7 @@ menu:
 
 ## v1.5.9 [2021-04-01]
 
-## Features
+### Features
 
 #### New event handler
 
@@ -53,7 +53,7 @@ If you’ve installed this release, please roll back to v1.5.7 as soon as possib
 
 ## v1.5.7 [2020-10-26]
 
-## Features
+### Features
 
 - Add the `.recoveryaction()` method to support overriding the OpsGenieV2 alert recovery action in a TICKscript, thanks @zabullet!
 - Add support for templating URLs in the [`httpPost` node](/kapacitor/v1.6/nodes/http_post_node/) and [`alert` node](/kapacitor/v1.6/nodes/alert_node/). To set up an template:
@@ -69,7 +69,7 @@ If you’ve installed this release, please roll back to v1.5.7 as soon as possib
 
 ## v1.5.6 [2020-07-17]
 
-## Features
+### Features
 
 - Add [Microsoft Teams event handler](/kapacitor/v1.6/event_handlers/microsoftteams/), thanks @mmindenhall!
 - Add [Discord event handler](/kapacitor/v1.6/event_handlers/discord/), thanks @mattnotmitt!
@@ -88,7 +88,7 @@ If you’ve installed this release, please roll back to v1.5.7 as soon as possib
 
 ## v1.5.5 [2020-04-20]
 
-## Breaking changes
+### Breaking changes
 
 - Update release checksums (used to verify release bits haven't been tampered with) from MD5 (Message Digest, 128-bit digest) to SHA-256 (Secure Hash Algorithm 2, 256-bit digest).
 
@@ -98,7 +98,7 @@ If you’ve installed this release, please roll back to v1.5.7 as soon as possib
 
 ## v1.5.4 [2020-01-16]
 
-## Features
+### Features
 
 - Add the ability to use templates when specifying MQTT (message queue telemetry transport) topic.
 - Upgrade to support Python 3.0 for user defined functions (UDFs).

--- a/content/kapacitor/v1.6/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.6/about_the_project/releasenotes-changelog.md
@@ -6,6 +6,22 @@ menu:
     parent: About the project
 ---
 
+## v1.6.0 [2021-TK]
+
+### Features
+
+- Add Zenoss alert event handler. <!-- https://github.com/influxdata/kapacitor/pull/#2484 -->
+- Route kafka alerts to partitions by ID, and allow for configuring the hashing strategy. <!-- https://github.com/influxdata/kapacitor/pull/#2493 -->
+- Pull in auth code from Kapacitor Enterprise. <!-- https://github.com/influxdata/kapacitor/pull/#2512 -->
+- Add a node tricklenode that converts batches to streams, the inverse of windownode. <!-- https://github.com/influxdata/kapacitor/pull/#2530 -->
+- flux tasks skeleton in Kapacitor <!-- https://github.com/influxdata/kapacitor/pull/#2544 -->
+- run flux tasks with built-in flux engine <!-- https://github.com/influxdata/kapacitor/pull/#2555 -->
+- kapacitor cli supports flux tasks <!-- https://github.com/influxdata/kapacitor/pull/#2559 -->
+- enable new-style slack apps <!-- https://github.com/influxdata/kapacitor/pull/#2560 -->
+
+### Bugfixes
+- Fix a panic in the scraper handler when debug mode is enabled <!-- https://github.com/influxdata/kapacitor/pull/#2564 -->
+
 ## v1.5.9 [2021-04-01]
 
 ### Features

--- a/content/kapacitor/v1.6/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.6/about_the_project/releasenotes-changelog.md
@@ -10,17 +10,16 @@ menu:
 
 ### Features
 
-- Support Flux tasks in Kapacitor CLI. <!-- https://github.com/influxdata/kapacitor/pull/2559 -->
-- Run Flux tasks with built-in Flux engine. <!-- https://github.com/influxdata/kapacitor/pull/2555 -->
-- Add Zenoss alert event handler. <!-- https://github.com/influxdata/kapacitor/pull/2484 -->
-- Route kafka alerts to partitions by ID, and allow for configuring the hashing strategy. <!-- https://github.com/influxdata/kapacitor/pull/2493 -->
-- Pull in authorization code from Kapacitor Enterprise. <!-- https://github.com/influxdata/kapacitor/pull/2512 -->
-- Add a node `tricklenode` that converts batches to streams (the inverse of `windownode`). <!-- https://github.com/influxdata/kapacitor/pull/2530 -->
-- Enable new-style Slack apps. <!-- https://github.com/influxdata/kapacitor/pull/2560 -->
-<!-- - flux tasks skeleton in Kapacitor <\!-- https://github.com/influxdata/kapacitor/pull/2544 -\-> -->
+- Add Kapacitor Flux task commands to the `kapacitor` CLI.
+- Add built-in Flux engine to support Flux tasks in Kapacitor.
+- Add Zenoss alert event handler. 
+- Route Kafka alerts to partitions by ID, and support hashing strategy configuration .
+- Add user-based authentnication
+- Add TrickleNode (`trickle`) that converts batches to streams (the inverse of `windownode`). 
+- Enable new-style Slack applications.
 
 ### Bugfixes
-- Fix a panic in the scraper handler when debug mode is enabled. <!-- https://github.com/influxdata/kapacitor/pull/2564 -->
+- Fix a panic in the scraper handler when debug mode is enabled. 
 
 ## v1.5.9 [2021-04-01]
 

--- a/content/kapacitor/v1.6/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.6/about_the_project/releasenotes-changelog.md
@@ -10,8 +10,8 @@ menu:
 
 ### Features
 
-- Support flux tasks in Kapacitor CLI. <!-- https://github.com/influxdata/kapacitor/pull/2559 -->
-- Run flux tasks with built-in flux engine <!-- https://github.com/influxdata/kapacitor/pull/2555 -->
+- Support Flux tasks in Kapacitor CLI. <!-- https://github.com/influxdata/kapacitor/pull/2559 -->
+- Run Flux tasks with built-in Flux engine. <!-- https://github.com/influxdata/kapacitor/pull/2555 -->
 - Add Zenoss alert event handler. <!-- https://github.com/influxdata/kapacitor/pull/2484 -->
 - Route kafka alerts to partitions by ID, and allow for configuring the hashing strategy. <!-- https://github.com/influxdata/kapacitor/pull/2493 -->
 - Pull in authorization code from Kapacitor Enterprise. <!-- https://github.com/influxdata/kapacitor/pull/2512 -->

--- a/content/kapacitor/v1.6/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.6/about_the_project/releasenotes-changelog.md
@@ -10,17 +10,17 @@ menu:
 
 ### Features
 
-- Add Zenoss alert event handler. <!-- https://github.com/influxdata/kapacitor/pull/#2484 -->
-- Route kafka alerts to partitions by ID, and allow for configuring the hashing strategy. <!-- https://github.com/influxdata/kapacitor/pull/#2493 -->
-- Pull in auth code from Kapacitor Enterprise. <!-- https://github.com/influxdata/kapacitor/pull/#2512 -->
-- Add a node tricklenode that converts batches to streams, the inverse of windownode. <!-- https://github.com/influxdata/kapacitor/pull/#2530 -->
-- flux tasks skeleton in Kapacitor <!-- https://github.com/influxdata/kapacitor/pull/#2544 -->
-- run flux tasks with built-in flux engine <!-- https://github.com/influxdata/kapacitor/pull/#2555 -->
-- kapacitor cli supports flux tasks <!-- https://github.com/influxdata/kapacitor/pull/#2559 -->
-- enable new-style slack apps <!-- https://github.com/influxdata/kapacitor/pull/#2560 -->
+- Support flux tasks in Kapacitor CLI. <!-- https://github.com/influxdata/kapacitor/pull/2559 -->
+- Run flux tasks with built-in flux engine <!-- https://github.com/influxdata/kapacitor/pull/2555 -->
+- Add Zenoss alert event handler. <!-- https://github.com/influxdata/kapacitor/pull/2484 -->
+- Route kafka alerts to partitions by ID, and allow for configuring the hashing strategy. <!-- https://github.com/influxdata/kapacitor/pull/2493 -->
+- Pull in authorization code from Kapacitor Enterprise. <!-- https://github.com/influxdata/kapacitor/pull/2512 -->
+- Add a node `tricklenode` that converts batches to streams (the inverse of `windownode`). <!-- https://github.com/influxdata/kapacitor/pull/2530 -->
+- Enable new-style Slack apps. <!-- https://github.com/influxdata/kapacitor/pull/2560 -->
+<!-- - flux tasks skeleton in Kapacitor <\!-- https://github.com/influxdata/kapacitor/pull/2544 -\-> -->
 
 ### Bugfixes
-- Fix a panic in the scraper handler when debug mode is enabled <!-- https://github.com/influxdata/kapacitor/pull/#2564 -->
+- Fix a panic in the scraper handler when debug mode is enabled. <!-- https://github.com/influxdata/kapacitor/pull/2564 -->
 
 ## v1.5.9 [2021-04-01]
 


### PR DESCRIPTION

Closes https://github.com/influxdata/docs-v2/issues/2269.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
