### PR TITLE
install.md - wrong path for Docker volume

### DIFF
--- a/content/influxdb/v2.0/install.md
+++ b/content/influxdb/v2.0/install.md
@@ -405,7 +405,7 @@ _To run InfluxDB in [detached mode](https://docs.docker.com/engine/reference/run
    mkdir path/to/influxdb-docker-data-volume && cd $_
    ```
 2. From within your new directory, run the InfluxDB Docker container with the `--volume` flag to
-   persist data from `/root/.influxdb2/` _inside_ the container to the current working directory in
+   persist data from `/var/lib/influxdb2` _inside_ the container to the current working directory in
    the host file system.
 
    ```sh


### PR DESCRIPTION
The path in the command is inconsistent with the description of the command. Luckily, it's the path in the command which is right, so if somebody just pastes it, it works, but it can still cause confusion.
