### PR TITLE
feat: API Reference. Update and add response codes and samples.

### DIFF
--- a/api-docs/cloud/swagger.yml
+++ b/api-docs/cloud/swagger.yml
@@ -2,20 +2,44 @@ openapi: 3.0.0
 info:
   title: Influx Cloud API Service
   version: 2.0.1
-  description: >
-    The InfluxDB v2 API provides a programmatic interface for all interactions
-    with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.
+  description: |
+    The InfluxDB v2 API provides a programmatic interface for all interactions with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.
 servers:
   - url: /api/v2
 tags:
   - name: Authentication
     description: |
       Use one of the following schemes to authenticate to the InfluxDB API:
-      - [Token authentication](#section/Authentication/TokenAuth)
-      - [Basic authentication](#section/Authentication/BasicAuth)
-      - [Querystring authentication](#section/Authentication/QuerystringAuth)
+      - [Token authentication](#section/Authentication/TokenAuthentication)
+      - [Basic authentication](#section/Authentication/BasicAuthentication)
+      - [Querystring authentication](#section/Authentication/QuerystringAuthentication)
       <!-- ReDoc-Inject: <security-definitions> -->
     x-traitTag: true
+  - name: Quick start
+    x-traitTag: true
+    description: |
+      See the [**API Quick Start**](https://docs.influxdata.com/influxdb/cloud/api-guide/api_intro/) to get up and running authenticating with tokens, writing to buckets, and querying data.
+
+      [**InfluxDB API client libraries**](https://docs.influxdata.com/influxdb/cloud/api-guide/client-libraries/) are available for popular languages and ready to import into your application.
+  - name: Response codes
+    x-traitTag: true
+    description: |
+      The InfluxDB API uses standard HTTP status codes for success and failure responses.
+      The response body may include additional details. For details about a specific operation's response, see **Responses** and **Response Samples** for that operation.
+
+      API operations may return the following HTTP status codes:
+
+      | &nbsp;Code&nbsp; | Status                   | Description      |
+      |:-----------:|:------------------------ |:--------------------- |
+      | `200`       | Success                  |                       |
+      | `204`       | No content               | For a `POST` request, `204` indicates that InfluxDB accepted the request and request data is valid. Asynchronous operations, such as `write`, might not have completed yet. |
+      | `400`       | Bad request              | `Authorization` header is missing or malformed or the API token does not have permission for the operation. |
+      | `401`       | Unauthorized             | May indicate one of the following: <li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/)</li> |
+      | `404`       | Not found                | Requested resource was not found. `message` in the response body contains details about the requested resource. |
+      | `413`       | Request entity too large | Request payload exceeds the size limit. |
+      | `429`       | Too many requests        | API token is temporarily over the request quota. The `Retry-After` header describes when to try the request again. |
+      | `500`       | Internal server error    |                       |
+      | `503`       | Service unavailable      | Server is temporarily unavailable to process the request. The `Retry-After` header describes when to try the request again. |
   - name: Query
     description: |
       Retrieve data, analyze queries, and get query suggestions.
@@ -23,15 +47,15 @@ tags:
     description: |
       Write time series data to buckets.
   - name: Authorizations
-    description: >
-      Create and manage API tokens. An **authorization** associates a list of
-      permissions to an **organization** and provides a token for API access. To
-      assign a token to a specific user, scope the authorization to the user ID.
+    description: |
+      Create and manage API tokens. An **authorization** associates a list of permissions to an **organization** and provides a token for API access. To assign a token to a specific user, scope the authorization to the user ID.
 x-tagGroups:
-  - name: Get started
+  - name: Overview
     tags:
+      - Quick start
       - Authentication
-  - name: ' '
+      - Response codes
+  - name: Data I/O endpoints
     tags:
       - Write
       - Query
@@ -87,13 +111,11 @@ paths:
     post:
       operationId: PostSignin
       summary: Create a user session.
-      description: >-
-        Authenticates ***Basic Auth*** credentials for a user. If successful,
-        creates a new UI session for the user.
+      description: 'Authenticates ***Basic Auth*** credentials for a user. If successful, creates a new UI session for the user.'
       tags:
         - Signin
       security:
-        - BasicAuth: []
+        - BasicAuthentication: []
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
@@ -146,7 +168,7 @@ paths:
       operationId: GetPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       servers:
-        - url: /
+        - url: ''
       tags:
         - Ping
       responses:
@@ -165,7 +187,7 @@ paths:
       operationId: HeadPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       servers:
-        - url: /
+        - url: ''
       tags:
         - Ping
       responses:
@@ -195,8 +217,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Routes'
-      servers:
-        - url: /
   /documents/templates:
     get:
       operationId: GetDocumentsTemplates
@@ -1079,9 +1099,7 @@ paths:
               $ref: '#/components/schemas/AddResourceMemberRequestBody'
       responses:
         '201':
-          description: >-
-            Telegraf configuration owner was added. Returns a ResourceOwner that
-            references the User.
+          description: Telegraf configuration owner was added. Returns a ResourceOwner that references the User.
           content:
             application/json:
               schema:
@@ -1212,201 +1230,6 @@ paths:
                 $ref: '#/components/schemas/Error'
         default:
           description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /write:
-    post:
-      operationId: PostWrite
-      tags:
-        - Write
-      summary: Write data
-      description: >
-        Writes data to a bucket.
-
-
-        To write data into InfluxDB, you need the following:
-
-        - **organization** – _See [View
-        organizations](https://docs.influxdata.com/influxdb/cloud/organizations/view-orgs/#view-your-organization-id)
-        for instructions on viewing your organization ID._
-
-        - **bucket** – _See [View
-        buckets](https://docs.influxdata.com/influxdb/cloud/organizations/buckets/view-buckets/)
-        for
-         instructions on viewing your bucket ID._
-        - **API token** – _See [View
-        tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/view-tokens/)
-         for instructions on viewing your API token._
-        - **InfluxDB URL** – _See [InfluxDB
-        URLs](https://docs.influxdata.com/influxdb/cloud/reference/urls/)_.
-
-        - data in [line
-        protocol](https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol)
-        format.
-
-
-        For more information and examples, see [Write data with the InfluxDB
-        API](https://docs.influxdata.com/influxdb/cloud/write-data/developer-tools/api).
-      requestBody:
-        description: Data in line protocol format.
-        required: true
-        content:
-          text/plain:
-            schema:
-              type: string
-              format: byte
-      parameters:
-        - $ref: '#/components/parameters/TraceSpan'
-        - in: header
-          name: Content-Encoding
-          description: >-
-            When present, the header value tells the database that compression
-            is applied to the line protocol in the request body.
-          schema:
-            type: string
-            description: >-
-              The header value specifies that the line protocol in the request
-              body is encoded with gzip or not encoded with identity.
-            default: identity
-            enum:
-              - gzip
-              - identity
-        - in: header
-          name: Content-Type
-          description: >-
-            The header value indicates the format of the data in the request
-            body.
-          schema:
-            type: string
-            description: >
-              `text/plain` specifies line protocol. `UTF-8` is the default
-              character set.
-            default: text/plain; charset=utf-8
-            enum:
-              - text/plain
-              - text/plain; charset=utf-8
-              - application/vnd.influx.arrow
-        - in: header
-          name: Content-Length
-          description: >-
-            The header value indicates the size of the entity-body, in bytes,
-            sent to the database. If the length is greater than the database's
-            `max body` configuration option, the server responds with status
-            code `413`.
-          schema:
-            type: integer
-            description: The length in decimal number of octets.
-        - in: header
-          name: Accept
-          description: The header value specifies the response format.
-          schema:
-            type: string
-            description: The response format for errors.
-            default: application/json
-            enum:
-              - application/json
-        - in: query
-          name: org
-          description: >-
-            The parameter value specifies the destination organization for
-            writes. The database writes all points in the batch to this
-            organization. If you provide both `orgID` and `org` parameters,
-            `org` takes precedence.
-          required: true
-          schema:
-            type: string
-            description: Organization name or ID.
-        - in: query
-          name: orgID
-          description: >-
-            The parameter value specifies the ID of the destination organization
-            for writes. If both `orgID` and `org` are specified, `org` takes
-            precedence.
-          schema:
-            type: string
-        - in: query
-          name: bucket
-          description: The destination bucket for writes.
-          required: true
-          schema:
-            type: string
-            description: All points within batch are written to this bucket.
-        - in: query
-          name: precision
-          description: The precision for the unix timestamps within the body line-protocol.
-          schema:
-            $ref: '#/components/schemas/WritePrecision'
-      responses:
-        '204':
-          description: >-
-            InfluxDB validated the request data format and accepted the data for
-            writing to the bucket. `204` doesn't indicate a successful write
-            operation since writes are asynchronous. See [how to check for write
-            errors](https://docs.influxdata.com/influxdb/cloud/write-data/troubleshoot).
-        '400':
-          description: >-
-            Bad request. The line protocol data in the request is malformed. The
-            response body contains the first malformed line in the data.
-            InfluxDB rejected the batch and did not write any data.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LineProtocolError'
-        '401':
-          description: |
-            Unauthorized. The error may indicate one of the following:
-              * The `Authorization: Token` header is missing or malformed.
-              * The API token value is missing from the header.
-              * The token does not have sufficient permissions to write to this organization and bucket.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '404':
-          description: >-
-            Not found. A requested resource was not found. The response body
-            contains the requested resource type, e.g. `organization name` or
-            `bucket`, and name.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '413':
-          description: >-
-            Request entity too large. The payload exceeded the 50MB limit.
-            InfluxDB rejected the batch and did not write any data.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LineProtocolLengthError'
-        '429':
-          description: >-
-            The token is temporarily over quota. The Retry-After header
-            describes when to try the write again.
-          headers:
-            Retry-After:
-              description: >-
-                A non-negative decimal integer indicating the seconds to delay
-                after the response is received.
-              schema:
-                type: integer
-                format: int32
-        '503':
-          description: >-
-            The server is temporarily unavailable to accept writes.  The
-            `Retry-After` header describes when to try the write again.
-          headers:
-            Retry-After:
-              description: >-
-                A non-negative decimal integer indicating the seconds to delay
-                after the response is received.
-              schema:
-                type: integer
-                format: int32
-        default:
-          description: Internal server error
           content:
             application/json:
               schema:
@@ -1642,9 +1465,7 @@ paths:
             type: string
             enum:
               - properties
-          description: >-
-            Includes the cell view properties in the response if set to
-            `properties`
+          description: Includes the cell view properties in the response if set to `properties`
       responses:
         '200':
           description: Retrieve a single dashboard
@@ -1687,9 +1508,7 @@ paths:
                   description: 'optional, when provided will replace the description'
                   type: string
                 cells:
-                  description: >-
-                    optional, when provided will replace all existing cells with
-                    the cells provided
+                  description: 'optional, when provided will replace all existing cells with the cells provided'
                   $ref: '#/components/schemas/CellWithViewProperties'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -1753,9 +1572,7 @@ paths:
         - Cells
         - Dashboards
       summary: Replace cells in a dashboard
-      description: >-
-        Replaces all cells in a dashboard. This is used primarily to update the
-        positional information of all cells.
+      description: Replaces all cells in a dashboard. This is used primarily to update the positional information of all cells.
       requestBody:
         required: true
         content:
@@ -1836,9 +1653,7 @@ paths:
         - Cells
         - Dashboards
       summary: Update the non-positional information related to a cell
-      description: >-
-        Updates the non positional information related to a cell. Updates to a
-        single cell's positional data could cause grid conflicts.
+      description: Updates the non positional information related to a cell. Updates to a single cell's positional data could cause grid conflicts.
       requestBody:
         required: true
         content:
@@ -2403,42 +2218,25 @@ paths:
       tags:
         - Query
       summary: Query data
-      description: >
+      description: |
         Retrieves data from InfluxDB buckets.
 
-
         To query data, you need the following:
-
-        - **organization** – _See [View
-        organizations](https://docs.influxdata.com/influxdb/cloud/organizations/view-orgs/#view-your-organization-id)
-        for instructions on viewing your organization ID._
-
-        - **API token** – _See [View
-        tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/view-tokens/)
+        - **organization** – _See [View organizations](https://docs.influxdata.com/influxdb/cloud/organizations/view-orgs/#view-your-organization-id) for instructions on viewing your organization ID._
+        - **API token** – _See [View tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/view-tokens/)
          for instructions on viewing your API token._
-        - **InfluxDB URL** – _See [InfluxDB
-        URLs](https://docs.influxdata.com/influxdb/cloud/reference/urls/)_.
+        - **InfluxDB URL** – _See [InfluxDB URLs](https://docs.influxdata.com/influxdb/cloud/reference/urls/)_.
+        - [Flux](https://docs.influxdata.com/influxdb/cloud/reference/flux) or [InfluxQL](https://docs.influxdata.com/influxdb/cloud/query-data/influxql/) query.
 
-        - [Flux](https://docs.influxdata.com/influxdb/cloud/reference/flux) or
-        [InfluxQL](https://docs.influxdata.com/influxdb/cloud/query-data/influxql/)
-        query.
-
-
-        For more information and examples, see [Query with the InfluxDB
-        API](https://docs.influxdata.com/influxdb/cloud/query-data/execute-queries/influx-api/).
+        For more information and examples, see [Query with the InfluxDB API](https://docs.influxdata.com/influxdb/cloud/query-data/execute-queries/influx-api/).
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: header
           name: Accept-Encoding
-          description: >-
-            The Accept-Encoding request HTTP header advertises which content
-            encoding, usually a compression algorithm, the client is able to
-            understand.
+          description: 'The Accept-Encoding request HTTP header advertises which content encoding, usually a compression algorithm, the client is able to understand.'
           schema:
             type: string
-            description: >-
-              Specifies that the query response in the body should be encoded
-              with gzip or not encoded with identity.
+            description: Specifies that the query response in the body should be encoded with gzip or not encoded with identity.
             default: identity
             enum:
               - gzip
@@ -2452,17 +2250,12 @@ paths:
               - application/vnd.flux
         - in: query
           name: org
-          description: >-
-            Specifies the name of the organization executing the query. Takes
-            either the ID or Name. If both `orgID` and `org` are specified,
-            `org` takes precedence.
+          description: 'Specifies the name of the organization executing the query. Takes either the ID or Name. If both `orgID` and `org` are specified, `org` takes precedence.'
           schema:
             type: string
         - in: query
           name: orgID
-          description: >-
-            Specifies the ID of the organization executing the query. If both
-            `orgID` and `org` are specified, `org` takes precedence.
+          description: 'Specifies the ID of the organization executing the query. If both `orgID` and `org` are specified, `org` takes precedence.'
           schema:
             type: string
       requestBody:
@@ -2481,23 +2274,16 @@ paths:
           description: Success. Returns query results.
           headers:
             Content-Encoding:
-              description: >-
-                The Content-Encoding entity header is used to compress the
-                media-type.  When present, its value indicates which encodings
-                were applied to the entity-body
+              description: 'The Content-Encoding entity header is used to compress the media-type.  When present, its value indicates which encodings were applied to the entity-body'
               schema:
                 type: string
-                description: >-
-                  Specifies that the response in the body is encoded with gzip
-                  or not encoded with identity.
+                description: Specifies that the response in the body is encoded with gzip or not encoded with identity.
                 default: identity
                 enum:
                   - gzip
                   - identity
             Trace-Id:
-              description: >-
-                The Trace-Id header reports the request's trace ID, if one was
-                generated.
+              description: 'The Trace-Id header reports the request''s trace ID, if one was generated.'
               schema:
                 type: string
                 description: Specifies the request's trace ID.
@@ -2505,24 +2291,17 @@ paths:
             text/csv:
               schema:
                 type: string
-                example: >
-                  result,table,_start,_stop,_time,region,host,_value
-                  mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:00Z,east,A,15.43
-                  mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:20Z,east,B,59.25
-                  mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,east,C,52.62
+                example: |
+                  result,table,_start,_stop,_time,region,host,_value mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:00Z,east,A,15.43 mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:20Z,east,B,59.25 mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,east,C,52.62
             application/vnd.influx.arrow:
               schema:
                 type: string
                 format: binary
         '429':
-          description: >-
-            Token is temporarily over quota. The Retry-After header describes
-            when to try the read again.
+          description: Token is temporarily over quota. The Retry-After header describes when to try the read again.
           headers:
             Retry-After:
-              description: >-
-                A non-negative decimal integer indicating the seconds to delay
-                after the response is received.
+              description: A non-negative decimal integer indicating the seconds to delay after the response is received.
               schema:
                 type: integer
                 format: int32
@@ -3687,21 +3466,15 @@ paths:
               $ref: '#/components/schemas/TemplateApply'
       responses:
         '200':
-          description: >
-            Success. The package dry-run succeeded. No new resources were
-            created. Returns a diff and summary of the dry-run. The diff and
-            summary won't contain IDs for resources that didn't exist at the
-            time of the dry-run.
+          description: |
+            Success. The package dry-run succeeded. No new resources were created. Returns a diff and summary of the dry-run. The diff and summary won't contain IDs for resources that didn't exist at the time of the dry-run.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TemplateSummary'
         '201':
-          description: >
-            Success. The package applied successfully. Returns a diff and
-            summary of the run. The summary contains newly created resources.
-            The diff compares the initial state to the state after the package
-            applied. This corresponds to `"dryRun": true`.
+          description: |
+            Success. The package applied successfully. Returns a diff and summary of the run. The summary contains newly created resources. The diff compares the initial state to the state after the package applied. This corresponds to `"dryRun": true`.
           content:
             application/json:
               schema:
@@ -3729,9 +3502,7 @@ paths:
                 - $ref: '#/components/schemas/TemplateExportByName'
       responses:
         '200':
-          description: >-
-            The template was created successfully. Returns the newly created
-            template.
+          description: The template was created successfully. Returns the newly created template.
           content:
             application/json:
               schema:
@@ -4214,7 +3985,7 @@ paths:
         - Users
       summary: Update a password
       security:
-        - BasicAuth: []
+        - BasicAuthentication: []
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       requestBody:
@@ -4418,7 +4189,7 @@ paths:
         - Users
       summary: Update a password
       security:
-        - BasicAuth: []
+        - BasicAuthentication: []
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4738,9 +4509,7 @@ paths:
         - in: query
           name: orgID
           required: true
-          description: >-
-            Only show notification rules that belong to a specific organization
-            ID.
+          description: Only show notification rules that belong to a specific organization ID.
           schema:
             type: string
         - in: query
@@ -4750,9 +4519,7 @@ paths:
             type: string
         - in: query
           name: tag
-          description: >-
-            Only return notification rules that "would match" statuses which
-            contain the tag key value pairs provided.
+          description: Only return notification rules that "would match" statuses which contain the tag key value pairs provided.
           schema:
             type: string
             pattern: '^[a-zA-Z0-9_]+:[a-zA-Z0-9_]+$'
@@ -5114,9 +4881,7 @@ paths:
         - in: query
           name: orgID
           required: true
-          description: >-
-            Only show notification endpoints that belong to specific
-            organization ID.
+          description: Only show notification endpoints that belong to specific organization ID.
           schema:
             type: string
       responses:
@@ -5506,9 +5271,7 @@ paths:
       tags:
         - Setup
       summary: Retrieve setup status
-      description: >-
-        Check if setup is allowed. Returns `true` if no default user,
-        organization, or bucket have been created.
+      description: 'Check if setup is allowed. Returns `true` if no default user, organization, or bucket have been created.'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
@@ -5523,9 +5286,7 @@ paths:
       tags:
         - Setup
       summary: 'Create an initial user, organization, and bucket'
-      description: >-
-        Post an onboarding request to create an initial user, organization, and
-        bucket.
+      description: 'Post an onboarding request to create an initial user, organization, and bucket.'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       requestBody:
@@ -5551,9 +5312,7 @@ paths:
       tags:
         - Setup
       summary: 'Create a new user, organization, and bucket'
-      description: >-
-        Post an onboarding request to create a new user, organization, and
-        bucket.
+      description: 'Post an onboarding request to create a new user, organization, and bucket.'
       requestBody:
         description: Source to create
         required: true
@@ -6029,42 +5788,31 @@ paths:
               examples:
                 badNameExample:
                   summary: Invalid name
-                  description: >-
-                    The error returned when the name is invalid, such as too few
-                    or too many characters or the name contains non-printable
-                    ASCII or is not valid UTF-8.
+                  description: 'The error returned when the name is invalid, such as too few or too many characters or the name contains non-printable ASCII or is not valid UTF-8.'
                   value:
                     code: invalid
                     message: name is invalid
                 missingColumnsExample:
                   summary: Missing columns
-                  description: >-
-                    The error returned when the request body is missing the
-                    columns property.
+                  description: The error returned when the request body is missing the columns property.
                   value:
                     code: invalid
                     message: columns is required
                 missingTimestampExample:
                   summary: Missing timestamp
-                  description: >-
-                    The error returned when the request body is missing a
-                    timestamp type column.
+                  description: The error returned when the request body is missing a timestamp type column.
                   value:
                     code: invalid
                     message: Timestamp column is required
                 duplicateColumnNamesExample:
                   summary: Duplicate column names
-                  description: >-
-                    The error returned when the request body contains duplicate
-                    column names.
+                  description: The error returned when the request body contains duplicate column names.
                   value:
                     code: invalid
                     message: Duplicate column names
                 missingFieldExample:
                   summary: Missing field
-                  description: >-
-                    The error returned when the request body is missing at least
-                    one field type column.
+                  description: The error returned when the request body is missing at least one field type column.
                   value:
                     code: invalid
                     message: At least one field column is required
@@ -6159,9 +5907,7 @@ paths:
               examples:
                 missingColumnsExample:
                   summary: Deleted columns
-                  description: >-
-                    The error returned when the request body does not contain
-                    all the columns from the source.
+                  description: The error returned when the request body does not contain all the columns from the source.
                   value:
                     code: invalid
                     message: Unable to delete columns from schema
@@ -6231,15 +5977,10 @@ paths:
           description: Usage data
           headers:
             Content-Encoding:
-              description: >-
-                The Content-Encoding entity header is used to compress the
-                media-type. When present, its value indicates which encodings
-                were applied to the entity-body
+              description: 'The Content-Encoding entity header is used to compress the media-type. When present, its value indicates which encodings were applied to the entity-body'
               schema:
                 type: string
-                description: >-
-                  Specifies that the response in the body is encoded with gzip
-                  or not encoded with identity.
+                description: Specifies that the response in the body is encoded with gzip or not encoded with identity.
                 default: identity
                 enum:
                   - gzip
@@ -6248,13 +5989,8 @@ paths:
             text/csv:
               schema:
                 type: string
-                example: >
-                  #group,false,false,true,true,false,false,true,true,true,true
-                  #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
-                  #default,_result,,,,,,,,,
-                  ,result,table,_start,_stop,_time,_value,_field,_measurement,bucket_id,org_id
-                  ,,0,2021-05-10T14:25:10.865702397Z,2021-05-10T15:25:10.865702397Z,2021-05-10T15:00:00Z,5434066,gauge,storage_usage_bucket_bytes,2f6ba0cf9a2fdcbb,cec6fc1d2176dc11
-                  ,,1,2021-05-10T14:25:10.865702397Z,2021-05-10T15:25:10.865702397Z,2021-05-10T15:00:00Z,9924053.966666665,gauge,storage_usage_bucket_bytes,8af67bcaf69d9daf,cec6fc1d2176dc11
+                example: |
+                  #group,false,false,true,true,false,false,true,true,true,true #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string #default,_result,,,,,,,,, ,result,table,_start,_stop,_time,_value,_field,_measurement,bucket_id,org_id ,,0,2021-05-10T14:25:10.865702397Z,2021-05-10T15:25:10.865702397Z,2021-05-10T15:00:00Z,5434066,gauge,storage_usage_bucket_bytes,2f6ba0cf9a2fdcbb,cec6fc1d2176dc11 ,,1,2021-05-10T14:25:10.865702397Z,2021-05-10T15:25:10.865702397Z,2021-05-10T15:00:00Z,9924053.966666665,gauge,storage_usage_bucket_bytes,8af67bcaf69d9daf,cec6fc1d2176dc11
         default:
           description: unexpected error
           $ref: '#/components/responses/ServerError'
@@ -6307,9 +6043,7 @@ paths:
           description: The non-zero number of dashboards to return
         - in: query
           name: owner
-          description: >-
-            A user identifier. Returns only dashboards where this user has the
-            `owner` role.
+          description: A user identifier. Returns only dashboards where this user has the `owner` role.
           schema:
             type: string
         - in: query
@@ -6323,9 +6057,7 @@ paths:
               - UpdatedAt
         - in: query
           name: id
-          description: >-
-            A list of dashboard identifiers. Returns only the listed dashboards.
-            If both `id` and `owner` are specified, only `id` is used.
+          description: 'A list of dashboard identifiers. Returns only the listed dashboards. If both `id` and `owner` are specified, only `id` is used.'
           schema:
             type: array
             items:
@@ -6452,6 +6184,187 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /write:
+    post:
+      operationId: PostWrite
+      tags:
+        - Write
+      summary: Write data
+      description: |
+        Writes data to a bucket.
+
+        To write data into InfluxDB, you need the following:
+
+        - **organization name or ID** – _See [View organizations](https://docs.influxdata.com/influxdb/cloud/organizations/view-orgs/#view-your-organization-id) for instructions on viewing your organization ID._
+        - **bucket** – _See [View buckets](https://docs.influxdata.com/influxdb/cloud/organizations/buckets/view-buckets/) for
+         instructions on viewing your bucket ID._
+        - **API token** – _See [View tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/view-tokens/)
+         for instructions on viewing your API token._
+        - **InfluxDB URL** – _See [InfluxDB URLs](https://docs.influxdata.com/influxdb/cloud/reference/urls/)_.
+        - data in [line protocol](https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol) format.
+
+        For more information and examples, see [Write data with the InfluxDB API](https://docs.influxdata.com/influxdb/cloud/write-data/developer-tools/api).
+      requestBody:
+        description: Data in line protocol format.
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+              format: byte
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: header
+          name: Content-Encoding
+          description: 'When present, the header value tells the database that compression is applied to the line protocol in the request body.'
+          schema:
+            type: string
+            description: The header value specifies that the line protocol in the request body is encoded with gzip or not encoded with identity.
+            default: identity
+            enum:
+              - gzip
+              - identity
+        - in: header
+          name: Content-Type
+          description: The header value indicates the format of the data in the request body.
+          schema:
+            type: string
+            description: |
+              `text/plain` specifies line protocol. `UTF-8` is the default character set.
+            default: text/plain; charset=utf-8
+            enum:
+              - text/plain
+              - text/plain; charset=utf-8
+              - application/vnd.influx.arrow
+        - in: header
+          name: Content-Length
+          description: 'The header value indicates the size of the entity-body, in bytes, sent to the database. If the length is greater than the database''s `max body` configuration option, the server responds with status code `413`.'
+          schema:
+            type: integer
+            description: The length in decimal number of octets.
+        - in: header
+          name: Accept
+          description: The header value specifies the response format.
+          schema:
+            type: string
+            description: The response format for errors.
+            default: application/json
+            enum:
+              - application/json
+        - in: query
+          name: org
+          description: 'The parameter value specifies the destination organization for writes. The database writes all points in the batch to this organization. If you provide both `orgID` and `org` parameters, `org` takes precedence.'
+          required: true
+          schema:
+            type: string
+            description: Organization name or ID.
+        - in: query
+          name: orgID
+          description: 'The parameter value specifies the ID of the destination organization for writes. If both `orgID` and `org` are specified, `org` takes precedence.'
+          schema:
+            type: string
+        - in: query
+          name: bucket
+          description: The destination bucket for writes.
+          required: true
+          schema:
+            type: string
+            description: All points within batch are written to this bucket.
+        - in: query
+          name: precision
+          description: The precision for the unix timestamps within the body line-protocol.
+          schema:
+            $ref: '#/components/schemas/WritePrecision'
+      responses:
+        '204':
+          description: 'InfluxDB validated the request data format and accepted the data for writing to the bucket. `204` doesn''t indicate a successful write operation since writes are asynchronous. See [how to check for write errors](https://docs.influxdata.com/influxdb/cloud/write-data/troubleshoot).'
+        '400':
+          description: Bad request. The line protocol data in the request is malformed. The response body contains the first malformed line in the data. InfluxDB rejected the batch and did not write any data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LineProtocolError'
+              examples:
+                measurementSchemaFieldTypeConflict:
+                  summary: Field type conflict thrown by an explicit bucket schema
+                  value:
+                    code: invalid
+                    message: 'partial write error (2 written): unable to parse ''air_sensor,service=S1,sensor=L1 temperature="90.5",humidity=70.0 1632850122'': schema: field type for field "temperature" not permitted by schema; got String but expected Float'
+        '401':
+          description: |
+            Unauthorized. The error may indicate one of the following:
+              * The `Authorization: Token` header is missing or malformed.
+              * The API token value is missing from the header.
+              * The token does not have sufficient permissions to write to this organization and bucket.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                tokenNotAuthorized:
+                  summary: Token is not authorized to access the organization or resource
+                  value:
+                    code: unauthorized
+                    message: unauthorized access
+        '404':
+          description: 'Not found. A requested resource was not found. The response body contains the requested resource type, e.g. `organization name` or `bucket`, and name.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                resource-not-found:
+                  summary: Not found error
+                  value:
+                    code: not found
+                    message: bucket "air_sensor" not found
+        '413':
+          description: Request entity too large. The payload exceeded the 50MB size limit. InfluxDB rejected the batch and did not write any data.
+          content:
+            text/html:
+              schema:
+                type: string
+              examples:
+                dataExceedsSizeLimit:
+                  summary: Cloud response
+                  value: |
+                    <html>
+                      <head><title>413 Request Entity Too Large</title></head>
+                      <body>
+                        <center><h1>413 Request Entity Too Large</h1></center>
+                        <hr>
+                        <center>nginx</center>
+                      </body>
+                    </html>
+        '429':
+          description: The token is temporarily over quota. The Retry-After header describes when to try the write again.
+          headers:
+            Retry-After:
+              description: A non-negative decimal integer indicating the seconds to delay after the response is received.
+              schema:
+                type: integer
+                format: int32
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internalError:
+                  summary: Internal error example
+                  value:
+                    code: internal error
+        '503':
+          description: The server is temporarily unavailable to accept writes.  The `Retry-After` header describes when to try the write again.
+          headers:
+            Retry-After:
+              description: A non-negative decimal integer indicating the seconds to delay after the response is received.
+              schema:
+                type: integer
+                format: int32
+        default:
+          $ref: '#/components/responses/ServerError'
 components:
   parameters:
     TraceSpan:
@@ -6501,9 +6414,8 @@ components:
       required: false
       schema:
         type: string
-      description: >
-        The last resource ID from which to seek from (but not including). This
-        is to be used instead of `offset`.
+      description: |
+        The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.
   schemas:
     LanguageRequest:
       description: Flux query to be analyzed.
@@ -6533,16 +6445,12 @@ components:
         params:
           type: object
           additionalProperties: true
-          description: >
-            Enumeration of key/value pairs that respresent parameters to be
-            injected into query (can only specify either this field or extern
-            and not both)
+          description: |
+            Enumeration of key/value pairs that respresent parameters to be injected into query (can only specify either this field or extern and not both)
         dialect:
           $ref: '#/components/schemas/Dialect'
         now:
-          description: >-
-            Specifies the time that should be reported as "now" in the query.
-            Default is the server's now time.
+          description: Specifies the time that should be reported as "now" in the query. Default is the server's now time.
           type: string
           format: date-time
     InfluxQLQuery:
@@ -6560,9 +6468,7 @@ components:
           enum:
             - influxql
         bucket:
-          description: >-
-            Bucket is to be used instead of the database and retention policy
-            specified in the InfluxQL query.
+          description: Bucket is to be used instead of the database and retention policy specified in the InfluxQL query.
           type: string
     Package:
       description: Represents a complete package source tree.
@@ -6668,9 +6574,7 @@ components:
         - $ref: '#/components/schemas/BuiltinStatement'
         - $ref: '#/components/schemas/TestStatement'
     BadStatement:
-      description: >-
-        A placeholder for statements for which no correct statement nodes can be
-        created
+      description: A placeholder for statements for which no correct statement nodes can be created
       type: object
       properties:
         type:
@@ -6699,9 +6603,7 @@ components:
         init:
           $ref: '#/components/schemas/Expression'
     ExpressionStatement:
-      description: >-
-        May consist of an expression that does not return a value and is
-        executed solely for its side-effects
+      description: May consist of an expression that does not return a value and is executed solely for its side-effects
       type: object
       properties:
         type:
@@ -6838,9 +6740,7 @@ components:
           items:
             $ref: '#/components/schemas/Expression'
     ConditionalExpression:
-      description: >-
-        Selects one of two expressions, `Alternate` or `Consequent`, depending
-        on a third boolean expression, `Test`
+      description: 'Selects one of two expressions, `Alternate` or `Consequent`, depending on a third boolean expression, `Test`'
       type: object
       properties:
         type:
@@ -6852,9 +6752,7 @@ components:
         consequent:
           $ref: '#/components/schemas/Expression'
     LogicalExpression:
-      description: >-
-        Represents the rule conditions that collectively evaluate to either true
-        or false
+      description: Represents the rule conditions that collectively evaluate to either true or false
       type: object
       properties:
         type:
@@ -6933,9 +6831,7 @@ components:
         value:
           type: boolean
     DateTimeLiteral:
-      description: >-
-        Represents an instant in time with nanosecond precision using the syntax
-        of golang's RFC3339 Nanosecond variant
+      description: Represents an instant in time with nanosecond precision using the syntax of golang's RFC3339 Nanosecond variant
       type: object
       properties:
         type:
@@ -6944,9 +6840,7 @@ components:
           type: string
           format: date-time
     DurationLiteral:
-      description: >-
-        Represents the elapsed time between two instants as an int64 nanosecond
-        count with syntax of golang's time.Duration
+      description: Represents the elapsed time between two instants as an int64 nanosecond count with syntax of golang's time.Duration
       type: object
       properties:
         type:
@@ -6957,9 +6851,7 @@ components:
           items:
             $ref: '#/components/schemas/Duration'
     FloatLiteral:
-      description: >-
-        Represents floating point numbers according to the double
-        representations defined by the IEEE-754-1985
+      description: Represents floating point numbers according to the double representations defined by the IEEE-754-1985
       type: object
       properties:
         type:
@@ -6975,17 +6867,13 @@ components:
         value:
           type: string
     PipeLiteral:
-      description: >-
-        Represents a specialized literal value, indicating the left hand value
-        of a pipe expression
+      description: 'Represents a specialized literal value, indicating the left hand value of a pipe expression'
       type: object
       properties:
         type:
           $ref: '#/components/schemas/NodeType'
     RegexpLiteral:
-      description: >-
-        Expressions begin and end with `/` and are regular expressions with
-        syntax accepted by RE2
+      description: Expressions begin and end with `/` and are regular expressions with syntax accepted by RE2
       type: object
       properties:
         type:
@@ -7009,9 +6897,7 @@ components:
         value:
           type: string
     Duration:
-      description: >-
-        A pair consisting of length of time and the unit of time measured. It is
-        the atomic unit from which all duration literals are composed.
+      description: A pair consisting of length of time and the unit of time measured. It is the atomic unit from which all duration literals are composed.
       type: object
       properties:
         type:
@@ -7043,9 +6929,7 @@ components:
         name:
           type: string
     Dialect:
-      description: >-
-        Dialect are options to change the default CSV output format;
-        https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions
+      description: 'Dialect are options to change the default CSV output format; https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions'
       type: object
       properties:
         header:
@@ -7084,9 +6968,7 @@ components:
     AuthorizationUpdateRequest:
       properties:
         status:
-          description: >-
-            If inactive the token is inactive and requests using the token will
-            be rejected.
+          description: If inactive the token is inactive and requests using the token will be rejected.
           default: active
           type: string
           enum:
@@ -7223,9 +7105,7 @@ components:
         everySeconds:
           type: integer
           format: int64
-          description: >-
-            Duration in seconds for how long data will be kept in the database.
-            0 means infinite.
+          description: Duration in seconds for how long data will be kept in the database. 0 means infinite.
           example: 86400
           minimum: 0
         shardGroupDurationSeconds:
@@ -7245,9 +7125,7 @@ components:
         everySeconds:
           type: integer
           format: int64
-          description: >-
-            Duration in seconds for how long data will be kept in the database.
-            0 means infinite.
+          description: Duration in seconds for how long data will be kept in the database. 0 means infinite.
           example: 86400
           minimum: 0
         shardGroupDurationSeconds:
@@ -7520,10 +7398,7 @@ components:
                 $ref: '#/components/schemas/TemplateKind'
               name:
                 type: string
-                description: >-
-                  if defined with id, name is used for resource exported by id.
-                  if defined independently, resources strictly matching name are
-                  exported
+                description: 'if defined with id, name is used for resource exported by id. if defined independently, resources strictly matching name are exported'
             required:
               - id
               - kind
@@ -7588,9 +7463,7 @@ components:
             description: Field the environment reference corresponds too
           envRefKey:
             type: string
-            description: >-
-              Key identified as environment reference and is the key identified
-              in the template
+            description: Key identified as environment reference and is the key identified in the template
           value:
             description: Value provided to fulfill reference
             nullable: true
@@ -7600,9 +7473,7 @@ components:
               - type: number
               - type: boolean
           defaultValue:
-            description: >-
-              Default value that will be provided for the reference when no
-              value is provided
+            description: Default value that will be provided for the reference when no value is provided
             nullable: true
             oneOf:
               - type: string
@@ -8395,9 +8266,7 @@ components:
       properties:
         scheduledFor:
           nullable: true
-          description: >-
-            Time used for run's "now" option, RFC3339.  Default is the server's
-            now time.
+          description: 'Time used for run''s "now" option, RFC3339.  Default is the server''s now time.'
           type: string
           format: date-time
     Tasks:
@@ -8417,9 +8286,7 @@ components:
           readOnly: true
           type: string
         type:
-          description: >-
-            The type of task, this can be used for filtering tasks on list
-            actions.
+          description: 'The type of task, this can be used for filtering tasks on list actions.'
           type: string
         orgID:
           description: The ID of the organization that owns this Task.
@@ -8441,9 +8308,7 @@ components:
         labels:
           $ref: '#/components/schemas/Labels'
         authorizationID:
-          description: >-
-            The ID of the authorization used when this task communicates with
-            the query engine.
+          description: The ID of the authorization used when this task communicates with the query engine.
           type: string
         flux:
           description: The Flux script to run for this task.
@@ -8452,15 +8317,10 @@ components:
           description: A simple task repetition schedule; parsed from Flux.
           type: string
         cron:
-          description: >-
-            A task repetition schedule in the form '* * * * * *'; parsed from
-            Flux.
+          description: A task repetition schedule in the form '* * * * * *'; parsed from Flux.
           type: string
         offset:
-          description: >-
-            Duration to delay after the schedule, before executing the task;
-            parsed from flux, if set to zero it will remove this option and use
-            0 as the default.
+          description: 'Duration to delay after the schedule, before executing the task; parsed from flux, if set to zero it will remove this option and use 0 as the default.'
           type: string
         latestCompleted:
           description: 'Timestamp of latest scheduled, completed run, RFC3339.'
@@ -8716,15 +8576,11 @@ components:
           type: string
         op:
           readOnly: true
-          description: >-
-            op describes the logical code operation during error. Useful for
-            debugging.
+          description: op describes the logical code operation during error. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: >-
-            err is a stack of errors that occurred during processing of the
-            request. Useful for debugging.
+          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
@@ -8748,15 +8604,11 @@ components:
           type: string
         op:
           readOnly: true
-          description: >-
-            Op describes the logical code operation during error. Useful for
-            debugging.
+          description: Op describes the logical code operation during error. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: >-
-            Err is a stack of errors that occurred during processing of the
-            request. Useful for debugging.
+          description: Err is a stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
         line:
           readOnly: true
@@ -8793,14 +8645,10 @@ components:
       type: object
       properties:
         value:
-          description: >-
-            value is the value of the field.  Meaning of the value is implied by
-            the `type` key
+          description: value is the value of the field.  Meaning of the value is implied by the `type` key
           type: string
         type:
-          description: >-
-            `type` describes the field type. `func` is a function. `field` is a
-            field reference.
+          description: '`type` describes the field type. `func` is a function. `field` is a field reference.'
           type: string
           enum:
             - func
@@ -8810,9 +8658,7 @@ components:
             - regex
             - wildcard
         alias:
-          description: >-
-            Alias overrides the field name in the returned response.  Applies
-            only if type is `func`
+          description: Alias overrides the field name in the returned response.  Applies only if type is `func`
           type: string
         args:
           description: Args are the arguments to the function
@@ -8887,9 +8733,7 @@ components:
           type: array
           minItems: 0
           maxItems: 2
-          description: >-
-            The extents of an axis in the form [lower, upper]. Clients determine
-            whether bounds are to be inclusive or exclusive of their limits
+          description: 'The extents of an axis in the form [lower, upper]. Clients determine whether bounds are to be inclusive or exclusive of their limits'
           items:
             type: string
         label:
@@ -9792,37 +9636,27 @@ components:
           type: object
           properties:
             verticalTimeAxis:
-              description: >-
-                verticalTimeAxis describes the orientation of the table by
-                indicating whether the time axis will be displayed vertically
+              description: verticalTimeAxis describes the orientation of the table by indicating whether the time axis will be displayed vertically
               type: boolean
             sortBy:
               $ref: '#/components/schemas/RenamableField'
             wrapping:
-              description: >-
-                Wrapping describes the text wrapping style to be used in table
-                views
+              description: Wrapping describes the text wrapping style to be used in table views
               type: string
               enum:
                 - truncate
                 - wrap
                 - single-line
             fixFirstColumn:
-              description: >-
-                fixFirstColumn indicates whether the first column of the table
-                should be locked
+              description: fixFirstColumn indicates whether the first column of the table should be locked
               type: boolean
         fieldOptions:
-          description: >-
-            fieldOptions represent the fields retrieved by the query with
-            customization options
+          description: fieldOptions represent the fields retrieved by the query with customization options
           type: array
           items:
             $ref: '#/components/schemas/RenamableField'
         timeFormat:
-          description: >-
-            timeFormat describes the display format for time values according to
-            moment.js date formatting
+          description: timeFormat describes the display format for time values according to moment.js date formatting
           type: string
         decimalPlaces:
           $ref: '#/components/schemas/DecimalPlaces'
@@ -10092,9 +9926,7 @@ components:
           type: boolean
           default: true
         detectCoordinateFields:
-          description: >-
-            If true, search results get automatically regroupped so that lon,lat
-            and value are treated as columns
+          description: 'If true, search results get automatically regroupped so that lon,lat and value are treated as columns'
           type: boolean
           default: true
         useS2CellID:
@@ -10180,9 +10012,7 @@ components:
           type: number
           format: float
     DecimalPlaces:
-      description: >-
-        Indicates whether decimal places should be enforced, and how many digits
-        it should show.
+      description: 'Indicates whether decimal places should be enforced, and how many digits it should show.'
       type: object
       properties:
         isEnforced:
@@ -10695,9 +10525,7 @@ components:
       type: object
       properties:
         allowed:
-          description: >-
-            True means that the influxdb instance has NOT had initial setup;
-            false means that the database has been setup.
+          description: True means that the influxdb instance has NOT had initial setup; false means that the database has been setup.
           type: boolean
     PasswordResetBody:
       properties:
@@ -10770,9 +10598,7 @@ components:
           type: object
           additionalProperties:
             type: string
-          description: >-
-            Key/Value pairs associated with this label. Keys can be removed by
-            sending an update with an empty value.
+          description: Key/Value pairs associated with this label. Keys can be removed by sending an update with an empty value.
           example:
             color: ffb3b3
             description: this is a description
@@ -10790,9 +10616,7 @@ components:
           type: object
           additionalProperties:
             type: string
-          description: >-
-            Key/Value pairs associated with this label. Keys can be removed by
-            sending an update with an empty value.
+          description: Key/Value pairs associated with this label. Keys can be removed by sending an update with an empty value.
           example:
             color: ffb3b3
             description: this is a description
@@ -10805,9 +10629,7 @@ components:
           type: object
           additionalProperties:
             type: string
-          description: >-
-            Key/Value pairs associated with this label. Keys can be removed by
-            sending an update with an empty value.
+          description: Key/Value pairs associated with this label. Keys can be removed by sending an update with an empty value.
           example:
             color: ffb3b3
             description: this is a description
@@ -11065,9 +10887,7 @@ components:
               description: String duration before deadman triggers.
               type: string
             staleTime:
-              description: >-
-                String duration for time that a series is considered stale and
-                should not trigger deadman.
+              description: String duration for time that a series is considered stale and should not trigger deadman.
               type: string
             reportZero:
               description: 'If only zero values reported since time, trigger an alert'
@@ -11286,14 +11106,10 @@ components:
         runbookLink:
           type: string
         limitEvery:
-          description: >-
-            Don't notify me more than <limit> times every <limitEvery> seconds.
-            If set, limit cannot be empty.
+          description: 'Don''t notify me more than <limit> times every <limitEvery> seconds. If set, limit cannot be empty.'
           type: integer
         limit:
-          description: >-
-            Don't notify me more than <limit> times every <limitEvery> seconds.
-            If set, limitEvery cannot be empty.
+          description: 'Don''t notify me more than <limit> times every <limitEvery> seconds. If set, limitEvery cannot be empty.'
           type: integer
         tagRules:
           description: List of tag rules the notification rule attempts to match.
@@ -11443,9 +11259,7 @@ components:
         - channel
       properties:
         type:
-          description: >-
-            The discriminator between other types of notification rules is
-            "telegram".
+          description: The discriminator between other types of notification rules is "telegram".
           type: string
           enum:
             - telegram
@@ -11453,19 +11267,14 @@ components:
           description: The message template as a flux interpolated string.
           type: string
         parseMode:
-          description: >-
-            Parse mode of the message text per
-            https://core.telegram.org/bots/api#formatting-options . Defaults to
-            "MarkdownV2" .
+          description: 'Parse mode of the message text per https://core.telegram.org/bots/api#formatting-options . Defaults to "MarkdownV2" .'
           type: string
           enum:
             - MarkdownV2
             - HTML
             - Markdown
         disableWebPagePreview:
-          description: >-
-            Disables preview of web links in the sent messages when "true".
-            Defaults to "false" .
+          description: Disables preview of web links in the sent messages when "true". Defaults to "false" .
           type: boolean
     NotificationEndpointUpdate:
       type: object
@@ -11570,9 +11379,7 @@ components:
         - type: object
           properties:
             url:
-              description: >-
-                Specifies the URL of the Slack endpoint. Specify either `URL` or
-                `Token`.
+              description: Specifies the URL of the Slack endpoint. Specify either `URL` or `Token`.
               type: string
             token:
               description: Specifies the API token string. Specify either `URL` or `Token`.
@@ -11636,14 +11443,10 @@ components:
             - channel
           properties:
             token:
-              description: >-
-                Specifies the Telegram bot token. See
-                https://core.telegram.org/bots#creating-a-new-bot .
+              description: 'Specifies the Telegram bot token. See https://core.telegram.org/bots#creating-a-new-bot .'
               type: string
             channel:
-              description: >-
-                ID of the telegram channel, a chat_id in
-                https://core.telegram.org/bots/api#sendmessage .
+              description: 'ID of the telegram channel, a chat_id in https://core.telegram.org/bots/api#sendmessage .'
               type: string
     NotificationEndpointType:
       type: string
@@ -11673,9 +11476,7 @@ components:
           description: InfluxDB v1 retention policy
         default:
           type: boolean
-          description: >-
-            Specify if this mapping represents the default retention policy for
-            the database specificed.
+          description: Specify if this mapping represents the default retention policy for the database specificed.
         links:
           $ref: '#/components/schemas/Links'
       required:
@@ -11718,9 +11519,7 @@ components:
           description: InfluxDB v1 retention policy
         default:
           type: boolean
-          description: >-
-            Specify if this mapping represents the default retention policy for
-            the database specificed.
+          description: Specify if this mapping represents the default retention policy for the database specificed.
       required:
         - bucketID
         - database
@@ -11840,9 +11639,7 @@ components:
         id:
           type: string
           nullable: true
-          description: >-
-            If ID is set that is a permission for a specific resource. if it is
-            not set it is a permission for all resources of that resource type.
+          description: If ID is set that is a permission for a specific resource. if it is not set it is a permission for all resources of that resource type.
         name:
           type: string
           nullable: true
@@ -11850,10 +11647,7 @@ components:
         orgID:
           type: string
           nullable: true
-          description: >-
-            If orgID is set that is a permission for all resources owned my that
-            org. if it is not set it is a permission for all resources of that
-            resource type.
+          description: If orgID is set that is a permission for all resources owned my that org. if it is not set it is a permission for all resources of that resource type.
         org:
           type: string
           nullable: true
@@ -11892,9 +11686,7 @@ components:
             permissions:
               type: array
               minItems: 1
-              description: >-
-                List of permissions for an auth.  An auth must have at least one
-                Permission.
+              description: List of permissions for an auth.  An auth must have at least one Permission.
               items:
                 $ref: '#/components/schemas/Permission'
             id:
@@ -11903,9 +11695,7 @@ components:
             token:
               readOnly: true
               type: string
-              description: >-
-                Passed via the Authorization Header and Token Authentication
-                type.
+              description: Passed via the Authorization Header and Token Authentication type.
             userID:
               readOnly: true
               type: string
@@ -12219,6 +12009,8 @@ components:
       type: object
       example:
         id: 1a3c5e7f9b0a8642
+        orgID: 0a3c5e7f9b0a0001
+        bucketID: ba3c5e7f9b0a0010
         name: cpu
         columns:
           - name: time
@@ -12245,6 +12037,12 @@ components:
         id:
           type: string
           readOnly: true
+        orgID:
+          type: string
+          description: ID of organization that the measurement schema is associated with.
+        bucketID:
+          type: string
+          description: ID of the bucket that the measurement schema is associated with.
         name:
           type: string
           nullable: false
@@ -12311,14 +12109,20 @@ components:
       example:
         measurementSchemas:
           - id: 1a3c5e7f9b0a8642
+            orgID: 0a3c5e7f9b0a0001
+            bucketID: ba3c5e7f9b0a0010
             name: cpu
             createdAt: '2021-01-21T00:48:40.993Z'
             updatedAt: '2021-01-21T00:48:40.993Z'
           - id: 1a3c5e7f9b0a8643
+            orgID: 0a3c5e7f9b0a0001
+            bucketID: ba3c5e7f9b0a0010
             name: memory
             createdAt: '2021-01-21T00:48:40.993Z'
             updatedAt: '2021-01-21T00:48:40.993Z'
           - id: 1a3c5e7f9b0a8644
+            orgID: 0a3c5e7f9b0a0001
+            bucketID: ba3c5e7f9b0a0010
             name: disk
             createdAt: '2021-01-21T00:48:40.993Z'
             updatedAt: '2021-01-21T00:48:40.993Z'
@@ -12363,22 +12167,18 @@ components:
           schema:
             $ref: '#/components/schemas/Error'
   securitySchemes:
-    TokenAuth:
+    TokenAuthentication:
       type: http
       scheme: token
       bearerFormat: InfluxDB Token String
-      description: >
-        InfluxDB API tokens ensure secure interaction between users and data. A
-        token belongs to an organization and identifies InfluxDB permissions
-        within the organization.
+      description: |
+        ### Token authentication scheme
 
+        InfluxDB API tokens ensure secure interaction between users and data. A token belongs to an organization and identifies InfluxDB permissions within the organization.
 
-        Include your API token in an `Authentication: Token YOUR_API_TOKEN` HTTP
-        header with each request.
-
+        Include your API token in an `Authentication: Token YOUR_API_TOKEN` HTTP header with each request.
 
         ### Example
-
 
         `curl https://us-east-1-1.aws.cloud2.influxdata.com/
               --header "Authentication: Token YOUR_API_TOKEN"`
@@ -12387,52 +12187,43 @@ components:
           - [Use tokens in API requests](https://docs.influxdata.com/influxdb/cloud/api-guide/api_intro/#authentication).
           - [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens).
           - [`/authorizations`](#tag/Authorizations) endpoint.
-    BasicAuth:
+    BasicAuthentication:
       type: http
       scheme: basic
-      description: >
-        Use Basic authentication with clients that support the InfluxDB 1.x
-        convention of username and password (that don't support the
-        `Authorization: Token` scheme):
+      description: |
+        ### Basic authentication scheme
+
+        Use HTTP Basic Auth with clients that support the InfluxDB 1.x convention of username and password (that don't support the `Authorization: Token` scheme):
           - **username**: InfluxDB Cloud username
           - **password**: InfluxDB Cloud API token
 
         ### Example
 
-
         `curl --get "https://europe-west1-1.gcp.cloud2.influxdata.com/query"
               --user "YOUR_USERNAME":"YOUR_TOKEN_OR_PASSWORD"`
 
-        For more information and examples, see how to [authenticate with a
-        username and password
-        scheme](https://docs.influxdata.com/influxdb/cloud/reference/api/influxdb-1x/).
-    QuerystringAuth:
+        For more information and examples, see how to [authenticate with a username and password scheme](https://docs.influxdata.com/influxdb/cloud/reference/api/influxdb-1x/).
+    QuerystringAuthentication:
       type: apiKey
       in: query
       name: u=&p=
-      description: >
-        Use InfluxDB 1.x API parameters to provide credentials through the query
-        string.
+      description: |
+        ### Querystring authentication scheme
 
+        Use InfluxDB 1.x API parameters to provide credentials through the query string.
 
         Username and password schemes require the following credentials:
-
         - **username**: InfluxDB Cloud username
-
         - **password**: InfluxDB Cloud API token
 
-
         ### Example
-
 
         `curl --get "https://europe-west1-1.gcp.cloud2.influxdata.com/query"
               --data-urlencode "u=YOUR_USERNAME"
               --data-urlencode "p=YOUR_TOKEN_OR_PASSWORD"`
 
-        For more information and examples, see how to [authenticate with a
-        username and password
-        scheme](https://docs.influxdata.com/influxdb/cloud/reference/api/influxdb-1x/).
+        For more information and examples, see how to [authenticate with a username and password scheme](https://docs.influxdata.com/influxdb/cloud/reference/api/influxdb-1x/).
 security:
-  - TokenAuth: []
-  - BasicAuth: []
-  - QuerystringAuth: []
+  - TokenAuthentication: []
+  - BasicAuthentication: []
+  - QuerystringAuthentication: []

--- a/api-docs/v2.0/swagger.yml
+++ b/api-docs/v2.0/swagger.yml
@@ -2,20 +2,44 @@ openapi: 3.0.0
 info:
   title: Influx OSS API Service
   version: 2.0.0
-  description: >
-    The InfluxDB v2 API provides a programmatic interface for all interactions
-    with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.
+  description: |
+    The InfluxDB v2 API provides a programmatic interface for all interactions with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.
 servers:
   - url: /api/v2
 tags:
   - name: Authentication
     description: |
       Use one of the following schemes to authenticate to the InfluxDB API:
-      - [Token authentication](#section/Authentication/TokenAuth)
-      - [Basic authentication](#section/Authentication/BasicAuth)
-      - [Querystring authentication](#section/Authentication/QuerystringAuth)
+      - [Token authentication](#section/Authentication/TokenAuthentication)
+      - [Basic authentication](#section/Authentication/BasicAuthentication)
+      - [Querystring authentication](#section/Authentication/QuerystringAuthentication)
       <!-- ReDoc-Inject: <security-definitions> -->
     x-traitTag: true
+  - name: Quick start
+    x-traitTag: true
+    description: |
+      See the [**API Quick Start**](https://docs.influxdata.com/influxdb/v2.0/api-guide/api_intro/) to get up and running authenticating with tokens, writing to buckets, and querying data.
+
+      [**InfluxDB API client libraries**](https://docs.influxdata.com/influxdb/v2.0/api-guide/client-libraries/) are available for popular languages and ready to import into your application.
+  - name: Response codes
+    x-traitTag: true
+    description: |
+      The InfluxDB API uses standard HTTP status codes for success and failure responses.
+      The response body may include additional details. For details about a specific operation's response, see **Responses** and **Response Samples** for that operation.
+
+      API operations may return the following HTTP status codes:
+
+      | &nbsp;Code&nbsp; | Status                   | Description      |
+      |:-----------:|:------------------------ |:--------------------- |
+      | `200`       | Success                  |                       |
+      | `204`       | No content               | For a `POST` request, `204` indicates that InfluxDB accepted the request and request data is valid. Asynchronous operations, such as `write`, might not have completed yet. |
+      | `400`       | Bad request              | `Authorization` header is missing or malformed or the API token does not have permission for the operation. |
+      | `401`       | Unauthorized             | May indicate one of the following: <li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/v2.0/security/tokens/)</li> |
+      | `404`       | Not found                | Requested resource was not found. `message` in the response body contains details about the requested resource. |
+      | `413`       | Request entity too large | Request payload exceeds the size limit. |
+      | `429`       | Too many requests        | API token is temporarily over the request quota. The `Retry-After` header describes when to try the request again. |
+      | `500`       | Internal server error    |                       |
+      | `503`       | Service unavailable      | Server is temporarily unavailable to process the request. The `Retry-After` header describes when to try the request again. |
   - name: Query
     description: |
       Retrieve data, analyze queries, and get query suggestions.
@@ -23,15 +47,15 @@ tags:
     description: |
       Write time series data to buckets.
   - name: Authorizations
-    description: >
-      Create and manage API tokens. An **authorization** associates a list of
-      permissions to an **organization** and provides a token for API access. To
-      assign a token to a specific user, scope the authorization to the user ID.
+    description: |
+      Create and manage API tokens. An **authorization** associates a list of permissions to an **organization** and provides a token for API access. To assign a token to a specific user, scope the authorization to the user ID.
 x-tagGroups:
-  - name: Get started
+  - name: Overview
     tags:
+      - Quick start
       - Authentication
-  - name: ' '
+      - Response codes
+  - name: Data I/O endpoints
     tags:
       - Write
       - Query
@@ -91,13 +115,11 @@ paths:
     post:
       operationId: PostSignin
       summary: Create a user session.
-      description: >-
-        Authenticates ***Basic Auth*** credentials for a user. If successful,
-        creates a new UI session for the user.
+      description: 'Authenticates ***Basic Auth*** credentials for a user. If successful, creates a new UI session for the user.'
       tags:
         - Signin
       security:
-        - BasicAuth: []
+        - BasicAuthentication: []
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
@@ -150,7 +172,7 @@ paths:
       operationId: GetPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       servers:
-        - url: /
+        - url: ''
       tags:
         - Ping
       responses:
@@ -169,7 +191,7 @@ paths:
       operationId: HeadPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       servers:
-        - url: /
+        - url: ''
       tags:
         - Ping
       responses:
@@ -199,8 +221,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Routes'
-      servers:
-        - url: /
   /documents/templates:
     get:
       operationId: GetDocumentsTemplates
@@ -1083,9 +1103,7 @@ paths:
               $ref: '#/components/schemas/AddResourceMemberRequestBody'
       responses:
         '201':
-          description: >-
-            Telegraf configuration owner was added. Returns a ResourceOwner that
-            references the User.
+          description: Telegraf configuration owner was added. Returns a ResourceOwner that references the User.
           content:
             application/json:
               schema:
@@ -1216,201 +1234,6 @@ paths:
                 $ref: '#/components/schemas/Error'
         default:
           description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /write:
-    post:
-      operationId: PostWrite
-      tags:
-        - Write
-      summary: Write data
-      description: >
-        Writes data to a bucket.
-
-
-        To write data into InfluxDB, you need the following:
-
-        - **organization** – _See [View
-        organizations](https://docs.influxdata.com/influxdb/v2.0/organizations/view-orgs/#view-your-organization-id)
-        for instructions on viewing your organization ID._
-
-        - **bucket** – _See [View
-        buckets](https://docs.influxdata.com/influxdb/v2.0/organizations/buckets/view-buckets/)
-        for
-         instructions on viewing your bucket ID._
-        - **API token** – _See [View
-        tokens](https://docs.influxdata.com/influxdb/v2.0/security/tokens/view-tokens/)
-         for instructions on viewing your API token._
-        - **InfluxDB URL** – _See [InfluxDB
-        URLs](https://docs.influxdata.com/influxdb/v2.0/reference/urls/)_.
-
-        - data in [line
-        protocol](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol)
-        format.
-
-
-        For more information and examples, see [Write data with the InfluxDB
-        API](https://docs.influxdata.com/influxdb/v2.0/write-data/developer-tools/api).
-      requestBody:
-        description: Data in line protocol format.
-        required: true
-        content:
-          text/plain:
-            schema:
-              type: string
-              format: byte
-      parameters:
-        - $ref: '#/components/parameters/TraceSpan'
-        - in: header
-          name: Content-Encoding
-          description: >-
-            When present, the header value tells the database that compression
-            is applied to the line protocol in the request body.
-          schema:
-            type: string
-            description: >-
-              The header value specifies that the line protocol in the request
-              body is encoded with gzip or not encoded with identity.
-            default: identity
-            enum:
-              - gzip
-              - identity
-        - in: header
-          name: Content-Type
-          description: >-
-            The header value indicates the format of the data in the request
-            body.
-          schema:
-            type: string
-            description: >
-              `text/plain` specifies line protocol. `UTF-8` is the default
-              character set.
-            default: text/plain; charset=utf-8
-            enum:
-              - text/plain
-              - text/plain; charset=utf-8
-              - application/vnd.influx.arrow
-        - in: header
-          name: Content-Length
-          description: >-
-            The header value indicates the size of the entity-body, in bytes,
-            sent to the database. If the length is greater than the database's
-            `max body` configuration option, the server responds with status
-            code `413`.
-          schema:
-            type: integer
-            description: The length in decimal number of octets.
-        - in: header
-          name: Accept
-          description: The header value specifies the response format.
-          schema:
-            type: string
-            description: The response format for errors.
-            default: application/json
-            enum:
-              - application/json
-        - in: query
-          name: org
-          description: >-
-            The parameter value specifies the destination organization for
-            writes. The database writes all points in the batch to this
-            organization. If you provide both `orgID` and `org` parameters,
-            `org` takes precedence.
-          required: true
-          schema:
-            type: string
-            description: Organization name or ID.
-        - in: query
-          name: orgID
-          description: >-
-            The parameter value specifies the ID of the destination organization
-            for writes. If both `orgID` and `org` are specified, `org` takes
-            precedence.
-          schema:
-            type: string
-        - in: query
-          name: bucket
-          description: The destination bucket for writes.
-          required: true
-          schema:
-            type: string
-            description: All points within batch are written to this bucket.
-        - in: query
-          name: precision
-          description: The precision for the unix timestamps within the body line-protocol.
-          schema:
-            $ref: '#/components/schemas/WritePrecision'
-      responses:
-        '204':
-          description: >-
-            InfluxDB validated the request data format and accepted the data for
-            writing to the bucket. `204` doesn't indicate a successful write
-            operation since writes are asynchronous. See [how to check for write
-            errors](https://docs.influxdata.com/influxdb/v2.0/write-data/troubleshoot).
-        '400':
-          description: >-
-            Bad request. The line protocol data in the request is malformed. The
-            response body contains the first malformed line in the data.
-            InfluxDB rejected the batch and did not write any data.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LineProtocolError'
-        '401':
-          description: |
-            Unauthorized. The error may indicate one of the following:
-              * The `Authorization: Token` header is missing or malformed.
-              * The API token value is missing from the header.
-              * The token does not have sufficient permissions to write to this organization and bucket.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '404':
-          description: >-
-            Not found. A requested resource was not found. The response body
-            contains the requested resource type, e.g. `organization name` or
-            `bucket`, and name.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '413':
-          description: >-
-            Request entity too large. The payload exceeded the 50MB limit.
-            InfluxDB rejected the batch and did not write any data.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LineProtocolLengthError'
-        '429':
-          description: >-
-            The token is temporarily over quota. The Retry-After header
-            describes when to try the write again.
-          headers:
-            Retry-After:
-              description: >-
-                A non-negative decimal integer indicating the seconds to delay
-                after the response is received.
-              schema:
-                type: integer
-                format: int32
-        '503':
-          description: >-
-            The server is temporarily unavailable to accept writes.  The
-            `Retry-After` header describes when to try the write again.
-          headers:
-            Retry-After:
-              description: >-
-                A non-negative decimal integer indicating the seconds to delay
-                after the response is received.
-              schema:
-                type: integer
-                format: int32
-        default:
-          description: Internal server error
           content:
             application/json:
               schema:
@@ -1646,9 +1469,7 @@ paths:
             type: string
             enum:
               - properties
-          description: >-
-            Includes the cell view properties in the response if set to
-            `properties`
+          description: Includes the cell view properties in the response if set to `properties`
       responses:
         '200':
           description: Retrieve a single dashboard
@@ -1691,9 +1512,7 @@ paths:
                   description: 'optional, when provided will replace the description'
                   type: string
                 cells:
-                  description: >-
-                    optional, when provided will replace all existing cells with
-                    the cells provided
+                  description: 'optional, when provided will replace all existing cells with the cells provided'
                   $ref: '#/components/schemas/CellWithViewProperties'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -1757,9 +1576,7 @@ paths:
         - Cells
         - Dashboards
       summary: Replace cells in a dashboard
-      description: >-
-        Replaces all cells in a dashboard. This is used primarily to update the
-        positional information of all cells.
+      description: Replaces all cells in a dashboard. This is used primarily to update the positional information of all cells.
       requestBody:
         required: true
         content:
@@ -1840,9 +1657,7 @@ paths:
         - Cells
         - Dashboards
       summary: Update the non-positional information related to a cell
-      description: >-
-        Updates the non positional information related to a cell. Updates to a
-        single cell's positional data could cause grid conflicts.
+      description: Updates the non positional information related to a cell. Updates to a single cell's positional data could cause grid conflicts.
       requestBody:
         required: true
         content:
@@ -2407,42 +2222,25 @@ paths:
       tags:
         - Query
       summary: Query data
-      description: >
+      description: |
         Retrieves data from InfluxDB buckets.
 
-
         To query data, you need the following:
-
-        - **organization** – _See [View
-        organizations](https://docs.influxdata.com/influxdb/v2.0/organizations/view-orgs/#view-your-organization-id)
-        for instructions on viewing your organization ID._
-
-        - **API token** – _See [View
-        tokens](https://docs.influxdata.com/influxdb/v2.0/security/tokens/view-tokens/)
+        - **organization** – _See [View organizations](https://docs.influxdata.com/influxdb/v2.0/organizations/view-orgs/#view-your-organization-id) for instructions on viewing your organization ID._
+        - **API token** – _See [View tokens](https://docs.influxdata.com/influxdb/v2.0/security/tokens/view-tokens/)
          for instructions on viewing your API token._
-        - **InfluxDB URL** – _See [InfluxDB
-        URLs](https://docs.influxdata.com/influxdb/v2.0/reference/urls/)_.
+        - **InfluxDB URL** – _See [InfluxDB URLs](https://docs.influxdata.com/influxdb/v2.0/reference/urls/)_.
+        - [Flux](https://docs.influxdata.com/influxdb/v2.0/reference/flux) or [InfluxQL](https://docs.influxdata.com/influxdb/v2.0/query-data/influxql/) query.
 
-        - [Flux](https://docs.influxdata.com/influxdb/v2.0/reference/flux) or
-        [InfluxQL](https://docs.influxdata.com/influxdb/v2.0/query-data/influxql/)
-        query.
-
-
-        For more information and examples, see [Query with the InfluxDB
-        API](https://docs.influxdata.com/influxdb/v2.0/query-data/execute-queries/influx-api/).
+        For more information and examples, see [Query with the InfluxDB API](https://docs.influxdata.com/influxdb/v2.0/query-data/execute-queries/influx-api/).
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: header
           name: Accept-Encoding
-          description: >-
-            The Accept-Encoding request HTTP header advertises which content
-            encoding, usually a compression algorithm, the client is able to
-            understand.
+          description: 'The Accept-Encoding request HTTP header advertises which content encoding, usually a compression algorithm, the client is able to understand.'
           schema:
             type: string
-            description: >-
-              Specifies that the query response in the body should be encoded
-              with gzip or not encoded with identity.
+            description: Specifies that the query response in the body should be encoded with gzip or not encoded with identity.
             default: identity
             enum:
               - gzip
@@ -2456,17 +2254,12 @@ paths:
               - application/vnd.flux
         - in: query
           name: org
-          description: >-
-            Specifies the name of the organization executing the query. Takes
-            either the ID or Name. If both `orgID` and `org` are specified,
-            `org` takes precedence.
+          description: 'Specifies the name of the organization executing the query. Takes either the ID or Name. If both `orgID` and `org` are specified, `org` takes precedence.'
           schema:
             type: string
         - in: query
           name: orgID
-          description: >-
-            Specifies the ID of the organization executing the query. If both
-            `orgID` and `org` are specified, `org` takes precedence.
+          description: 'Specifies the ID of the organization executing the query. If both `orgID` and `org` are specified, `org` takes precedence.'
           schema:
             type: string
       requestBody:
@@ -2485,23 +2278,16 @@ paths:
           description: Success. Returns query results.
           headers:
             Content-Encoding:
-              description: >-
-                The Content-Encoding entity header is used to compress the
-                media-type.  When present, its value indicates which encodings
-                were applied to the entity-body
+              description: 'The Content-Encoding entity header is used to compress the media-type.  When present, its value indicates which encodings were applied to the entity-body'
               schema:
                 type: string
-                description: >-
-                  Specifies that the response in the body is encoded with gzip
-                  or not encoded with identity.
+                description: Specifies that the response in the body is encoded with gzip or not encoded with identity.
                 default: identity
                 enum:
                   - gzip
                   - identity
             Trace-Id:
-              description: >-
-                The Trace-Id header reports the request's trace ID, if one was
-                generated.
+              description: 'The Trace-Id header reports the request''s trace ID, if one was generated.'
               schema:
                 type: string
                 description: Specifies the request's trace ID.
@@ -2509,24 +2295,17 @@ paths:
             text/csv:
               schema:
                 type: string
-                example: >
-                  result,table,_start,_stop,_time,region,host,_value
-                  mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:00Z,east,A,15.43
-                  mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:20Z,east,B,59.25
-                  mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,east,C,52.62
+                example: |
+                  result,table,_start,_stop,_time,region,host,_value mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:00Z,east,A,15.43 mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:20Z,east,B,59.25 mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,east,C,52.62
             application/vnd.influx.arrow:
               schema:
                 type: string
                 format: binary
         '429':
-          description: >-
-            Token is temporarily over quota. The Retry-After header describes
-            when to try the read again.
+          description: Token is temporarily over quota. The Retry-After header describes when to try the read again.
           headers:
             Retry-After:
-              description: >-
-                A non-negative decimal integer indicating the seconds to delay
-                after the response is received.
+              description: A non-negative decimal integer indicating the seconds to delay after the response is received.
               schema:
                 type: integer
                 format: int32
@@ -3691,21 +3470,15 @@ paths:
               $ref: '#/components/schemas/TemplateApply'
       responses:
         '200':
-          description: >
-            Success. The package dry-run succeeded. No new resources were
-            created. Returns a diff and summary of the dry-run. The diff and
-            summary won't contain IDs for resources that didn't exist at the
-            time of the dry-run.
+          description: |
+            Success. The package dry-run succeeded. No new resources were created. Returns a diff and summary of the dry-run. The diff and summary won't contain IDs for resources that didn't exist at the time of the dry-run.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TemplateSummary'
         '201':
-          description: >
-            Success. The package applied successfully. Returns a diff and
-            summary of the run. The summary contains newly created resources.
-            The diff compares the initial state to the state after the package
-            applied. This corresponds to `"dryRun": true`.
+          description: |
+            Success. The package applied successfully. Returns a diff and summary of the run. The summary contains newly created resources. The diff compares the initial state to the state after the package applied. This corresponds to `"dryRun": true`.
           content:
             application/json:
               schema:
@@ -3733,9 +3506,7 @@ paths:
                 - $ref: '#/components/schemas/TemplateExportByName'
       responses:
         '200':
-          description: >-
-            The template was created successfully. Returns the newly created
-            template.
+          description: The template was created successfully. Returns the newly created template.
           content:
             application/json:
               schema:
@@ -4218,7 +3989,7 @@ paths:
         - Users
       summary: Update a password
       security:
-        - BasicAuth: []
+        - BasicAuthentication: []
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       requestBody:
@@ -4422,7 +4193,7 @@ paths:
         - Users
       summary: Update a password
       security:
-        - BasicAuth: []
+        - BasicAuthentication: []
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4742,9 +4513,7 @@ paths:
         - in: query
           name: orgID
           required: true
-          description: >-
-            Only show notification rules that belong to a specific organization
-            ID.
+          description: Only show notification rules that belong to a specific organization ID.
           schema:
             type: string
         - in: query
@@ -4754,9 +4523,7 @@ paths:
             type: string
         - in: query
           name: tag
-          description: >-
-            Only return notification rules that "would match" statuses which
-            contain the tag key value pairs provided.
+          description: Only return notification rules that "would match" statuses which contain the tag key value pairs provided.
           schema:
             type: string
             pattern: '^[a-zA-Z0-9_]+:[a-zA-Z0-9_]+$'
@@ -5118,9 +4885,7 @@ paths:
         - in: query
           name: orgID
           required: true
-          description: >-
-            Only show notification endpoints that belong to specific
-            organization ID.
+          description: Only show notification endpoints that belong to specific organization ID.
           schema:
             type: string
       responses:
@@ -5396,7 +5161,7 @@ paths:
         - Health
       summary: Get the health of an instance
       servers:
-        - url: /
+        - url: ''
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
@@ -5422,7 +5187,7 @@ paths:
         - Ready
       summary: Get the readiness of an instance at startup
       servers:
-        - url: /
+        - url: ''
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
@@ -5567,9 +5332,7 @@ paths:
       tags:
         - Setup
       summary: 'Check if database has default user, org, bucket'
-      description: >-
-        Returns `true` if no default user, organization, or bucket has been
-        created.
+      description: 'Returns `true` if no default user, organization, or bucket has been created.'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
@@ -6324,9 +6087,7 @@ paths:
             type: string
         - in: query
           name: id
-          description: >-
-            List of scraper target IDs to return. If both `id` and `owner` are
-            specified, only `id` is used.
+          description: 'List of scraper target IDs to return. If both `id` and `owner` are specified, only `id` is used.'
           schema:
             type: array
             items:
@@ -6735,10 +6496,7 @@ paths:
       operationId: GetBackupKV
       tags:
         - Backup
-      summary: >-
-        Download snapshot of metadata stored in the server's embedded KV store.
-        Should not be used in versions greater than 2.1.x, as it doesn't include
-        metadata stored in embedded SQL.
+      summary: 'Download snapshot of metadata stored in the server''s embedded KV store. Should not be used in versions greater than 2.1.x, as it doesn''t include metadata stored in embedded SQL.'
       deprecated: true
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -6763,15 +6521,10 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: header
           name: Accept-Encoding
-          description: >-
-            The Accept-Encoding request HTTP header advertises which content
-            encoding, usually a compression algorithm, the client is able to
-            understand.
+          description: 'The Accept-Encoding request HTTP header advertises which content encoding, usually a compression algorithm, the client is able to understand.'
           schema:
             type: string
-            description: >-
-              Specifies that the query response in the body should be encoded
-              with gzip or not encoded with identity.
+            description: Specifies that the query response in the body should be encoded with gzip or not encoded with identity.
             default: identity
             enum:
               - gzip
@@ -6781,15 +6534,10 @@ paths:
           description: Snapshot of metadata
           headers:
             Content-Encoding:
-              description: >-
-                The Content-Encoding entity header is used to compress the
-                media-type.  When present, its value indicates which encodings
-                were applied to the entity-body
+              description: 'The Content-Encoding entity header is used to compress the media-type.  When present, its value indicates which encodings were applied to the entity-body'
               schema:
                 type: string
-                description: >-
-                  Specifies that the response in the body is encoded with gzip
-                  or not encoded with identity.
+                description: Specifies that the response in the body is encoded with gzip or not encoded with identity.
                 default: identity
                 enum:
                   - gzip
@@ -6811,15 +6559,10 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: header
           name: Accept-Encoding
-          description: >-
-            The Accept-Encoding request HTTP header advertises which content
-            encoding, usually a compression algorithm, the client is able to
-            understand.
+          description: 'The Accept-Encoding request HTTP header advertises which content encoding, usually a compression algorithm, the client is able to understand.'
           schema:
             type: string
-            description: >-
-              Specifies that the query response in the body should be encoded
-              with gzip or not encoded with identity.
+            description: Specifies that the query response in the body should be encoded with gzip or not encoded with identity.
             default: identity
             enum:
               - gzip
@@ -6842,15 +6585,10 @@ paths:
           description: TSM snapshot.
           headers:
             Content-Encoding:
-              description: >-
-                The Content-Encoding entity header is used to compress the
-                media-type.  When present, its value indicates which encodings
-                were applied to the entity-body
+              description: 'The Content-Encoding entity header is used to compress the media-type.  When present, its value indicates which encodings were applied to the entity-body'
               schema:
                 type: string
-                description: >-
-                  Specifies that the response in the body is encoded with gzip
-                  or not encoded with identity.
+                description: Specifies that the response in the body is encoded with gzip or not encoded with identity.
                 default: identity
                 enum:
                   - gzip
@@ -6879,14 +6617,10 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: header
           name: Content-Encoding
-          description: >-
-            When present, its value indicates to the database that compression
-            is applied to the line-protocol body.
+          description: 'When present, its value indicates to the database that compression is applied to the line-protocol body.'
           schema:
             type: string
-            description: >-
-              Specifies that the line protocol in the body is encoded with gzip
-              or not encoded with identity.
+            description: Specifies that the line protocol in the body is encoded with gzip or not encoded with identity.
             default: identity
             enum:
               - gzip
@@ -6915,9 +6649,7 @@ paths:
                 type: object
                 properties:
                   token:
-                    description: >-
-                      token is the root token for the instance after restore
-                      (this is overwritten during the restore)
+                    description: token is the root token for the instance after restore (this is overwritten during the restore)
                     type: string
         '204':
           description: KV store successfully overwritten.
@@ -6929,21 +6661,15 @@ paths:
       operationId: PostRestoreSQL
       tags:
         - Restore
-      summary: >-
-        Overwrite the embedded SQL store on the server with a backed-up
-        snapshot.
+      summary: Overwrite the embedded SQL store on the server with a backed-up snapshot.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: header
           name: Content-Encoding
-          description: >-
-            When present, its value indicates to the database that compression
-            is applied to the line-protocol body.
+          description: 'When present, its value indicates to the database that compression is applied to the line-protocol body.'
           schema:
             type: string
-            description: >-
-              Specifies that the line protocol in the body is encoded with gzip
-              or not encoded with identity.
+            description: Specifies that the line protocol in the body is encoded with gzip or not encoded with identity.
             default: identity
             enum:
               - gzip
@@ -7045,14 +6771,10 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: header
           name: Content-Encoding
-          description: >-
-            When present, its value indicates to the database that compression
-            is applied to the line-protocol body.
+          description: 'When present, its value indicates to the database that compression is applied to the line-protocol body.'
           schema:
             type: string
-            description: >-
-              Specifies that the line protocol in the body is encoded with gzip
-              or not encoded with identity.
+            description: Specifies that the line protocol in the body is encoded with gzip or not encoded with identity.
             default: identity
             enum:
               - gzip
@@ -7467,9 +7189,7 @@ paths:
         - $ref: '#/components/parameters/Descending'
         - in: query
           name: owner
-          description: >-
-            A user identifier. Returns only dashboards where this user has the
-            `owner` role.
+          description: A user identifier. Returns only dashboards where this user has the `owner` role.
           schema:
             type: string
         - in: query
@@ -7483,9 +7203,7 @@ paths:
               - UpdatedAt
         - in: query
           name: id
-          description: >-
-            A list of dashboard identifiers. Returns only the listed dashboards.
-            If both `id` and `owner` are specified, only `id` is used.
+          description: 'A list of dashboard identifiers. Returns only the listed dashboards. If both `id` and `owner` are specified, only `id` is used.'
           schema:
             type: array
             items:
@@ -7602,6 +7320,167 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /write:
+    post:
+      operationId: PostWrite
+      tags:
+        - Write
+      summary: Write data
+      description: |
+        Writes data to a bucket.
+
+        To write data into InfluxDB, you need the following:
+        - **organization** – _See [View organizations](https://docs.influxdata.com/influxdb/v2.0/organizations/view-orgs/#view-your-organization-id) for instructions on viewing your organization ID._
+        - **bucket** – _See [View buckets](https://docs.influxdata.com/influxdb/v2.0/organizations/buckets/view-buckets/) for
+         instructions on viewing your bucket ID._
+        - **API token** – _See [View tokens](https://docs.influxdata.com/influxdb/v2.0/security/tokens/view-tokens/)
+         for instructions on viewing your API token._
+        - **InfluxDB URL** – _See [InfluxDB URLs](https://docs.influxdata.com/influxdb/v2.0/reference/urls/)_.
+        - data in [line protocol](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol) format.
+
+        For more information and examples, see [Write data with the InfluxDB API](https://docs.influxdata.com/influxdb/v2.0/write-data/developer-tools/api).
+      requestBody:
+        description: Data in line protocol format.
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+              format: byte
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: header
+          name: Content-Encoding
+          description: 'When present, the header value tells the database that compression is applied to the line protocol in the request body.'
+          schema:
+            type: string
+            description: The header value specifies that the line protocol in the request body is encoded with gzip or not encoded with identity.
+            default: identity
+            enum:
+              - gzip
+              - identity
+        - in: header
+          name: Content-Type
+          description: The header value indicates the format of the data in the request body.
+          schema:
+            type: string
+            description: |
+              `text/plain` specifies line protocol. `UTF-8` is the default character set.
+            default: text/plain; charset=utf-8
+            enum:
+              - text/plain
+              - text/plain; charset=utf-8
+              - application/vnd.influx.arrow
+        - in: header
+          name: Content-Length
+          description: 'The header value indicates the size of the entity-body, in bytes, sent to the database. If the length is greater than the database''s `max body` configuration option, the server responds with status code `413`.'
+          schema:
+            type: integer
+            description: The length in decimal number of octets.
+        - in: header
+          name: Accept
+          description: The header value specifies the response format.
+          schema:
+            type: string
+            description: The response format for errors.
+            default: application/json
+            enum:
+              - application/json
+        - in: query
+          name: org
+          description: 'The parameter value specifies the destination organization for writes. The database writes all points in the batch to this organization. If you provide both `orgID` and `org` parameters, `org` takes precedence.'
+          required: true
+          schema:
+            type: string
+            description: Organization name or ID.
+        - in: query
+          name: orgID
+          description: 'The parameter value specifies the ID of the destination organization for writes. If both `orgID` and `org` are specified, `org` takes precedence.'
+          schema:
+            type: string
+        - in: query
+          name: bucket
+          description: The destination bucket for writes.
+          required: true
+          schema:
+            type: string
+            description: All points within batch are written to this bucket.
+        - in: query
+          name: precision
+          description: The precision for the unix timestamps within the body line-protocol.
+          schema:
+            $ref: '#/components/schemas/WritePrecision'
+      responses:
+        '204':
+          description: 'InfluxDB validated the request data format and accepted the data for writing to the bucket. `204` doesn''t indicate a successful write operation since writes are asynchronous. See [how to check for write errors](https://docs.influxdata.com/influxdb/v2.0/write-data/troubleshoot).'
+        '400':
+          description: Bad request. The line protocol data in the request is malformed. The response body contains the first malformed line in the data. InfluxDB rejected the batch and did not write any data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LineProtocolError'
+              examples:
+                measurementSchemaFieldTypeConflict:
+                  summary: Example of a field type conflict thrown by an explicit bucket schema
+                  value:
+                    code: invalid
+                    message: 'partial write error (2 written): unable to parse ''air_sensor,service=S1,sensor=L1 temperature="90.5",humidity=70.0 1632850122'': schema: field type for field "temperature" not permitted by schema; got String but expected Float'
+        '401':
+          description: |
+            Unauthorized. The error may indicate one of the following:
+              * The `Authorization: Token` header is missing or malformed.
+              * The API token value is missing from the header.
+              * The token does not have sufficient permissions to write to this organization and bucket.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                tokenNotAuthorized:
+                  summary: Token is not authorized to access the organization or resource
+                  value:
+                    code: unauthorized
+                    message: unauthorized access
+        '404':
+          description: 'Not found. A requested resource was not found. The response body contains the requested resource type, e.g. `organization name` or `bucket`, and name.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                resource-not-found:
+                  summary: Not found error
+                  value:
+                    code: not found
+                    message: bucket "air_sensor" not found
+        '413':
+          description: |
+            All request data was rejected and not written. InfluxDB OSS only returns this error if the [Go (golang) `ioutil.ReadAll()`](https://pkg.go.dev/io/ioutil#ReadAll) function raises an error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LineProtocolLengthError'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internalError:
+                  summary: Internal error example
+                  value:
+                    code: internal error
+        '503':
+          description: The server is temporarily unavailable to accept writes.  The `Retry-After` header describes when to try the write again.
+          headers:
+            Retry-After:
+              description: A non-negative decimal integer indicating the seconds to delay after the response is received.
+              schema:
+                type: integer
+                format: int32
+        default:
+          $ref: '#/components/responses/ServerError'
 components:
   parameters:
     TraceSpan:
@@ -7651,9 +7530,8 @@ components:
       required: false
       schema:
         type: string
-      description: >
-        The last resource ID from which to seek from (but not including). This
-        is to be used instead of `offset`.
+      description: |
+        The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.
   schemas:
     LanguageRequest:
       description: Flux query to be analyzed.
@@ -7683,16 +7561,12 @@ components:
         params:
           type: object
           additionalProperties: true
-          description: >
-            Enumeration of key/value pairs that respresent parameters to be
-            injected into query (can only specify either this field or extern
-            and not both)
+          description: |
+            Enumeration of key/value pairs that respresent parameters to be injected into query (can only specify either this field or extern and not both)
         dialect:
           $ref: '#/components/schemas/Dialect'
         now:
-          description: >-
-            Specifies the time that should be reported as "now" in the query.
-            Default is the server's now time.
+          description: Specifies the time that should be reported as "now" in the query. Default is the server's now time.
           type: string
           format: date-time
     InfluxQLQuery:
@@ -7710,9 +7584,7 @@ components:
           enum:
             - influxql
         bucket:
-          description: >-
-            Bucket is to be used instead of the database and retention policy
-            specified in the InfluxQL query.
+          description: Bucket is to be used instead of the database and retention policy specified in the InfluxQL query.
           type: string
     Package:
       description: Represents a complete package source tree.
@@ -7818,9 +7690,7 @@ components:
         - $ref: '#/components/schemas/BuiltinStatement'
         - $ref: '#/components/schemas/TestStatement'
     BadStatement:
-      description: >-
-        A placeholder for statements for which no correct statement nodes can be
-        created
+      description: A placeholder for statements for which no correct statement nodes can be created
       type: object
       properties:
         type:
@@ -7849,9 +7719,7 @@ components:
         init:
           $ref: '#/components/schemas/Expression'
     ExpressionStatement:
-      description: >-
-        May consist of an expression that does not return a value and is
-        executed solely for its side-effects
+      description: May consist of an expression that does not return a value and is executed solely for its side-effects
       type: object
       properties:
         type:
@@ -7988,9 +7856,7 @@ components:
           items:
             $ref: '#/components/schemas/Expression'
     ConditionalExpression:
-      description: >-
-        Selects one of two expressions, `Alternate` or `Consequent`, depending
-        on a third boolean expression, `Test`
+      description: 'Selects one of two expressions, `Alternate` or `Consequent`, depending on a third boolean expression, `Test`'
       type: object
       properties:
         type:
@@ -8002,9 +7868,7 @@ components:
         consequent:
           $ref: '#/components/schemas/Expression'
     LogicalExpression:
-      description: >-
-        Represents the rule conditions that collectively evaluate to either true
-        or false
+      description: Represents the rule conditions that collectively evaluate to either true or false
       type: object
       properties:
         type:
@@ -8083,9 +7947,7 @@ components:
         value:
           type: boolean
     DateTimeLiteral:
-      description: >-
-        Represents an instant in time with nanosecond precision using the syntax
-        of golang's RFC3339 Nanosecond variant
+      description: Represents an instant in time with nanosecond precision using the syntax of golang's RFC3339 Nanosecond variant
       type: object
       properties:
         type:
@@ -8094,9 +7956,7 @@ components:
           type: string
           format: date-time
     DurationLiteral:
-      description: >-
-        Represents the elapsed time between two instants as an int64 nanosecond
-        count with syntax of golang's time.Duration
+      description: Represents the elapsed time between two instants as an int64 nanosecond count with syntax of golang's time.Duration
       type: object
       properties:
         type:
@@ -8107,9 +7967,7 @@ components:
           items:
             $ref: '#/components/schemas/Duration'
     FloatLiteral:
-      description: >-
-        Represents floating point numbers according to the double
-        representations defined by the IEEE-754-1985
+      description: Represents floating point numbers according to the double representations defined by the IEEE-754-1985
       type: object
       properties:
         type:
@@ -8125,17 +7983,13 @@ components:
         value:
           type: string
     PipeLiteral:
-      description: >-
-        Represents a specialized literal value, indicating the left hand value
-        of a pipe expression
+      description: 'Represents a specialized literal value, indicating the left hand value of a pipe expression'
       type: object
       properties:
         type:
           $ref: '#/components/schemas/NodeType'
     RegexpLiteral:
-      description: >-
-        Expressions begin and end with `/` and are regular expressions with
-        syntax accepted by RE2
+      description: Expressions begin and end with `/` and are regular expressions with syntax accepted by RE2
       type: object
       properties:
         type:
@@ -8159,9 +8013,7 @@ components:
         value:
           type: string
     Duration:
-      description: >-
-        A pair consisting of length of time and the unit of time measured. It is
-        the atomic unit from which all duration literals are composed.
+      description: A pair consisting of length of time and the unit of time measured. It is the atomic unit from which all duration literals are composed.
       type: object
       properties:
         type:
@@ -8193,9 +8045,7 @@ components:
         name:
           type: string
     Dialect:
-      description: >-
-        Dialect are options to change the default CSV output format;
-        https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions
+      description: 'Dialect are options to change the default CSV output format; https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions'
       type: object
       properties:
         header:
@@ -8234,9 +8084,7 @@ components:
     AuthorizationUpdateRequest:
       properties:
         status:
-          description: >-
-            If inactive the token is inactive and requests using the token will
-            be rejected.
+          description: If inactive the token is inactive and requests using the token will be rejected.
           default: active
           type: string
           enum:
@@ -8373,9 +8221,7 @@ components:
         everySeconds:
           type: integer
           format: int64
-          description: >-
-            Duration in seconds for how long data will be kept in the database.
-            0 means infinite.
+          description: Duration in seconds for how long data will be kept in the database. 0 means infinite.
           example: 86400
           minimum: 0
         shardGroupDurationSeconds:
@@ -8395,9 +8241,7 @@ components:
         everySeconds:
           type: integer
           format: int64
-          description: >-
-            Duration in seconds for how long data will be kept in the database.
-            0 means infinite.
+          description: Duration in seconds for how long data will be kept in the database. 0 means infinite.
           example: 86400
           minimum: 0
         shardGroupDurationSeconds:
@@ -8670,10 +8514,7 @@ components:
                 $ref: '#/components/schemas/TemplateKind'
               name:
                 type: string
-                description: >-
-                  if defined with id, name is used for resource exported by id.
-                  if defined independently, resources strictly matching name are
-                  exported
+                description: 'if defined with id, name is used for resource exported by id. if defined independently, resources strictly matching name are exported'
             required:
               - id
               - kind
@@ -8738,9 +8579,7 @@ components:
             description: Field the environment reference corresponds too
           envRefKey:
             type: string
-            description: >-
-              Key identified as environment reference and is the key identified
-              in the template
+            description: Key identified as environment reference and is the key identified in the template
           value:
             description: Value provided to fulfill reference
             nullable: true
@@ -8750,9 +8589,7 @@ components:
               - type: number
               - type: boolean
           defaultValue:
-            description: >-
-              Default value that will be provided for the reference when no
-              value is provided
+            description: Default value that will be provided for the reference when no value is provided
             nullable: true
             oneOf:
               - type: string
@@ -9545,9 +9382,7 @@ components:
       properties:
         scheduledFor:
           nullable: true
-          description: >-
-            Time used for run's "now" option, RFC3339.  Default is the server's
-            now time.
+          description: 'Time used for run''s "now" option, RFC3339.  Default is the server''s now time.'
           type: string
           format: date-time
     Tasks:
@@ -9567,9 +9402,7 @@ components:
           readOnly: true
           type: string
         type:
-          description: >-
-            The type of task, this can be used for filtering tasks on list
-            actions.
+          description: 'The type of task, this can be used for filtering tasks on list actions.'
           type: string
         orgID:
           description: The ID of the organization that owns this Task.
@@ -9591,9 +9424,7 @@ components:
         labels:
           $ref: '#/components/schemas/Labels'
         authorizationID:
-          description: >-
-            The ID of the authorization used when this task communicates with
-            the query engine.
+          description: The ID of the authorization used when this task communicates with the query engine.
           type: string
         flux:
           description: The Flux script to run for this task.
@@ -9602,15 +9433,10 @@ components:
           description: A simple task repetition schedule; parsed from Flux.
           type: string
         cron:
-          description: >-
-            A task repetition schedule in the form '* * * * * *'; parsed from
-            Flux.
+          description: A task repetition schedule in the form '* * * * * *'; parsed from Flux.
           type: string
         offset:
-          description: >-
-            Duration to delay after the schedule, before executing the task;
-            parsed from flux, if set to zero it will remove this option and use
-            0 as the default.
+          description: 'Duration to delay after the schedule, before executing the task; parsed from flux, if set to zero it will remove this option and use 0 as the default.'
           type: string
         latestCompleted:
           description: 'Timestamp of latest scheduled, completed run, RFC3339.'
@@ -9866,15 +9692,11 @@ components:
           type: string
         op:
           readOnly: true
-          description: >-
-            op describes the logical code operation during error. Useful for
-            debugging.
+          description: op describes the logical code operation during error. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: >-
-            err is a stack of errors that occurred during processing of the
-            request. Useful for debugging.
+          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
@@ -9898,15 +9720,11 @@ components:
           type: string
         op:
           readOnly: true
-          description: >-
-            Op describes the logical code operation during error. Useful for
-            debugging.
+          description: Op describes the logical code operation during error. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: >-
-            Err is a stack of errors that occurred during processing of the
-            request. Useful for debugging.
+          description: Err is a stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
         line:
           readOnly: true
@@ -9943,14 +9761,10 @@ components:
       type: object
       properties:
         value:
-          description: >-
-            value is the value of the field.  Meaning of the value is implied by
-            the `type` key
+          description: value is the value of the field.  Meaning of the value is implied by the `type` key
           type: string
         type:
-          description: >-
-            `type` describes the field type. `func` is a function. `field` is a
-            field reference.
+          description: '`type` describes the field type. `func` is a function. `field` is a field reference.'
           type: string
           enum:
             - func
@@ -9960,9 +9774,7 @@ components:
             - regex
             - wildcard
         alias:
-          description: >-
-            Alias overrides the field name in the returned response.  Applies
-            only if type is `func`
+          description: Alias overrides the field name in the returned response.  Applies only if type is `func`
           type: string
         args:
           description: Args are the arguments to the function
@@ -10037,9 +9849,7 @@ components:
           type: array
           minItems: 0
           maxItems: 2
-          description: >-
-            The extents of an axis in the form [lower, upper]. Clients determine
-            whether bounds are to be inclusive or exclusive of their limits
+          description: 'The extents of an axis in the form [lower, upper]. Clients determine whether bounds are to be inclusive or exclusive of their limits'
           items:
             type: string
         label:
@@ -10942,37 +10752,27 @@ components:
           type: object
           properties:
             verticalTimeAxis:
-              description: >-
-                verticalTimeAxis describes the orientation of the table by
-                indicating whether the time axis will be displayed vertically
+              description: verticalTimeAxis describes the orientation of the table by indicating whether the time axis will be displayed vertically
               type: boolean
             sortBy:
               $ref: '#/components/schemas/RenamableField'
             wrapping:
-              description: >-
-                Wrapping describes the text wrapping style to be used in table
-                views
+              description: Wrapping describes the text wrapping style to be used in table views
               type: string
               enum:
                 - truncate
                 - wrap
                 - single-line
             fixFirstColumn:
-              description: >-
-                fixFirstColumn indicates whether the first column of the table
-                should be locked
+              description: fixFirstColumn indicates whether the first column of the table should be locked
               type: boolean
         fieldOptions:
-          description: >-
-            fieldOptions represent the fields retrieved by the query with
-            customization options
+          description: fieldOptions represent the fields retrieved by the query with customization options
           type: array
           items:
             $ref: '#/components/schemas/RenamableField'
         timeFormat:
-          description: >-
-            timeFormat describes the display format for time values according to
-            moment.js date formatting
+          description: timeFormat describes the display format for time values according to moment.js date formatting
           type: string
         decimalPlaces:
           $ref: '#/components/schemas/DecimalPlaces'
@@ -11242,9 +11042,7 @@ components:
           type: boolean
           default: true
         detectCoordinateFields:
-          description: >-
-            If true, search results get automatically regroupped so that lon,lat
-            and value are treated as columns
+          description: 'If true, search results get automatically regroupped so that lon,lat and value are treated as columns'
           type: boolean
           default: true
         useS2CellID:
@@ -11330,9 +11128,7 @@ components:
           type: number
           format: float
     DecimalPlaces:
-      description: >-
-        Indicates whether decimal places should be enforced, and how many digits
-        it should show.
+      description: 'Indicates whether decimal places should be enforced, and how many digits it should show.'
       type: object
       properties:
         isEnforced:
@@ -11845,9 +11641,7 @@ components:
       type: object
       properties:
         allowed:
-          description: >-
-            True means that the influxdb instance has NOT had initial setup;
-            false means that the database has been setup.
+          description: True means that the influxdb instance has NOT had initial setup; false means that the database has been setup.
           type: boolean
     PasswordResetBody:
       properties:
@@ -11920,9 +11714,7 @@ components:
           type: object
           additionalProperties:
             type: string
-          description: >-
-            Key/Value pairs associated with this label. Keys can be removed by
-            sending an update with an empty value.
+          description: Key/Value pairs associated with this label. Keys can be removed by sending an update with an empty value.
           example:
             color: ffb3b3
             description: this is a description
@@ -11940,9 +11732,7 @@ components:
           type: object
           additionalProperties:
             type: string
-          description: >-
-            Key/Value pairs associated with this label. Keys can be removed by
-            sending an update with an empty value.
+          description: Key/Value pairs associated with this label. Keys can be removed by sending an update with an empty value.
           example:
             color: ffb3b3
             description: this is a description
@@ -11955,9 +11745,7 @@ components:
           type: object
           additionalProperties:
             type: string
-          description: >-
-            Key/Value pairs associated with this label. Keys can be removed by
-            sending an update with an empty value.
+          description: Key/Value pairs associated with this label. Keys can be removed by sending an update with an empty value.
           example:
             color: ffb3b3
             description: this is a description
@@ -12215,9 +12003,7 @@ components:
               description: String duration before deadman triggers.
               type: string
             staleTime:
-              description: >-
-                String duration for time that a series is considered stale and
-                should not trigger deadman.
+              description: String duration for time that a series is considered stale and should not trigger deadman.
               type: string
             reportZero:
               description: 'If only zero values reported since time, trigger an alert'
@@ -12436,14 +12222,10 @@ components:
         runbookLink:
           type: string
         limitEvery:
-          description: >-
-            Don't notify me more than <limit> times every <limitEvery> seconds.
-            If set, limit cannot be empty.
+          description: 'Don''t notify me more than <limit> times every <limitEvery> seconds. If set, limit cannot be empty.'
           type: integer
         limit:
-          description: >-
-            Don't notify me more than <limit> times every <limitEvery> seconds.
-            If set, limitEvery cannot be empty.
+          description: 'Don''t notify me more than <limit> times every <limitEvery> seconds. If set, limitEvery cannot be empty.'
           type: integer
         tagRules:
           description: List of tag rules the notification rule attempts to match.
@@ -12593,9 +12375,7 @@ components:
         - channel
       properties:
         type:
-          description: >-
-            The discriminator between other types of notification rules is
-            "telegram".
+          description: The discriminator between other types of notification rules is "telegram".
           type: string
           enum:
             - telegram
@@ -12603,19 +12383,14 @@ components:
           description: The message template as a flux interpolated string.
           type: string
         parseMode:
-          description: >-
-            Parse mode of the message text per
-            https://core.telegram.org/bots/api#formatting-options . Defaults to
-            "MarkdownV2" .
+          description: 'Parse mode of the message text per https://core.telegram.org/bots/api#formatting-options . Defaults to "MarkdownV2" .'
           type: string
           enum:
             - MarkdownV2
             - HTML
             - Markdown
         disableWebPagePreview:
-          description: >-
-            Disables preview of web links in the sent messages when "true".
-            Defaults to "false" .
+          description: Disables preview of web links in the sent messages when "true". Defaults to "false" .
           type: boolean
     NotificationEndpointUpdate:
       type: object
@@ -12720,9 +12495,7 @@ components:
         - type: object
           properties:
             url:
-              description: >-
-                Specifies the URL of the Slack endpoint. Specify either `URL` or
-                `Token`.
+              description: Specifies the URL of the Slack endpoint. Specify either `URL` or `Token`.
               type: string
             token:
               description: Specifies the API token string. Specify either `URL` or `Token`.
@@ -12786,14 +12559,10 @@ components:
             - channel
           properties:
             token:
-              description: >-
-                Specifies the Telegram bot token. See
-                https://core.telegram.org/bots#creating-a-new-bot .
+              description: 'Specifies the Telegram bot token. See https://core.telegram.org/bots#creating-a-new-bot .'
               type: string
             channel:
-              description: >-
-                ID of the telegram channel, a chat_id in
-                https://core.telegram.org/bots/api#sendmessage .
+              description: 'ID of the telegram channel, a chat_id in https://core.telegram.org/bots/api#sendmessage .'
               type: string
     NotificationEndpointType:
       type: string
@@ -12823,9 +12592,7 @@ components:
           description: InfluxDB v1 retention policy
         default:
           type: boolean
-          description: >-
-            Specify if this mapping represents the default retention policy for
-            the database specificed.
+          description: Specify if this mapping represents the default retention policy for the database specificed.
         links:
           $ref: '#/components/schemas/Links'
       required:
@@ -12868,9 +12635,7 @@ components:
           description: InfluxDB v1 retention policy
         default:
           type: boolean
-          description: >-
-            Specify if this mapping represents the default retention policy for
-            the database specificed.
+          description: Specify if this mapping represents the default retention policy for the database specificed.
       required:
         - bucketID
         - database
@@ -12908,9 +12673,7 @@ components:
             permissions:
               type: array
               minItems: 1
-              description: >-
-                List of permissions for an auth.  An auth must have at least one
-                Permission.
+              description: List of permissions for an auth.  An auth must have at least one Permission.
               items:
                 $ref: '#/components/schemas/Permission'
             id:
@@ -12919,9 +12682,7 @@ components:
             token:
               readOnly: true
               type: string
-              description: >-
-                Passed via the Authorization Header and Token Authentication
-                type.
+              description: Passed via the Authorization Header and Token Authentication type.
             userID:
               readOnly: true
               type: string
@@ -12964,9 +12725,7 @@ components:
             permissions:
               type: array
               minItems: 1
-              description: >-
-                List of permissions for an auth.  An auth must have at least one
-                Permission.
+              description: List of permissions for an auth.  An auth must have at least one Permission.
               items:
                 $ref: '#/components/schemas/Permission'
     LegacyAuthorizationPostRequest:
@@ -12989,9 +12748,7 @@ components:
             permissions:
               type: array
               minItems: 1
-              description: >-
-                List of permissions for an auth.  An auth must have at least one
-                Permission.
+              description: List of permissions for an auth.  An auth must have at least one Permission.
               items:
                 $ref: '#/components/schemas/Permission'
     Authorizations:
@@ -13045,18 +12802,13 @@ components:
             - notebooks
         id:
           type: string
-          description: >-
-            If ID is set that is a permission for a specific resource. if it is
-            not set it is a permission for all resources of that resource type.
+          description: If ID is set that is a permission for a specific resource. if it is not set it is a permission for all resources of that resource type.
         name:
           type: string
           description: Optional name of the resource if the resource has a name field.
         orgID:
           type: string
-          description: >-
-            If orgID is set that is a permission for all resources owned my that
-            org. if it is not set it is a permission for all resources of that
-            resource type.
+          description: If orgID is set that is a permission for all resources owned my that org. if it is not set it is a permission for all resources of that resource type.
         org:
           type: string
           description: Optional name of the organization of the organization with orgID.
@@ -13108,15 +12860,12 @@ components:
         retentionPeriodHrs:
           type: integer
           deprecated: true
-          description: >
-            Retention period *in nanoseconds* for the new bucket. This key's
-            name has been misleading since OSS 2.0 GA, please transition to use
-            `retentionPeriodSeconds`
+          description: |
+            Retention period *in nanoseconds* for the new bucket. This key's name has been misleading since OSS 2.0 GA, please transition to use `retentionPeriodSeconds`
         token:
           type: string
-          description: >
-            Authentication token to set on the initial user. If not specified,
-            the server will generate a token.
+          description: |
+            Authentication token to set on the initial user. If not specified, the server will generate a token.
       required:
         - username
         - org
@@ -13696,19 +13445,16 @@ components:
           schema:
             $ref: '#/components/schemas/Error'
   securitySchemes:
-    TokenAuth:
+    TokenAuthentication:
       type: http
       scheme: token
       bearerFormat: InfluxDB Token String
-      description: >
-        InfluxDB API tokens ensure secure interaction between users and data. A
-        token belongs to an organization and identifies InfluxDB permissions
-        within the organization.
+      description: |
+        ### Token authentication scheme
 
+        InfluxDB API tokens ensure secure interaction between users and data. A token belongs to an organization and identifies InfluxDB permissions within the organization.
 
-        Include your API token in an `Authentication: Token YOUR_API_TOKEN` HTTP
-        header with each request.
-
+        Include your API token in an `Authentication: Token YOUR_API_TOKEN` HTTP header with each request.
 
         ### Example
 
@@ -13719,52 +13465,45 @@ components:
           - [Use tokens in API requests](https://docs.influxdata.com/influxdb/v2.0/api-guide/api_intro/#authentication).
           - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.0/security/tokens).
           - [`/authorizations`](#tag/Authorizations) endpoint.
-    BasicAuth:
+    BasicAuthentication:
       type: http
       scheme: basic
-      description: >
-        Use Basic authentication with clients that support the InfluxDB 1.x
-        convention of username and password (that don't support the
-        `Authorization: Token` scheme).
+      description: |
+        ### Basic authentication scheme
 
+        Use HTTP Basic Auth with clients that support the InfluxDB 1.x convention of username and password (that don't support the `Authorization: Token` scheme).
 
         Username and password schemes require the following credentials:
           - **username**: 1.x username (this is separate from the UI login username)
           - **password**: 1.x password or InfluxDB API token
 
         ### Example
-
 
         `curl --get "http://localhost:8086/query"
               --user "YOUR_1.x_USERNAME":"YOUR_TOKEN_OR_PASSWORD"`
 
-        For more information and examples, see how to [authenticate with a
-        username and password
-        scheme](https://docs.influxdata.com/influxdb/v2.0/reference/api/influxdb-1x/)
-    QuerystringAuth:
+        For more information and examples, see how to [authenticate with a username and password scheme](https://docs.influxdata.com/influxdb/v2.0/reference/api/influxdb-1x/)
+    QuerystringAuthentication:
       type: apiKey
       in: query
       name: u=&p=
-      description: >
-        Use InfluxDB 1.x API parameters to provide credentials through the query
-        string.
+      description: |
+        ### Querystring authentication scheme
 
+        Use InfluxDB 1.x API parameters to provide credentials through the query string.
 
         Username and password schemes require the following credentials:
           - **username**: 1.x username (this is separate from the UI login username)
           - **password**: 1.x password or InfluxDB API token
 
         ### Example
-
 
         `curl --get "http://localhost:8086/query"
               --data-urlencode "u=YOUR_1.x_USERNAME"
               --data-urlencode "p=YOUR_TOKEN_OR_PASSWORD"`
 
-        For more information and examples, see how to [authenticate with a
-        username and password
-        scheme](https://docs.influxdata.com/influxdb/v2.0/reference/api/influxdb-1x/)
+        For more information and examples, see how to [authenticate with a username and password scheme](https://docs.influxdata.com/influxdb/v2.0/reference/api/influxdb-1x/)
 security:
-  - TokenAuth: []
-  - BasicAuth: []
-  - QuerystringAuth: []
+  - TokenAuthentication: []
+  - BasicAuthentication: []
+  - QuerystringAuthentication: []


### PR DESCRIPTION
* Update to latest openapi repo master that closed https://github.com/influxdata/openapi/issues/203
* Adds and updates Response codes in /write for OSS and Cloud.
* Adds Response samples for /write, reusable for other paths.
* Adds Overview > Response codes page with common response codes and descriptions.
* Adds group heading Data I/O endpoints for /write and /query.
* Relies on openapi-cli decorators to replace root-level paths.