### PR TITLE
Fix Telegraf 1.18 and 1.19 versions

### DIFF
--- a/content/telegraf/v1.18/introduction/installation.md
+++ b/content/telegraf/v1.18/introduction/installation.md
@@ -16,7 +16,7 @@ Installation of the Telegraf package may require `root` or administrator privile
 
 ### Networking
 
-Telegraf offers multiple service [input plugins](/telegraf/v1.17/plugins/inputs/) that may
+Telegraf offers multiple service [input plugins](/telegraf/v1.18/plugins/inputs/) that may
 require custom ports.
 Modify port mappings through the configuration file (`telegraf.conf`).
 
@@ -136,7 +136,7 @@ To manually install the Debian package from a `.deb` file:
 2. Run the following command (making sure to supply the correct version number for the downloaded file):
 
    ```sh
-   sudo sudo dpkg -i telegraf_1.17_amd64.deb
+   sudo sudo dpkg -i telegraf_{{< latest-patch >}}-1_amd64.deb
    ```
 
 {{% telegraf/verify %}}
@@ -157,7 +157,7 @@ telegraf --input-filter <pluginname>[:<pluginname>] --output-filter <outputname>
 ```
 
 For more advanced configuration details, see the
-[configuration documentation](/telegraf/v1.17/administration/configuration/).
+[configuration documentation](/telegraf/v1.18/administration/configuration/).
 {{% /tab-content %}}
 <!---------- BEGIN RedHat & CentOS ---------->
 {{% tab-content %}}
@@ -208,7 +208,7 @@ telegraf --input-filter <pluginname>[:<pluginname>] --output-filter <outputname>
 ```
 
 For more advanced configuration details, see the
-[configuration documentation](/telegraf/v1.17/administration/configuration/).
+[configuration documentation](/telegraf/v1.18/administration/configuration/).
 {{% /tab-content %}}
 <!---------- BEGIN SLES & openSUSE ---------->
 {{% tab-content %}}
@@ -239,7 +239,7 @@ telegraf --input-filter <pluginname>[:<pluginname>] --output-filter <outputname>
 ```
 
 For more advanced configuration details, see the
-[configuration documentation](/telegraf/v1.17/administration/configuration/).
+[configuration documentation](/telegraf/v1.18/administration/configuration/).
 {{% /tab-content %}}
 <!---------- BEGIN FreeBSD/PC-BSD ---------->
 {{% tab-content %}}
@@ -270,7 +270,7 @@ telegraf --input-filter <pluginname>[:<pluginname>] --output-filter <outputname>
 ```
 
 For more advanced configuration details, see the
-[configuration documentation](/telegraf/v1.17/administration/configuration/).
+[configuration documentation](/telegraf/v1.18/administration/configuration/).
 {{% /tab-content %}}
 <!---------- BEGIN macOS ---------->
 {{% tab-content %}}
@@ -314,7 +314,7 @@ telegraf --input-filter <pluginname>[:<pluginname>] --output-filter <outputname>
 ```
 
 For more advanced configuration details, see the
-[configuration documentation](/telegraf/v1.17/administration/configuration/).
+[configuration documentation](/telegraf/v1.18/administration/configuration/).
 {{% /tab-content %}}
 <!---------- BEGIN Windows ---------->
 {{% tab-content %}}
@@ -330,7 +330,7 @@ Extract the contents of the ZIP archive to `C:\Program Files\InfluxData\Telegraf
 To obtain the SHA256 hash for the Windows Telegraf download, use the following PowerShell command:
 
 ```powershell
-CertUtil -hashfile <path to your download>/telegraf-1.17_windows_amd64.zip SHA256
+CertUtil -hashfile <path to your download>/telegraf-{{< latest-patch >}}_windows_amd64.zip SHA256
 ```
 
 Compare the output from this command to the hash listed on the downloads page to ensure the integrity of the download.
@@ -338,7 +338,7 @@ Compare the output from this command to the hash listed on the downloads page to
 ### Configure an input plugin
 
 The Telegraf ZIP archive contains a default configuration file (`telegraf.conf`).
-In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.17/plugins/#win_perf_counters) is already activated.
+In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.18/plugins/#win_perf_counters) is already activated.
 With this plugin, Telegraf monitors the following defined Windows Operating System objects:
 
 - Processor
@@ -350,7 +350,7 @@ With this plugin, Telegraf monitors the following defined Windows Operating Syst
 - Paging File
 
 Telegraf can capture metrics and log information from a wide variety of sources.
