### PR TITLE
Edit description for amd_rocm_smi Telegraf plugin

### DIFF
--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -1546,10 +1546,10 @@ input:
     introduced: 1.17.0
     tags: [linux, macos, windows]
 
-  - name: ROCm System Management Interface (SMI)
+  - name: AMD ROCm System Management Interface (SMI)
     id: amd_rocm_smi
     description: |
-      The ROCm System Management Interface plugin pulls statistics from NVIDIA GPU stats including memory, usage, and temperature.
+      The ROCm System Management Interface plugin pulls statistics from AMD GPUs including memory, usage, and temperature.
     introduced: 1.20.0
     tags: [linux, macos, windows, systems]
 


### PR DESCRIPTION
Edit name and description for amd_rocm_smi Telegraf plugin. 

Not sure if this is the only location that it needs to be udpated.


