### PR TITLE
Task retry commands require All-Access token

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -998,6 +998,56 @@ Use either `includeRange` argument name or provide the boolean value as the thir
 {{% flux/sample "int" true true %}}
 ```
 
+### Duplicate OSS content in Cloud
+The latest InfluxDB OSS version and InfluxDB Cloud share the majority of content.
+To prevent duplication of content between versions, use the following shortcodes:
+
+- `{{< duplicate-oss >}}`
+- `{{% oss-only %}}`
+- `{{% cloud-only %}}
+
+#### duplicate-oss
+The `{{< duplicate-oss >}}` shortcode copies the page content of the file located
+at the identical file path in the most recent InfluxDB OSS version.
+The Cloud version of this markdown file should contain the frontmatter required
+for all pages, but the body content should just be the `{{< duplicate-oss >}}` shortcode.
+
+#### oss-only
+Wrap content that should only appear in the OSS version of the doc with the `{{% oss-only %}}` shortcode.
+Use the shortcode on both inline and content blocks:
+
+```md
+{{% oss-only %}}This is inline content that only renders in the InfluxDB OSS docs{{% /oss-only %}}
+
+{{% oss-only %}}
+
+This is a multi-paragraph content block that spans multiple paragraphs and  will
+only render in the InfluxDB OSS documentation.
+
+**Note:** Notice the blank newline after the opening short-code tag.
+This is necessary to get the first sentence/paragraph to render correctly.
+
+{{% /oss-only %}}
+```
+
+#### cloud-only
+Wrap content that should only appear in the Cloud version of the doc with the `{{% cloud-only %}}` shortcode.
+Use the shortcode on both inline and content blocks:
+
+```md
+{{% cloud-only %}}This is inline content that only renders in the InfluxDB Cloud docs{{% /cloud-only %}}
+
+{{% cloud-only %}}
+
+This is a multi-paragraph content block that spans multiple paragraphs and will
+only render in the InfluxDB Cloud documentation.
+
+**Note:** Notice the blank newline after the opening short-code tag.
+This is necessary to get the first sentence/paragraph to render correctly.
+
+{{% /cloud-only %}}
+```
+
 ### Reference content
 The InfluxDB documentation is "task-based," meaning content primarily focuses on
 what a user is **doing**, not what they are **using**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1004,7 +1004,7 @@ To prevent duplication of content between versions, use the following shortcodes
 
 - `{{< duplicate-oss >}}`
 - `{{% oss-only %}}`
-- `{{% cloud-only %}}
+- `{{% cloud-only %}}`
 
 #### duplicate-oss
 The `{{< duplicate-oss >}}` shortcode copies the page content of the file located

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -999,7 +999,7 @@ Use either `includeRange` argument name or provide the boolean value as the thir
 ```
 
 ### Duplicate OSS content in Cloud
-The latest InfluxDB OSS version and InfluxDB Cloud share the majority of content.
+Docs for InfluxDB OSS and InfluxDB Cloud share a majority of content.
 To prevent duplication of content between versions, use the following shortcodes:
 
 - `{{< duplicate-oss >}}`

--- a/content/influxdb/v2.0/reference/cli/influx/task/retry-failed.md
+++ b/content/influxdb/v2.0/reference/cli/influx/task/retry-failed.md
@@ -39,6 +39,11 @@ influx task retry-failed [flags]
 
 {{< cli/influx-creds-note >}}
 
+{{% note %}}
+#### Required permissions
+Use an [{{% oss-only %}}**Operator** or{{% /oss-only %}} **All-Access** token](/influxdb/v2.0/security/tokens/) to retry failed tasks.
+{{% /note %}}
+
 - [Retry failed task runs for a specific task ID](#retry-failed-task-runs-for-a-specific-task-id)
 - [Retry failed task runs that occurred before a specific time](#retry-failed-task-runs-that-occurred-before-a-specific-time)
 - [Retry failed task runs that occurred after a specific time](#retry-failed-task-runs-that-occurred-after-a-specific-time)

--- a/content/influxdb/v2.0/reference/cli/influx/task/run/retry.md
+++ b/content/influxdb/v2.0/reference/cli/influx/task/run/retry.md
@@ -32,6 +32,11 @@ influx task run retry [flags]
 
 {{< cli/influx-creds-note >}}
 
+{{% note %}}
+#### Required permissions
+Use an [{{% oss-only %}}**Operator** or{{% /oss-only %}} <span>**All-Access**</span> token](/influxdb/v2.0/security/tokens/) to retry tasks.
+{{% /note %}}
+
 ##### Retry a task run
 ```sh
 influx task run retry \

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -8,7 +8,7 @@
     {{ partial "article/flux-experimental.html" . }}
     {{ partial "article/flux-contrib.html" . }}
     {{ partial "article/prepend.html" . }}
-    {{ .Content }}
+    {{ partial "article/content.html" . }}
     {{ partial "article/append.html" . }}
     {{ partial "article/related.html" . }}
     {{ partial "article/tags.html" . }}

--- a/layouts/partials/article/content.html
+++ b/layouts/partials/article/content.html
@@ -1,0 +1,13 @@
+{{ $productPathData := findRE "[^/]+.*?" .RelPermalink }}
+{{ $product := index $productPathData 0 }}
+{{ $version := index $productPathData 1 }}
+{{ $influxdbOSS := and (eq $product "influxdb") (ne $version "cloud") }}
+{{ $influxdbCloud := and (eq $product "influxdb") (eq $version "cloud") }}
+
+{{ if $influxdbOSS }}
+  {{ .Content | replaceRE `(?U)(<span class=\'cloud\-only\'>.*<\/span><\!\-\- close \-\-\>)` "" | replaceRE `(?Us)(<div class=\'cloud\-only\'>.*<\/div><\!\-\- close \-\-\>)` "" | safeHTML}}
+{{ else if $influxdbCloud }}
+  {{ .Content | replaceRE `(?U)(<span class=\'oss\-only\'>.*<\/span><\!\-\- close \-\-\>)` "" | replaceRE `(?Us)(<div class=\'oss\-only\'>.*<\/div><\!\-\- close \-\-\>)` "" | safeHTML}}
+{{ else }}
+  {{ .Content }}
+{{ end }}

--- a/layouts/shortcodes/cloud-only.html
+++ b/layouts/shortcodes/cloud-only.html
@@ -1,0 +1,3 @@
+{{- $el := cond (gt (len (findRE `\n` .Inner)) 0) "div" "span" -}}
+{{- $output := print "<" $el " class='cloud-only'>" .Inner "</" $el "><!-- close -->" | safeHTML -}}
+{{ $output }}

--- a/layouts/shortcodes/oss-only.html
+++ b/layouts/shortcodes/oss-only.html
@@ -1,0 +1,3 @@
+{{- $el := cond (gt (len (findRE `\n` .Inner)) 0) "div" "span" -}}
+{{- $output := print "<" $el " class='oss-only'>" .Inner "</" $el "><!-- close -->" | safeHTML -}}
+{{ $output }}


### PR DESCRIPTION
Closes influxdata/DAR#230

This PR does a few things:
- Adds `oss-` and `cloud-only` shortcodes
- Adds token information about ask retry commands

<!-- -->
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