-For more advanced configuration details, see the [configuration documentation](/telegraf/v1.17/administration/configuration/).
+For more advanced configuration details, see the [configuration documentation](/telegraf/v1.18/administration/configuration/).
 
 ### Configure an output plugin
 
@@ -358,8 +358,8 @@ Before you start the Telegraf agent, configure an output plugin to send data to 
 Choose the appropriate plugin based on the version of InfluxDB you are using.
 
 The `telegraf.conf` file included in the ZIP archive contains sections for configuring
-both the [InfluxDB v1](/telegraf/v1.17/plugins/#influxdb) and
-[InfluxDB v2](/telegraf/v1.17/plugins/#influxdb_v2) output plugins.
+both the [InfluxDB v1](/telegraf/v1.18/plugins/#influxdb) and
+[InfluxDB v2](/telegraf/v1.18/plugins/#influxdb_v2) output plugins.
 
 #### Writing data to InfluxDB 1.x
 
@@ -384,7 +384,7 @@ Once configured, run the following commands in PowerShell to begin sending metri
 ```
 ## Install Telegraf as a Windows Service
 
-See [Running Telegraf as a Windows service](/telegraf/v1.17/administration/windows_service).
+See [Running Telegraf as a Windows service](/telegraf/v1.18/administration/windows_service).
 
 {{< /tab-content >}}
 {{< /tabs-wrapper >}}

--- a/content/telegraf/v1.19/introduction/installation.md
+++ b/content/telegraf/v1.19/introduction/installation.md
@@ -16,7 +16,7 @@ Installation of the Telegraf package may require `root` or administrator privile
 
 ### Networking
 
-Telegraf offers multiple service [input plugins](/telegraf/v1.17/plugins/inputs/) that may
+Telegraf offers multiple service [input plugins](/telegraf/v1.19/plugins/inputs/) that may
 require custom ports.
 Modify port mappings through the configuration file (`telegraf.conf`).
 
@@ -145,7 +145,7 @@ To manually install the Debian package from a `.deb` file:
 2. Run the following command (making sure to supply the correct version number for the downloaded file):
 
    ```sh
-   sudo sudo dpkg -i telegraf_1.17_amd64.deb
+   sudo sudo dpkg -i telegraf_{{< latest-patch >}}-1_amd64.deb
    ```
 
 {{% telegraf/verify %}}
@@ -166,7 +166,7 @@ telegraf --input-filter <pluginname>[:<pluginname>] --output-filter <outputname>
 ```
 
 For more advanced configuration details, see the
-[configuration documentation](/telegraf/v1.17/administration/configuration/).
+[configuration documentation](/telegraf/v1.19/administration/configuration/).
 {{% /tab-content %}}
 <!---------- BEGIN RedHat & CentOS ---------->
 {{% tab-content %}}
@@ -217,7 +217,7 @@ telegraf --input-filter <pluginname>[:<pluginname>] --output-filter <outputname>
 ```
 
 For more advanced configuration details, see the
-[configuration documentation](/telegraf/v1.17/administration/configuration/).
+[configuration documentation](/telegraf/v1.19/administration/configuration/).
 {{% /tab-content %}}
 <!---------- BEGIN SLES & openSUSE ---------->
 {{% tab-content %}}
@@ -248,7 +248,7 @@ telegraf --input-filter <pluginname>[:<pluginname>] --output-filter <outputname>
 ```
 
 For more advanced configuration details, see the
-[configuration documentation](/telegraf/v1.17/administration/configuration/).
+[configuration documentation](/telegraf/v1.19/administration/configuration/).
 {{% /tab-content %}}
 <!---------- BEGIN FreeBSD/PC-BSD ---------->
 {{% tab-content %}}
@@ -279,7 +279,7 @@ telegraf --input-filter <pluginname>[:<pluginname>] --output-filter <outputname>
 ```
 
 For more advanced configuration details, see the
-[configuration documentation](/telegraf/v1.17/administration/configuration/).
+[configuration documentation](/telegraf/v1.19/administration/configuration/).
 {{% /tab-content %}}
 <!---------- BEGIN macOS ---------->
 {{% tab-content %}}
@@ -323,7 +323,7 @@ telegraf --input-filter <pluginname>[:<pluginname>] --output-filter <outputname>
 ```
 
 For more advanced configuration details, see the
-[configuration documentation](/telegraf/v1.17/administration/configuration/).
+[configuration documentation](/telegraf/v1.19/administration/configuration/).
 {{% /tab-content %}}
 <!---------- BEGIN Windows ---------->
 {{% tab-content %}}
@@ -339,7 +339,7 @@ Extract the contents of the ZIP archive to `C:\Program Files\InfluxData\Telegraf
 To obtain the SHA256 hash for the Windows Telegraf download, use the following PowerShell command:
 
 ```powershell
-CertUtil -hashfile <path to your download>/telegraf-1.17_windows_amd64.zip SHA256
+CertUtil -hashfile <path to your download>/telegraf-{{< latest-patch >}}_windows_amd64.zip SHA256
 ```
 
 Compare the output from this command to the hash listed on the downloads page to ensure the integrity of the download.
@@ -347,7 +347,7 @@ Compare the output from this command to the hash listed on the downloads page to
 ### Configure an input plugin
 
 The Telegraf ZIP archive contains a default configuration file (`telegraf.conf`).
-In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.17/plugins/#win_perf_counters) is already activated.
+In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.19/plugins/#win_perf_counters) is already activated.
 With this plugin, Telegraf monitors the following defined Windows Operating System objects:
 
 - Processor
@@ -359,7 +359,7 @@ With this plugin, Telegraf monitors the following defined Windows Operating Syst
 - Paging File
 
 Telegraf can capture metrics and log information from a wide variety of sources.
-For more advanced configuration details, see the [configuration documentation](/telegraf/v1.17/administration/configuration/).
+For more advanced configuration details, see the [configuration documentation](/telegraf/v1.19/administration/configuration/).
 
 ### Configure an output plugin
 
@@ -367,8 +367,8 @@ Before you start the Telegraf agent, configure an output plugin to send data to 
 Choose the appropriate plugin based on the version of InfluxDB you are using.
 
 The `telegraf.conf` file included in the ZIP archive contains sections for configuring
-both the [InfluxDB v1](/telegraf/v1.17/plugins/#influxdb) and
-[InfluxDB v2](/telegraf/v1.17/plugins/#influxdb_v2) output plugins.
+both the [InfluxDB v1](/telegraf/v1.19/plugins/#influxdb) and
+[InfluxDB v2](/telegraf/v1.19/plugins/#influxdb_v2) output plugins.
 
 #### Writing data to InfluxDB 1.x
 
@@ -393,7 +393,7 @@ Once configured, run the following commands in PowerShell to begin sending metri
 ```
 ## Install Telegraf as a Windows Service
 
-See [Running Telegraf as a Windows service](/telegraf/v1.17/administration/windows_service).
+See [Running Telegraf as a Windows service](/telegraf/v1.19/administration/windows_service).
 
 {{< /tab-content >}}
 {{< /tabs-wrapper >}}

--- a/layouts/shortcodes/telegraf/verify.md
+++ b/layouts/shortcodes/telegraf/verify.md
@@ -1,3 +1,7 @@
+{{- $productPathData := findRE "[^/]+.*?" .Page.RelPermalink -}}
+{{- $version := replaceRE "v" "" (index $productPathData 1) -}}
+{{- $patchVersions := .Site.Data.products.telegraf.latest_patches -}}
+{{- $latestPatch := print $version "." (index $patchVersions $version) -}}
 ### Verify the authenticity of downloaded binary (optional)
 
 InfluxData cryptographically signs each Telegraf binary release.
@@ -16,13 +20,13 @@ If `gpg` is not available, see the [GnuPG homepage](https://gnupg.org/download/)
    For example:
 
     ```
-    wget https://dl.influxdata.com/telegraf/releases/telegraf-1.14.1_linux_amd64.tar.gz.asc
+    wget https://dl.influxdata.com/telegraf/releases/telegraf-{{ $latestPatch }}_linux_amd64.tar.gz.asc
     ```
 
 3. Verify the signature with `gpg --verify`:
 
     ```
-    gpg --verify telegraf-1.14.1_linux_amd64.tar.gz.asc telegraf-1.14.1_linux_amd64.tar.gz
+    gpg --verify telegraf-{{ $latestPatch }}_linux_amd64.tar.gz.asc telegraf-{{ $latestPatch }}_linux_amd64.tar.gz
     ```
 
     The output from this command should include the following:


### PR DESCRIPTION
- Updated the `telegraf/verify` shortcode to use the latest patch version for each Telegraf version.
- Updated links pointing to old versions of Telegraf on the install page.

<!-- -->
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
