### PR TITLE
Revised edits and --http-debug addition

### DIFF
--- a/content/influxdb/cloud/reference/cli/influx/_index.md
+++ b/content/influxdb/cloud/reference/cli/influx/_index.md
@@ -74,9 +74,10 @@ For more information about managing CLI configurations, see the
 
 ## Flags
 
-| Flag |          | Description                   |
-|:---- |:---      |:-----------                   |
-| `-h` | `--help` | Help for the `influx` command |
+| Flag |                | Description                                 |
+|:---- |:---            |:-----------                                 |
+| `-h` | `--help`       | Help for the `influx` command               |
+|      | `--http-debug` | Inspect communication with InfluxDB servers |
 
 ### Flag patterns and conventions
 The `influx` CLI uses the following patterns and conventions:

--- a/content/influxdb/cloud/reference/release-notes/influx-cli.md
+++ b/content/influxdb/cloud/reference/release-notes/influx-cli.md
@@ -8,6 +8,20 @@ menu:
     name: influx CLI 
 ---
 
+## v2.1.1 [unreleased]
+
+## Go Version 
+
+This release upgrades the project to `go` version 1.17.
+
+## Bug Fixes 
+
+- Fix shell completion for top-level `influx` commands.
+- Make global `--http-debug` flag visible in help text.
+- Don't set empty strings for IDs in permission resources.
+- Detect and error out on incorrect positional args.
+- Respect value of `--host` flag when writing CLI configs in `setup`.
+
 ## v2.1.0 [2021-07-29]
 
 ## New repository

--- a/content/influxdb/cloud/reference/release-notes/influx-cli.md
+++ b/content/influxdb/cloud/reference/release-notes/influx-cli.md
@@ -8,7 +8,7 @@ menu:
     name: influx CLI 
 ---
 
-## v2.1.1 [unreleased]
+## v2.1.1 [2021-09-24]
 
 ## Go version 
 

--- a/content/influxdb/cloud/reference/release-notes/influx-cli.md
+++ b/content/influxdb/cloud/reference/release-notes/influx-cli.md
@@ -19,7 +19,7 @@ Upgrade to Go 1.17.
 - Fix shell completion for top-level `influx` commands.
 - Make global `--http-debug` flag visible in help text.
 - Don't set empty strings for IDs in permission resources.
-- Detect and error out on incorrect positional args.
+- Detect and error out on incorrect positional arguments.
 - Respect value of `--host` flag when writing CLI configs in `setup`.
 
 ## v2.1.0 [2021-07-29]

--- a/content/influxdb/cloud/reference/release-notes/influx-cli.md
+++ b/content/influxdb/cloud/reference/release-notes/influx-cli.md
@@ -10,7 +10,7 @@ menu:
 
 ## v2.1.1 [unreleased]
 
-## Go Version 
+## Go version 
 
 This release upgrades the project to `go` version 1.17.
 

--- a/content/influxdb/cloud/reference/release-notes/influx-cli.md
+++ b/content/influxdb/cloud/reference/release-notes/influx-cli.md
@@ -14,7 +14,7 @@ menu:
 
 Upgrade to Go 1.17.
 
-## Bug Fixes 
+## Bug fixes 
 
 - Fix shell completion for top-level `influx` commands.
 - Make global `--http-debug` flag visible in help text.

--- a/content/influxdb/cloud/reference/release-notes/influx-cli.md
+++ b/content/influxdb/cloud/reference/release-notes/influx-cli.md
@@ -12,7 +12,7 @@ menu:
 
 ## Go version 
 
-This release upgrades the project to `go` version 1.17.
+Upgrade to Go 1.17.
 
 ## Bug Fixes 
 


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/3116

Deleting issues from the previous PR. Added CLI release notes and the --http-debug flag to references.

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
