### PR TITLE
fix: clarify validate-keys behavior

### DIFF
--- a/content/influxdb/v1.8/administration/config.md
+++ b/content/influxdb/v1.8/administration/config.md
@@ -279,8 +279,8 @@ Environment variable: `INFLUXDB_DATA_STRICT_ERROR_HANDLING`
 
 #### `validate-keys = false`
 
-Validates incoming writes to ensure keys only have valid Unicode characters.
-This setting will incur a small overhead because every key must be checked.
+Validates incoming writes to ensure measurement keys and tag keys only have valid Unicode characters.
+This setting will incur a small overhead because every key must be checked. This will not validate field keys.
 
 
 ### Settings for the TSM engine


### PR DESCRIPTION
Closes #

based on testing in this issue: https://github.com/influxdata/influxdb/issues/21650

This should also be updated in the storage-validate-keys config option for 2.0.

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
