### PR TITLE
Make cloud CLI info more prominent (addresses #2624 )

### DIFF
--- a/content/influxdb/cloud/reference/cli/influx/_index.md
+++ b/content/influxdb/cloud/reference/cli/influx/_index.md
@@ -48,29 +48,29 @@ For more information about managing CLI configurations, see the
 
 | Command                                                      | Description                                          |
 |:-------                                                      |:-----------                                          |
-| [apply](/influxdb/v2.0/reference/cli/influx/apply)           | Apply an InfluxDB template                           |
-| [auth](/influxdb/v2.0/reference/cli/influx/auth)             | Authentication token management commands             |
-| [backup](/influxdb/v2.0/reference/cli/influx/backup)         | Back up data                                         |
-| [bucket](/influxdb/v2.0/reference/cli/influx/bucket)         | Bucket management commands                           |
-| [completion](/influxdb/v2.0/reference/cli/influx/completion) | Generate completion scripts                          |
-| [config](/influxdb/v2.0/reference/cli/influx/config)         | Configuration management commands                    |
-| [dashboards](/influxdb/v2.0/reference/cli/influx/dashboards) | List dashboards                                      |
-| [delete](/influxdb/v2.0/reference/cli/influx/delete)         | Delete points from InfluxDB                          |
-| [export](/influxdb/v2.0/reference/cli/influx/export)         | Export resources as a template                       |
-| [help](/influxdb/v2.0/reference/cli/influx/help)             | Help about any command                               |
-| [org](/influxdb/v2.0/reference/cli/influx/org)               | Organization management commands                     |
-| [ping](/influxdb/v2.0/reference/cli/influx/ping)             | Check the InfluxDB `/health` endpoint                |
-| [query](/influxdb/v2.0/reference/cli/influx/query)           | Execute a Flux query                                 |
-| [secret](/influxdb/v2.0/reference/cli/influx/secret)         | Manage secrets                                       |
-| [setup](/influxdb/v2.0/reference/cli/influx/setup)           | Create default username, password, org, bucket, etc. |
-| [stacks](/influxdb/v2.0/reference/cli/influx/stacks)         | Manage InfluxDB stacks                               |
-| [task](/influxdb/v2.0/reference/cli/influx/task)             | Task management commands                             |
-| [telegrafs](/influxdb/v2.0/reference/cli/influx/telegrafs)   | Telegraf configuration management commands           |
-| [template](/influxdb/v2.0/reference/cli/influx/template)     | Summarize and validate an InfluxDB template          |
-| [user](/influxdb/v2.0/reference/cli/influx/user)             | User management commands                             |
-| [v1](/influxdb/v2.0/reference/cli/influx/v1)                 | Work with the v1 compatibility API                   |
-| [version](/influxdb/v2.0/reference/cli/influx/version)       | Print the influx CLI version                         |
-| [write](/influxdb/v2.0/reference/cli/influx/write)           | Write points to InfluxDB                             |
+| [apply](/influxdb/cloud/reference/cli/influx/apply)           | Apply an InfluxDB template                           |
+| [auth](/influxdb/cloud/reference/cli/influx/auth)             | Authentication token management commands             |
+| [backup](/influxdb/cloud/reference/cli/influx/backup)         | Back up data                                         |
+| [bucket](/influxdb/cloud/reference/cli/influx/bucket)         | Bucket management commands                           |
+| [completion](/influxdb/cloud/reference/cli/influx/completion) | Generate completion scripts                          |
+| [config](/influxdb/cloud/reference/cli/influx/config)         | Configuration management commands                    |
+| [dashboards](/influxdb/cloud/reference/cli/influx/dashboards) | List dashboards                                      |
+| [delete](/influxdb/cloud/reference/cli/influx/delete)         | Delete points from InfluxDB                          |
+| [export](/influxdb/cloud/reference/cli/influx/export)         | Export resources as a template                       |
+| [help](/influxdb/cloud/reference/cli/influx/help)             | Help about any command                               |
+| [org](/influxdb/cloud/reference/cli/influx/org)               | Organization management commands                     |
+| [ping](/influxdb/cloud/reference/cli/influx/ping)             | Check the InfluxDB `/health` endpoint                |
+| [query](/influxdb/cloud/reference/cli/influx/query)           | Execute a Flux query                                 |
+| [secret](/influxdb/cloud/reference/cli/influx/secret)         | Manage secrets                                       |
+| [setup](/influxdb/cloud/reference/cli/influx/setup)           | Create default username, password, org, bucket, etc. |
+| [stacks](/influxdb/cloud/reference/cli/influx/stacks)         | Manage InfluxDB stacks                               |
+| [task](/influxdb/cloud/reference/cli/influx/task)             | Task management commands                             |
+| [telegrafs](/influxdb/cloud/reference/cli/influx/telegrafs)   | Telegraf configuration management commands           |
+| [template](/influxdb/cloud/reference/cli/influx/template)     | Summarize and validate an InfluxDB template          |
+| [user](/influxdb/cloud/reference/cli/influx/user)             | User management commands                             |
+| [v1](/influxdb/cloud/reference/cli/influx/v1)                 | Work with the v1 compatibility API                   |
+| [version](/influxdb/cloud/reference/cli/influx/version)       | Print the influx CLI version                         |
+| [write](/influxdb/cloud/reference/cli/influx/write)           | Write points to InfluxDB                             |
 
 ## Flags
 

--- a/content/influxdb/cloud/reference/cli/influx/_index.md
+++ b/content/influxdb/cloud/reference/cli/influx/_index.md
@@ -12,5 +12,106 @@ weight: 101
 influxdb/cloud/tags: [cli]
 ---
 
-{{< duplicate-oss >}}
+The `influx` command line interface (CLI) includes commands to manage many aspects of InfluxDB,
+including buckets, organizations, users, tasks, etc.
 
+For information about setting up and configuring the `influx` CLI, see [Download, install, and use the influx CLI](/influxdb/cloud/sign-up/#optional-download-install-and-use-the-influx-cli).
+
+## Usage
+
+```
+influx [flags]
+influx [command]
+```
+
+### Provide required authentication credentials
+To avoid having to pass your InfluxDB **host**, **authentication token**, and **organization**
+with each command, store them in an `influx` CLI configuration (config).
+`influx` commands that require these credentials automatically retrieve these
+credentials from the active config.
+
+Use the [`influx config create` command](/influxdb/cloud/reference/cli/influx/config/create/)
+to create an `influx` CLI config and set it as active:
+
+```sh
+influx config create --config-name <config-name> \
+  --host-url http://localhost:8086 \
+  --org <your-org> \
+  --token <your-auth-token \
+  --active
+```
+
+For more information about managing CLI configurations, see the
+[`influx config` documentation](/influxdb/cloud/reference/cli/influx/config/).
+
+## Commands
+
+| Command                                                      | Description                                          |
+|:-------                                                      |:-----------                                          |
+| [apply](/influxdb/v2.0/reference/cli/influx/apply)           | Apply an InfluxDB template                           |
+| [auth](/influxdb/v2.0/reference/cli/influx/auth)             | Authentication token management commands             |
+| [backup](/influxdb/v2.0/reference/cli/influx/backup)         | Back up data                                         |
+| [bucket](/influxdb/v2.0/reference/cli/influx/bucket)         | Bucket management commands                           |
+| [completion](/influxdb/v2.0/reference/cli/influx/completion) | Generate completion scripts                          |
+| [config](/influxdb/v2.0/reference/cli/influx/config)         | Configuration management commands                    |
+| [dashboards](/influxdb/v2.0/reference/cli/influx/dashboards) | List dashboards                                      |
+| [delete](/influxdb/v2.0/reference/cli/influx/delete)         | Delete points from InfluxDB                          |
+| [export](/influxdb/v2.0/reference/cli/influx/export)         | Export resources as a template                       |
+| [help](/influxdb/v2.0/reference/cli/influx/help)             | Help about any command                               |
+| [org](/influxdb/v2.0/reference/cli/influx/org)               | Organization management commands                     |
+| [ping](/influxdb/v2.0/reference/cli/influx/ping)             | Check the InfluxDB `/health` endpoint                |
+| [query](/influxdb/v2.0/reference/cli/influx/query)           | Execute a Flux query                                 |
+| [secret](/influxdb/v2.0/reference/cli/influx/secret)         | Manage secrets                                       |
+| [setup](/influxdb/v2.0/reference/cli/influx/setup)           | Create default username, password, org, bucket, etc. |
+| [stacks](/influxdb/v2.0/reference/cli/influx/stacks)         | Manage InfluxDB stacks                               |
+| [task](/influxdb/v2.0/reference/cli/influx/task)             | Task management commands                             |
+| [telegrafs](/influxdb/v2.0/reference/cli/influx/telegrafs)   | Telegraf configuration management commands           |
+| [template](/influxdb/v2.0/reference/cli/influx/template)     | Summarize and validate an InfluxDB template          |
+| [user](/influxdb/v2.0/reference/cli/influx/user)             | User management commands                             |
+| [v1](/influxdb/v2.0/reference/cli/influx/v1)                 | Work with the v1 compatibility API                   |
+| [version](/influxdb/v2.0/reference/cli/influx/version)       | Print the influx CLI version                         |
+| [write](/influxdb/v2.0/reference/cli/influx/write)           | Write points to InfluxDB                             |
+
+## Flags
+
+| Flag |          | Description                   |
+|:---- |:---      |:-----------                   |
+| `-h` | `--help` | Help for the `influx` command |
+
+### Flag patterns and conventions
+The `influx` CLI uses the following patterns and conventions:
+
+- [Mapped environment variables](#mapped-environment-variables)
+- [Shorthand and longhand flags](#shorthand-and-longhand-flags)
+- [Flag input types](#flag-input-types)
+
+#### Mapped environment variables
+`influx` CLI flags mapped to environment variables are listed in the **Mapped to** column.
+Mapped flags inherit the value of the environment variable.
+To override environment variables, set the flag explicitly in your command.
+
+#### Shorthand and longhand flags
+Many `influx` CLI flags support both shorthand and longhand forms.
+
+- **shorthand:** a shorthand flag begins with a single hyphen followed by a single letter (for example: `-c`).
+- **longhand:** a longhand flag starts with two hyphens followed by a multi-letter,
+  hyphen-spaced flag name (for example: `--active-config`).
+
+Commands can use both shorthand and longhand flags in a single execution.
+
+#### Flag input types
+`influx` CLI flag input types are listed in each the table of flags for each command.
+Flags support the following input types:
+
+##### string
+Text string, but the flag can be used **only once** per command execution.
+
+##### stringArray
+Single text string, but the flag can be used **multiple times** per command execution.
+
+##### integer
+Sequence of digits representing an integer value.
+
+##### duration
+Length of time represented by an integer and a duration unit
+(`1ns`, `1us`, `1µs`, `1ms`, `1s`, `1m`, `1h`, `1d`, `1w`).

--- a/content/influxdb/cloud/sign-up.md
+++ b/content/influxdb/cloud/sign-up.md
@@ -20,6 +20,12 @@ The primary differences between InfluxDB OSS 2.0 and InfluxDB Cloud are:
   targets are not available in {{< cloud-name "short" >}}.
 - {{< cloud-name "short" >}} instances are currently limited to a single organization.
 
+- [Start for free](#start-for-free)
+- [Sign up](#sign-up)
+- [(Optional) Download, install, and use the influx CLI](#optional-download-install-and-use-the-influx-cli)
+- [Sign in](#sign-in)
+- [Get started working with data](#get-started-working-with-data)
+
 ## Start for free
 
 Start using {{< cloud-name >}} at no cost with the [Free Plan](/influxdb/cloud/account-management/pricing-plans/#free-plan).

--- a/content/influxdb/cloud/sign-up.md
+++ b/content/influxdb/cloud/sign-up.md
@@ -7,7 +7,7 @@ menu:
   influxdb_cloud:
     name: Sign up
 weight: 1
-influxdb/cloud/tags: [get-started, install]
+influxdb/cloud/tags: [get-started, install, cli]
 ---
 
 InfluxDB Cloud is a fully managed and hosted version of InfluxDB 2.0, the time series

--- a/content/influxdb/cloud/tools/clis.md
+++ b/content/influxdb/cloud/tools/clis.md
@@ -13,4 +13,6 @@ Use the `influx` CLI to interact with and manage data in your **InfluxDB** insta
 Write and query data, generate InfluxDB templates, export data, manage organizations
 and users, and more.
 
-_For more information, see the [`influx` reference documentation](/influxdb/cloud/reference/cli/influx/)._
+_For information about setting up and configuring the `influx` CLI, see [Download, install, and use the influx CLI](/influxdb/cloud/sign-up/#optional-download-install-and-use-the-influx-cli)._
+
+_For more information about using the `influx` CLI, see the [`influx` reference documentation](/influxdb/cloud/reference/cli/influx/)._


### PR DESCRIPTION
Addresses #2624 by:

- Adding headings to Sign up doc for cloud to make CLI info more prominent/scannable
- Add link to CLI instructions from Cloud influx CLI index page (required replacing `duplicate-oss` shortcode and updating). 

@russorat, It looks like all the content you're requesting (Download and install the influx cli tool, Configure the cli tool to connect to your cloud instance, Additional references and/or examples) is all already in this section. Is there something missing from [this procedure](https://docs.influxdata.com/influxdb/cloud/sign-up/#optional-download-install-and-use-the-influx-cli) that you'd like to see added? Or is it just making it more prominent and clear that it's a separate CLI for Cloud?

