### PR TITLE
Add notes about the one organization rule.

### DIFF
--- a/content/influxdb/cloud/account-management/multi-user/_index.md
+++ b/content/influxdb/cloud/account-management/multi-user/_index.md
@@ -12,9 +12,10 @@ aliases:
   - /influxdb/cloud/users/
 ---
 
-{{< cloud-name >}} accounts support multiple users in an organization.
+{{< cloud-name >}} accounts support multiple users in an organization. 
 Collaborate with others using these features.
-By default, each user has full permissions on resources in your organization.
+By default, each user has full permissions on resources in your organization. 
+Every user on the [Free Plan](/influxdb/cloud/account-management/pricing-plans/#free-plan) is able to work in exactly one organization.
 
 {{< youtube Qg7Zs3uM_wo >}}
 

--- a/content/influxdb/cloud/account-management/multi-user/invite-user.md
+++ b/content/influxdb/cloud/account-management/multi-user/invite-user.md
@@ -16,7 +16,7 @@ Use the InfluxDB Cloud user interface (UI) to invite users to collaborate in
 your InfluxDB Cloud organization.
 
 {{% note %}}
-You can not invite someone who already has an account. Users on the free plan are limited to one organization. 
+You cannot invite someone who already has an account. Users on the Free Plan are limited to one organization. 
 {{% /note %}}
 
 - [Invite a user](#invite-a-user)

--- a/content/influxdb/cloud/account-management/multi-user/invite-user.md
+++ b/content/influxdb/cloud/account-management/multi-user/invite-user.md
@@ -15,6 +15,10 @@ aliases:
 Use the InfluxDB Cloud user interface (UI) to invite users to collaborate in
 your InfluxDB Cloud organization.
 
+{{% note %}}
+You can not invite someone who already has an account. Users on the free plan are limited to one organization. 
+{{% /note %}}
+
 - [Invite a user](#invite-a-user)
 - [Withdraw an invitation](#withdraw-an-invitation)
 

--- a/content/influxdb/cloud/organizations/members/_index.md
+++ b/content/influxdb/cloud/organizations/members/_index.md
@@ -10,7 +10,7 @@ weight: 106
 influxdb/cloud/tags: [members]
 ---
 
-A **member** is a user that belongs to an organization.
+A **member** is a user that belongs to an organization. Each member on the [Free Plan](/influxdb/cloud/account-management/pricing-plans/#free-plan) has access to exactly one organization, but one organization can have multiple members. 
 The following articles provide information about managing users:
 
 {{< children >}}

--- a/content/influxdb/cloud/sign-up.md
+++ b/content/influxdb/cloud/sign-up.md
@@ -33,7 +33,7 @@ Use it as much and as long as you like within the plan's rate-limits.
 Limits are designed to let you monitor 5-10 sensors, stacks or servers comfortably.
 
 {{% note %}}
-Users on the free plan are limited to one organization. 
+Users on the Free Plan are limited to one organization. 
 {{% /note %}}
 
 ## Sign up

--- a/content/influxdb/cloud/sign-up.md
+++ b/content/influxdb/cloud/sign-up.md
@@ -32,6 +32,10 @@ Start using {{< cloud-name >}} at no cost with the [Free Plan](/influxdb/cloud/a
 Use it as much and as long as you like within the plan's rate-limits.
 Limits are designed to let you monitor 5-10 sensors, stacks or servers comfortably.
 
+{{% note %}}
+Users on the free plan are limited to one organization. 
+{{% /note %}}
+
 ## Sign up
 
 1. Choose one of the following:


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/2917

Currently adding notes in sign-up or organization docs that let the users know that they can only be in one organization at a time. 

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
