### PR TITLE
Temporarily disable search

### DIFF
--- a/data/notifications.yaml
+++ b/data/notifications.yaml
@@ -7,6 +7,15 @@
 #   message: |
 #     Markdown message content.
 
+- id: search-disabled
+  level: warn
+  scope:
+    - /
+  message: |
+    ### Search maintenance
+    Our documentation search functionality is undergoing maintenance and has
+    been temporarily disabled. It will be back shortly. Thank you for your patience.
+
 - id: v2-cloud-upgrade
   level: note
   scope:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -27,7 +27,7 @@
     </div>
   </div>
   <div class="section search">
-    <div class="sidebar--search">
+    <div class="sidebar--search" style="opacity:0.25">
       <input  class="sidebar--search-field"
               id="algolia-search-input"
               type="text"
@@ -37,7 +37,9 @@
               autocapitalize="off"
               spellcheck="false"
               dir="auto"
-              placeholder='Search the docs'>
+              placeholder='Search the docs'
+              disabled
+              >
     </div>
   </div>
 

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -32,7 +32,7 @@
 <aside class="sidebar">
   <div class="sidebar-toggle" onclick="toggle_sidebar('sidebar-closed');return false;"><a href="#">&#59672;</a></div>
   <div class="search-and-nav-toggle">
-    <div class="sidebar--search">
+    <div class="sidebar--search" style="opacity:0.25">
       <input  class="sidebar--search-field"
               id="algolia-search-input"
               type="text"
@@ -42,7 +42,9 @@
               autocapitalize="off"
               spellcheck="false"
               dir="auto"
-              placeholder='{{ $searchPlaceholder }}'>
+              placeholder='{{ $searchPlaceholder }}'
+              disabled
+              >
     </div>
     <a id="contents-toggle-btn" href="#">
       <span class="toggle-hamburger"></span>


### PR DESCRIPTION
The Flux restructure changes how the documentation search functionality works and requires a full reindex to get searches to return results. This change disables the search fields throughout the site and adds a site-wide notification that tells users it's temporarily disabled.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
