### PR TITLE
Flux sample package

### DIFF
--- a/assets/styles/layouts/article/_buttons.scss
+++ b/assets/styles/layouts/article/_buttons.scss
@@ -40,4 +40,11 @@ a.btn {
     margin-right: .5rem;
     font-size: 1.1rem;
   }
+
+  &.github:before {
+    content: "\eab0";
+    font-family: "icomoon";
+    margin-right: .5rem;
+    font-size: 1.1rem;
+  }
 }

--- a/assets/styles/layouts/article/_captions.scss
+++ b/assets/styles/layouts/article/_captions.scss
@@ -13,3 +13,11 @@
     margin-top: -2.75rem;
   }
 }
+
+h2,h3,h4,h5,h6,p {
+  & + .caption {
+    padding: 0;
+    margin: -.75rem 0 0;
+    opacity: 1;
+  }
+}

--- a/assets/styles/layouts/article/_captions.scss
+++ b/assets/styles/layouts/article/_captions.scss
@@ -14,10 +14,18 @@
   }
 }
 
-h2,h3,h4,h5,h6,p {
+p {
   & + .caption {
     padding: 0;
     margin: -.75rem 0 0;
+    opacity: 1;
+  }
+}
+
+h2,h3,h4,h5,h6 {
+  & + .caption {
+    padding: 0;
+    margin: 0;
     opacity: 1;
   }
 }

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-sample/_index.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-sample/_index.md
@@ -5,7 +5,7 @@ description: >
   The Flux InfluxDB sample package provides functions for downloading and outputting InfluxDB data sample.
   Import the `influxdata/influxdb/sample` package.
 menu:
-  influxdb_2_0_ref:
+  influxdb_cloud_ref:
     name: InfluxDB Sample
     parent: Flux standard library
 weight: 202
@@ -13,12 +13,4 @@ influxdb/v2.0/tags: [functions, sample, package]
 introduced: 0.123.0
 ---
 
-The Flux InfluxDB sample package provides functions for downloading and outputting InfluxDB data sample.
-
-Import the `influxdata/influxdb/sample` package:
-
-```js
-import "influxdata/influxdb/sample"
-```
-
-{{< children type="functions" show="pages" >}}
+{{< duplicate-oss >}}

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-sample/data.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-sample/data.md
@@ -1,0 +1,15 @@
+---
+title: sample.data() function
+description: >
+  The `sample.data()` function downloads and outputs an InfluxDB sample dataset.
+menu:
+  influxdb_cloud_ref:
+    name: sample.data
+    parent: InfluxDB Sample
+weight: 301
+related:
+  - /influxdb/cloud/reference/sample-data/
+introduced: 0.123.0
+---
+
+{{< duplicate-oss >}}

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-sample/list.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-sample/list.md
@@ -3,19 +3,13 @@ title: sample.list() function
 description: >
   The `sample.list()` function outputs information about available InfluxDB sample datasets.
 menu:
-  influxdb_2_0_ref:
+  influxdb_cloud_ref:
     name: sample.list
     parent: InfluxDB Sample
 weight: 301
 related:
-  - /influxdb/v2.0/reference/sample-data/
+  - /influxdb/cloud/reference/sample-data/
 introduced: 0.123.0
 ---
 
-The `sample.list()` function outputs information about available InfluxDB sample datasets.
-
-```js
-import "influxdata/influxdb/sample"
-
-sample.list()
-```
+{{< duplicate-oss >}}

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/_index.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/_index.md
@@ -8,7 +8,7 @@ aliases:
   - /influxdb/cloud/reference/flux/functions/influxdb-v1/
 menu:
   influxdb_cloud_ref:
-    name: InfluxDB Schema
+    name: InfluxDB schema
     parent: Flux standard library
 weight: 202
 influxdb/v2.0/tags: [functions, schema, package]

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/fieldkeys.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/fieldkeys.md
@@ -4,7 +4,7 @@ description: The `schema.fieldKeys()` function returns field keys in a bucket.
 menu:
   influxdb_cloud_ref:
     name: schema.fieldKeys
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 influxdb/v2.0/tags: [fields]
 aliases:

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/fieldsascols.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/fieldsascols.md
@@ -9,7 +9,7 @@ aliases:
 menu:
   influxdb_cloud_ref:
     name: schema.fieldsAsCols
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 introduced: 0.88.0
 ---

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/measurementfieldkeys.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/measurementfieldkeys.md
@@ -4,7 +4,7 @@ description: The `schema.measurementFieldKeys()` function returns a list of fiel
 menu:
   influxdb_cloud_ref:
     name: schema.measurementFieldKeys
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 influxdb/v2.0/tags: [fields]
 aliases:

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/measurements.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/measurements.md
@@ -6,7 +6,7 @@ aliases:
 menu:
   influxdb_cloud_ref:
     name: schema.measurements
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 influxdb/v2.0/tags: [measurements]
 related:

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/measurementtagkeys.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/measurementtagkeys.md
@@ -6,7 +6,7 @@ aliases:
 menu:
   influxdb_cloud_ref:
     name: schema.measurementTagKeys
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 influxdb/v2.0/tags: [tags]
 related:

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/measurementtagvalues.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/measurementtagvalues.md
@@ -6,7 +6,7 @@ aliases:
 menu:
   influxdb_cloud_ref:
     name: schema.measurementTagValues
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 influxdb/v2.0/tags: [tags]
 related:

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/tagkeys.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/tagkeys.md
@@ -6,7 +6,7 @@ aliases:
 menu:
   influxdb_cloud_ref:
     name: schema.tagKeys
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 influxdb/v2.0/tags: [tags]
 related:

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/tagvalues.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-schema/tagvalues.md
@@ -6,7 +6,7 @@ aliases:
 menu:
   influxdb_cloud_ref:
     name: schema.tagValues
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 influxdb/v2.0/tags: [tags]
 related:

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-tasks/_index.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-tasks/_index.md
@@ -1,15 +1,15 @@
 ---
-title: Flux InfluxDB Tasks package
-list_title: InfluxDB Tasks package
+title: Flux InfluxDB tasks package
+list_title: InfluxDB tasks package
 description: >
-  The Flux InfluxDB Tasks package provides options and functions for working with
+  The Flux InfluxDB tasks package provides options and functions for working with
   [InfluxDB tasks](/influxdb/cloud/process-data/get-started/).
   Import the `influxdata/influxdb/tasks` package.
 aliases:
   - /influxdb/cloud/reference/flux/functions/influxdb-v1/
 menu:
   influxdb_cloud_ref:
-    name: InfluxDB Tasks
+    name: InfluxDB tasks
     parent: Flux standard library
 weight: 202
 influxdb/v2.0/tags: [functions, tasks, package]
@@ -17,7 +17,7 @@ related:
   - /influxdb/cloud/process-data/get-started/
 ---
 
-The Flux InfluxDB Tasks package provides options and functions for working with
+The Flux InfluxDB tasks package provides options and functions for working with
 [InfluxDB tasks](/influxdb/cloud/process-data/get-started/).
 Import the `influxdata/influxdb/tasks` package:
 
@@ -26,7 +26,7 @@ import "influxdata/influxdb/tasks"
 ```
 
 ## Options
-The InfluxDB Tasks package provides the following options:
+The InfluxDB tasks package provides the following options:
 
 #### lastSuccessTime
 Define the time of the last successful task run.

--- a/content/influxdb/cloud/reference/flux/stdlib/influxdb-tasks/lastsuccess.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/influxdb-tasks/lastsuccess.md
@@ -4,7 +4,7 @@ description: The `tasks.lastSuccess()` function returns ...
 menu:
   influxdb_cloud_ref:
     name: tasks.lastSuccess
-    parent: InfluxDB Tasks
+    parent: InfluxDB tasks
 weight: 301
 ---
 

--- a/content/influxdb/cloud/reference/flux/stdlib/monitor/_index.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/monitor/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Flux InfluxDB Monitor package
-list_title: InfluxDB Monitor package
+title: Flux InfluxDB monitor package
+list_title: InfluxDB monitor package
 description: >
   The Flux Monitor package provides tools for monitoring and alerting with InfluxDB.
   Import the `influxdata/influxdb/monitor` package.
@@ -8,7 +8,7 @@ aliases:
   - /influxdb/cloud/reference/flux/functions/monitor/
 menu:
   influxdb_cloud_ref:
-    name: InfluxDB Monitor
+    name: InfluxDB monitor
     parent: Flux standard library
 weight: 202
 influxdb/v2.0/tags: [functions, monitor, alerts, package]

--- a/content/influxdb/cloud/reference/flux/stdlib/monitor/check.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/monitor/check.md
@@ -8,7 +8,7 @@ aliases:
 menu:
   influxdb_cloud_ref:
     name: monitor.check
-    parent: InfluxDB Monitor
+    parent: InfluxDB monitor
 weight: 202
 ---
 

--- a/content/influxdb/cloud/reference/flux/stdlib/monitor/deadman.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/monitor/deadman.md
@@ -7,7 +7,7 @@ aliases:
 menu:
   influxdb_cloud_ref:
     name: monitor.deadman
-    parent: InfluxDB Monitor
+    parent: InfluxDB monitor
 weight: 202
 cloud_all: true
 ---

--- a/content/influxdb/cloud/reference/flux/stdlib/monitor/from.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/monitor/from.md
@@ -8,7 +8,7 @@ aliases:
 menu:
   influxdb_cloud_ref:
     name: monitor.from
-    parent: InfluxDB Monitor
+    parent: InfluxDB monitor
 weight: 202
 ---
 

--- a/content/influxdb/cloud/reference/flux/stdlib/monitor/logs.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/monitor/logs.md
@@ -8,7 +8,7 @@ aliases:
 menu:
   influxdb_cloud_ref:
     name: monitor.logs
-    parent: InfluxDB Monitor
+    parent: InfluxDB monitor
 weight: 202
 ---
 

--- a/content/influxdb/cloud/reference/flux/stdlib/monitor/notify.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/monitor/notify.md
@@ -8,7 +8,7 @@ aliases:
 menu:
   influxdb_cloud_ref:
     name: monitor.notify
-    parent: InfluxDB Monitor
+    parent: InfluxDB monitor
 weight: 202
 ---
 

--- a/content/influxdb/cloud/reference/flux/stdlib/monitor/statechanges.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/monitor/statechanges.md
@@ -8,7 +8,7 @@ aliases:
 menu:
   influxdb_cloud_ref:
     name: monitor.stateChanges
-    parent: InfluxDB Monitor
+    parent: InfluxDB monitor
 weight: 202
 ---
 

--- a/content/influxdb/cloud/reference/flux/stdlib/monitor/statechangesonly.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/monitor/statechangesonly.md
@@ -6,7 +6,7 @@ description: >
 menu:
   influxdb_cloud_ref:
     name: monitor.stateChangesOnly
-    parent: InfluxDB Monitor
+    parent: InfluxDB monitor
 weight: 202
 ---
 

--- a/content/influxdb/cloud/reference/flux/stdlib/secrets/_index.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/secrets/_index.md
@@ -8,7 +8,7 @@ aliases:
   - /influxdb/cloud/reference/flux/functions/secrets/
 menu:
   influxdb_cloud_ref:
-    name: InfluxDB Secrets
+    name: InfluxDB secrets
     parent: Flux standard library
 weight: 202
 influxdb/v2.0/tags: [functions, secrets, package]

--- a/content/influxdb/cloud/reference/flux/stdlib/secrets/get.md
+++ b/content/influxdb/cloud/reference/flux/stdlib/secrets/get.md
@@ -7,7 +7,7 @@ aliases:
 menu:
   influxdb_cloud_ref:
     name: secrets.get
-    parent: InfluxDB Secrets
+    parent: InfluxDB secrets
 weight: 202
 ---
 

--- a/content/influxdb/cloud/reference/sample-data.md
+++ b/content/influxdb/cloud/reference/sample-data.md
@@ -24,46 +24,117 @@ Demo data is not available for use with third-party integrations such as Grafana
 {{% /note %}}
 
 ## Sample data sets
-The following sample data sets are used as examples in [InfluxDB query guides](/influxdb/cloud/query-data/flux).
 
 - [Air sensor sample data](#air-sensor-sample-data)
 - [Bird migration sample data](#bird-migration-sample-data)
-- [NOAA water sample data](#noaa-water-sample-data)
-- [USGS earthquake data](#usgs-earthquake-data)
+- [NOAA sample data](#noaa-sample-data)
+  - [NOAA NDBC data](#noaa-ndbc-data)
+  - [NOAA water sample data](#noaa-water-sample-data)
+- [USGS Earthquake data](#usgs-earthquake-data)
 
 ### Air sensor sample data
+
+{{% caption %}}
+**Size**: ~600 KB • **Updated**: every 15m
+{{% /caption %}}
+
 Air sensor sample data represents an "Internet of Things" (IoT) use case by simulating
 temperature, humidity, and carbon monoxide levels for multiple rooms in a building.
-The dataset also includes a relational SQL dataset with meta information about sensors in each room.
 
-<a class="btn" href="https://github.com/influxdata/influxdb2-sample-data/tree/master/air-sensor-data" target="\_blank">
-  <span class="icon-github"></span> View air sensor sample data
-</a>
+To download and output the air sensor sample dataset, use the
+[`sample.data()` function](/influxdb/cloud/reference/flux/stdlib/influxdb-sample/data/).
 
-_Used in [Query SQL data sources](/influxdb/cloud/query-data/flux/sql/)._
+```js
+import "influxdata/influxdb/sample"
+
+sample.data(set: "airSensor")
+```
+
+#### Companion SQL sensor data
+The air sensor sample dataset is paired with a relational SQL dataset with meta
+information about sensors in each room.
+These two sample datasets are used to demonstrate
+[how to join time series data and relational data with Flux](/influxdb/cloud/query-data/flux/sql/#join-sql-data-with-data-in-influxdb)
+in the [Query SQL data sources](/influxdb/cloud/query-data/flux/sql/) guide.
+
+<a class="btn download" href="https://influx-testdata.s3.amazonaws.com/sample-sensor-info.csv" download>Download SQL air sensor data</a>
 
 ### Bird migration sample data
-Bird migration data is adapted from the
-[Movebank: Animal Tracking data set on Kaggle](https://www.kaggle.com/pulkit8595/movebank-animal-tracking)
+
+{{% caption %}}
+**Size**: ~1.2 MB • **Updated**: N/A
+{{% /caption %}}
+
+Bird migration sample data is adapted from the
+[Movebank: Animal Tracking data set](https://www.kaggle.com/pulkit8595/movebank-animal-tracking)
 and represents animal migratory movements throughout 2019.
-Use the [Flux Geo package](/influxdb/cloud/reference/flux/stdlib/experimental/geo/#geo-schema-requirements)
-to query and analyze the geo-temporal data in this sample data set.
 
-<a class="btn" href="https://github.com/influxdata/influxdb2-sample-data/tree/master/bird-migration-data" target="\_blank">
- <span class="icon-github"></span> View bird migration sample data
-</a>
+To download and output the bird migration sample dataset, use the
+[`sample.data()` function](/influxdb/cloud/reference/flux/stdlib/influxdb-sample/data/).
 
-_Used in [Work with geo-temporal data](/influxdb/cloud/query-data/flux/geo/)._
+```js
+import "influxdata/influxdb/sample"
 
-### NOAA water sample data
+sample.data(set: "birdMigration")
+```
 
-This data set is  publicly available data from the [National Oceanic and Atmospheric Administration’s (NOAA) Center for Operational Oceanographic Products and Services](http://tidesandcurrents.noaa.gov/stations.html).
+The bird migration sample dataset is used in the [Work with geo-temporal data](/influxdb/cloud/query-data/flux/geo/)
+guide to demonstrate how to query and analyze geo-temporal data.
 
-[The CSV data](https://influx-testdata.s3.amazonaws.com/noaa.csv) includes 15,258
-observations of water levels (ft) collected every six minutes at two stations
+### NOAA sample data
+
+There are two National Oceanic and Atmospheric Administration (NOAA) datasets 
+available to use with InfluxDB.
+
+- [NOAA NDBC data](#noaa-ndbc-data)
+- [NOAA water sample data](#noaa-water-sample-data)
+
+#### NOAA NDBC data
+
+{{% caption %}}
+**Size**: ~1.3 MB • **Updated**: every 15m
+{{% /caption %}}
+
+The **NOAA National Data Buoy Center (NDBC)** dataset provides the latest
+observations from the NOAA NDBC network of buoys throughout the world.
+Observations are updated approximately every 15 minutes.
+
+To download and output the most recent NOAA NDBC observations, use the
+[`sample.data()` function](/influxdb/cloud/reference/flux/stdlib/influxdb-sample/data/).
+
+```js
+import "influxdata/influxdb/sample"
+
+sample.data(set: "noaa")
+```
+
+{{% note %}}
+##### Store historical NOAA NDBC data
+
+The **NOAA NDBC sample dataset** only returns the most recent observations;
+not historical observations.
+To regularly query and store NOAA NDBC observations, add the following as an
+[InfluxDB task](/inflxudb/v2.0/process-data/manage-tasks/).
+Replace `example-org` and `example-bucket` with your organization name and the
+name of the bucket to store data in.
+
+{{% get-shared-text "flux/noaa-ndbc-sample-task.md" %}}
+{{% /note %}}
+
+#### NOAA water sample data
+
+{{% caption %}}
+**Size**: ~10 MB • **Updated**: N/A
+{{% /caption %}}
+
+The **NOAA water sample dataset** is static dataset extracted from
+[NOAA Center for Operational Oceanographic Products and Services](http://tidesandcurrents.noaa.gov/stations.html) data.
+The sample dataset includes 15,258 observations of water levels (ft) collected every six minutes at two stations
 (Santa Monica, CA (ID 9410840) and Coyote Creek, CA (ID 9414575)) over the period
-from August 18, 2015 through September 18, 2015.
+from **August 18, 2015** through **September 18, 2015**.
 
+{{% note %}}
+##### Store NOAA water sample data to avoid bandwidth usage
 To avoid having to re-download this 10MB dataset every time you run a query,
 we recommend that you [create a new bucket](/influxdb/cloud/organizations/buckets/create-bucket/)
 (`noaa`) and write the NOAA data to it.
@@ -84,88 +155,27 @@ csv.from(url: "https://influx-testdata.s3.amazonaws.com/noaa.csv")
   |> relativeToNow()
   |> to(bucket: "noaa", org: "example-org")
 ```
+{{% /note %}}
 
-_Used in [Common queries](/influxdb/cloud/query-data/common-queries/) and [Common tasks](/influxdb/cloud/process-data/common-tasks/)._
+The NOAA water sample dataset is used to demonstrate Flux queries in the
+[Common queries](/influxdb/cloud/query-data/common-queries/) and
+[Common tasks](/influxdb/cloud/process-data/common-tasks/) guides.
 
-### USGS earthquake data
-The United States Geological Survey (USGS) collects earthquake data and makes
-this data publicly available.
-Each earthquake event includes information such as latitude and longitude
-coordinates, magnitude, depth, and [more](#collected-usgs-data).
+### USGS Earthquake data
 
-**To periodically retrieve and write USGS earthquake data to InfluxDB**
+{{% caption %}}
+**Size**: ~6 MB • **Updated**: every 15m
+{{% /caption %}}
 
-1. [Create a new bucket](/influxdb/cloud/organizations/buckets/create-bucket/) named `usgs`.
-2. [Create a new task](/influxdb/cloud/process-data/manage-tasks/create-task/)
-   and include the following Flux script:
+The United States Geological Survey (USGS) earthquake dataset contains observations
+collected from USGS seismic sensors around the world over the last week.
+Data is updated approximately every 15m.
 
-   {{% truncate %}}
+To download and output the last week of USGS seismic data, use the
+[`sample.data()` function](/influxdb/cloud/reference/flux/stdlib/influxdb-sample/data/).
+
 ```js
-import "csv"
-import "experimental"
-import "experimental/http"
+import "influxdata/influxdb/sample"
 
-usgsCSV = string(v: (http.get(url: "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_day.csv")).body)
-
-csv.from(csv: usgsCSV, mode: "raw")
-  |> map(fn: (r) => ({
-    _measurement: "earthquakes",
-    _time: time(v: r.time),
-    lat: float(v: r.latitude),
-    lon: float(v: r.longitude),
-    depth: float(v: r.depth),
-    depthError: float(v: r.depthError),
-    mag: float(v: r.mag),
-    magType: string(v: r.magType),
-    nst: int(v: r.nst),
-    gap: float(v: r.gap),
-    dmin: float(v: r.dmin),
-    rms: float(v: r.rms),
-    net: string(v: r.net),
-    id: string(v: r.id),
-    updated: int(v: time(v: r.updated)) / 1000000,
-    place: string(v: r.place),
-    type: string(v: r.type),
-    locationSource: string(v: r.locationSource),
-    magSource: string(v: r.magSource),
-    horizontalError: float(v: r.horizontalError),
-    magError: float(v: r.magError),
-    magNst: int(v: r.magNst),
-  }))
-  |> group(columns: ["_measurement", "locationSource", "magSource", "type", "net", "magType"])
-  |> experimental.to(bucket: "usgs")
+sample.data(set: "usgs")
 ```
-    {{% /truncate %}}
-    {{% note %}}
-USGS updates earthquake data every minute.
-This task retrieves earthquake data for the current day.
-Set your task's `every` interval between `1m` and `24h`, depending on how often
-you want to retrieve new data.
-    {{% /note %}}
-
-#### Collected USGS data
-The task above writes the following to InfluxDB:
-
-**Fields:**  
-[lat](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#latitude),
-[lon](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#longitude),
-[depth](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#depth),
-[depthError](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#depthError),
-[mag](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#mag),
-[nst](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#nst),
-[gap](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#gap),
-[dmin](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#dmin),
-[rms](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#rms),
-[id](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#id),
-[updated](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#updated),
-[place](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#place),
-[horizontalError](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#horizontalError),
-[magError](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#magError),
-[magNst](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#magNst)
-
-**Tags:**  
-[magType](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#magType),
-[net](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#net),
-[type](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#type),
-[locationSource](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#locationSource),
-[magSource](https://earthquake.usgs.gov/data/comcat/data-eventterms.php#magSource)

--- a/content/influxdb/cloud/reference/sample-data.md
+++ b/content/influxdb/cloud/reference/sample-data.md
@@ -10,12 +10,18 @@ menu: influxdb_cloud_ref
 weight: 7
 ---
 
-Use sample data to familiarize yourself with time series data and InfluxDB.
-InfluxData provides many sample time series datasets to use with **InfluxDB Cloud**.
+Use **demo data** and **sample data** to familiarize yourself with time series data and InfluxDB Cloud.
+InfluxDB Cloud lets you access **Demo data buckets** that contain real-time time
+series data without having to write data to InfluxDB. 
+Sample datasets are also available for download and can be written to InfluxDB
+or loaded at query time.
+
+- [InfluxDB Cloud demo data](#influxdb-cloud-demo-data)
+- [Sample datasets](#sample-datasets)
 
 ## InfluxDB Cloud demo data
 Use [InfluxDB Cloud demo data buckets](/influxdb/cloud/reference/sample-data/#influxdb-cloud-demo-data) for quick,
-free access to different types of sample data.
+free access to different time series datasets.
 
 {{< youtube GSaByPC1Bdc >}}
 
@@ -23,7 +29,7 @@ free access to different types of sample data.
 Demo data is not available for use with third-party integrations such as Grafana.
 {{% /note %}}
 
-## Sample data sets
+## Sample datasets
 
 - [Air sensor sample data](#air-sensor-sample-data)
 - [Bird migration sample data](#bird-migration-sample-data)

--- a/content/influxdb/cloud/write-data/_index.md
+++ b/content/influxdb/cloud/write-data/_index.md
@@ -138,7 +138,7 @@ See [Sample data](/influxdb/cloud/reference/sample-data) for more sample InfluxD
 {{% /note %}}
 
 ## Sample data
-Use [sample data sets](/influxdb/cloud/reference/sample-data/#sample-data-sets)
+Use [sample data sets](/influxdb/cloud/reference/sample-data/#sample-datasets)
 to quickly populate InfluxDB with sample time series data.
 
 ---

--- a/content/influxdb/v2.0/query-data/common-queries/_index.md
+++ b/content/influxdb/v2.0/query-data/common-queries/_index.md
@@ -11,7 +11,8 @@ menu:
 weight: 104
 ---
 
-The following articles walk through common queries using the [NOAA water database data](https://influx-testdata.s3.amazonaws.com/noaa.csv).
+The following articles walk through common queries using the
+[NOAA water database data](/influxdb/v2.0/reference/sample-data/#noaa-water-sample-data).
 
 {{< children >}}
 

--- a/content/influxdb/v2.0/query-data/flux/geo/_index.md
+++ b/content/influxdb/v2.0/query-data/flux/geo/_index.md
@@ -48,43 +48,22 @@ By using it, you agree to the [risks of experimental functions](/influxdb/v2.0/r
 ## Sample data
 Many of the examples in this section use a `sampleGeoData` variable that represents
 a sample set of geo-temporal data.
-The [Bird Migration Sample Data](https://github.com/influxdata/influxdb2-sample-data/tree/master/bird-migration-data)
-available on GitHub provides sample geo-temporal data that meets the
+The [Bird Migration Sample Data](/influxdb/v2.0/reference/sample-data/#bird-migration-sample-data)
+provides sample geo-temporal data that meets the
 [requirements of the Flux Geo package](/influxdb/v2.0/reference/flux/stdlib/experimental/geo/#geo-schema-requirements).
 
-### Load annotated CSV sample data
-Use the [experimental `csv.from()` function](/influxdb/v2.0/reference/flux/stdlib/experimental/csv/from/)
-to load the sample bird migration annotated CSV data from GitHub:
+### Load bird migration sample data
+Use the [`sample.data()` function](/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data/)
+to load the sample bird migration data:
 
 ```js
-import `experimental/csv`
+import "influxdata/influxdb/sample"
 
-sampleGeoData = csv.from(
-  url: "https://github.com/influxdata/influxdb2-sample-data/blob/master/bird-migration-data/bird-migration.csv"
-)
+sampleGeoData = sample.data(set: "birdMigration")
 ```
 
 {{% note %}}
-`csv.from(url: ...)` downloads sample data each time you execute the query **(~1.3 MB)**.
+`sample.data()` downloads sample data each time you execute the query **(~1.3 MB)**.
 If bandwidth is a concern, use the [`to()` function](/influxdb/v2.0/reference/flux/stdlib/built-in/outputs/to/)
 to write the data to a bucket, and then query the bucket with [`from()`](/influxdb/v2.0/reference/flux/stdlib/built-in/inputs/from/).
 {{% /note %}}
-
-### Write sample data to InfluxDB with line protocol
-Use `curl` and the `influx write` command to write bird migration line protocol to InfluxDB.
-Replace `example-bucket` with your destination bucket:
-
-```sh
-curl https://raw.githubusercontent.com/influxdata/influxdb2-sample-data/master/bird-migration-data/bird-migration.line \
-  --output ./tmp-data
-influx write -b example-bucket @./tmp-data
-rm -f ./tmp-data
-```
-
-Use Flux to query the bird migration data and assign it to the `sampleGeoData` variable:
-
-```js
-sampleGeoData = from(bucket: "example-bucket")
-  |> range(start: 2019-01-01T00:00:00Z, stop: 2019-12-31T23:59:59Z)
-  |> filter(fn: (r) => r._measurement == "migration")
-```

--- a/content/influxdb/v2.0/query-data/flux/sql.md
+++ b/content/influxdb/v2.0/query-data/flux/sql.md
@@ -292,7 +292,7 @@ sql.from(
 ---
 
 ## Sample sensor data
-The [sample data generator](#download-and-run-the-sample-data-generator) and
+The [air sensor sample data](#download-sample-air-sensor-data) and
 [sample sensor information](#import-the-sample-sensor-information) simulate a
 group of sensors that measure temperature, humidity, and carbon monoxide
 in rooms throughout a building.
@@ -303,53 +303,43 @@ Sample sensor information is stored in PostgreSQL.
 **Sample data includes:**
 
 - Simulated data collected from each sensor and stored in the `airSensors` measurement in **InfluxDB**:
-    - temperature
-    - humidity
-    - co
+  - temperature
+  - humidity
+  - co
 
 - Information about each sensor stored in the `sensors` table in **PostgreSQL**:
-    - sensor_id
-    - location
-    - model_number
-    - last_inspected
+  - sensor_id
+  - location
+  - model_number
+  - last_inspected
 
-### Import and generate sample sensor data
+#### Download sample air sensor data
 
-#### Download and run the sample data generator
-`air-sensor-data.rb` is a script that generates air sensor data and stores the data in InfluxDB.
-To use `air-sensor-data.rb`:
+1.  [Create a bucket](/influxdb/v2.0/organizations/buckets/create-bucket/) to store the data.
+2.  [Create an InfluxDB task](/influxdb/v2.0/process-data/manage-tasks/create-task/)
+    and use the [`sample.data()` function](/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data/)
+    to download sample air sensor data every 15 minutes.
+    Write the downloaded sample data to your new bucket:
 
-1. [Create a bucket](/influxdb/v2.0/organizations/buckets/create-bucket/) to store the data.
-2. Download the sample data generator. _This tool requires [Ruby](https://www.ruby-lang.org/en/)._
+    ```js
+    import "influxdata/influxdb/sample"
 
-    <a class="btn download" href="/downloads/air-sensor-data.rb" download>Download Air Sensor Generator</a>
+    option task = {
+      name: "Collect sample air sensor data",
+      every: 15m
+    }
 
-3. Give `air-sensor-data.rb` executable permissions:
-
+    sample.data(set: "airSensor")
+      |> to(
+        org: "example-org",
+        bucket: "example-bucket"
+      )
     ```
-    chmod +x air-sensor-data.rb
-    ```
 
-4. Start the generator. Specify your organization, bucket, and authorization token.
-  _For information about retrieving your token, see [View tokens](/influxdb/v2.0/security/tokens/view-tokens/)._
+3.  [Query your target bucket](/influxdb/v2.0/query-data/execute-queries/) after
+    the first task run to ensure the sample data is writing successfully.
 
-    ```
-    ./air-sensor-data.rb -o your-org -b your-bucket -t YOURAUTHTOKEN
-    ```
-
-    The generator begins to write data to InfluxDB and will continue until stopped.
-    Use `ctrl-c` to stop the generator.
-
-    {{% note %}}
-    Use the `--help` flag to view other configuration options.
-    {{% /note %}}
-
-5. [Query your target bucket](/influxdb/v2.0/query-data/execute-queries/) to ensure the
-   generated data is writing successfully.
-   The generator doesn't catch errors from write requests, so it will continue running
-   even if data is not writing to InfluxDB successfully.
-
-    ```
+    ```js
     from(bucket: "example-bucket")
        |> range(start: -1m)
        |> filter(fn: (r) => r._measurement == "airSensors")
@@ -359,7 +349,7 @@ To use `air-sensor-data.rb`:
 1. [Download and install PostgreSQL](https://www.postgresql.org/download/).
 2. Download the sample sensor information CSV.
 
-    <a class="btn download" href="/downloads/sample-sensor-info.csv" download>Download Sample Data</a>
+    <a class="btn download" href="https://influx-testdata.s3.amazonaws.com/sample-sensor-info.csv" download>Download sample sensor information</a>
 
 3. Use a PostgreSQL client (`psql` or a GUI) to create the `sensors` table:
 
@@ -389,6 +379,6 @@ To use `air-sensor-data.rb`:
 #### Import the sample data dashboard
 Download and import the Air Sensors dashboard to visualize the generated data:
 
-<a class="btn download" href="/downloads/air-sensors-dashboard.json" download>Download Air Sensors dashboard</a>
+<a class="btn github" href="https://raw.githubusercontent.com/influxdata/influxdb2-sample-data/master/air-sensor-data/air-sensors-dashboard.json" target="_blank">View Air Sensors dashboard JSON</a>
 
 _For information about importing a dashboard, see [Create a dashboard](/influxdb/v2.0/visualize-data/dashboards/create-dashboard)._

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/_index.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/_index.md
@@ -6,7 +6,7 @@ description: >
   Import the `influxdata/influxdb/sample` package.
 menu:
   influxdb_2_0_ref:
-    name: InfluxDB Sample
+    name: InfluxDB sample
     parent: Flux standard library
 weight: 202
 influxdb/v2.0/tags: [functions, sample, package]

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/_index.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/_index.md
@@ -1,0 +1,24 @@
+---
+title: Flux InfluxDB sample package
+list_title: InfluxDB sample package
+description: >
+  The Flux InfluxDB sample package provides functions for downloading and outputting InfluxDB data sample.
+  Import the `influxdata/influxdb/sample` package.
+menu:
+  influxdb_2_0_ref:
+    name: InfluxDB sample
+    parent: Flux standard library
+weight: 202
+influxdb/v2.0/tags: [functions, sample, package]
+introduced: 0.88.0
+---
+
+The Flux InfluxDB sample package provides functions for downloading and outputting InfluxDB data sample.
+
+Import the `influxdata/influxdb/sample` package:
+
+```js
+import "influxdata/influxdb/sample"
+```
+
+{{< children type="functions" show="pages" >}}

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data.md
@@ -5,7 +5,7 @@ description: >
 menu:
   influxdb_2_0_ref:
     name: sample.data
-    parent: InfluxDB sample
+    parent: InfluxDB Sample
 weight: 301
 related:
   - /influxdb/v2.0/reference/sample-data/

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data.md
@@ -5,7 +5,7 @@ description: >
 menu:
   influxdb_2_0_ref:
     name: sample.data
-    parent: InfluxDB Sample
+    parent: InfluxDB sample
 weight: 301
 related:
   - /influxdb/v2.0/reference/sample-data/

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data.md
@@ -99,17 +99,4 @@ sample.data(set: "usgs")
 Add the following as an [InfluxDB task](/influxdb/v2.0/process-data/) to regularly
 collect the latest reported observations from the NOAA NDBC.
 
-```js
-import "influxdata/influxdb/sample"
-
-option task = {
-  name: "Collect NOAA NDBC data"
-  every: 15m,
-}
-
-sample.data(set: "noaa")
-  |> to(
-      org: "example-org",
-      bucket: "example-bucket"
-  )
-```
+{{% get-shared-text "flux/noaa-ndbc-sample-task.md" %}}

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data.md
@@ -1,0 +1,115 @@
+---
+title: sample.data() function
+description: >
+  The `sample.data()` function downloads and outputs an InfluxDB sample dataset.
+menu:
+  influxdb_2_0_ref:
+    name: sample.data
+    parent: InfluxDB sample
+weight: 301
+related:
+  - /influxdb/v2.0/reference/sample-data/
+introduced: 0.123.0
+---
+
+The `sample.data()` function downloads and outputs an InfluxDB sample dataset.
+
+```js
+import "influxdata/influxdb/sample"
+
+sample.data(
+  set: "airSensor"
+)
+```
+
+{{% note %}}
+#### Network bandwidth
+Each execution of `sample.data()` downloads the specified dataset from **Amazon S3**.
+If using [InfluxDB Cloud](/influxdb/cloud/) or a hosted InfluxDB OSS instance,
+you may see additional network bandwidth costs when using this function.
+Approximate sample dataset sizes are listed [below](#available-influxdb-sample-datasets)
+and in the output of [`sample.list()`](/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/list/).
+{{% /note %}}
+
+## Available InfluxDB sample datasets
+
+### airSensor
+
+Simulated office building air sensor data with temperature,
+humidity, and carbon monoxide metrics.
+
+{{% caption %}}
+**Size**: ~600 KB • **Updated**: every 15m
+{{% /caption %}}
+
+### birdMigration
+
+2019 African bird migration data from the
+[Movebank: Animal Tracking](https://www.kaggle.com/pulkit8595/movebank-animal-tracking) dataset.
+Contains geotemporal data between 2019-01-01 and 2019-12-31.
+
+{{% caption %}}
+**Size**: ~1.2 MB • **Updated**: N/A
+{{% /caption %}}
+
+### noaa
+
+Latest observations from the [NOAA National Data Buoy Center (NDBC)](https://www.ndbc.noaa.gov/).
+Contains only the most recent observations (no historical data).
+Data is updated approximately every 15m.
+
+{{% caption %}}
+**Size**: ~1.3 MB • **Updated**: every 15m
+{{% /caption %}}
+
+### usgs
+
+USGS earthquake data from the last week.
+Contains geotemporal data collected from USGS seismic sensors around the world.
+Data is updated approximately every 15m. 
+
+{{% caption %}}
+**Size**: ~6 MB • **Updated**: every 15m
+{{% /caption %}}
+
+
+## Parameters
+
+### set
+({{< req >}}) InfluxDB sample dataset to download and output.
+
+**Valid values**:
+
+- `airSensor`
+- `birdMigration`
+- `noaa`
+- `usgs`
+
+
+## Examples
+
+##### Return USGS earthquake data from the last week
+```js
+import "influxdata/influxdb/sample"
+
+sample.data(set: "usgs")
+```
+
+##### Download and write NOAA NDBC data to InfluxDB
+Add the following as an [InfluxDB task](/influxdb/v2.0/process-data/) to regularly
+collect the latest reported observations from the NOAA NDBC.
+
+```js
+import "influxdata/influxdb/sample"
+
+option task = {
+  name: "Collect NOAA NDBC data"
+  every: 15m,
+}
+
+sample.data(set: "noaa")
+  |> to(
+      org: "example-org",
+      bucket: "example-bucket"
+  )
+```

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/list.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/list.md
@@ -5,7 +5,7 @@ description: >
 menu:
   influxdb_2_0_ref:
     name: sample.list
-    parent: InfluxDB Sample
+    parent: InfluxDB sample
 weight: 301
 related:
   - /influxdb/v2.0/reference/sample-data/

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/list.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/list.md
@@ -1,0 +1,21 @@
+---
+title: sample.list() function
+description: >
+  The `sample.list()` function outputs information about available InfluxDB sample datasets.
+menu:
+  influxdb_2_0_ref:
+    name: sample.list
+    parent: InfluxDB sample
+weight: 301
+related:
+  - /influxdb/v2.0/reference/sample-data/
+introduced: 0.123.0
+---
+
+The `sample.list()` function outputs information about available InfluxDB sample datasets.
+
+```js
+import "influxdata/influxdb/sample"
+
+sample.list()
+```

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/_index.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/_index.md
@@ -8,7 +8,7 @@ aliases:
   - /influxdb/v2.0/reference/flux/functions/influxdb-v1/
 menu:
   influxdb_2_0_ref:
-    name: InfluxDB Schema
+    name: InfluxDB schema
     parent: Flux standard library
 weight: 202
 influxdb/v2.0/tags: [functions, schema, package]

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/fieldkeys.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/fieldkeys.md
@@ -4,7 +4,7 @@ description: The `schema.fieldKeys()` function returns field keys in a bucket.
 menu:
   influxdb_2_0_ref:
     name: schema.fieldKeys
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 influxdb/v2.0/tags: [fields]
 aliases:

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/fieldsascols.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/fieldsascols.md
@@ -9,7 +9,7 @@ aliases:
 menu:
   influxdb_2_0_ref:
     name: schema.fieldsAsCols
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 introduced: 0.88.0
 ---

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurementfieldkeys.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurementfieldkeys.md
@@ -4,7 +4,7 @@ description: The `schema.measurementFieldKeys()` function returns a list of fiel
 menu:
   influxdb_2_0_ref:
     name: schema.measurementFieldKeys
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 influxdb/v2.0/tags: [fields]
 aliases:

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurements.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurements.md
@@ -6,7 +6,7 @@ aliases:
 menu:
   influxdb_2_0_ref:
     name: schema.measurements
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 influxdb/v2.0/tags: [measurements]
 related:

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurementtagkeys.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurementtagkeys.md
@@ -6,7 +6,7 @@ aliases:
 menu:
   influxdb_2_0_ref:
     name: schema.measurementTagKeys
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 influxdb/v2.0/tags: [tags]
 related:

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurementtagvalues.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurementtagvalues.md
@@ -6,7 +6,7 @@ aliases:
 menu:
   influxdb_2_0_ref:
     name: schema.measurementTagValues
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 influxdb/v2.0/tags: [tags]
 related:

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/tagkeys.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/tagkeys.md
@@ -6,7 +6,7 @@ aliases:
 menu:
   influxdb_2_0_ref:
     name: schema.tagKeys
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 influxdb/v2.0/tags: [tags]
 related:

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/tagvalues.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/tagvalues.md
@@ -6,7 +6,7 @@ aliases:
 menu:
   influxdb_2_0_ref:
     name: schema.tagValues
-    parent: InfluxDB Schema
+    parent: InfluxDB schema
 weight: 301
 influxdb/v2.0/tags: [tags]
 related:

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-tasks/_index.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-tasks/_index.md
@@ -1,15 +1,15 @@
 ---
-title: Flux InfluxDB Tasks package
-list_title: InfluxDB Tasks package
+title: Flux InfluxDB tasks package
+list_title: InfluxDB tasks package
 description: >
-  The Flux InfluxDB Tasks package provides options and functions for working with
+  The Flux InfluxDB tasks package provides options and functions for working with
   [InfluxDB tasks](/influxdb/v2.0/process-data/get-started/).
   Import the `influxdata/influxdb/tasks` package.
 aliases:
   - /influxdb/v2.0/reference/flux/functions/influxdb-v1/
 menu:
   influxdb_2_0_ref:
-    name: InfluxDB Tasks
+    name: InfluxDB tasks
     parent: Flux standard library
 weight: 202
 influxdb/v2.0/tags: [functions, tasks, package]
@@ -17,7 +17,7 @@ related:
   - /influxdb/v2.0/process-data/get-started/
 ---
 
-The Flux InfluxDB Tasks package provides options and functions for working with
+The Flux InfluxDB tasks package provides options and functions for working with
 [InfluxDB tasks](/influxdb/v2.0/process-data/get-started/).
 Import the `influxdata/influxdb/tasks` package:
 
@@ -26,7 +26,7 @@ import "influxdata/influxdb/tasks"
 ```
 
 ## Options
-The InfluxDB Tasks package provides the following options:
+The InfluxDB tasks package provides the following options:
 
 #### lastSuccessTime
 Define the time of the last successful task run.

--- a/content/influxdb/v2.0/reference/flux/stdlib/influxdb-tasks/lastsuccess.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/influxdb-tasks/lastsuccess.md
@@ -4,7 +4,7 @@ description: The `tasks.lastSuccess()` function returns ...
 menu:
   influxdb_2_0_ref:
     name: tasks.lastSuccess
-    parent: InfluxDB Tasks
+    parent: InfluxDB tasks
 weight: 301
 ---
 

--- a/content/influxdb/v2.0/reference/flux/stdlib/monitor/_index.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/monitor/_index.md
@@ -1,14 +1,14 @@
 ---
-title: Flux InfluxDB Monitor package
-list_title: InfluxDB Monitor package
+title: Flux InfluxDB monitor package
+list_title: InfluxDB monitor package
 description: >
-  The Flux Monitor package provides tools for monitoring and alerting with InfluxDB.
+  The Flux monitor package provides tools for monitoring and alerting with InfluxDB.
   Import the `influxdata/influxdb/monitor` package.
 aliases:
   - /influxdb/v2.0/reference/flux/functions/monitor/
 menu:
   influxdb_2_0_ref:
-    name: InfluxDB Monitor
+    name: InfluxDB monitor
     parent: Flux standard library
 weight: 202
 influxdb/v2.0/tags: [functions, monitor, alerts, package]

--- a/content/influxdb/v2.0/reference/flux/stdlib/monitor/check.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/monitor/check.md
@@ -8,7 +8,7 @@ aliases:
 menu:
   influxdb_2_0_ref:
     name: monitor.check
-    parent: InfluxDB Monitor
+    parent: InfluxDB monitor
 weight: 202
 ---
 

--- a/content/influxdb/v2.0/reference/flux/stdlib/monitor/deadman.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/monitor/deadman.md
@@ -7,7 +7,7 @@ aliases:
 menu:
   influxdb_2_0_ref:
     name: monitor.deadman
-    parent: InfluxDB Monitor
+    parent: InfluxDB monitor
 weight: 202
 cloud_all: true
 ---

--- a/content/influxdb/v2.0/reference/flux/stdlib/monitor/from.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/monitor/from.md
@@ -8,7 +8,7 @@ aliases:
 menu:
   influxdb_2_0_ref:
     name: monitor.from
-    parent: InfluxDB Monitor
+    parent: InfluxDB monitor
 weight: 202
 ---
 

--- a/content/influxdb/v2.0/reference/flux/stdlib/monitor/logs.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/monitor/logs.md
@@ -8,7 +8,7 @@ aliases:
 menu:
   influxdb_2_0_ref:
     name: monitor.logs
-    parent: InfluxDB Monitor
+    parent: InfluxDB monitor
 weight: 202
 ---
 

--- a/content/influxdb/v2.0/reference/flux/stdlib/monitor/notify.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/monitor/notify.md
@@ -8,7 +8,7 @@ aliases:
 menu:
   influxdb_2_0_ref:
     name: monitor.notify
-    parent: InfluxDB Monitor
+    parent: InfluxDB monitor
 weight: 202
 ---
 

--- a/content/influxdb/v2.0/reference/flux/stdlib/monitor/statechanges.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/monitor/statechanges.md
@@ -8,7 +8,7 @@ aliases:
 menu:
   influxdb_2_0_ref:
     name: monitor.stateChanges
-    parent: InfluxDB Monitor
+    parent: InfluxDB monitor
 weight: 202
 ---
 

--- a/content/influxdb/v2.0/reference/flux/stdlib/monitor/statechangesonly.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/monitor/statechangesonly.md
@@ -6,7 +6,7 @@ description: >
 menu:
   influxdb_2_0_ref:
     name: monitor.stateChangesOnly
-    parent: InfluxDB Monitor
+    parent: InfluxDB monitor
 weight: 202
 ---
 

--- a/content/influxdb/v2.0/reference/flux/stdlib/secrets/_index.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/secrets/_index.md
@@ -1,20 +1,20 @@
 ---
-title: Flux InfluxDB Secrets package
-list_title: InfluxDB Secrets package
+title: Flux InfluxDB secrets package
+list_title: InfluxDB secrets package
 description: >
-  The Flux InfluxDB Secrets package provides functions for working with sensitive secrets managed by InfluxDB.
+  The Flux InfluxDB secrets package provides functions for working with sensitive secrets managed by InfluxDB.
   Import the `influxdata/influxdb/secrets` package.
 aliases:
   - /influxdb/v2.0/reference/flux/functions/secrets/
 menu:
   influxdb_2_0_ref:
-    name: InfluxDB Secrets
+    name: InfluxDB secrets
     parent: Flux standard library
 weight: 202
 influxdb/v2.0/tags: [functions, secrets, package]
 ---
 
-InfluxDB Secrets Flux functions provide tools for working with sensitive secrets managed by InfluxDB.
+InfluxDB secrets Flux functions provide tools for working with sensitive secrets managed by InfluxDB.
 Import the `influxdata/influxdb/secrets` package:
 
 ```js

--- a/content/influxdb/v2.0/reference/flux/stdlib/secrets/get.md
+++ b/content/influxdb/v2.0/reference/flux/stdlib/secrets/get.md
@@ -7,7 +7,7 @@ aliases:
 menu:
   influxdb_2_0_ref:
     name: secrets.get
-    parent: InfluxDB Secrets
+    parent: InfluxDB secrets
 weight: 202
 ---
 

--- a/content/influxdb/v2.0/reference/sample-data.md
+++ b/content/influxdb/v2.0/reference/sample-data.md
@@ -18,50 +18,79 @@ to view, download, and output sample datasets.
 - [Air sensor sample data](#air-sensor-sample-data)
 - [Bird migration sample data](#bird-migration-sample-data)
 - [NOAA sample data](#noaa-sample-data)
-  - [NOAA NDBC data](#noaa-water-sample-data)
+  - [NOAA NDBC data](#noaa-ndbc-data)
   - [NOAA water sample data](#noaa-water-sample-data)
 - [USGS Earthquake data](#usgs-earthquake-data)
 
 ## Air sensor sample data
+
+{{% caption %}}
+**Size**: ~600 KB • **Updated**: every 15m
+{{% /caption %}}
+
 Air sensor sample data represents an "Internet of Things" (IoT) use case by simulating
 temperature, humidity, and carbon monoxide levels for multiple rooms in a building.
-The dataset also includes a relational SQL dataset with meta information about sensors in each room.
 
-<a class="btn" href="https://github.com/influxdata/influxdb2-sample-data/tree/master/air-sensor-data" target="\_blank">
-  <span class="icon-github"></span> View air sensor sample data
-</a>
+To download and output the air sensor sample dataset, use the
+[`sample.data()` function](/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data/).
 
-_Used in [Query SQL data sources](/influxdb/v2.0/query-data/flux/sql/)._
+```js
+import "influxdata/influxdb/sample"
+
+sample.data(set: "airSensor")
+```
+
+#### Companion SQL sensor data
+The air sensor sample dataset is paired with a relational SQL dataset with meta
+information about sensors in each room.
+These two sample datasets are used to demonstrate
+[how to join time series data and relational data with Flux](/influxdb/v2.0/query-data/flux/sql/#join-sql-data-with-data-in-influxdb)
+in the [Query SQL data sources](/influxdb/v2.0/query-data/flux/sql/) guide.
+
+<a class="btn download" href="https://influx-testdata.s3.amazonaws.com/sample-sensor-info.csv" download>Download SQL air sensor data</a>
 
 ## Bird migration sample data
-Bird migration data is adapted from the
-[Movebank: Animal Tracking data set on Kaggle](https://www.kaggle.com/pulkit8595/movebank-animal-tracking)
+
+{{% caption %}}
+**Size**: ~1.2 MB • **Updated**: N/A
+{{% /caption %}}
+
+Bird migration sample data is adapted from the
+[Movebank: Animal Tracking data set](https://www.kaggle.com/pulkit8595/movebank-animal-tracking)
 and represents animal migratory movements throughout 2019.
-Use the [Flux Geo package](/influxdb/v2.0/reference/flux/stdlib/experimental/geo/#geo-schema-requirements)
-to query and analyze the geo-temporal data in this sample data set.
 
-<a class="btn" href="https://github.com/influxdata/influxdb2-sample-data/tree/master/bird-migration-data" target="\_blank">
- <span class="icon-github"></span> View bird migration sample data
-</a>
+To download and output the bird migration sample dataset, use the
+[`sample.data()` function](/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data/).
 
-_Used in [Work with geo-temporal data](/influxdb/v2.0/query-data/flux/geo/)._
+```js
+import "influxdata/influxdb/sample"
+
+sample.data(set: "birdMigration")
+```
+
+The bird migration sample dataset is used in the [Work with geo-temporal data](/influxdb/v2.0/query-data/flux/geo/)
+guide to demonstrate how to query and analyze geo-temporal data.
 
 ## NOAA sample data
 
 There are two National Oceanic and Atmospheric Administration (NOAA) datasets 
 available to use with InfluxDB.
 
-- [NOAA NDBC data](#noaa-water-sample-data)
+- [NOAA NDBC data](#noaa-ndbc-data)
 - [NOAA water sample data](#noaa-water-sample-data)
 
 ### NOAA NDBC data
+
+{{% caption %}}
+**Size**: ~1.3 MB • **Updated**: every 15m
+{{% /caption %}}
 
 The **NOAA National Data Buoy Center (NDBC)** dataset provides the latest
 observations from the NOAA NDBC network of buoys throughout the world.
 Observations are updated approximately every 15 minutes.
 
-To download and output the most recent NOAA NDBC observations, import the Flux
-`influxdata/influxdb/sample` package Use the [`sample.data()` function](/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data/).
+To download and output the most recent NOAA NDBC observations, use the
+[`sample.data()` function](/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data/).
 
 ```js
 import "influxdata/influxdb/sample"
@@ -72,7 +101,8 @@ sample.data(set: "noaa")
 {{% note %}}
 #### Store historical NOAA NDBC data
 
-The NOAA NDBC sample dataset only returns the most recent observations; not historical observations.
+The **NOAA NDBC sample dataset** only returns the most recent observations;
+not historical observations.
 To regularly query and store NOAA NDBC observations, add the following as an
 [InfluxDB task](/inflxudb/v2.0/process-data/manage-tasks/).
 Replace `example-org` and `example-bucket` with your organization name and the
@@ -83,35 +113,49 @@ name of the bucket to store data in.
 
 ### NOAA water sample data
 
-This data set is publicly available data from the [NOAA Center for Operational Oceanographic Products and Services](http://tidesandcurrents.noaa.gov/stations.html).
+{{% caption %}}
+**Size**: ~10 MB • **Updated**: N/A
+{{% /caption %}}
 
-[The CSV data](https://influx-testdata.s3.amazonaws.com/noaa.csv) includes 15,258
-observations of water levels (ft) collected every six minutes at two stations
+The **NOAA water sample dataset** is static dataset extracted from
+[NOAA Center for Operational Oceanographic Products and Services](http://tidesandcurrents.noaa.gov/stations.html) data.
+The sample dataset includes 15,258 observations of water levels (ft) collected every six minutes at two stations
 (Santa Monica, CA (ID 9410840) and Coyote Creek, CA (ID 9414575)) over the period
-from August 18, 2015 through September 18, 2015.
+from **August 18, 2015** through **September 18, 2015**.
 
+{{% note %}}
+#### Store NOAA water sample data to avoid bandwidth usage
 To avoid having to re-download this 10MB dataset every time you run a query,
 we recommend that you [create a new bucket](/influxdb/v2.0/organizations/buckets/create-bucket/)
-(`noaa`) and write the NOAA data to it.
-We also recommend updating the timestamps of the data to be relative to `now()`.
-To do so, run the following:
+(`noaa`) and write the NOAA sample water data to it.
 
 ```js
 import "experimental/csv"
 
-relativeToNow = (tables=<-) =>
-  tables
-    |> elapsed()
-    |> sort(columns: ["_time"], desc: true)
-    |> cumulativeSum(columns: ["elapsed"])
-    |> map(fn: (r) => ({ r with _time: time(v: int(v: now()) - (r.elapsed * 1000000000))}))
-
 csv.from(url: "https://influx-testdata.s3.amazonaws.com/noaa.csv")
-  |> relativeToNow()
   |> to(bucket: "noaa", org: "example-org")
 ```
+{{% /note %}}
 
-_Used in [Common queries](/influxdb/v2.0/query-data/common-queries/) and [Common tasks](/influxdb/v2.0/process-data/common-tasks/)._
+The NOAA water sample dataset is used to demonstrate Flux queries in the
+[Common queries](/influxdb/v2.0/query-data/common-queries/) and
+[Common tasks](/influxdb/v2.0/process-data/common-tasks/) guides.
 
 ## USGS Earthquake data
-_placeholder_
+
+{{% caption %}}
+**Size**: ~6 MB • **Updated**: every 15m
+{{% /caption %}}
+
+The United States Geological Survey (USGS) earthquake dataset contains observations
+collected from USGS seismic sensors around the world over the last week.
+Data is updated approximately every 15m.
+
+To download and output the last week of USGS seismic data, use the
+[`sample.data()` function](/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data/).
+
+```js
+import "influxdata/influxdb/sample"
+
+sample.data(set: "usgs")
+```

--- a/content/influxdb/v2.0/reference/sample-data.md
+++ b/content/influxdb/v2.0/reference/sample-data.md
@@ -19,7 +19,10 @@ and can be used with **InfluxDB OSS** or **InfluxDB Cloud**.
 
 - [Air sensor sample data](#air-sensor-sample-data)
 - [Bird migration sample data](#bird-migration-sample-data)
-- [NOAA water sample data](#noaa-water-sample-data)
+- [NOAA]
+  - [NOAA NDBC data](#noaa-water-sample-data)
+  - [NOAA water sample data](#noaa-water-sample-data)
+- [USGS Earthquake data](#usgs-earthquake-data)
 
 ### Air sensor sample data
 Air sensor sample data represents an "Internet of Things" (IoT) use case by simulating
@@ -45,7 +48,9 @@ to query and analyze the geo-temporal data in this sample data set.
 
 _Used in [Work with geo-temporal data](/influxdb/v2.0/query-data/flux/geo/)._
 
-### NOAA water sample data
+### NOAA sample data
+
+#### NOAA water sample data
 
 This data set is  publicly available data from the [National Oceanic and Atmospheric Administration’s (NOAA) Center for Operational Oceanographic Products and Services](http://tidesandcurrents.noaa.gov/stations.html).
 
@@ -76,3 +81,6 @@ csv.from(url: "https://influx-testdata.s3.amazonaws.com/noaa.csv")
 ```
 
 _Used in [Common queries](/influxdb/v2.0/query-data/common-queries/) and [Common tasks](/influxdb/v2.0/process-data/common-tasks/)._
+
+### USGS Earthquake data
+_placeholder_

--- a/content/influxdb/v2.0/reference/sample-data.md
+++ b/content/influxdb/v2.0/reference/sample-data.md
@@ -12,19 +12,17 @@ weight: 7
 
 Use sample data to familiarize yourself with time series data and InfluxDB.
 InfluxData provides many sample time series datasets to use with InfluxDB.
-
-## Sample data sets
-The following sample data sets are used as examples in [InfluxDB query guides](/influxdb/v2.0/query-data/flux)
-and can be used with **InfluxDB OSS** or **InfluxDB Cloud**.
+You can also use the [Flux InfluxDB sample package](/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/)
+to view, download, and output sample datasets.
 
 - [Air sensor sample data](#air-sensor-sample-data)
 - [Bird migration sample data](#bird-migration-sample-data)
-- [NOAA]
+- [NOAA sample data](#noaa-sample-data)
   - [NOAA NDBC data](#noaa-water-sample-data)
   - [NOAA water sample data](#noaa-water-sample-data)
 - [USGS Earthquake data](#usgs-earthquake-data)
 
-### Air sensor sample data
+## Air sensor sample data
 Air sensor sample data represents an "Internet of Things" (IoT) use case by simulating
 temperature, humidity, and carbon monoxide levels for multiple rooms in a building.
 The dataset also includes a relational SQL dataset with meta information about sensors in each room.
@@ -35,7 +33,7 @@ The dataset also includes a relational SQL dataset with meta information about s
 
 _Used in [Query SQL data sources](/influxdb/v2.0/query-data/flux/sql/)._
 
-### Bird migration sample data
+## Bird migration sample data
 Bird migration data is adapted from the
 [Movebank: Animal Tracking data set on Kaggle](https://www.kaggle.com/pulkit8595/movebank-animal-tracking)
 and represents animal migratory movements throughout 2019.
@@ -48,11 +46,44 @@ to query and analyze the geo-temporal data in this sample data set.
 
 _Used in [Work with geo-temporal data](/influxdb/v2.0/query-data/flux/geo/)._
 
-### NOAA sample data
+## NOAA sample data
 
-#### NOAA water sample data
+There are two National Oceanic and Atmospheric Administration (NOAA) datasets 
+available to use with InfluxDB.
 
-This data set is  publicly available data from the [National Oceanic and Atmospheric Administration’s (NOAA) Center for Operational Oceanographic Products and Services](http://tidesandcurrents.noaa.gov/stations.html).
+- [NOAA NDBC data](#noaa-water-sample-data)
+- [NOAA water sample data](#noaa-water-sample-data)
+
+### NOAA NDBC data
+
+The **NOAA National Data Buoy Center (NDBC)** dataset provides the latest
+observations from the NOAA NDBC network of buoys throughout the world.
+Observations are updated approximately every 15 minutes.
+
+To download and output the most recent NOAA NDBC observations, import the Flux
+`influxdata/influxdb/sample` package Use the [`sample.data()` function](/influxdb/v2.0/reference/flux/stdlib/influxdb-sample/data/).
+
+```js
+import "influxdata/influxdb/sample"
+
+sample.data(set: "noaa")
+```
+
+{{% note %}}
+#### Store historical NOAA NDBC data
+
+The NOAA NDBC sample dataset only returns the most recent observations; not historical observations.
+To regularly query and store NOAA NDBC observations, add the following as an
+[InfluxDB task](/inflxudb/v2.0/process-data/manage-tasks/).
+Replace `example-org` and `example-bucket` with your organization name and the
+name of the bucket to store data in.
+
+{{% get-shared-text "flux/noaa-ndbc-sample-task.md" %}}
+{{% /note %}}
+
+### NOAA water sample data
+
+This data set is publicly available data from the [NOAA Center for Operational Oceanographic Products and Services](http://tidesandcurrents.noaa.gov/stations.html).
 
 [The CSV data](https://influx-testdata.s3.amazonaws.com/noaa.csv) includes 15,258
 observations of water levels (ft) collected every six minutes at two stations
@@ -82,5 +113,5 @@ csv.from(url: "https://influx-testdata.s3.amazonaws.com/noaa.csv")
 
 _Used in [Common queries](/influxdb/v2.0/query-data/common-queries/) and [Common tasks](/influxdb/v2.0/process-data/common-tasks/)._
 
-### USGS Earthquake data
+## USGS Earthquake data
 _placeholder_

--- a/shared/text/flux/noaa-ndbc-sample-task.md
+++ b/shared/text/flux/noaa-ndbc-sample-task.md
@@ -1,0 +1,14 @@
+```js
+import "influxdata/influxdb/sample"
+
+option task = {
+  name: "Collect NOAA NDBC data"
+  every: 15m,
+}
+
+sample.data(set: "noaa")
+  |> to(
+      org: "example-org",
+      bucket: "example-bucket"
+  )
+```


### PR DESCRIPTION
Closes #2845

Adds the new Flux `influxdata/influxdb/sample` package and updates sample data instructions to use the `sample.data()` function to load certain data sets.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
