### PR TITLE
Sample data: fix sample.data() function links

### DIFF
--- a/content/influxdb/v2.0/reference/sample-data.md
+++ b/content/influxdb/v2.0/reference/sample-data.md
@@ -32,7 +32,7 @@ Air sensor sample data represents an "Internet of Things" (IoT) use case by simu
 temperature, humidity, and carbon monoxide levels for multiple rooms in a building.
 
 To download and output the air sensor sample dataset, use the
-[`sample.data()` function](/{{< latest "flux" >}}/stdlib/universe/influxdata/influxdb/sample/data/).
+[`sample.data()` function](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/sample/data/).
 
 ```js
 import "influxdata/influxdb/sample"
@@ -60,7 +60,7 @@ Bird migration sample data is adapted from the
 and represents animal migratory movements throughout 2019.
 
 To download and output the bird migration sample dataset, use the
-[`sample.data()` function](/{{< latest "flux" >}}/stdlib/universe/influxdata/influxdb/sample/data/).
+[`sample.data()` function](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/sample/data/).
 
 ```js
 import "influxdata/influxdb/sample"
@@ -90,7 +90,7 @@ observations from the NOAA NDBC network of buoys throughout the world.
 Observations are updated approximately every 15 minutes.
 
 To download and output the most recent NOAA NDBC observations, use the
-[`sample.data()` function](/{{< latest "flux" >}}/stdlib/universe/influxdata/influxdb/sample/data/).
+[`sample.data()` function](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/sample/data/).
 
 ```js
 import "influxdata/influxdb/sample"
@@ -152,7 +152,7 @@ collected from USGS seismic sensors around the world over the last week.
 Data is updated approximately every 15m.
 
 To download and output the last week of USGS seismic data, use the
-[`sample.data()` function](/{{< latest "flux" >}}/stdlib/universe/influxdata/influxdb/sample/data/).
+[`sample.data()` function](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/sample/data/).
 
 ```js
 import "influxdata/influxdb/sample"


### PR DESCRIPTION
The sample data page refers to the sample.data() function in each
dataset section of the page, whilst linking to the function documentation.
The link results in a page does not exist error in the live documentation.
Correct the link to point to the correct page.

Signed-off-by: Stephen Lawrence <stephen.lawrence@renesas.com>

Closes #

I have not built the documentation locally. I believe the new URL is correct based on searching the live documentation but I am new to the project so please review.

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [X] Rebased/mergeable
