### PR TITLE
fix: example for updating a bucket retention period

### DIFF
--- a/content/influxdb/cloud/organizations/buckets/update-bucket.md
+++ b/content/influxdb/cloud/organizations/buckets/update-bucket.md
@@ -73,8 +73,8 @@ Valid retention period duration units are nanoseconds (`ns`), microseconds (`us`
 
 ```sh
 # Syntax
-influx bucket update -i <bucket-id> -r <retention period in nanoseconds>
+influx bucket update -i <bucket-id> -r <retention period with units>
 
 # Example
-influx bucket update -i 034ad714fdd6f000 -r 1209600000000000
+influx bucket update -i 034ad714fdd6f000 -r 1209600000000000ns
 ```

--- a/content/influxdb/v2.0/organizations/buckets/update-bucket.md
+++ b/content/influxdb/v2.0/organizations/buckets/update-bucket.md
@@ -66,8 +66,8 @@ Valid retention period duration units are nanoseconds (`ns`), microseconds (`us`
 
 ```sh
 # Syntax
-influx bucket update -i <bucket-id> -r <retention period in nanoseconds>
+influx bucket update -i <bucket-id> -r <retention period with units>
 
 # Example
-influx bucket update -i 034ad714fdd6f000 -r 1209600000000000
+influx bucket update -i 034ad714fdd6f000 -r 1209600000000000ns
 ```


### PR DESCRIPTION
The example at https://docs.influxdata.com/influxdb/v2.0/organizations/buckets/update-bucket/#update-a-buckets-retention-period doesn't work quite right; for this command to work, a duration needs to be provided, and it isn't necessarily nanoseconds. I updated the documentation so that the example will work better.