### PR TITLE
Simplify 'send email' code examples

### DIFF
--- a/content/influxdb/v2.0/monitor-alert/send-email.md
+++ b/content/influxdb/v2.0/monitor-alert/send-email.md
@@ -43,12 +43,6 @@ Send an alert email using a third-party service, such as [SendGrid](https://send
    - Use the `map()` function to evaluate the criteria to send an alert using `http.post()`.
    - Specify your email service `url` (endpoint), include applicable request `headers`, and verify your request `data` format follows the format specified for your email service.
 
-{{% note %}}
-#### Escape double quotes in your request body
-To successfully byte-encode request bodies (`data`) in the `http.post()` function,
-escape all double-quote characters with a backslash (`\"`).
-{{% /note %}}
-
 #### Examples
 
 {{< tabs-wrapper >}}


### PR DESCRIPTION
* instead of defining the HTTP POST payload as a string, define it as a record and use [`json.encode`](https://docs.influxdata.com/flux/v0.x/stdlib/json/encode/) to encode into bytes
* use [implicit string conversion](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#string-literals) when interpolating values into the payload

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [x] Rebased/mergeable
