### PR TITLE
updated the email docs

### DIFF
--- a/content/kapacitor/v1.6/event_handlers/email.md
+++ b/content/kapacitor/v1.6/event_handlers/email.md
@@ -156,7 +156,7 @@ stream
   |from()
     .measurement('cpu')
   |alert()
-    .crit(lambda: "usage_idle" < 10)
+    .crit(lambda: int("usage_idle") < 10)
     .message('Hey, check your CPU')
     .topic('cpu')
 ```

--- a/content/kapacitor/v1.6/event_handlers/email.md
+++ b/content/kapacitor/v1.6/event_handlers/email.md
@@ -134,7 +134,7 @@ stream
   |from()
     .measurement('cpu')
   |alert()
-    .crit(lambda: 'usage_idle' < 10)
+    .crit(lambda: "usage_idle" < 10)
     .message('Hey, check your CPU')
     .email()
       .to('oncall1@mydomain.com')

--- a/content/kapacitor/v1.6/event_handlers/email.md
+++ b/content/kapacitor/v1.6/event_handlers/email.md
@@ -156,7 +156,7 @@ stream
   |from()
     .measurement('cpu')
   |alert()
-    .crit(lambda: int("usage_idle") < 10)
+    .crit(lambda: "usage_idle" < 10)
     .message('Hey, check your CPU')
     .topic('cpu')
 ```


### PR DESCRIPTION
single & double quotes in tickscript hold different meanings. In cpu_alert.tick tickscript 'usage_idle' must be enclosed within double quotes,ie., "usage_idle", otherwise kapacitor throws error -> enabling task cpu_alert: Failed to compile stateful expression for crit: mismatched type to binary operator. got string < int. see bool(), int(), float(), string(), duration()

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
