### PR TITLE
Fix handler yaml example

### DIFF
--- a/content/kapacitor/v1.5/event_handlers/exec.md
+++ b/content/kapacitor/v1.5/event_handlers/exec.md
@@ -29,7 +29,8 @@ topic: topic-name
 kind: exec
 options:
   prog: /path/to/executable
-  args: 'executable arguments'
+  args:
+    - 'executable arguments'
 ```
 
 ### Example: TICKscript
@@ -100,7 +101,8 @@ topic: cpu
 kind: exec
 options:
   prog: '/usr/bin/python'
-  args: 'sound-the-alarm.py'
+  args:
+    - 'sound-the-alarm.py'
 ```
 
 Add the handler:

--- a/content/kapacitor/v1.6/event_handlers/exec.md
+++ b/content/kapacitor/v1.6/event_handlers/exec.md
@@ -30,7 +30,8 @@ topic: topic-name
 kind: exec
 options:
   prog: /path/to/executable
-  args: 'executable arguments'
+  args: 
+    - 'executable arguments'
 ```
 
 ### Example: TICKscript
@@ -101,7 +102,8 @@ topic: cpu
 kind: exec
 options:
   prog: '/usr/bin/python'
-  args: 'sound-the-alarm.py'
+  args: 
+    - 'sound-the-alarm.py'
 ```
 
 Add the handler:


### PR DESCRIPTION
The type of `arg` should be "list of string" and the current examples uses just a string. If used as is the following error will occur:

```
"failed to decode options into *alert.ExecHandlerConfig: 1 error(s) decoding:\n\n* 'args': source data must be an array or slice, got string"
```

Changed the handler examples from:

```yaml
id: handler-id
topic: topic-name
kind: exec
options:
  prog: /path/to/executable
  args: 'executable arguments'
```

to

```yaml
id: handler-id
topic: topic-name
kind: exec
options:
  prog: /path/to/executable
  args:
    - 'executable arguments'
```
In both 1.5 and 1.6 docs

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
