### PR TITLE
Add back crosslinks between new versions of Chronograf and Kapacitor

### DIFF
--- a/content/chronograf/v1.9/guides/advanced-kapacitor.md
+++ b/content/chronograf/v1.9/guides/advanced-kapacitor.md
@@ -6,6 +6,8 @@ menu:
   chronograf_1_9:
     weight: 100
     parent: Guides
+related:
+  - /{{< latest "kapacitor" >}}/working/flux/
 ---
 
 Chronograf provides a user interface for [Kapacitor](/{{< latest "kapacitor" >}}/),
@@ -65,7 +67,7 @@ On this page, you can:
 
 ### Manage Kapacitor Flux tasks
 **Kapacitor 1.6+** supports Flux tasks.
-Chronograf lets you view and manage Kapacitor Flux tasks.
+Chronograf lets you view and manage [Kapacitor Flux tasks](/{{< latest "kapacitor" >}}/working/flux/).
 
 To manage Kapacitor Flux tasks in Chronograf, click
 **{{< icon "alert">}} Alerts** in the left navigation bar.

--- a/content/kapacitor/v1.6/working/flux/manage/_index.md
+++ b/content/kapacitor/v1.6/working/flux/manage/_index.md
@@ -10,6 +10,16 @@ weight: 1
 cascade:
   related:
     - /kapacitor/v1.6/working/flux/
+    - /{{< latest "chronograf" >}}/guides/advanced-kapacitor/
 ---
+
+Use the **`kapacitor` CLI** and the **Kapacitor HTTP API** to manage Kapacitor Flux tasks.
+
+{{% note %}}
+**Chronograf 1.9+** provides a user interface for enabling or disabling Flux tasks,
+viewing task logs, and more.
+Kapacitor Flux task code is read-only in Chronograf.
+For more information, see [Advanced Kapacitor usage](/{{< latest "chronograf" >}}/guides/advanced-kapacitor/#manage-kapacitor-flux-tasks).
+{{% /note %}}
 
 {{< children >}}


### PR DESCRIPTION
**This PR should not be merged until Kapacitor 1.6.1 is released.**

Reverts influxdata/docs-v2#2793