### PR TITLE
fix(flux): mqtt changes

### DIFF
--- a/content/flux/v0.x/stdlib/experimental/mqtt/publish.md
+++ b/content/flux/v0.x/stdlib/experimental/mqtt/publish.md
@@ -1,0 +1,96 @@
+---
+title: mqtt.publish() function
+description: >
+  The `mqtt.publish()` function outputs data to an MQTT broker using MQTT protocol.
+aliases:
+  - /influxdb/v2.0/reference/flux/stdlib/experimental/mqtt/publish/
+  - /influxdb/cloud/reference/flux/stdlib/experimental/mqtt/publish/
+menu:
+  flux_0_x_ref:
+    name: mqtt.publish
+    parent: mqtt
+weight: 401
+flux/v0.x/tags: [outputs]
+introduced: 0.133.0
+---
+
+The `mqtt.publish()` function outputs data to an MQTT broker using MQTT protocol.
+
+```js
+import "experimental/mqtt"
+
+mqtt.publish(
+  broker: "tcp://localhost:8883",
+  topic: "example-topic",
+  message: "Example message",
+  clientid: "flux-mqtt",
+  username: "username",
+  password: "password"
+)
+```
+
+## Parameters
+
+### broker {data-type="string"}
+The MQTT broker connection string.
+
+### topic {data-type="string"}
+The MQTT topic to send data to.
+
+### message {data-type="string"}
+The message to send to the MQTT broker.
+
+### qos {data-type="int"}
+The [MQTT Quality of Service (QoS)](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901103) level.
+Values range from `[0-2]`.
+Default is `0`.
+
+### clientid {data-type="string"}
+The MQTT client ID.
+
+### username {data-type="string"}
+The username to send to the MQTT broker.
+Username is only required if the broker requires authentication.
+If you provide a username, you must provide a [password](#password).
+
+### password {data-type="string"}
+The password to send to the MQTT broker.
+Password is only required if the broker requires authentication.
+If you provide a password, you must provide a [username](#username).
+
+### timeout {data-type="duration"}
+The MQTT connection timeout.
+Default is `1s`.
+
+## Examples
+
+### Send arbitrary message to an MQTT endpoint
+```js
+import "experimental/mqtt"
+
+mqtt.publish(
+  broker: "tcp://localhost:8883",
+  topic: "alerts",
+  message: "wake up",
+  clientid: "alert-watcher"
+)
+```
+
+### Send data related message to an MQTT endpoint
+```js
+import "experimental/mqtt"
+
+from(bucket: "example-bucket")
+  |> range(start: -5m)
+  |> filter(fn: (r) => r._measurement == "airSensor")
+  |> last()
+  |> map(fn: (r) => ({
+    r with
+      sent: mqtt.publish(
+        broker: "tcp://localhost:8883",
+        topic: "air-sensors/last/${r.sensorID}",
+        message: string(v: r._value),
+        clientid: "sensor-12a4"
+      )
+  }))
+```

--- a/content/flux/v0.x/stdlib/experimental/mqtt/publish.md
+++ b/content/flux/v0.x/stdlib/experimental/mqtt/publish.md
@@ -45,6 +45,10 @@ The [MQTT Quality of Service (QoS)](https://docs.oasis-open.org/mqtt/mqtt/v5.0/o
 Values range from `[0-2]`.
 Default is `0`.
 
+### retain {data-type="bool"}
+The [MQTT retain](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901042) flag.
+Default is `false`.
+
 ### clientid {data-type="string"}
 The MQTT client ID.
 
@@ -72,7 +76,8 @@ mqtt.publish(
   broker: "tcp://localhost:8883",
   topic: "alerts",
   message: "wake up",
-  clientid: "alert-watcher"
+  clientid: "alert-watcher",
+  retain: true
 )
 ```
 

--- a/content/flux/v0.x/stdlib/experimental/mqtt/publish.md
+++ b/content/flux/v0.x/stdlib/experimental/mqtt/publish.md
@@ -2,15 +2,11 @@
 title: mqtt.publish() function
 description: >
   The `mqtt.publish()` function outputs data to an MQTT broker using MQTT protocol.
-aliases:
-  - /influxdb/v2.0/reference/flux/stdlib/experimental/mqtt/publish/
-  - /influxdb/cloud/reference/flux/stdlib/experimental/mqtt/publish/
 menu:
   flux_0_x_ref:
     name: mqtt.publish
     parent: mqtt
 weight: 401
-flux/v0.x/tags: [outputs]
 introduced: 0.133.0
 ---
 
@@ -23,9 +19,12 @@ mqtt.publish(
   broker: "tcp://localhost:8883",
   topic: "example-topic",
   message: "Example message",
+  qos: 0,
+  retain: false,
   clientid: "flux-mqtt",
   username: "username",
-  password: "password"
+  password: "password",
+  timeout: 1s
 )
 ```
 
@@ -68,7 +67,7 @@ Default is `1s`.
 
 ## Examples
 
-### Send arbitrary message to an MQTT endpoint
+#### Send a message to an MQTT endpoint
 ```js
 import "experimental/mqtt"
 
@@ -81,13 +80,13 @@ mqtt.publish(
 )
 ```
 
-### Send data related message to an MQTT endpoint
+#### Send a message to an MQTT endpoint using input data
 ```js
 import "experimental/mqtt"
+import "influxdata/influxdb/sample"
 
-from(bucket: "example-bucket")
-  |> range(start: -5m)
-  |> filter(fn: (r) => r._measurement == "airSensor")
+sample.data(set: "airSensor")
+  |> range(start: -20m)
   |> last()
   |> map(fn: (r) => ({
     r with

--- a/content/flux/v0.x/stdlib/experimental/mqtt/to.md
+++ b/content/flux/v0.x/stdlib/experimental/mqtt/to.md
@@ -47,6 +47,10 @@ The [MQTT Quality of Service (QoS)](https://docs.oasis-open.org/mqtt/mqtt/v5.0/o
 Values range from `[0-2]`.
 Default is `0`.
 
+### retain {data-type="bool"}
+The [MQTT retain](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901042) flag.
+Default is `false`.
+
 ### clientid {data-type="string"}
 The MQTT client ID.
 

--- a/content/flux/v0.x/stdlib/experimental/mqtt/to.md
+++ b/content/flux/v0.x/stdlib/experimental/mqtt/to.md
@@ -22,7 +22,6 @@ import "experimental/mqtt"
 mqtt.to(
   broker: "tcp://localhost:8883",
   topic: "example-topic",
-  message: "Example message",
   qos: 0,
   clientid: "flux-mqtt",
   username: "username",
@@ -42,15 +41,6 @@ The MQTT broker connection string.
 
 ### topic {data-type="string"}
 The MQTT topic to send data to.
-
-### message {data-type="string"}
-The message or payload to send to the MQTT broker.
-The default payload is an output table.
-If there are multiple output tables, it sends each table as a separate MQTT message.
-
-{{% note %}}
-When you specify a message, the function sends the message string only (no output table).
-{{% /note %}}
 
 ### qos {data-type="int"}
 The [MQTT Quality of Service (QoS)](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901103) level.


### PR DESCRIPTION
This PR contains updates to Flux `experimental/mqtt` package to reflect changes in [#4081](https://github.com/influxdata/flux/pull/4081):
- added `publish` function
- changed `to` function:
  - added `retain` parameter
  - removed `message` parameter

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
