### PR TITLE
Noted that single-user org. can delete 

### DIFF
--- a/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
@@ -16,7 +16,7 @@ For details on changes incorporated from the InfluxDB OSS release, see
 
 ## v1.8.8 [unreleased]
 
-Due to encountering several issues building v.1.8.8, this version will not be released.  
+Due to encountering several issues with the build dependency of v.1.8.8, this version will not be released.  
 
 ## v1.8.7 [2021-07-21]
 The InfluxDB Enterprise 1.8.7 release builds on the InfluxDB OSS 1.8.7 release.

--- a/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.8/about-the-project/release-notes-changelog.md
@@ -16,7 +16,7 @@ For details on changes incorporated from the InfluxDB OSS release, see
 
 ## v1.8.8 [unreleased]
 
-Due to encountering several issues with the build dependency of v.1.8.8, this version will not be released.  
+Due to encountering several issues with build dependencies in v.1.8.8, this version will not be released.  
 
 ## v1.8.7 [2021-07-21]
 The InfluxDB Enterprise 1.8.7 release builds on the InfluxDB OSS 1.8.7 release.

--- a/content/influxdb/cloud/account-management/multi-user/remove-user.md
+++ b/content/influxdb/cloud/account-management/multi-user/remove-user.md
@@ -22,7 +22,7 @@ Delete a single-user organization from one of the following:
 - Free plan
 - Usage-based plan
 
-#### Free Plan 
+#### Free plan 
 
 1. Click your user avatar in the left navigation bar and select **Users**.
 

--- a/content/influxdb/cloud/account-management/multi-user/remove-user.md
+++ b/content/influxdb/cloud/account-management/multi-user/remove-user.md
@@ -16,7 +16,7 @@ To remove a user from your InfluxDB Cloud organization, select one of the follow
 - [Single-user organization](#single-user-organization)
 - [Multi-user orgaanization](#multi-user-organization)
 
-### Single-user organization 
+### Delete a single-user organization 
 
 Delete a single-user organization on: 
 

--- a/content/influxdb/cloud/account-management/multi-user/remove-user.md
+++ b/content/influxdb/cloud/account-management/multi-user/remove-user.md
@@ -48,4 +48,4 @@ Please contact InfluxData Support to [delete-an-organization](#delete-an-organiz
 
 #### Remove yourself from an organization 
 
-1. Get another organization owner to remove you. 
+- Get another person in your organization to remove you. 

--- a/content/influxdb/cloud/account-management/multi-user/remove-user.md
+++ b/content/influxdb/cloud/account-management/multi-user/remove-user.md
@@ -29,7 +29,7 @@ Delete a single-user organization on:
 2. Hover over the user you want to remove and then click the {{< icon "delete" >}} icon that appears.
 3. Confirm the removal.
 
-#### User-based Plan 
+#### Usage-based plan 
 
 1. Click on the **user icon > billing**. 
 2. [Cancel your service](/influxdb/cloud/account-management/offboarding/#cancel-service) to delete your organization. 

--- a/content/influxdb/cloud/account-management/multi-user/remove-user.md
+++ b/content/influxdb/cloud/account-management/multi-user/remove-user.md
@@ -12,7 +12,15 @@ aliases:
   - /influxdb/v2.0/account-management/multi-user/remove-user/
 ---
 
-To remove a user from your InfluxDB Cloud organization:
+To remove a user from your InfluxDB Cloud organization, select one of the following:
+- [Single-user organization](#single-user-organization)
+- [Multi-user orgaanization](#multi-user-organization)
+
+### Single-user organization 
+
+Delete a single-user organization on: 
+
+#### Free Plan 
 
 1. Click your user avatar in the left navigation bar and select **Users**.
 
@@ -20,3 +28,22 @@ To remove a user from your InfluxDB Cloud organization:
 
 2. Hover over the user you want to remove and then click the {{< icon "delete" >}} icon that appears.
 3. Confirm the removal.
+
+#### User-based Plan 
+
+1. Click on the **user icon > billing**. 
+2. [Cancel your service](/influxdb/cloud/account-management/offboarding/#cancel-service) to delete your organization. 
+
+### Multi-user organization 
+
+You can not delete a multi-user organization on your own. 
+
+To remove or delete an organization with multiple users, do one of the following: 
+
+#### Delete an organization
+
+1. Contact [InfluxData Support](support@influxdata.com) to delete an organization with multiple users. 
+
+#### Remove yourself from an organization 
+
+1. Get another organization owner to remove you. 

--- a/content/influxdb/cloud/account-management/multi-user/remove-user.md
+++ b/content/influxdb/cloud/account-management/multi-user/remove-user.md
@@ -40,7 +40,7 @@ Delete a single-user organization from one of the following:
 
 You can not delete a multi-user organization on your own. 
 
-To remove or delete an organization with multiple users, do one of the following: 
+Please contact InfluxData Support to [delete-an-organization](#delete-an-organization), or [remove yourself from an organization](#remove-yourself-from-an-organization).
 
 #### Delete an organization
 

--- a/content/influxdb/cloud/account-management/multi-user/remove-user.md
+++ b/content/influxdb/cloud/account-management/multi-user/remove-user.md
@@ -44,7 +44,7 @@ Please contact InfluxData Support to [delete-an-organization](#delete-an-organiz
 
 #### Delete an organization
 
-1. Contact [InfluxData Support](support@influxdata.com) to delete an organization with multiple users. 
+- Contact [InfluxData Support](support@influxdata.com) to delete an organization with multiple users. 
 
 #### Remove yourself from an organization 
 

--- a/content/influxdb/cloud/account-management/multi-user/remove-user.md
+++ b/content/influxdb/cloud/account-management/multi-user/remove-user.md
@@ -18,7 +18,9 @@ To remove a user from your InfluxDB Cloud organization, select one of the follow
 
 ### Delete a single-user organization 
 
-Delete a single-user organization on: 
+Delete a single-user organization from one of the following:
+- Free plan
+- Usage-based plan
 
 #### Free Plan 
 

--- a/content/influxdb/cloud/account-management/offboarding.md
+++ b/content/influxdb/cloud/account-management/offboarding.md
@@ -56,6 +56,10 @@ To request a backup of data in your {{< cloud-name "short" >}} instance, contact
 
 ### Cancel service
 
+{{% note %}}
+ Cancelling your usage-based plan will delete your organization. However, those in multi-user organizations must contact [InfluxData Support](support@influxdata.com) to delete your organization. 
+{{% /note %}}
+
 1. Click the **user avatar** in the top right corner of your {{< cloud-name "short" >}}
    user interface (UI) and select **Billing**.
 

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -21,7 +21,7 @@ v2: /influxdb/v2.0/reference/release-notes/influxdb/
 
 ## v1.8.8 [unreleased]
 
-Due to encountering several issues with the build dependency of v.1.8.8, this version will not be released.  
+Due to encountering several issues with build dependencies in v.1.8.8, this version will not be released.  
 
 ## v1.8.7 [2021-07-21]
 

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -21,7 +21,7 @@ v2: /influxdb/v2.0/reference/release-notes/influxdb/
 
 ## v1.8.8 [unreleased]
 
-Due to encountering several issues building v.1.8.8, this version will not be released.  
+Due to encountering several issues with the build dependency of v.1.8.8, this version will not be released.  
 
 ## v1.8.7 [2021-07-21]
 


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/2330 https://github.com/influxdata/docs-v2/issues/3004

Noted that single-user orgs can delete, but multi-users cannot. (Also added edits to 1.8.9 that are not associated with the organizations.)

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
