### PR TITLE
Today and related links

### DIFF
--- a/content/influxdb/v2.0/reference/flux/stdlib/built-in/misc/now.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/built-in/misc/now.md
@@ -9,6 +9,7 @@ menu:
     parent: built-in-misc
 weight: 401
 related:
+  - /influxdb/v2.0/reference/flux/stdlib/built-in/misc/today/
   - /influxdb/v2.0/reference/flux/stdlib/system/time/
 ---
 

--- a/content/influxdb/v2.0/reference/flux/stdlib/built-in/misc/today.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/built-in/misc/today.md
@@ -13,6 +13,9 @@ introduced: 0.116.0
 
 The `today()` function returns the `now()` timestamp truncated to the day unit.
 
+_**Function type:** Date/Time_  
+_**Output data type:** Time_
+
 ```js
 today()
 ```

--- a/content/influxdb/v2.0/reference/flux/stdlib/built-in/misc/today.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/built-in/misc/today.md
@@ -7,6 +7,10 @@ menu:
     name: today
     parent: built-in-misc
 weight: 401
+related:
+  - /influxdb/v2.0/reference/flux/stdlib/built-in/misc/now/
+  - /influxdb/v2.0/reference/flux/stdlib/date/truncate/
+  - /influxdb/v2.0/reference/flux/stdlib/system/time/
 influxdb/v2.0/tags: [date/time]
 introduced: 0.116.0
 ---

--- a/content/influxdb/v2.0/reference/flux/stdlib/date/truncate.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/date/truncate.md
@@ -9,6 +9,8 @@ menu:
     name: date.truncate
     parent: Date
 weight: 301
+related:
+  - /influxdb/v2.0/reference/flux/stdlib/built-in/misc/today/
 ---
 
 The `date.truncate()` function truncates a time to a specified unit.

--- a/content/influxdb/v2.0/reference/flux/stdlib/system/time.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/system/time.md
@@ -12,6 +12,7 @@ menu:
 weight: 401
 related:
   - /influxdb/v2.0/reference/flux/stdlib/built-in/misc/now/
+  - /influxdb/v2.0/reference/flux/stdlib/built-in/misc/today/
 ---
 
 The `system.time()` function returns the current system time.


### PR DESCRIPTION
Added types for `today()` and added some _related_ links/references.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
