### PR TITLE
Add `max-body-size` to Enterprise data node docs

### DIFF
--- a/content/enterprise_influxdb/v1.8/administration/config-data-nodes.md
+++ b/content/enterprise_influxdb/v1.8/administration/config-data-nodes.md
@@ -853,6 +853,14 @@ The JWT authorization shared secret used to validate requests using JSON web tok
 
 Environment variable: `INFLUXDB_HTTP_SHARED_SECRET`
 
+#### `max-body-size = 25000000`
+
+The maximum size, in bytes, of a client request body.
+When a HTTP client sends data that exceeds the configured maximum size, a `413 Request Entity Too Large` HTTP response is returned.
+To disable the limit, set the value to `0`.
+
+Environment variable: `INFLUXDB_HTTP_MAX_BODY_SIZE`
+
 #### `max-row-limit = 0`
 
 The default chunk size for result sets that should be chunked.

--- a/content/enterprise_influxdb/v1.9/administration/config-data-nodes.md
+++ b/content/enterprise_influxdb/v1.9/administration/config-data-nodes.md
@@ -880,6 +880,14 @@ The JWT authorization shared secret used to validate requests using JSON web tok
 
 Environment variable: `INFLUXDB_HTTP_SHARED_SECRET`
 
+#### `max-body-size = 25000000`
+
+The maximum size, in bytes, of a client request body.
+When a HTTP client sends data that exceeds the configured maximum size, a `413 Request Entity Too Large` HTTP response is returned.
+To disable the limit, set the value to `0`.
+
+Environment variable: `INFLUXDB_HTTP_MAX_BODY_SIZE`
+
 #### `max-row-limit = 0`
 
 The default chunk size for result sets that should be chunked.


### PR DESCRIPTION
Add to Enterprise 1.8 and 1.9.

Closes #2548.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
