### PR TITLE
Fixed latest patch rendering in powershell code blocks

### DIFF
--- a/content/telegraf/v1.18/administration/windows_service.md
+++ b/content/telegraf/v1.18/administration/windows_service.md
@@ -1,9 +1,9 @@
 ---
-title: Running Telegraf as a Windows service
+title: Run Telegraf as a Windows service
 description: How to configure Telegraf as a Windows service using PowerShell.
 menu:
   telegraf_1_18:
-    name: Running as Windows service
+    name: Run as Windows service
     weight: 20
     parent: Administration
 ---
@@ -32,45 +32,51 @@ see "[Launch PowerShell as administrator](https://docs.microsoft.com/en-us/power
 
 In PowerShell _as an administrator_, do the following:
 
-1. Use the following commands to download the Telegraf Windows binary
-   and extract its contents to `C:\Program Files\InfluxData\telegraf\`:
-   ```
-   > wget https://dl.influxdata.com/telegraf/releases/telegraf-{{< latest-patch >}}_windows_amd64.zip -UseBasicParsing -OutFile telegraf-{{< latest-patch >}}_windows_amd64.zip
-   > Expand-Archive .\telegraf-{{< latest-patch >}}_windows_amd64.zip -DestinationPath 'C:\Program Files\InfluxData\telegraf\'
-   ```
+1.  Use the following commands to download the Telegraf Windows binary
+    and extract its contents to `C:\Program Files\InfluxData\telegraf\`:
 
-2. Move the `telegraf.exe` and `telegraf.conf` files from
-   `C:\Program Files\InfluxData\telegraf\telegraf-{{< latest-patch >}}`
-   up a level to `C:\Program Files\InfluxData\telegraf`:
-   ```
-   > cd "C:\Program Files\InfluxData\telegraf"
-   > mv .\telegraf-{{< latest-patch >}}\telegraf.* .
-   ```
-   Or create a [Windows symbolic link (Symlink)](https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/)
-   to point to this directory.
+    ```powershell
+    > wget https://dl.influxdata.com/telegraf/releases/telegraf-{{% latest-patch %}}_windows_amd64.zip -UseBasicParsing -OutFile telegraf-{{< latest-patch >}}_windows_amd64.zip
+    > Expand-Archive .\telegraf-{{% latest-patch %}}_windows_amd64.zip -DestinationPath 'C:\Program Files\InfluxData\telegraf\'
+    ```
 
-   {{% note %}}
+2.  Move the `telegraf.exe` and `telegraf.conf` files from
+    `C:\Program Files\InfluxData\telegraf\telegraf-{{% latest-patch %}}`
+    up a level to `C:\Program Files\InfluxData\telegraf`:
+   
+    ```powershell
+    > cd "C:\Program Files\InfluxData\telegraf"
+    > mv .\telegraf-{{% latest-patch %}}\telegraf.* .
+    ```
+    
+    Or create a [Windows symbolic link (Symlink)](https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/)
+    to point to this directory.
+
+    {{% note %}}
 The instructions below assume that either the `telegraf.exe` and `telegraf.conf` files are stored in
 `C:\Program Files\InfluxData\telegraf`, or you've created a Symlink to point to this directory.
-   {{% /note %}}
+    {{% /note %}}
 
-3. Install Telegraf as a service:
-   ```powershell
-   > .\telegraf.exe --service install --config "C:\Program Files\InfluxData\telegraf\telegraf.conf"
-   ```
-   Make sure to provide the absolute path of the `telegraf.conf` configuration file,
-   otherwise the Windows service may fail to start.
-3. To test that the installation works, run:
+3.  Install Telegraf as a service:
 
-   ```powershell
-   > C:\"Program Files"\InfluxData\telegraf\telegraf.exe --config C:\"Program Files"\InfluxData\telegraf\telegraf.conf --test
-   ```
+    ```powershell
+    > .\telegraf.exe --service install --config "C:\Program Files\InfluxData\telegraf\telegraf.conf"
+    ```
 
-4. To start collecting data, run:
+    Make sure to provide the absolute path of the `telegraf.conf` configuration file,
+    otherwise the Windows service may fail to start.
 
-   ```powershell
-   telegraf.exe --service start
-   ```
+3.  To test that the installation works, run:
+
+    ```powershell
+    > C:\"Program Files"\InfluxData\telegraf\telegraf.exe --config C:\"Program Files"\InfluxData\telegraf\telegraf.conf --test
+    ```
+
+4.  To start collecting data, run:
+
+    ```powershell
+    telegraf.exe --service start
+    ```
 
 <!--
 #### (Optional) Specify multiple configuration files

--- a/content/telegraf/v1.19/administration/windows_service.md
+++ b/content/telegraf/v1.19/administration/windows_service.md
@@ -1,9 +1,9 @@
 ---
-title: Running Telegraf as a Windows service
+title: Run Telegraf as a Windows service
 description: How to configure Telegraf as a Windows service using PowerShell.
 menu:
   telegraf_1_19:
-    name: Running as Windows service
+    name: Run as Windows service
     weight: 20
     parent: Administration
 ---
@@ -32,45 +32,51 @@ see "[Launch PowerShell as administrator](https://docs.microsoft.com/en-us/power
 
 In PowerShell _as an administrator_, do the following:
 
-1. Use the following commands to download the Telegraf Windows binary
-   and extract its contents to `C:\Program Files\InfluxData\telegraf\`:
-   ```
-   > wget https://dl.influxdata.com/telegraf/releases/telegraf-{{< latest-patch >}}_windows_amd64.zip -UseBasicParsing -OutFile telegraf-{{< latest-patch >}}_windows_amd64.zip
-   > Expand-Archive .\telegraf-{{< latest-patch >}}_windows_amd64.zip -DestinationPath 'C:\Program Files\InfluxData\telegraf\'
-   ```
+1.  Use the following commands to download the Telegraf Windows binary
+    and extract its contents to `C:\Program Files\InfluxData\telegraf\`:
 
-2. Move the `telegraf.exe` and `telegraf.conf` files from
-   `C:\Program Files\InfluxData\telegraf\telegraf-{{< latest-patch >}}`
-   up a level to `C:\Program Files\InfluxData\telegraf`:
-   ```
-   > cd "C:\Program Files\InfluxData\telegraf"
-   > mv .\telegraf-{{< latest-patch >}}\telegraf.* .
-   ```
-   Or create a [Windows symbolic link (Symlink)](https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/)
-   to point to this directory.
+    ```powershell
+    > wget https://dl.influxdata.com/telegraf/releases/telegraf-{{% latest-patch %}}_windows_amd64.zip -UseBasicParsing -OutFile telegraf-{{< latest-patch >}}_windows_amd64.zip
+    > Expand-Archive .\telegraf-{{% latest-patch %}}_windows_amd64.zip -DestinationPath 'C:\Program Files\InfluxData\telegraf\'
+    ```
 
-   {{% note %}}
+2.  Move the `telegraf.exe` and `telegraf.conf` files from
+    `C:\Program Files\InfluxData\telegraf\telegraf-{{% latest-patch %}}`
+    up a level to `C:\Program Files\InfluxData\telegraf`:
+   
+    ```powershell
+    > cd "C:\Program Files\InfluxData\telegraf"
+    > mv .\telegraf-{{% latest-patch %}}\telegraf.* .
+    ```
+    
+    Or create a [Windows symbolic link (Symlink)](https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/)
+    to point to this directory.
+
+    {{% note %}}
 The instructions below assume that either the `telegraf.exe` and `telegraf.conf` files are stored in
 `C:\Program Files\InfluxData\telegraf`, or you've created a Symlink to point to this directory.
-   {{% /note %}}
+    {{% /note %}}
 
-3. Install Telegraf as a service:
-   ```powershell
-   > .\telegraf.exe --service install --config "C:\Program Files\InfluxData\telegraf\telegraf.conf"
-   ```
-   Make sure to provide the absolute path of the `telegraf.conf` configuration file,
-   otherwise the Windows service may fail to start.
-3. To test that the installation works, run:
+3.  Install Telegraf as a service:
 
-   ```powershell
-   > C:\"Program Files"\InfluxData\telegraf\telegraf.exe --config C:\"Program Files"\InfluxData\telegraf\telegraf.conf --test
-   ```
+    ```powershell
+    > .\telegraf.exe --service install --config "C:\Program Files\InfluxData\telegraf\telegraf.conf"
+    ```
 
-4. To start collecting data, run:
+    Make sure to provide the absolute path of the `telegraf.conf` configuration file,
+    otherwise the Windows service may fail to start.
 
-   ```powershell
-   telegraf.exe --service start
-   ```
+3.  To test that the installation works, run:
+
+    ```powershell
+    > C:\"Program Files"\InfluxData\telegraf\telegraf.exe --config C:\"Program Files"\InfluxData\telegraf\telegraf.conf --test
+    ```
+
+4.  To start collecting data, run:
+
+    ```powershell
+    telegraf.exe --service start
+    ```
 
 <!--
 #### (Optional) Specify multiple configuration files


### PR DESCRIPTION
Closes #2809

If using the `latest-patch` shorcode inside of a powershell code block, for whatever reason, the shortcode should be parsed as markdown (`{{% latest-patch %}}`) instead of HTML (`{{< latest-patch >`}}).

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
