### PR TITLE
Fix Enterprise v1.9 links

### DIFF
--- a/content/enterprise_influxdb/v1.9/administration/backup-and-restore.md
+++ b/content/enterprise_influxdb/v1.9/administration/backup-and-restore.md
@@ -388,7 +388,7 @@ Copying data to <hostname>:8088... Copying data to <hostname>:8088... Done. Rest
 Restored from my-incremental-backup/ in 56.623615ms, transferred 588800 bytes
 ```
 
-Then, in the [`influx` client](/enterprise_influxdb/v1.9/tools/use-influx/), use an [`INTO` query](/enterprise_influxdb/v1.9/query_language/explore-data/#the-into-clause) to copy the data from the new database into the existing `telegraf` database:
+Then, in the [`influx` client](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/), use an [`INTO` query](/enterprise_influxdb/v1.9/query_language/explore-data/#the-into-clause) to copy the data from the new database into the existing `telegraf` database:
 
 ```bash
 $ influx

--- a/content/enterprise_influxdb/v1.9/administration/cluster-commands.md
+++ b/content/enterprise_influxdb/v1.9/administration/cluster-commands.md
@@ -30,4 +30,4 @@ For more information, see [`influxd-ctl`](/enterprise_influxdb/v1.9/tools/influx
 Use the `influx` command line interface (CLI) to write data to your cluster, query data interactively, and view query output in different formats.
 The `influx` CLI is available on all [data nodes](/enterprise_influxdb/v1.9/concepts/glossary/#data-node).
 
-See [InfluxDB command line interface (CLI/shell)](/enterprise_influxdb/v1.9/tools/use-influx/) for details on using the `influx` command line interface.
+See [InfluxDB command line interface (CLI/shell)](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) for details on using the `influx` command line interface.

--- a/content/enterprise_influxdb/v1.9/administration/config-data-nodes.md
+++ b/content/enterprise_influxdb/v1.9/administration/config-data-nodes.md
@@ -191,8 +191,6 @@ Controls where the actual shard data for InfluxDB lives and how it is compacted 
 "dir" may need to be changed to a suitable place for your system.
 The defaults should work for most systems.
 
-For InfluxDB OSS, see the [OSS documentation](/enterprise_influxdb/v1.9/administration/config/#data-settings).
-
 #### `dir = "/var/lib/influxdb/data"`
 
 The directory where the TSM storage engine stores TSM (read-optimized) files.
@@ -384,7 +382,7 @@ to perform most RPC requests. In special circumstances, for example, when copyin
 a single-use TCP connection may be used.
 
 For information on InfluxDB `_internal` measurement statistics related to clusters, RPCs, and shards,
-see [Measurements for monitoring InfluxDB OSS and InfluxDB Enterprise (`_inernal`)](/platform/monitoring/influxdata-platform/tools/measurements-internal/#cluster-enterprise-only).
+see [Measurements for monitoring InfluxDB Enterprise (`_internal`)](/platform/monitoring/influxdata-platform/tools/measurements-internal/#cluster-enterprise-only).
 
 #### `dial-timeout = "1s"`
 
@@ -747,8 +745,6 @@ Environment variable: `INFLUXDB_MONITOR_REMOTE_COLLECT_INTERVAL`
 ### `[http]`
 
 Controls how the HTTP endpoints are configured. These are the primary mechanism for getting data into and out of InfluxDB.
-
-For InfluxDB OSS, see the [OSS documentation](/enterprise_influxdb/v1.9/administration/config/#http-endpoint-settings-http).
 
 #### `enabled = true`
 

--- a/content/enterprise_influxdb/v1.9/administration/ports.md
+++ b/content/enterprise_influxdb/v1.9/administration/ports.md
@@ -31,7 +31,7 @@ It's also used by meta nodes for cluster-type operations (e.g., tell a data node
 
 This is the default port used for RPC calls used for inter-node communication and by the CLI for backup and restore operations
 (`influxdb backup` and `influxd restore`).
-[Configure this port](/enterprise_influxdb/v1.9/administration/config#bind-address-127-0-0-1-8088)
+[Configure this port](/enterprise_influxdb/v1.9/administration/config/#bind-address-127-0-0-1-8088)
 in the configuration file.
 
 This port should not be exposed outside the cluster.

--- a/content/enterprise_influxdb/v1.9/concepts/schema_and_data_layout.md
+++ b/content/enterprise_influxdb/v1.9/concepts/schema_and_data_layout.md
@@ -62,7 +62,11 @@ We recommend that you:
 
 [Tags](/enterprise_influxdb/v1.9/concepts/glossary/#tag) containing highly variable information like UUIDs, hashes, and random strings lead to a large number of [series](/enterprise_influxdb/v1.9/concepts/glossary/#series) in the database, also known as high series cardinality. High series cardinality is a primary driver of high memory usage for many database workloads.
 
-See [Hardware sizing guidelines](/enterprise_influxdb/v1.9/reference/hardware_sizing/) for [series cardinality](/enterprise_influxdb/v1.9/concepts/glossary/#series-cardinality) recommendations based on your hardware. If the system has memory constraints, consider storing high-cardinality data as a field rather than a tag.
+<!--  See [Hardware sizing guidelines](/enterprise_influxdb/v1.9/reference/hardware_sizing/) for [series cardinality](/enterprise_influxdb/v1.9/concepts/glossary/#series-cardinality) recommendations based on your hardware. --> 
+
+If the system has memory constraints, consider storing high-cardinality data as a field rather than a tag. For more information, see [series cardinality](/enterprise_influxdb/v1.9/concepts/glossary/#series-cardinality).
+
+<!-- When adding back hardware sizing gudelies, update line 65-67 -->
 
 #### Avoid the same name for a tag and a field
 

--- a/content/enterprise_influxdb/v1.9/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.9/guides/https_setup.md
@@ -231,7 +231,7 @@ With a self-signed certificate, you must also use the `-k` option to skip certif
     enterprise-meta-03:8091   1.x.y-c1.x.z
     ```
 
-    Next, verify that HTTPS is working by connecting to InfluxDB Enterprise with the [`influx` command line interface](/enterprise_influxdb/v1.9/tools/use-influx/):
+    Next, verify that HTTPS is working by connecting to InfluxDB Enterprise with the [`influx` command line interface](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/):
 
     ```sh
     influx -ssl -host <domain_name>.com

--- a/content/enterprise_influxdb/v1.9/guides/query_data.md
+++ b/content/enterprise_influxdb/v1.9/guides/query_data.md
@@ -13,7 +13,7 @@ v2: /influxdb/v2.0/query-data/
 ---
 
 
-The InfluxDB API is the primary means for querying data in InfluxDB (see the [command line interface](/enterprise_influxdb/v1.9/tools/use-influx/) and [client libraries](/enterprise_influxdb/v1.9/tools/api_client_libraries/) for alternative ways to query the database).
+The InfluxDB API is the primary means for querying data in InfluxDB (see the [command line interface](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) and [client libraries](/enterprise_influxdb/v1.9/tools/api_client_libraries/) for alternative ways to query the database).
 
 Query data with the InfluxDB API using [Flux](#query-data-with-flux) or [InfluxQL](#query-data-with-influxql).
 

--- a/content/enterprise_influxdb/v1.9/guides/rebalance.md
+++ b/content/enterprise_influxdb/v1.9/guides/rebalance.md
@@ -267,7 +267,7 @@ shards across the three data nodes in the cluster.
 
 The following query increases the replication factor to three.
 Run the query on any data node for each retention policy and database.
-Here, we use InfluxDB's [CLI](/enterprise_influxdb/v1.9/tools/use-influx/) to execute the query:
+Here, we use InfluxDB's [CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) to execute the query:
 
 ```
 > ALTER RETENTION POLICY "<retention_policy_name>" ON "<database_name>" REPLICATION 3

--- a/content/enterprise_influxdb/v1.9/guides/write_data.md
+++ b/content/enterprise_influxdb/v1.9/guides/write_data.md
@@ -11,7 +11,7 @@ aliases:
 v2: /influxdb/v2.0/write-data/
 ---
 
-Write data into InfluxDB using the [command line interface](/enterprise_influxdb/v1.9/tools/use-influx/), [client libraries](/enterprise_influxdb/v1.9/clients/api/), and plugins for common data formats such as [Graphite](/enterprise_influxdb/v1.9/write_protocols/graphite/).
+Write data into InfluxDB using the [command line interface](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/), [client libraries](/enterprise_influxdb/v1.9/clients/api/), and plugins for common data formats such as [Graphite](/enterprise_influxdb/v1.9/write_protocols/graphite/).
 
 > **Note**: The following examples use `curl`, a command line tool that transfers data using URLs. Learn the basics of `curl` with the [HTTP Scripting Guide](https://curl.haxx.se/docs/httpscripting.html).
 

--- a/content/enterprise_influxdb/v1.9/introduction/install-and-deploy/deploying/azure.md
+++ b/content/enterprise_influxdb/v1.9/introduction/install-and-deploy/deploying/azure.md
@@ -59,7 +59,7 @@ To deploy InfluxDB Enterprise clusters on platforms other than Azure, see [Deplo
 
 Once the cluster is created, access the InfluxDB API at the IP address associated with the load balancer resource (`lb-influxdb`). If external access was configured during setup, the load balancer is publicly accessible. Otherwise, the load balancer is only accessible to the cluster's virtual network.
 
-Use the load balancer IP address and the InfluxDB admin credentials entered during the cluster creation to interact with InfluxDB Enterprise via the [`influx` CLI](/enterprise_influxdb/v1.9/tools/use-influx/) or use the InfluxDB's [query](/enterprise_influxdb/v1.9/guides/query_data/) and [write](/enterprise_influxdb/v1.9/guides/write_data/) HTTP APIs.
+Use the load balancer IP address and the InfluxDB admin credentials entered during the cluster creation to interact with InfluxDB Enterprise via the [`influx` CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) or use the InfluxDB's [query](/enterprise_influxdb/v1.9/guides/query_data/) and [write](/enterprise_influxdb/v1.9/guides/write_data/) HTTP APIs.
 
 ## Access the cluster
 

--- a/content/enterprise_influxdb/v1.9/introduction/install-and-deploy/deploying/google-cloud-platform.md
+++ b/content/enterprise_influxdb/v1.9/introduction/install-and-deploy/deploying/google-cloud-platform.md
@@ -49,7 +49,10 @@ Before deploying an InfluxDB Enterprise cluster on GCP, verify you have the foll
 4. Adjust data node fields as needed, including:
 
   - Data node instance count: Enter the number of data nodes to include in your cluster (we recommend starting with the default, 2).
-  - Data node machine type: Select the virtual machine type to use for data nodes (by default, 4 vCPUs). Use the down arrow to scroll through list. Notice the amount of memory available for the selected machine. To alter the number of cores and memory for your selected machine type, click the **Customize** link. For detail, see our recommended [hardware sizing guidelines](/enterprise_influxdb/v1.9/reference/hardware_sizing/).
+  - Data node machine type: Select the virtual machine type to use for data nodes (by default, 4 vCPUs). Use the down arrow to scroll through list. Notice the amount of memory available for the selected machine. To alter the number of cores and memory for your selected machine type, click the **Customize** link. 
+  
+  <!-- For detail, see our recommended [hardware sizing guidelines](/enterprise_influxdb/v1.9/reference/hardware_sizing/). -->
+  
   - (Optional) By default, the data node disk type is SSD Persistent Disk and the disk size is 250 GB. To alter these defaults, click More and update if needed.
 
         > **Note:** Typically, fields in collapsed sections don't need to be altered.

--- a/content/enterprise_influxdb/v1.9/query_language/explore-data.md
+++ b/content/enterprise_influxdb/v1.9/query_language/explore-data.md
@@ -144,8 +144,8 @@ The `FROM` clause supports several formats for specifying a [measurement(s)](/en
 `FROM <measurement_name>`
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 Returns data from a single measurement.
-If you're using the [CLI](/enterprise_influxdb/v1.9/tools/use-influx/) InfluxDB queries the measurement in the
-[`USE`d](/enterprise_influxdb/v1.9/tools/use-influx/#commands)
+If you're using the [CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) InfluxDB queries the measurement in the
+[`USE`d](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/#commands)
 [database](/enterprise_influxdb/v1.9/concepts/glossary/#database) and the `DEFAULT` [retention policy](/enterprise_influxdb/v1.9/concepts/glossary/#retention-policy-rp).
 If you're using the [InfluxDB API](/enterprise_influxdb/v1.9/tools/api/) InfluxDB queries the
 measurement in the database specified in the [`db` query string parameter](/enterprise_influxdb/v1.9/tools/api/#query-string-parameters)
@@ -198,7 +198,7 @@ The query selects all [fields](/enterprise_influxdb/v1.9/concepts/glossary/#fiel
 [tags](/enterprise_influxdb/v1.9/concepts/glossary/#tag) from the `h2o_feet`
 [measurement](/enterprise_influxdb/v1.9/concepts/glossary/#measurement).
 
-If you're using the [CLI](/enterprise_influxdb/v1.9/tools/use-influx/) be sure to enter
+If you're using the [CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) be sure to enter
 `USE NOAA_water_database` before you run the query.
 The CLI queries the data in the `USE`d database and the
 `DEFAULT` [retention policy](/enterprise_influxdb/v1.9/concepts/glossary/#retention-policy-rp).
@@ -1695,8 +1695,8 @@ The `INTO` clause supports several formats for specifying a [measurement](/enter
 `INTO <measurement_name>`
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 Writes data to the specified measurement.
-If you're using the [CLI](/enterprise_influxdb/v1.9/tools/use-influx/) InfluxDB writes the data to the measurement in the
-[`USE`d](/enterprise_influxdb/v1.9/tools/use-influx/#commands)
+If you're using the [CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) InfluxDB writes the data to the measurement in the
+[`USE`d](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/#commands)
 [database](/enterprise_influxdb/v1.9/concepts/glossary/#database) and the `DEFAULT` [retention policy](/enterprise_influxdb/v1.9/concepts/glossary/#retention-policy-rp).
 If you're using the [InfluxDB API](/enterprise_influxdb/v1.9/tools/api/) InfluxDB writes the data to the
 measurement in the database specified in the [`db` query string parameter](/enterprise_influxdb/v1.9/tools/api/#query-string-parameters)
@@ -1788,7 +1788,7 @@ time                   water_level
 ```
 
 The query writes its results a new [measurement](/enterprise_influxdb/v1.9/concepts/glossary/#measurement): `h2o_feet_copy_1`.
-If you're using the [CLI](/enterprise_influxdb/v1.9/tools/use-influx/), InfluxDB writes the data to
+If you're using the [CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/), InfluxDB writes the data to
 the `USE`d [database](/enterprise_influxdb/v1.9/concepts/glossary/#database) and the `DEFAULT` [retention policy](/enterprise_influxdb/v1.9/concepts/glossary/#retention-policy-rp).
 If you're using the [InfluxDB API](/enterprise_influxdb/v1.9/tools/api/), InfluxDB writes the
 data to the database and retention policy specified in the `db` and `rp`
@@ -2684,7 +2684,7 @@ a `GROUP BY time()` clause must provide an alternative upper bound in the
 
 #### Example
 
-Use the [CLI](/enterprise_influxdb/v1.9/tools/use-influx/) to write a point to the `NOAA_water_database` that occurs after `now()`:
+Use the [CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) to write a point to the `NOAA_water_database` that occurs after `now()`:
 
 ```sql
 > INSERT h2o_feet,location=santa_monica water_level=3.1 1587074400000000000
@@ -2729,10 +2729,10 @@ the lower bound to `now()` such that the query's time range is between
 
 ### Configuring the returned timestamps
 
-The [CLI](/enterprise_influxdb/v1.9/tools/use-influx/) returns timestamps in
+The [CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) returns timestamps in
 nanosecond epoch format by default.
 Specify alternative formats with the
-[`precision <format>` command](/enterprise_influxdb/v1.9/tools/use-influx/#influx-commands).
+[`precision <format>` command](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/#influx-commands).
 The [InfluxDB API](/enterprise_influxdb/v1.9/tools/api/) returns timestamps
 in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format by default.
 Specify alternative formats with the
@@ -3062,7 +3062,7 @@ Separate multiple [`SELECT` statements](#the-basic-select-statement) in a query 
 
 {{% tab-content %}}
 
-In the InfluxDB [CLI](/enterprise_influxdb/v1.9/tools/use-influx/):
+In the InfluxDB [CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/):
 
 ```sql
 > SELECT MEAN("water_level") FROM "h2o_feet"; SELECT "water_level" FROM "h2o_feet" LIMIT 2

--- a/content/enterprise_influxdb/v1.9/query_language/explore-schema.md
+++ b/content/enterprise_influxdb/v1.9/query_language/explore-schema.md
@@ -85,7 +85,7 @@ SHOW RETENTION POLICIES [ON <database_name>]
 
 `ON <database_name>` is optional.
 If the query does not include `ON <database_name>`, you must specify the
-database with `USE <database_name>` in the [CLI](/enterprise_influxdb/v1.9/tools/use-influx/) or with the `db` query
+database with `USE <database_name>` in the [CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) or with the `db` query
 string parameter in the [InfluxDB API](/enterprise_influxdb/v1.9/tools/api/#query-string-parameters) request.
 
 ### Examples
@@ -186,7 +186,7 @@ SHOW SERIES [ON <database_name>] [FROM_clause] [WHERE <tag_key> <operator> [ '<t
 
 `ON <database_name>` is optional.
 If the query does not include `ON <database_name>`, you must specify the
-database with `USE <database_name>` in the [CLI](/enterprise_influxdb/v1.9/tools/use-influx/) or with the `db` query
+database with `USE <database_name>` in the [CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) or with the `db` query
 string parameter in the [InfluxDB API](/enterprise_influxdb/v1.9/tools/api/#query-string-parameters) request.
 
 The `FROM`, `WHERE`, `LIMIT`, and `OFFSET` clauses are optional.
@@ -419,7 +419,7 @@ SHOW MEASUREMENTS [ON <database_name>] [WITH MEASUREMENT <operator> ['<measureme
 
 `ON <database_name>` is optional.
 If the query does not include `ON <database_name>`, you must specify the
-database with `USE <database_name>` in the [CLI](/enterprise_influxdb/v1.9/tools/use-influx/) or with the `db` query
+database with `USE <database_name>` in the [CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) or with the `db` query
 string parameter in the [InfluxDB API](/enterprise_influxdb/v1.9/tools/api/#query-string-parameters) request.
 
 The `WITH`, `WHERE`, `LIMIT` and `OFFSET` clauses are optional.
@@ -578,7 +578,7 @@ SHOW TAG KEYS [ON <database_name>] [FROM_clause] WITH KEY [ [<operator> "<tag_ke
 
 `ON <database_name>` is optional.
 If the query does not include `ON <database_name>`, you must specify the
-database with `USE <database_name>` in the [CLI](/enterprise_influxdb/v1.9/tools/use-influx/) or with the `db` query
+database with `USE <database_name>` in the [CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) or with the `db` query
 string parameter in the [InfluxDB API](/enterprise_influxdb/v1.9/tools/api/#query-string-parameters) request.
 
 The `FROM` clause and the `WHERE` clause are optional.
@@ -811,7 +811,7 @@ SHOW TAG VALUES [ON <database_name>][FROM_clause] WITH KEY [ [<operator> "<tag_k
 
 `ON <database_name>` is optional.
 If the query does not include `ON <database_name>`, you must specify the
-database with `USE <database_name>` in the [CLI](/enterprise_influxdb/v1.9/tools/use-influx/) or with the `db` query string parameter in the [InfluxDB API](/enterprise_influxdb/v1.9/tools/api/#query-string-parameters) request.
+database with `USE <database_name>` in the [CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) or with the `db` query string parameter in the [InfluxDB API](/enterprise_influxdb/v1.9/tools/api/#query-string-parameters) request.
 
 The `WITH` clause is required.
 It supports specifying a single tag key, a regular expression, and multiple tag keys.
@@ -954,7 +954,7 @@ SHOW FIELD KEYS [ON <database_name>] [FROM <measurement_name>]
 
 `ON <database_name>` is optional.
 If the query does not include `ON <database_name>`, you must specify the
-database with `USE <database_name>` in the [CLI](/enterprise_influxdb/v1.9/tools/use-influx/) or with the `db` query
+database with `USE <database_name>` in the [CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) or with the `db` query
 string parameter in the [InfluxDB API](/enterprise_influxdb/v1.9/tools/api/#query-string-parameters) request.
 
 The `FROM` clause is also optional.

--- a/content/enterprise_influxdb/v1.9/query_language/sample-data.md
+++ b/content/enterprise_influxdb/v1.9/query_language/sample-data.md
@@ -35,7 +35,7 @@ InfluxDB shell 1.4.x
 * The InfluxDB API runs on port `8086` by default.
 Therefore, `influx` will connect to port `8086` and `localhost` by default.
 If you need to alter these defaults, run `influx --help`.
-* The [`-precision` argument](/enterprise_influxdb/v1.9/tools/use-influx/#influx-arguments) specifies the format/precision of any returned timestamps.
+* The [`-precision` argument](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/#influx-arguments) specifies the format/precision of any returned timestamps.
 In the example above, `rfc3339` tells InfluxDB to return timestamps in [RFC3339 format](https://www.ietf.org/rfc/rfc3339.txt) (`YYYY-MM-DDTHH:MM:SS.nnnnnnnnnZ`).
 
 The command line is now ready to take input in the form of the Influx Query Language (a.k.a InfluxQL) statements.

--- a/content/enterprise_influxdb/v1.9/query_language/spec.md
+++ b/content/enterprise_influxdb/v1.9/query_language/spec.md
@@ -985,7 +985,8 @@ Estimates or counts exactly the cardinality of the series for the current databa
 
 [Series cardinality](/enterprise_influxdb/v1.9/concepts/glossary/#series-cardinality) is the major factor that affects RAM requirements. For more information, see:
 
-- [When do I need more RAM?](/enterprise_influxdb/v1.9/reference/hardware_sizing/#when-do-i-need-more-ram) in [Hardware Sizing Guidelines](/enterprise_influxdb/v1.9/reference/hardware_sizing/)
+-<!-- [When do I need more RAM?](/enterprise_influxdb/v1.9/reference/hardware_sizing/#when-do-i-need-more-ram) in [Hardware Sizing Guidelines](/enterprise_influxdb/v1.9/reference/hardware_sizing/) -->
+
 - [Don't have too many series](/enterprise_influxdb/v1.9/concepts/schema_and_data_layout/#avoid-too-many-series)
 
 > **Note:** `ON <database>`, `FROM <sources>`, `WITH KEY = <key>`, `WHERE <condition>`, `GROUP BY <dimensions>`, and `LIMIT/OFFSET` clauses are optional.

--- a/content/enterprise_influxdb/v1.9/tools/api.md
+++ b/content/enterprise_influxdb/v1.9/tools/api.md
@@ -380,7 +380,7 @@ The `mymeas` [measurement](/enterprise_influxdb/v1.9/concepts/glossary/#measurem
 The first point has the [timestamp](/enterprise_influxdb/v1.9/concepts/glossary/#timestamp) `2017-03-01T00:16:18Z`, a `myfield` value of `33.1`, and no tag values for the `mytag1` and `mytag2` [tag keys](/enterprise_influxdb/v1.9/concepts/glossary/#tag-key).
 The second point has the timestamp `2017-03-01T00:17:18Z`, a `myfield` value of `12.4`, a `mytag1` value of `12`, and a `mytag2` value of `14`.
 
-The same query in the InfluxDB [Command Line Interface](/enterprise_influxdb/v1.9/tools/use-influx/) (CLI) returns the following table:
+The same query in the InfluxDB [Command Line Interface](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) (CLI) returns the following table:
 
 ```sql
 name: mymeas

--- a/content/enterprise_influxdb/v1.9/tools/influx_inspect.md
+++ b/content/enterprise_influxdb/v1.9/tools/influx_inspect.md
@@ -320,7 +320,7 @@ If a user writes points with timestamps set by the client, then multiple points 
 Exports all TSM files in InfluxDB line protocol data format.
 Writes all WAL file data for `_internal/monitor`.
 This output file can be imported using the
-[influx](/enterprise_influxdb/v1.9/tools/use-influx/#import-data-from-a-file-with-import) command.
+[influx](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/#import-data-from-a-file-with-import) command.
 
 #### Syntax
 

--- a/content/enterprise_influxdb/v1.9/troubleshooting/errors.md
+++ b/content/enterprise_influxdb/v1.9/troubleshooting/errors.md
@@ -21,7 +21,7 @@ common resolutions.
 The `database name required` error occurs when certain `SHOW` queries do
 not specify a [database](/enterprise_influxdb/v1.9/concepts/glossary/#database).
 Specify a database with an `ON` clause in the `SHOW` query, with `USE <database_name>` in the
-[CLI](/enterprise_influxdb/v1.9/tools/use-influx/), or with the `db` query string parameter in
+[CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/), or with the `db` query string parameter in
 the [InfluxDB API](/enterprise_influxdb/v1.9/tools/api/#query-string-parameters) request.
 
 The relevant `SHOW` queries include `SHOW RETENTION POLICIES`, `SHOW SERIES`,
@@ -370,7 +370,7 @@ Find common errors that occur when importing data in the command line interface 
   - [Unnamed import file](#unnamed-import-file)
   - [Docker container cannot read host files](#docker-container-cannot-read-host-files)
 
-  >**Note:** To learn how to use the `-import` command, see [Import data from a file with `-import`](/enterprise_influxdb/v1.9/tools/use-influx/#import-data-from-a-file-with-import).
+  >**Note:** To learn how to use the `-import` command, see [Import data from a file with `-import`](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/#import-data-from-a-file-with-import).
 
 ### Inconsistent data types
 

--- a/content/enterprise_influxdb/v1.9/troubleshooting/frequently-asked-questions.md
+++ b/content/enterprise_influxdb/v1.9/troubleshooting/frequently-asked-questions.md
@@ -121,7 +121,7 @@ Request-Id: 1e08aeb6-fec0-11e6-8486-000000000000
 Date: Wed, 01 Mar 2017 20:46:17 GMT
 ```
 
-#### Launch the InfluxDB [Command Line Interface](/enterprise_influxdb/v1.9/tools/use-influx/):
+#### Launch the InfluxDB [Command Line Interface](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/):
 
 ```bash
 $ influx
@@ -247,7 +247,7 @@ InfluxDB shell 0.xx.x
 >
 ```
 
-Check out [CLI/Shell](/enterprise_influxdb/v1.9/tools/use-influx/) for more useful CLI options.
+Check out [CLI/Shell](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/) for more useful CLI options.
 
 ## How can a non-admin user `USE` a database in the InfluxDB CLI?
 
@@ -640,7 +640,7 @@ Avoid using the same name for a tag and field key. If you inadvertently add the 
 
 #### Example
 
-1. [Launch `influx`](/enterprise_influxdb/v1.9/tools/use-influx/#launch-influx).
+1. [Launch `influx`](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/#launch-influx).
 
 2. Write the following points to create both a field and tag key with the same name `leaves`:
 
@@ -705,7 +705,7 @@ Avoid using the same name for a tag and field key. If you inadvertently add the 
 
 #### Remove a duplicate key
 
-1. [Launch `influx`](/enterprise_influxdb/v1.9/tools/use-influx/#launch-influx).
+1. [Launch `influx`](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/#launch-influx).
 
 2. Use the following queries to remove a duplicate key:
    ```sql

--- a/content/enterprise_influxdb/v1.9/write_protocols/line_protocol_tutorial.md
+++ b/content/enterprise_influxdb/v1.9/write_protocols/line_protocol_tutorial.md
@@ -473,7 +473,7 @@ and more examples, see the [API Reference](/enterprise_influxdb/v1.9/tools/api/#
 #### CLI
 
 Write data to InfluxDB using the InfluxDB command line interface (CLI).
-[Launch](/enterprise_influxdb/v1.9/tools/use-influx/#launch-influx) the CLI, use the relevant
+[Launch](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/#launch-influx) the CLI, use the relevant
 database, and put `INSERT` in
 front of your line protocol:
 
@@ -482,13 +482,13 @@ INSERT weather,location=us-midwest temperature=82 1465839830100400200
 ```
 
 You can also use the CLI to
-[import](/enterprise_influxdb/v1.9/tools/use-influx/#import-data-from-a-file-with-import) Line
+[import](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/#import-data-from-a-file-with-import) Line
 Protocol from a file.
 
 There are several ways to write data to InfluxDB.
 See the [Tools](/enterprise_influxdb/v1.9/tools/) section for more
 on the [InfluxDB API](/enterprise_influxdb/v1.9/tools/api/#write-http-endpoint), the
-[CLI](/enterprise_influxdb/v1.9/tools/use-influx/), and the available Service Plugins (
+[CLI](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/), and the available Service Plugins (
 [UDP](/enterprise_influxdb/v1.9/tools/udp/),
 [Graphite](/enterprise_influxdb/v1.9/tools/graphite/),
 [CollectD](/enterprise_influxdb/v1.9/tools/collectd/), and


### PR DESCRIPTION
Added missing directory in URL path, removed links to outdated OSS content, fixed syntax error, and hid hardware-sizing links. 