### PR TITLE
Kapacitor Flux tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,6 +333,18 @@ current product. Easier to maintain being you update the version number in the `
 {{< latest-patch >}}
 ```
 
+### API endpoint
+Use the `{{< api-endpoint >}}` shortcode to generate a code block that contains
+a colored request method and a specified API endpoint.
+Provide the following arguments:
+
+- **method**: HTTP request method (get, post, patch, put, or delete)
+- **endpoint**: API endpoint
+
+```md
+{{< api-endpoint method="get" endpoint="/api/v2/tasks">}}
+```
+
 ### Tabbed Content
 Shortcodes are available for creating "tabbed" content (content that is changed by a users' selection).
 Ther following three must be used:

--- a/assets/styles/layouts/article/_code.scss
+++ b/assets/styles/layouts/article/_code.scss
@@ -80,8 +80,11 @@ pre .api {
   font-weight: bold;
   font-size: .9rem;
 
-  &.get { background: $gr-rainforest; }
+  &.get { background: $gr-viridian; }
   &.post { background: $b-ocean; }
+  &.patch { background: $y-topaz; }
+  &.delete { background: $r-ruby; }
+  &.put {background: $br-pulsar; }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/content/kapacitor/v1.6/working/cli_client.md
+++ b/content/kapacitor/v1.6/working/cli_client.md
@@ -24,7 +24,7 @@ arguments applicable to that command.
 kapacitor [options] [command] [args]
 ```
 
-This document provides an overview of all the commands provided by the `kapacitor` CLI:
+This document provides an overview of the commands provided by the `kapacitor` CLI:
 
 - [General options](#general-options)
 - [Core commands](#core-commands)
@@ -1110,7 +1110,7 @@ The `flux tasks` command and its sub-commands manage Kapacitor Flux tasks.
 The `kapacitor flux task create` command creates a new Kapacitor Flux task.
 
 ```sh
-kapacitor flux task create [flags] [flux script or '-' for stdin]
+kapacitor flux task create [flags] [flux script or '-' to read from stdin]
 ```
 
 #### Flags

--- a/content/kapacitor/v1.6/working/cli_client.md
+++ b/content/kapacitor/v1.6/working/cli_client.md
@@ -9,17 +9,6 @@ menu:
     parent: work-w-kapacitor
 ---
 
-* [General options](#general-options)
-* [Core commands](#core-commands)
-* [Server management](#server-management)
-   * [Services](#services)
-   * [Logging](#logging)
-* [Data sampling](#data-sampling)
-* [Topics and topic handlers](#topics-and-topic-handlers)
-* [Tasks and task templates](#tasks-and-task-templates)
-
-## Overview
-
 Two key executables are packaged as a part of Kapacitor. The `kapacitord` daemon
 runs the Kapacitor server, including its HTTP interface. The `kapacitor` command
 line interface (CLI) leverages the HTTP interface and other resources, to provide
@@ -35,9 +24,17 @@ arguments applicable to that command.
 kapacitor [options] [command] [args]
 ```
 
-This document provides an overview of all the commands provided by the `kapacitor` CLI.
-These include general options, core commands, server management, data sampling,
-working with topics and topic handlers, and working with tasks and task templates.
+This document provides an overview of all the commands provided by the `kapacitor` CLI:
+
+- [General options](#general-options)
+- [Core commands](#core-commands)
+- [Server management](#server-management)
+   - [Services](#services)
+   - [Logging](#logging)
+- [Data sampling](#data-sampling)
+- [Topics and topic handlers](#topics-and-topic-handlers)
+- [Tasks and task templates](#tasks-and-task-templates)
+- [Flux tasks](#flux-tasks)
 
 ## General options
 
@@ -72,9 +69,9 @@ The `-skipVerify` option disables SSL verification.
 This option should be used when connecting to a Kapacitor server secured using a self-signed SSL certificate.
 When not set on the command line, the value of the environment variable `KAPACITOR_UNSAFE_SSL` is used.
 
-**Using command line options**
+##### Use command line options
 
-```
+```sh
 $ kapacitor -skipVerify -url https://192.168.67.88:9093 list tasks
 ID                                                 Type      Status    Executing Databases and Retention Policies
 batch_load_test                                    batch     enabled   true      ["telegraf"."autogen"]
@@ -240,7 +237,7 @@ Depending on which terminal you're using, you may need to pass patterns as strin
 by wrapping them in quotes. For example: `"a*"`.
 {{% /note %}}
 
-_**Example list services-test output**_
+##### Example list services-test output
 ```
 Service Name
 alerta
@@ -289,7 +286,7 @@ Depending on which terminal you're using, you may need to pass patterns as strin
 by wrapping them in quotes. For example: `"a*"`.
 {{% /note %}}
 
-_**Example of running service tests**_
+##### Example of running service tests
 ```bash
 $ kapacitor service-tests slack talk smtp
 Service             Success   Message
@@ -332,7 +329,7 @@ By default this will return messages only for the selected level.
 To view messages for the selected level and higher, add a `+` character to the
 end of the string.
 
-_**Monitoring log messages of level DEBUG and above for the HTTP service**_
+##### Monitoring log messages of level DEBUG and above for the HTTP service
 
 ```bash
 $ kapacitor logs service=http lvl=debug+
@@ -943,7 +940,7 @@ kapacitor show cpu_alert
 
 `REPLAY_ID` is the identifier of a currently running replay.
 
-_**Example show task output**_  
+##### Example show task output
 ```bash
 ID: cpu_alert
 Error:
@@ -990,7 +987,7 @@ kapacitor show-template <TEMPLATE_ID>
 kapacitor show-template generic_mean_alert
 ```
 
-_**Example show-template output**_  
+##### Example show-template output
 ```bash
 ID: generic_mean_alert
 Error:
@@ -1095,3 +1092,160 @@ the pattern `"generic*"`.
 This command returns no status or additional messages.
 It fails or succeeds silently.
 To verify the results, use the `list templates` command.
+
+## Flux tasks
+The `flux tasks` command and its sub-commands manage Kapacitor Flux tasks.
+
+- [`flux task create`](#flux-task-create)
+- [`flux task list`](#flux-task-list)
+- [`flux task update`](#flux-task-update)
+- [`flux task retry-failed`](#flux-task-retry-failed)
+- [`flux task log list`](#flux-task-log-list)
+- [`flux task run list`](#flux-task-run-list)
+- [`flux task run retry`](#flux-task-run-retry)
+
+---
+
+### flux task create
+The `kapacitor flux task create` command creates a new Kapacitor Flux task.
+
+```sh
+kapacitor flux task create [flags] [flux script or '-' for stdin]
+```
+
+#### Flags
+| Flag |          | Description              | Input type |
+| :--- | :------- | :----------------------- | :--------: |
+| `-f` | `--file` | Path to Flux script file |   string   |
+| `-h` | `--help` | Show command help        |            |
+|      | `--json` | Format output as JSON    |            |
+
+_For usage examples, see [Create Kapacitor Flux tasks](/kapacitor/v1.6/working/flux/manage/create/)._
+
+---
+
+### flux task list
+The `kapacitor flux task list` command lists Kapacitor Flux tasks.
+
+```sh
+kapacitor flux task list [flags]
+```
+
+**Aliases**: `find`, `ls`
+
+#### Flags
+| Flag |             | Description                              | Input type |
+| :--- | :---------- | :--------------------------------------- | :--------: |
+| `-h` | `--help`    | Show command help                        |            |
+| `-i` | `--id`      | Task ID                                  |   string   |
+|      | `--json`    | Format output as JSON                    |            |
+|      | `--limit`   | Number of tasks to list (default is 500) |  integer   |
+| `-n` | `--user-id` | Task owner ID                            |   string   |
+
+_For usage examples, see [List Kapacitor Flux tasks](/kapacitor/v1.6/working/flux/manage/list/)._
+
+---
+
+### flux task update
+The `kapacitor flux task update` command updates a Kapacitor Flux task.
+
+```sh
+kapacitor flux task update [flags] [flux script or '-' for stdin]
+```
+
+#### Flags
+| Flag |            | Description                                 | Input type |
+| :--- | :--------- | :------------------------------------------ | :--------: |
+| `-f` | `--file`   | Path to Flux script file                    |   string   |
+| `-h` | `--help`   | Show command help                           |            |
+| `-i` | `--id`     | ({{< req >}}) Task ID                       |   string   |
+|      | `--json`   | Format output as JSON                       |            |
+|      | `--status` | Update task status (`active` or `inactive`) |   string   |
+
+_For usage examples, see [Update Kapacitor Flux tasks](/kapacitor/v1.6/working/flux/manage/update/)._
+
+---
+
+### flux task retry-failed
+The `kapacitor flux task retry-failed` command retries failed Kapacitor Flux task runs.
+
+```sh
+kapacitor flux task retry-failed [flags]
+```
+
+#### Flags
+| Flag |                | Description                                                       | Input type |
+| :--- | :------------- | :---------------------------------------------------------------- | :--------: |
+|      | `--after`      | Retry runs that occurred after this time (RFC3339 timestamp)      |   string   |
+|      | `--before`     | Retry runs that occurred before this time (RFC3339 timestamp)     |   string   |
+|      | `--dry-run`    | Output information about runs that would be retried               |            |
+| `-h` | `--help`       | Show command help                                                 |            |
+| `-i` | `--id`         | Task ID                                                           |   string   |
+|      | `--json`       | Format output as JSON                                             |            |
+|      | `--run-limit`  | Maximum number of failed runs to retry per task (default is 100)  |  integer   |
+|      | `--status`     | Update task status (`active` or `inactive`)                       |   string   |
+|      | `--task-limit` | Maximum number of tasks to retry failed runs for (default is 100) |  integer   |
+
+_For usage examples, see [Retry failed Kapacitor Flux tasks](/kapacitor/v1.6/working/flux/manage/retry-failed/)._
+
+---
+
+### flux task log list
+The `kapacitor flux task log list` command outputs Kapacitor Flux task logs.
+
+```sh
+kapacitor flux task log list [flags]
+```
+
+#### Flags
+| Flag |             | Description           | Input type |
+| :--- | :---------- | :-------------------- | :--------: |
+| `-h` | `--help`    | Show command help     |            |
+|      | `--json`    | Format output as JSON |            |
+|      | `--run-id`  | Task run ID           |   string   |
+|      | `--task-id` | ({{< req >}}) Task ID |   string   |
+
+_For usage examples, see [View Kapacitor Flux task logs](/kapacitor/v1.6/working/flux/manage/view-task-logs/)._
+
+---
+
+### flux task run list
+The `kapacitor flux task run list` command lists runs of a Kapacitor Flux task.
+
+```sh
+kapacitor flux task run list [flags]
+```
+
+**Aliases**: `find`, `ls`
+
+#### Flags
+| Flag |             | Description                                                  | Input type |
+| :--- | :---------- | :----------------------------------------------------------- | :--------: |
+|      | `--after`   | List runs that occurred after this time (RFC3339 timestamp)  |   string   |
+|      | `--before`  | List runs that occurred before this time (RFC3339 timestamp) |   string   |
+| `-h` | `--help`    | Show command help                                            |            |
+|      | `--json`    | Format output as JSON                                        |            |
+|      | `--limit`   | Number of task runs to list (default is 100)                 |  integer   |
+|      | `--run-id`  | Task run ID                                                  |   string   |
+|      | `--task-id` | ({{< req >}}) Task ID                                        |   string   |
+
+_For usage examples, see [Mange Kapacitor Flux task runs](/kapacitor/v1.6/working/flux/manage/task-runs/#list-kapacitor-flux-tasks-runs)._
+
+---
+
+### flux task run retry
+The `kapacitor flux task run retry` command retries a run for a Kapacitor Flux task.
+
+```sh
+kapacitor flux task run retry [flags]
+```
+
+#### Flags
+| Flag |             | Description               | Input type |
+| :--- | :---------- | :------------------------ | :--------: |
+| `-h` | `--help`    | Show command help         |            |
+|      | `--json`    | Format output as JSON     |            |
+|      | `--run-id`  | ({{< req >}}) Task run ID |   string   |
+|      | `--task-id` | ({{< req >}}) Task ID     |   string   |
+
+_For usage examples, see [Mange Kapacitor Flux task runs](/kapacitor/v1.6/working/flux/manage/task-runs/#retry-a-kapacitor-flux-task-run)._

--- a/content/kapacitor/v1.6/working/flux/_index.md
+++ b/content/kapacitor/v1.6/working/flux/_index.md
@@ -1,0 +1,269 @@
+---
+title: Use Flux tasks with Kapacitor
+description: >
+  ...
+menu:
+  kapacitor_1_6:
+    name: Use Flux tasks
+    parent: work-w-kapacitor
+related: 
+  - /influxdb/cloud/tools/kapacitor/
+  - /{{< latest "influxdb" >}}/tools/kapacitor/
+  - /influxdb/cloud/process-data/get-started/, Get started with Flux tasks
+  - /influxdb/cloud/process-data/common-tasks/
+  - /influxdb/cloud/process-data/task-options/
+---
+
+Use **Kapacitor 1.6+** to run Flux tasks against InfluxDB and other data sources.
+Leverage the full library of Flux functionality to build powerful data processing
+and monitoring tasks in Kapacitor.
+
+## Before you start
+Before you get started, there are things to consider when using Kapacitor Flux tasks:
+
+- Kapacitor Flux tasks do not use Kapacitor topics or event handlers.
+  You can only send alerts from within a Flux script using Flux notification endpoints.
+- Flux tasks are scheduled and executed by the Flux task engine built into Kapacitor 1.6+.
+  This engine is separate from the Kapacitor TICKscript task engine.
+- Flux tasks are configured with the Flux `task` option inside of a Flux task script.
+  This includes the task name and execution schedule.
+
+**Select which version of InfluxDB you're using:**
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[InfluxDB 1.x](#)
+[InfluxDB Cloud or 2.x](#)
+{{% /tabs %}}
+<!------------------------- BEGIN InfluxDB 1.x content ------------------------>
+{{% tab-content %}}
+
+1. [Set up a Flux task database in InfluxDB](#set-up-a-flux-task-database-in-influxdb)
+2. [Configure Kapacitor Flux tasks](#configure-kapacitor-flux-tasks)
+3. [Create a Flux task](#create-a-flux-task)
+
+## Set up a Flux task database in InfluxDB
+_({{< req "Optional but encouraged" >}})_
+
+When Kapacitor executes a Flux task, it can store information about the task
+execution (run) in an InfluxDB database.
+To store this data, do the following:
+
+1. Create a new database in InfluxDB to store Flux task run and log data in.
+
+    ```sql
+    CREATE DATABASE kapacitorfluxtasks
+    ```
+
+2. To prevent large amounts of Kapacitor Flux task log data on disk, update
+   the default `autogen` retention policy with a finite retention period or
+   create a new retention policy (RP) with a finite retention period.
+
+    {{< code-tabs-wrapper >}}
+    {{% code-tabs %}}
+[Update RP](#)
+[Create new RP](#)
+    {{% /code-tabs %}}
+    {{% code-tab-content %}}
+
+```sql
+-- Syntax
+ALTER RETENTION POLICY <rp-name> ON <db-name> DURATION <new-retention-duration>
+
+-- Example
+ALTER RETENTION POLICY autogen ON kapacitorfluxtasks DURATION 3d
+```
+    {{% /code-tab-content %}}
+    {{% code-tab-content %}}
+```sql
+-- Syntax
+CREATE RETENTION POLICY <rp-name> on <db-name> DURATION <retention-duration>
+
+-- Example 
+CREATE RETENTION POLICY threedays on kapacitorfluxtasks DURATION 3d
+```
+    {{% /code-tab-content %}}
+    {{< /code-tabs-wrapper >}}
+
+
+## Configure Kapacitor Flux tasks
+Update or add the following settings under `[fluxtask]` your `kapacitor.conf`:
+
+- **enabled**: `true`
+- **task-run-influxdb**: Name of the [InfluxDB configuration in your `kapacitor.conf`](/kapacitor/v1.6/administration/configuration/#influxdb)
+  to use to store Flux task data.
+  _To disable Flux task logging, set to `"none"`._
+- **task-run-bucket**: InfluxDB bucket to store Flux task data and logs in.
+  Use the `"db-name/rp-name"` naming convention.
+  To use the default RP for the database, use `"db-name/"`.
+- Provide one of the following:
+    - **task-run-org**: _Leave as an empty string (`""`)_
+    - **task-run-orgid**: _Leave as an empty string (`""`)_
+- **task-run-measurement**: InfluxDB measurement to store task run and log data in.
+  Default is `"runs"`.
+
+##### Kapacitor Flux task configuration example
+```toml
+# ...
+
+[fluxtask]
+  enabled = true
+  task-run-influxdb = "default"
+  task-run-bucket = "kapacitorfluxtasks/autogen"
+  task-run-org = ""
+  task-run-orgid = ""
+  task-run-measurement = "runs"
+
+# ...
+```
+
+_For more information about Kapacitor `[fluxtasks]` configuration options,
+see [Configure Kapacitor](/kapacitor/v1.6/administration/configuration/)._
+
+## Create a Flux task
+
+1.  Create a Flux task script. Include [the task option](/influxdb/v2.0/process-data/task-options/)
+    in your script to configure the Kapacitor Flux task. _For more information about writing Flux tasks, see:_
+     
+    - [Get started with Flux tasks](/{{< latest "influxdb" >}}/process-data/get-started/)
+    - [Common data processing tasks](/{{< latest "influxdb" >}}/process-data/common-tasks/)
+
+    #### Provide InfluxDB connection credentials
+    [`from()`](/influxdb/v2.0/reference/flux/stdlib/built-in/inputs/from/) and
+    [`to()`](/influxdb/v2.0/reference/flux/stdlib/built-in/outputs/to/) functions
+    require your InfluxDB **host** and **token**.
+
+    - **host:** InfluxDB URL.
+    - **token:** If **[InfluxDB authentication is enabled](/{{< latest "influxdb" "v1" >}}/administration/authentication_and_authorization)**,
+      use the `username:password` syntax.
+      Otherwise, use an empty string (`""`) for your token.
+
+    #### Bucket name syntax
+    When querying or writing to InfluxDB 1.x with Flux, use the
+    `database-name/retention-policy-name` pattern to specify your bucket.
+
+    ##### example-task.flux
+    {{< keep-url >}}
+    ```js
+    option task = {
+      name: "example-task-name",
+      every: 1h,
+      offset: 10m
+    }
+
+    host = "http://localhost:8086"
+    token = ""
+
+    from(bucket: "example-db/example-rp", host: host, token: token)
+      |> range(start: -task.every)
+      |> filter(fn: (r) => r._measurement == "example-measurement")
+      |> aggregateWindow(every: 10m, fn: mean)
+      |> to(bucket: "example-db/example-rp-downsampled", host: host, token: token)
+    ```
+
+2. Use the `kapacitor flux task create` command to add your Flux script as a Kapacitor Flux task.
+
+    ```sh
+    kapacitor flux task create --file /path/to/example-task.flux
+    ```
+
+_For more details about creating Kapacitor Flux tasks, see [Create a Kapacitor Flux task](#)._
+{{% /tab-content %}}
+<!-------------------------- END InfluxDB 1.x content ------------------------->
+<!---------------------- BEGIN InfluxDB Cloud/2.x content --------------------->
+{{% tab-content %}}
+{{% warn %}}
+#### Consider using InfluxDB tasks
+If you're using **InfluxDB Cloud** or **InfluxDB OSS 2.x**, you certainly can
+use Kapacitor to run Flux tasks against them, but you should consider just using
+[native InfluxDB tasks](/influxdb/cloud/process-data/).
+{{% /warn %}}
+
+1. [Set up Kapacitor for InfluxDB Cloud or 2.x](#set-up-kapacitor-for-influxdb-cloud-or-2x)
+2. [Configure Kapacitor Flux tasks for InfluxDB Cloud or 2.x](#configure-kapacitor-flux-tasks-for-influxdb-cloud-or-2x)
+3. [Create a Flux task](#create-a-flux-task-v2)
+
+## Set up Kapacitor for InfluxDB Cloud or 2.x
+Configure Kapacitor to connect to InfluxDB Cloud or InfluxDB OSS 2.x.
+For detailed instructions, see the following:
+
+- [Use Kapacitor with InfluxDB Cloud](/influxdb/cloud/tools/kapacitor/)
+- [Use Kapacitor with InfluxDB 2.x OSS](/{{< latest "influxdb" >}}/tools/kapacitor/)
+
+## Configure Kapacitor Flux tasks for InfluxDB Cloud or 2.x
+Update or add the following settings under `[fluxtask]` your `kapacitor.conf`:
+
+- **enabled**: `true`
+- **task-run-influxdb**: Name of the [InfluxDB configuration in your `kapacitor.conf`](/kapacitor/v1.6/administration/configuration/#influxdb)
+  to use to store Flux task data.
+  _To disable Flux task logging, set to `"none"`._
+- **task-run-bucket**: InfluxDB bucket to store Flux task data and logs in.
+  Use the [_tasks system bucket](/influxdb/cloud/reference/internals/system-buckets/#_tasks-system-bucket)
+  or [create a new bucket](/influxdb/cloud/organizations/buckets/create-bucket/)
+  and provide the bucket name.
+- Provide one of the following:
+    - **task-run-org**: InfluxDB organization name.
+    - **task-run-orgid**: InfluxDB organization ID.
+- **task-run-measurement**: InfluxDB measurement to store task run and log data in.
+  Default is `"runs"`.
+
+```toml
+# ...
+
+[fluxtask]
+  enabled = true
+  task-run-influxdb = "InfluxDB"
+  task-run-bucket = "_tasks"
+  task-run-org = "example-org"
+  task-run-measurement = "runs"
+
+# ...
+```
+
+## Create a Flux task{id="create-a-flux-task-v2"}
+
+1.  Create a Flux task script. Include [the task option](/influxdb/v2.0/process-data/task-options/)
+    in your script to configure the Kapacitor Flux task. _For more information about writing Flux tasks, see:_
+     
+    - [Get started with Flux tasks](/{{< latest "influxdb" >}}/process-data/get-started/)
+    - [Common data processing tasks](/{{< latest "influxdb" >}}/process-data/common-tasks/)
+
+    #### Provide InfluxDB connection credentials
+    [`from()`](/influxdb/v2.0/reference/flux/stdlib/built-in/inputs/from/) and
+    [`to()`](/influxdb/v2.0/reference/flux/stdlib/built-in/outputs/to/) functions
+    require your InfluxDB **host** and **token**.
+
+    - **host:** InfluxDB URL.
+    - **token:** If **[InfluxDB authentication is enabled](/{{< latest "influxdb" "v1" >}}/administration/authentication_and_authorization)**,
+      use the `username:password` syntax.
+      Otherwise, use an empty string (`""`) for your token.
+
+    ##### example-task.flux
+    {{< keep-url >}}
+    ```js
+    option task = {
+      name: "example-task-name",
+      every: 1h,
+      offset: 10m
+    }
+
+    host = "http://localhost:8086"
+    token = ""
+
+    from(bucket: "example-bucket", host: host, token: token)
+      |> range(start: -task.every)
+      |> filter(fn: (r) => r._measurement == "example-measurement")
+      |> aggregateWindow(every: 10m, fn: mean)
+      |> to(bucket: "example-bucket-downsampled", host: host, token: token)
+    ```
+
+2. Use the `kapacitor flux task create` command to add your Flux script as a Kapacitor Flux task.
+
+    ```sh
+    kapacitor flux task create --file /path/to/example-task.flux
+    ```
+
+_For more details about creating Kapacitor Flux tasks, see [Create a Kapacitor Flux task](#)._
+{{% /tab-content %}}
+<!----------------------- END InfluxDB Cloud/2.x content ---------------------->
+{{< /tabs-wrapper >}}

--- a/content/kapacitor/v1.6/working/flux/_index.md
+++ b/content/kapacitor/v1.6/working/flux/_index.md
@@ -24,7 +24,7 @@ and monitoring tasks in Kapacitor.
 ## Before you start
 Before you get started with Flux tasks, consider:
 
-- Kapacitor Flux tasks do not use Kapacitor topics or event handlers.
+- Kapacitor Flux tasks can not use Kapacitor topics or event handlers.
   You can only send alerts from within a Flux script using Flux notification endpoints.
 - Flux tasks are scheduled and executed by the Flux task engine built into Kapacitor 1.6+.
   This engine is separate from the Kapacitor TICKscript task engine.

--- a/content/kapacitor/v1.6/working/flux/_index.md
+++ b/content/kapacitor/v1.6/working/flux/_index.md
@@ -1,7 +1,9 @@
 ---
 title: Use Flux tasks with Kapacitor
 description: >
-  ...
+  Use **Kapacitor 1.6+** to run Flux tasks against InfluxDB and other data sources.
+  Leverage the full library of Flux functionality to build powerful data processing
+  and monitoring tasks in Kapacitor.
 menu:
   kapacitor_1_6:
     name: Use Flux tasks
@@ -9,6 +11,7 @@ menu:
 related: 
   - /influxdb/cloud/tools/kapacitor/
   - /{{< latest "influxdb" >}}/tools/kapacitor/
+  - /kapacitor/v1.6/working/flux/manage/create/
   - /influxdb/cloud/process-data/get-started/, Get started with Flux tasks
   - /influxdb/cloud/process-data/common-tasks/
   - /influxdb/cloud/process-data/task-options/
@@ -167,7 +170,7 @@ see [Configure Kapacitor](/kapacitor/v1.6/administration/configuration/)._
     kapacitor flux task create --file /path/to/example-task.flux
     ```
 
-_For more details about creating Kapacitor Flux tasks, see [Create a Kapacitor Flux task](#)._
+_For more details about creating Kapacitor Flux tasks, see [Create a Kapacitor Flux task](/kapacitor/v1.6/working/flux/manage/create/)._
 {{% /tab-content %}}
 <!-------------------------- END InfluxDB 1.x content ------------------------->
 <!---------------------- BEGIN InfluxDB Cloud/2.x content --------------------->
@@ -263,7 +266,7 @@ Update or add the following settings under `[fluxtask]` your `kapacitor.conf`:
     kapacitor flux task create --file /path/to/example-task.flux
     ```
 
-_For more details about creating Kapacitor Flux tasks, see [Create a Kapacitor Flux task](#)._
+_For more details about creating Kapacitor Flux tasks, see [Create a Kapacitor Flux task](/kapacitor/v1.6/working/flux/manage/create/)._
 {{% /tab-content %}}
 <!----------------------- END InfluxDB Cloud/2.x content ---------------------->
 {{< /tabs-wrapper >}}

--- a/content/kapacitor/v1.6/working/flux/_index.md
+++ b/content/kapacitor/v1.6/working/flux/_index.md
@@ -22,7 +22,7 @@ Leverage the full library of Flux functionality to build powerful data processin
 and monitoring tasks in Kapacitor.
 
 ## Before you start
-Before you get started, there are things to consider when using Kapacitor Flux tasks:
+Before you get started with Flux tasks, consider:
 
 - Kapacitor Flux tasks do not use Kapacitor topics or event handlers.
   You can only send alerts from within a Flux script using Flux notification endpoints.
@@ -177,9 +177,8 @@ _For more details about creating Kapacitor Flux tasks, see [Create a Kapacitor F
 {{% tab-content %}}
 {{% warn %}}
 #### Consider using InfluxDB tasks
-If you're using **InfluxDB Cloud** or **InfluxDB OSS 2.x**, you certainly can
-use Kapacitor to run Flux tasks against them, but you should consider just using
-[native InfluxDB tasks](/influxdb/cloud/process-data/).
+If you're using **InfluxDB Cloud** or **InfluxDB OSS 2.x**, consider using
+[native InfluxDB tasks](/influxdb/cloud/process-data/) for data processing.
 {{% /warn %}}
 
 1. [Set up Kapacitor for InfluxDB Cloud or 2.x](#set-up-kapacitor-for-influxdb-cloud-or-2x)

--- a/content/kapacitor/v1.6/working/flux/manage/_index.md
+++ b/content/kapacitor/v1.6/working/flux/manage/_index.md
@@ -1,0 +1,15 @@
+---
+title: Manage Kapacitor Flux tasks
+description: >
+  Use the **`kapacitor` CLI** and the **Kapacitor HTTP API** to manage Kapacitor Flux tasks.
+menu:
+  kapacitor_1_6:
+    name: Manage Flux tasks
+    parent: Use Flux tasks
+weight: 1
+cascade:
+  related:
+    - /kapacitor/v1.6/working/flux/
+---
+
+{{< children >}}

--- a/content/kapacitor/v1.6/working/flux/manage/create.md
+++ b/content/kapacitor/v1.6/working/flux/manage/create.md
@@ -1,0 +1,68 @@
+---
+title: Create Kapacitor Flux tasks
+description: >
+  Use the **`kapacitor` CLI** or the **Kapacitor HTTP API** to create Kapacitor Flux tasks.
+menu:
+  kapacitor_1_6:
+    name: Create Flux tasks
+    parent: Manage Flux tasks
+weight: 1
+---
+
+Use the **`kapacitor` CLI** or the **Kapacitor HTTP API** to create Kapacitor Flux tasks.
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[CLI](#)
+[API](#)
+{{% /tabs %}}
+<!----------------------------- BEGIN CLI content ----------------------------->
+{{% tab-content %}}
+
+Use the `kapacitor flux task create` command to create a new Kapacitor Flux task.
+Provide the following flags:
+
+{{< req type="key" >}}
+-  {{< req "\*" >}} `-f`, `--file`: Filepath to the Flux task to add
+
+```sh
+kapacitor flux task create --file /path/to/task.flux
+```
+
+By default, new Flux tasks are set to `active` and will begin to run on their defined schedule.
+To disable a Flux task, [update the task status](#).
+
+{{% /tab-content %}}
+<!------------------------------ END CLI content ------------------------------>
+
+<!----------------------------- BEGIN API content ----------------------------->
+{{% tab-content %}}
+
+Use the following request method and endpoint to create a new Kapacitor Flux task.
+
+{{< api-endpoint method="post" endpoint="/kapacitor/v1/api/v2/tasks" >}}
+
+Provide the following with your request ({{< req type="key" >}}):
+
+#### Headers
+- {{< req "\*" >}} **Content-type:** application/json
+
+#### Request body
+JSON object with the following schema:
+- {{< req "\*" >}} **flux**: Flux task code
+- **status**: Flux tasks status (`active` or `inactive`, default is `active`)
+- **description**: Flux task description
+
+```sh
+curl --request POST 'http://localhost:9092/kapacitor/v1/api/v2/tasks' \
+  --header 'Content-Type: application/json' \
+  --data-raw '{
+    "flux": "option task = {name: \"CPU Total 1 Hour New\", every: 1h}\n\nhost = \"http://localhost:8086\"\ntoken = \"\"\n\nfrom(bucket: \"db/rp\", host:host, token:token)\n\t|> range(start: -1h)\n\t|> filter(fn: (r) =>\n\t\t(r._measurement == \"cpu\"))\n\t|> filter(fn: (r) =>\n\t\t(r._field == \"usage_system\"))\n\t|> filter(fn: (r) =>\n\t\t(r.cpu == \"cpu-total\"))\n\t|> aggregateWindow(every: 1h, fn: max)\n\t|> to(bucket: \"cpu_usage_user_total_1h\", host:host, token:token)",
+    "status": "active",
+    "description": "Downsample CPU data every hour"
+}'
+```
+
+{{% /tab-content %}}
+<!------------------------------ END API content ------------------------------>
+{{< /tabs-wrapper >}}

--- a/content/kapacitor/v1.6/working/flux/manage/delete.md
+++ b/content/kapacitor/v1.6/working/flux/manage/delete.md
@@ -1,0 +1,56 @@
+---
+title: Delete Kapacitor Flux tasks
+description: >
+  Use the **`kapacitor` CLI** or the **Kapacitor HTTP API** to delete Kapacitor Flux tasks.
+menu:
+  kapacitor_1_6:
+    name: Delete Flux tasks
+    parent: Manage Flux tasks
+weight: 6
+---
+
+Use the **`kapacitor` CLI** or the **Kapacitor HTTP API** to delete Kapacitor Flux tasks.
+Provide the **task ID** to delete.
+_Task IDs are provided in [task list](/kapacitor/v1.6/working/flux/manage/list/) output._
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[CLI](#)
+[API](#)
+{{% /tabs %}}
+<!----------------------------- BEGIN CLI content ----------------------------->
+{{% tab-content %}}
+
+Use the `kapacitor flux task delete` command to delete a Kapacitor Flux task.
+Provide the following flag:
+
+{{< req type="key" >}}
+-  {{< req "\*" >}}`-i`, `--id`: Task ID to delete
+
+```sh
+kapacitor flux task delete --id 000x00xX0xXXx00
+```
+
+{{% /tab-content %}}
+<!------------------------------ END CLI content ------------------------------>
+
+<!----------------------------- BEGIN API content ----------------------------->
+{{% tab-content %}}
+
+Use the following request method and endpoint to delete a Kapacitor Flux task.
+
+{{< api-endpoint method="delete" endpoint="/kapacitor/v1/api/v2/tasks/{taskID}" >}}
+
+Provide the following with your request ({{< req type="key" >}}):
+
+#### Path parameters
+- {{< req "\*" >}} **taskID**: Task ID to delete
+
+```sh
+# Delete task ID 000x00xX0xXXx00
+curl --request DELETE 'http://localhost:9092/kapacitor/v1/api/v2/tasks/000x00xX0xXXx00'
+```
+
+{{% /tab-content %}}
+<!------------------------------ END API content ------------------------------>
+{{< /tabs-wrapper >}}

--- a/content/kapacitor/v1.6/working/flux/manage/list.md
+++ b/content/kapacitor/v1.6/working/flux/manage/list.md
@@ -1,0 +1,114 @@
+---
+title: List Kapacitor Flux tasks
+description: >
+  Use the **`kapacitor` CLI** or the **Kapacitor HTTP API**  to list Kapacitor Flux tasks.
+menu:
+  kapacitor_1_6:
+    name: List Flux tasks
+    parent: Manage Flux tasks
+weight: 2
+---
+
+Use the **`kapacitor` CLI** or the **Kapacitor HTTP API** to list Kapacitor Flux tasks.
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[CLI](#)
+[API](#)
+{{% /tabs %}}
+<!----------------------------- BEGIN CLI content ----------------------------->
+{{% tab-content %}}
+
+Use the `kapacitor flux task list` command to list Kapacitor Flux tasks.
+Provide the following flags:
+
+- `-i`, `--id`: Filter by task ID
+- `--limit`: Limit the number of returned tasks (default is 500)
+
+## CLI examples 
+
+- [List all Flux tasks](#list-all-flux-tasks)
+- [List a limited number of Flux tasks](#list-a-limited-number-of-flux-tasks)
+- [List a specific Flux task](#list-a-specific-flux-task)
+
+##### List all Flux tasks
+```sh
+kapacitor flux task list
+```
+
+##### List a limited number of Flux tasks
+```sh
+kapacitor flux task list --limit 20
+```
+
+##### List a specific Flux task
+```sh
+kapacitor flux task list --id 000x00xX0xXXx00
+```
+
+{{% /tab-content %}}
+<!------------------------------ END CLI content ------------------------------>
+
+<!----------------------------- BEGIN API content ----------------------------->
+{{% tab-content %}}
+
+Use the following request method and endpoint to list Kapacitor Flux tasks.
+
+{{< api-endpoint method="get" endpoint="/kapacitor/v1/api/v2/tasks" >}}
+
+Provide the following with your request ({{< req type="key" >}}):
+
+#### Headers
+- {{< req "\*" >}} **Content-type:** application/json
+
+#### Query parameters
+- **after**: List tasks after a specific task ID
+- **limit**: Limit the number of tasks returned (default is 500)
+- **name**: Filter tasks by name
+- **status**: Filter tasks by status (`active` or `inactive`)
+
+## API examples
+
+- [List all Flux tasks](#list-all-flux-tasks-api)
+- [List a limited number of Flux tasks](#list-a-limited-number-of-flux-tasks-api)
+- [List a specific Flux task by name](#list-a-specific-flux-task-by-name-api)
+- [List Flux tasks after a specific task ID](#list-flux-tasks-after-a-specific-task-id)
+- [List only active Flux tasks](#list-only-active-flux-tasks)
+
+##### List all Flux tasks {id="list-all-flux-tasks-api"}
+```sh
+curl --GET 'http://localhost:9092/kapacitor/v1/api/v2/tasks' \
+  --header 'Content-Type: application/json'
+```
+
+##### List a limited number of Flux tasks {id="list-a-limited-number-of-flux-tasks-api"}
+```sh
+curl --GET 'http://localhost:9092/kapacitor/v1/api/v2/tasks' \
+  --header 'Content-Type: application/json' \
+  --data-urlencode "limit=1"
+```
+
+##### List a specific Flux task by name {id="list-a-specific-flux-task-by-name-api"}
+```sh
+curl --GET 'http://localhost:9092/kapacitor/v1/api/v2/tasks' \
+  --header 'Content-Type: application/json' \
+  --data-urlencode "name=example-flux-task-name"
+```
+
+##### List Flux tasks after a specific task ID
+```sh
+curl --GET 'http://localhost:9092/kapacitor/v1/api/v2/tasks' \
+  --header 'Content-Type: application/json' \
+  --data-urlencode "after=000x00xX0xXXx00"
+```
+
+##### List only active Flux tasks
+```sh
+curl --GET 'http://localhost:9092/kapacitor/v1/api/v2/tasks' \
+  --header 'Content-Type: application/json' \
+  --data-urlencode "status=active"
+```
+
+{{% /tab-content %}}
+<!------------------------------ END API content ------------------------------>
+{{< /tabs-wrapper >}}

--- a/content/kapacitor/v1.6/working/flux/manage/retry-failed.md
+++ b/content/kapacitor/v1.6/working/flux/manage/retry-failed.md
@@ -1,0 +1,73 @@
+---
+title: Retry failed Kapacitor Flux tasks
+description: >
+  Use the `kapacitor flux task retry-failed` command to retry failed Kapacitor Flux task runs.
+menu:
+  kapacitor_1_6:
+    name: Retry failed Flux tasks
+    parent: Manage Flux tasks
+weight: 5
+related:
+  - /kapacitor/v1.6/working/flux/
+  - /kapacitor/v1.6/working/flux/manage/task/runs
+---
+
+Use the `kapacitor flux task retry-failed` command to retry failed Kapacitor Flux task runs.
+Provide the following flags:
+
+- `-i`, `--id`: task ID
+- `--before`: Retry failed runs that occurred before this time (RFC3339 timestamp)
+- `--after`: Retry failed runs that occurred after this time (RFC3339 timestamp)
+- `--dry-run`: Output information about runs that would be retried **without retrying the failed runs**.
+- `--task-limit`: Limit the number of tasks to retry failed runs for (default: 100)
+- `--run-limit`: Limit the number of failed runs to retry per task (default: 100)
+
+{{% note %}}
+#### Rerun failed tasks with the Kapacitor API
+The `kapacitor flux task retry-failed` command is a convenience command that identifies
+failed task runs and attempts to run them again.
+The Kapacitor API doesn't provide a single endpoint for this functionality,
+but this process can be accomplished through a series of API calls.
+For more information, see [Manage Flux task runs](/kapacitor/v1.6/working/flux/manage/task-runs/?t=API).
+{{% /note %}}
+
+## Examples
+
+- [Retry failed Flux task runs for all tasks](#retry-failed-flux-task-runs-for-all-tasks)
+- [Retry failed Flux task runs for a specific task](#retry-failed-flux-task-runs-for-a-specific-task)
+- [Retry Flux task runs that failed in a specific time range](#retry-flux-task-runs-that-failed-in-a-specific-time-range)
+- [View information about failed runs that would be executed](#view-information-about-failed-runs-that-would-be-executed)
+- [Limit the number of tasks to retry failed runs for](#limit-the-number-of-tasks-to-retry-failed-runs-for)
+- [Limit the number of failed runs to retry for each task](#limit-the-number-of-failed-runs-to-retry-for-each-task)
+
+##### Retry failed Flux task runs for all tasks
+```sh
+kapacitor flux task retry-failed
+```
+
+##### Retry failed Flux task runs for a specific task
+```sh
+kapacitor flux task retry-failed --id 000x00xX0xXXx00
+```
+
+##### Retry Flux task runs that failed in a specific time range
+```sh
+kapacitor flux task retry-failed \
+  --after 2021-01-01T00:00:00Z \
+  --before 2021-01-31T00:00:00Z
+```
+
+##### View information about failed runs that would be executed
+```sh
+kapacitor flux task retry-failed --dry-run
+```
+
+##### Limit the number of tasks to retry failed runs for
+```sh
+kapacitor flux task retry-failed --task-limit 10
+```
+
+##### Limit the number of failed runs to retry for each task
+```sh
+kapacitor flux task retry-failed --run-limit 10
+```

--- a/content/kapacitor/v1.6/working/flux/manage/task-runs.md
+++ b/content/kapacitor/v1.6/working/flux/manage/task-runs.md
@@ -23,7 +23,7 @@ Each Flux task execution is considered a "run."
 <!----------------------------- BEGIN CLI content ----------------------------->
 {{% tab-content %}}
 
-Use the `kapacitor flux task run list` command and its subcommands to manage
+Use the `kapacitor flux task run list` command and its sub commands to manage
 Kapacitor Flux task runs.
 
 - [List Kapacitor Flux tasks runs](#list-kapacitor-flux-tasks-runs)

--- a/content/kapacitor/v1.6/working/flux/manage/task-runs.md
+++ b/content/kapacitor/v1.6/working/flux/manage/task-runs.md
@@ -1,0 +1,173 @@
+---
+title: Manage Kapacitor Flux task runs
+description: >
+  Use the **`kapacitor` CLI** or the **Kapacitor HTTP API** to manage Kapacitor Flux task runs.
+menu:
+  kapacitor_1_6:
+    name: Manage Flux task runs
+    parent: Manage Flux tasks
+weight: 4
+related:
+  - /kapacitor/v1.6/working/flux/manage/retry-failed/
+  - /kapacitor/v1.6/working/flux/
+---
+
+Use the **`kapacitor` CLI** or the **Kapacitor HTTP API** to manage Kapacitor Flux task runs.
+Each Flux task execution is considered a "run."
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[CLI](#)
+[API](#)
+{{% /tabs %}}
+<!----------------------------- BEGIN CLI content ----------------------------->
+{{% tab-content %}}
+
+Use the `kapacitor flux task run list` command and its subcommands to manage
+Kapacitor Flux task runs.
+
+- [List Kapacitor Flux tasks runs](#list-kapacitor-flux-tasks-runs)
+- [Retry a Kapacitor Flux task run](#retry-a-kapacitor-flux-task-run)
+
+## List Kapacitor Flux tasks runs
+Use the `kapacitor flux task run list` command to output Kapacitor Flux task logs.
+Provide the following flags:
+
+{{< req type="key" >}}
+
+- {{< req "\*" >}} `--task-id`: Task ID
+- `--run-id`: Filter by run ID
+- `--before`: Return task runs that occurred before this time (RFC3339 timestamp)
+- `--after`: Return task runs that occurred after this time (RFC3339 timestamp)
+- `--limit`: Limit the number of returned task runs (default is 100)
+
+### CLI Examples
+
+- [List runs for a Flux task](#list-runs-for-a-flux-task)
+- [List Flux task runs that occurred in a time range](#list-flux-task-runs-that-occurred-in-a-time-range)
+- [List a limited number of Flux task runs](#list-a-limited-number-of-flux-task-runs)
+
+##### List runs for a Flux task
+```sh
+kapacitor flux task run list --task-id 000x00xX0xXXx00
+```
+
+##### List Flux task runs that occurred in a time range
+```sh
+kapacitor flux task run list \
+  --task-id 000x00xX0xXXx00 \
+  --after 2021-01-01T00:00:00Z \
+  --before 2021-01-31T00:00:00Z
+```
+
+##### List a limited number of Flux task runs
+```sh
+kapacitor flux task run list \
+  --task-id 000x00xX0xXXx00 \
+  --limit 10
+```
+
+## Retry a Kapacitor Flux task run
+Use the `kapacitor flux task run retry` command to retry a Kapacitor Flux task run.
+Provide the following flags:
+
+{{< req type="key" >}}
+
+- {{< req "\*" >}} `--task-id`: Task ID
+- {{< req "\*" >}} `--run-id`: Run ID
+
+```sh
+kapacitor flux task run retry \
+  --task-id 000x00xX0xXXx00 \
+  --run-id XXX0xx0xX00Xx0X 
+```
+
+
+{{% /tab-content %}}
+<!------------------------------ END CLI content ------------------------------>
+
+<!----------------------------- BEGIN API content ----------------------------->
+{{% tab-content %}}
+
+- [List Kapacitor Flux task runs](#list-kapacitor-flux-task-runs)
+- [Retry a Kapacitor Flux task run](#retry-a-kapacitor-flux-task-run-api)
+
+## List Kapacitor Flux task runs
+Use the following request method and endpoint to list Kapacitor Flux task runs.
+
+{{< api-endpoint method="get" endpoint="/kapacitor/v1/api/v2/tasks/{taskID}/runs" >}}
+
+Provide the following with your request ({{< req type="key" >}}):
+
+#### Headers
+- {{< req "\*" >}} **Content-type:** application/json
+
+#### Path parameters
+- {{< req "\*" >}} **taskID**: Task ID
+
+#### Query parameters
+- **after**: List task runs after a specific run ID
+- **afterTime**: Return task runs that occurred after this time (RFC3339 timestamp)
+- **beforeTime**: Return task runs that occurred before this time (RFC3339 timestamp)
+- **limit**: Limit the number of task runs returned (default is 100)
+
+### API examples
+
+_The following examples use the task ID `000x00xX0xXXx00`._
+
+- [List all runs for a Flux task](#list-all-runs-for-a-flux-task)
+- [List a limited number of runs for a Flux task](#list-a-limited-number-of-runs-for-a-flux-task)
+- [List Flux task runs after a specific run ID](#list-flux-task-runs-after-a-specific-run-id)
+- [List Flux task runs that occurred in a time range](#list-flux-task-runs-that-occurred-in-a-time-range-api)
+
+##### List all runs for a Flux task
+```sh
+curl --GET 'http://localhost:9092/kapacitor/v1/api/v2/tasks/000x00xX0xXXx00/runs' \
+  --header 'Content-Type: application/json'
+```
+
+##### List a limited number of runs for a Flux task
+```sh
+curl --GET 'http://localhost:9092/kapacitor/v1/api/v2/tasks/000x00xX0xXXx00/runs' \
+  --header 'Content-Type: application/json' \
+  --data-urlencode "limit=10"
+```
+
+##### List Flux task runs after a specific run ID
+```sh
+curl --GET 'http://localhost:9092/kapacitor/v1/api/v2/tasks/000x00xX0xXXx00/runs' \
+  --header 'Content-Type: application/json' \
+  --data-urlencode "after=XXX0xx0xX00Xx0X"
+```
+
+##### List Flux task runs that occurred in a time range {id="list-flux-task-runs-that-occurred-in-a-time-range-api"}
+```sh
+curl --GET 'http://localhost:9092/kapacitor/v1/api/v2/tasks/000x00xX0xXXx00/runs' \
+  --header 'Content-Type: application/json' \
+  --data-urlencode 'afterTime=2021-01-01T00:00:00Z' \
+  --data-urlencode 'beforeTime=2021-01-31T00:00:00Z'
+```
+
+## Retry a Kapacitor Flux task run {#retry-a-kapacitor-flux-task-run-api}
+Use the following request method and endpoint to retry a Kapacitor Flux task run.
+
+{{< api-endpoint method="post" endpoint="/kapacitor/v1/api/v2/tasks/{taskID}/runs/{runID}/retry" >}}
+
+Provide the following with your request ({{< req type="key" >}}):
+
+#### Path parameters
+- {{< req "\*" >}} **taskID**: Task ID
+- {{< req "\*" >}} **runID**: Run ID to retry
+
+```sh
+# Retry run ID XXX0xx0xX00Xx0X for task ID 000x00xX0xXXx00
+curl --request POST \
+  'http://localhost:9092/kapacitor/v1/api/v2/tasks/000x00xX0xXXx00/runs/XXX0xx0xX00Xx0X'
+```
+
+
+{{% /tab-content %}}
+<!------------------------------ END API content ------------------------------>
+{{< /tabs-wrapper >}}
+
+For an easy way to retry all failed task runs, see [Retry failed Kapacitor tasks](/kapacitor/v1.6/working/flux/manage/retry-failed/).

--- a/content/kapacitor/v1.6/working/flux/manage/update.md
+++ b/content/kapacitor/v1.6/working/flux/manage/update.md
@@ -1,0 +1,116 @@
+---
+title: Update Kapacitor Flux tasks
+description: >
+  Use the **`kapacitor` CLI** or the **Kapacitor HTTP API**  to update Kapacitor Flux tasks.
+menu:
+  kapacitor_1_6:
+    name: Update Flux tasks
+    parent: Manage Flux tasks
+weight: 3
+---
+
+Use the **`kapacitor` CLI** or the **Kapacitor HTTP API** to update Kapacitor Flux tasks.
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[CLI](#)
+[API](#)
+{{% /tabs %}}
+<!----------------------------- BEGIN CLI content ----------------------------->
+{{% tab-content %}}
+
+Use the `kapacitor flux task update` command to update Kapacitor Flux task.
+Provide the following flags:
+
+{{< req type="key" >}}
+
+- {{< req "\*" >}} `-i`, `--id`: Task ID
+- `--status`: Updated tasks status (`active` or `inactive`)
+- `-f`, `--file`: Path to updated Flux script file
+
+## Examples
+
+- [Update Flux task code](#update-flux-task-code)
+- [Enable or disable a Flux task](#enable-or-disable-a-flux-task)
+
+##### Update Flux task code
+```sh
+kapacitor flux task update \
+  --id 000x00xX0xXXx00
+  --file /path/to/updated-task.flux
+```
+
+##### Enable or disable a Flux task
+```sh
+kapacitor flux task update \
+  --id 000x00xX0xXXx00
+  --status inactive
+```
+{{% /tab-content %}}
+<!------------------------------ END CLI content ------------------------------>
+
+<!----------------------------- BEGIN API content ----------------------------->
+{{% tab-content %}}
+
+Use the following request method and endpoint to update a new Kapacitor Flux task.
+
+{{< api-endpoint method="patch" endpoint="/kapacitor/v1/api/v2/tasks/{taskID}" >}}
+
+Provide the following with your request ({{< req type="key" >}}):
+
+#### Headers
+- {{< req "\*" >}} **Content-type**: application/json
+
+#### Path parameters
+- {{< req "\*" >}} **taskID**: Task ID to update
+
+#### Request body
+JSON object with the following schema:
+
+- **cron**: Override the `cron` Flux task option
+- **description**: New task description
+- **every**: Override the `every` Flux task option
+- **flux**: New Flux task code
+- **name**: Override the `name` Flux task option
+- **offset**: Override the `offset` Flux task option
+- **status**: New Flux task status (`active` or `inactive`)
+
+## API Examples
+
+_The following examples use the task ID `000x00xX0xXXx00`._
+
+- [Update Flux task code](#update-flux-task-code-api)
+- [Enable or disable a Flux task](#enable-or-disable-a-flux-task-api)
+- [Override Flux task options](#override-flux-task-options-api)
+
+##### Update Flux task code {id="update-flux-task-code-api"}
+{{< keep-url >}}
+```sh
+curl --request PATCH 'http://localhost:9092/kapacitor/v1/api/v2/tasks/000x00xX0xXXx00' \
+  --header 'Content-Type: application/json' \
+  --data-raw '{
+    "flux": "option task = {name: \"Updated task name\", every: 1h}\n\nhost = \"http://localhost:8086\"\ntoken = \"\"\n\nfrom(bucket: \"db/rp\", host:host, token:token)\n\t|> range(start: -1h)\n\t|> filter(fn: (r) =>\n\t\t(r._measurement == \"cpu\"))\n\t|> filter(fn: (r) =>\n\t\t(r._field == \"usage_system\"))\n\t|> filter(fn: (r) =>\n\t\t(r.cpu == \"cpu-total\"))\n\t|> aggregateWindow(every: 1h, fn: max)\n\t|> to(bucket: \"cpu_usage_user_total_1h\", host:host, token:token)"
+}'
+```
+
+##### Enable or disable a Flux task {id="enable-or-disable-a-flux-task-api"}
+```sh
+curl --request PATCH 'http://localhost:9092/kapacitor/v1/api/v2/tasks/000x00xX0xXXx00' \
+  --header 'Content-Type: application/json' \
+  --data-raw '{"status": "inactive"}'
+```
+
+##### Override Flux task options {id="override-flux-task-options-api"}
+```sh
+curl --request PATCH 'http://localhost:9092/kapacitor/v1/api/v2/tasks/000x00xX0xXXx00' \
+  --header 'Content-Type: application/json' \
+  --data-raw '{
+    "every": "1d",
+    "name": "New task name",
+    "offset": "15m"
+}'
+```
+
+{{% /tab-content %}}
+<!------------------------------ END API content ------------------------------>
+{{< /tabs-wrapper >}}

--- a/content/kapacitor/v1.6/working/flux/manage/update.md
+++ b/content/kapacitor/v1.6/working/flux/manage/update.md
@@ -19,7 +19,7 @@ Use the **`kapacitor` CLI** or the **Kapacitor HTTP API** to update Kapacitor Fl
 <!----------------------------- BEGIN CLI content ----------------------------->
 {{% tab-content %}}
 
-Use the `kapacitor flux task update` command to update Kapacitor Flux task.
+Use the `kapacitor flux task update` command to update Kapacitor Flux tasks.
 Provide the following flags:
 
 {{< req type="key" >}}

--- a/content/kapacitor/v1.6/working/flux/manage/view-task-logs.md
+++ b/content/kapacitor/v1.6/working/flux/manage/view-task-logs.md
@@ -1,0 +1,92 @@
+---
+title: View Kapacitor Flux task logs
+description: >
+  Use the **`kapacitor` CLI** or the **Kapacitor HTTP API**  to list Kapacitor Flux tasks.
+menu:
+  kapacitor_1_6:
+    name: View Flux task logs
+    parent: Manage Flux tasks
+weight: 4
+---
+
+Use the **`kapacitor` CLI** or the **Kapacitor HTTP API** to view Kapacitor Flux task logs.
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[CLI](#)
+[API](#)
+{{% /tabs %}}
+<!----------------------------- BEGIN CLI content ----------------------------->
+{{% tab-content %}}
+
+Use the `kapacitor flux task log list` command to output Kapacitor Flux task logs.
+Provide the following flags:
+
+{{< req type="key" >}}
+
+- {{< req "\*" >}} `--task-id`: Task ID
+- `--run-id`: Task run ID _(see [Manage Flux task runs](/kapacitor/v1.6/working/flux/manage/task-runs/))_
+
+## CLI examples 
+
+- [Show all run logs for a Flux task](#show-all-run-logs-for-a-flux-task)
+- [Show logs for a specific Flux task run](#show-logs-for-a-specific-flux-task-run)
+
+##### Show all run logs for a Flux task
+```sh
+kapacitor flux task log list --task-id 000x00xX0xXXx00
+```
+
+##### Show logs for a specific Flux task run
+```sh
+kapacitor flux task log list \
+  --task-id 000x00xX0xXXx00 \
+  --run-id XXX0xx0xX00Xx0X
+```
+
+{{% /tab-content %}}
+<!------------------------------ END CLI content ------------------------------>
+
+<!----------------------------- BEGIN API content ----------------------------->
+{{% tab-content %}}
+
+- [Show all run logs for a task](#show-all-run-logs-for-a-task-api)
+- [Show logs for a specific Flux task run](#show-logs-for-a-specific-flux-task-run-api)
+
+## Show all run logs for a task {id="show-all-run-logs-for-a-task-api"}
+Use the following request method and endpoint to show Kapacitor Flux task logs.
+
+{{< api-endpoint method="get" endpoint="/kapacitor/v1/api/v2/tasks/{taskID}/log" >}}
+
+Provide the following with your request ({{< req type="key" >}}):
+
+#### Path parameters
+- {{< req "\*" >}} **taskID**: Task ID
+
+```sh
+# Get logs for task ID 000x00xX0xXXx00
+curl --request GET \
+  'http://localhost:9092/kapacitor/v1/api/v2/tasks/000x00xX0xXXx00/logs'
+```
+
+## Show logs for a specific Flux task run {id="show-logs-for-a-specific-flux-task-run-api"}
+Use the following request method and endpoint to show logs for a specific
+Kapacitor Flux task run.
+
+{{< api-endpoint method="get" endpoint="/kapacitor/v1//api/v2/tasks/{taskID}/runs/{runID}/logs" >}}
+
+Provide the following with your request ({{< req type="key" >}}):
+
+#### Path parameters
+- {{< req "\*" >}} **taskID**: Task ID
+- {{< req "\*" >}} **runID**: Task run ID _(see [Manage Flux task runs](/kapacitor/v1.6/working/flux/manage/task-runs/))_
+
+```sh
+# Get logs for task ID 000x00xX0xXXx00, run ID XXX0xx0xX00Xx0X
+curl --request GET \
+  'http://localhost:9092/kapacitor/v1/api/v2/tasks/000x00xX0xXXx00/runs/XXX0xx0xX00Xx0X/logs'
+```
+
+{{% /tab-content %}}
+<!------------------------------ END API content ------------------------------>
+{{< /tabs-wrapper >}}

--- a/layouts/shortcodes/api-endpoint.html
+++ b/layouts/shortcodes/api-endpoint.html
@@ -1,0 +1,6 @@
+{{ $method := .Get "method" | upper }}
+{{ $methodStyle := .Get "method" | lower }}
+{{ $endpoint := .Get "endpoint" }}
+<pre>
+<span class="api {{ $methodStyle }}">{{ $method }}</span> {{ $endpoint }}
+</pre>


### PR DESCRIPTION
Closes #2564 

- Introduces task-based docs for setting up and managing Kapacitor Flux tasks
- Introduces new shortcode for displaying API request methods and endpoints
- Updates the `kapacitor` CLI docs with flux task commands
- Holding off on updating the API doc with Flux task endpoints until @jstirnaman wraps up the users endpoint docs

---

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
