### PR TITLE
 Include TLS setup in Enterprise post-install steps 

### DIFF
--- a/content/enterprise_influxdb/v1.9/guides/enable_tls.md
+++ b/content/enterprise_influxdb/v1.9/guides/enable_tls.md
@@ -90,7 +90,7 @@ Some Certificate Authorities provide certificate files with other extensions.
 Consult your CA if you are unsure about how to use these files.
     {{% /note %}}
 
-3. **Ensure file permissions for each Node.**
+3. **Ensure file permissions for each node.**
 
     Certificate files require read and write access by the `influxdb` user.
     Ensure that you have the correct file permissions in each meta node and data node by running the following commands:

--- a/content/enterprise_influxdb/v1.9/guides/enable_tls.md
+++ b/content/enterprise_influxdb/v1.9/guides/enable_tls.md
@@ -57,7 +57,7 @@ In general, each node node should have its own certificate, whether signed or un
 
 ## Set up HTTPS in an InfluxDB Enterprise cluster
 
-1. **Download or generate certificate files**
+1. **Download or generate certificate files.**
 
     If using a certificate provided by a CA, follow their instructions to download the certificate files.
 
@@ -79,7 +79,7 @@ You can choose to fill out these fields or leave them blank; both actions genera
 In subsequent steps, you will need to copy the certificate and key (or `.pem` file) to each node in the cluster.
     {{% /note %}}
 
-2. **Install the SSL/TLS certificate in each Node**
+2. **Install the SSL/TLS certificate in each Node.**
 
     Place the private key file (`.key`) and the signed certificate file (`.crt`)
     or the single bundled file (`.pem`)
@@ -90,7 +90,7 @@ Some Certificate Authorities provide certificate files with other extensions.
 Consult your CA if you are unsure about how to use these files.
     {{% /note %}}
 
-3. **Ensure file permissions for each Node**
+3. **Ensure file permissions for each Node.**
 
     Certificate files require read and write access by the `influxdb` user.
     Ensure that you have the correct file permissions in each meta node and data node by running the following commands:
@@ -101,7 +101,7 @@ Consult your CA if you are unsure about how to use these files.
     sudo chmod 600 /etc/ssl/<private-key-file>
     ```
 
-4. **Enable HTTPS within the configuration file for each meta node**
+4. **Enable HTTPS within the configuration file for each meta node.**
 
     Enable HTTPS for each meta node within the `[meta]` section of the meta node configuration file (`influxdb-meta.conf`) by setting:
 
@@ -128,32 +128,28 @@ Consult your CA if you are unsure about how to use these files.
 
     ```
 
-5. **Enable HTTPS within the configuration file for each data node**
+5. **Enable HTTPS within the configuration file for each data node.**
 
     Make the following sets of changes in the configuration file (`influxdb.conf`) on each data node:
-
     1. Enable HTTPS for each data node within the `[http]` section of the configuration file by setting:
+       ```toml
+       [http]
 
-      ```toml
-      [http]
+         [...]
 
-        [...]
+          # Determines whether HTTPS is enabled.
+          https-enabled = true
 
-        # Determines whether HTTPS is enabled.
-        https-enabled = true
+          [...]
 
-        [...]
+          # The SSL certificate to use when HTTPS is enabled.
+          https-certificate = "influxdb-data.crt"
 
-        # The SSL certificate to use when HTTPS is enabled.
-        https-certificate = "influxdb-data.crt"
-
-        # Use a separate private key location.
-        https-private-key = "influxdb-data.key"
-      ```
-
+          # Use a separate private key location.
+          https-private-key = "influxdb-data.key"
+       ```
     2. Configure the data nodes to use HTTPS when communicating with other data nodes.
        In the `[cluster]` section of the configuration file, set the following:
-
        ```toml
        [cluster]
 
@@ -171,10 +167,8 @@ Consult your CA if you are unsure about how to use these files.
          # If using a self-signed certificate:
          https-insecure-tls = true
        ```
-
     3. Configure the data nodes to use HTTPS when communicating with the meta nodes.
        In the `[meta]` section of the configuration file, set the following:
-
        ```toml
        [meta]
 
@@ -184,8 +178,7 @@ Consult your CA if you are unsure about how to use these files.
            # If using a self-signed certificate:
            meta-insecure-tls = true
        ```
-
-6. **Restart InfluxDB Enterprise**
+6. **Restart InfluxDB Enterprise.**
 
     Restart the InfluxDB Enterprise processes for the configuration changes to take effect:
 
@@ -199,7 +192,7 @@ Consult your CA if you are unsure about how to use these files.
     sudo systemctl restart influxdb
     ```
 
-7. **Verify the HTTPS Setup**
+7. **Verify the HTTPS Setup.**
 
     Verify that HTTPS is working on the meta nodes by using `influxd-ctl`.
 

--- a/content/enterprise_influxdb/v1.9/guides/enable_tls.md
+++ b/content/enterprise_influxdb/v1.9/guides/enable_tls.md
@@ -79,7 +79,7 @@ You can choose to fill out these fields or leave them blank; both actions genera
 In subsequent steps, you will need to copy the certificate and key (or `.pem` file) to each node in the cluster.
     {{% /note %}}
 
-2. **Install the SSL/TLS certificate in each Node.**
+2. **Install the SSL/TLS certificate in each node.**
 
     Place the private key file (`.key`) and the signed certificate file (`.crt`)
     or the single bundled file (`.pem`)

--- a/content/enterprise_influxdb/v1.9/guides/enable_tls.md
+++ b/content/enterprise_influxdb/v1.9/guides/enable_tls.md
@@ -192,7 +192,7 @@ Consult your CA if you are unsure about how to use these files.
     sudo systemctl restart influxdb
     ```
 
-7. **Verify the HTTPS Setup.**
+7. **Verify the HTTPS setup.**
 
     Verify that HTTPS is working on the meta nodes by using `influxd-ctl`.
 

--- a/content/enterprise_influxdb/v1.9/guides/enable_tls.md
+++ b/content/enterprise_influxdb/v1.9/guides/enable_tls.md
@@ -1,16 +1,18 @@
 ---
-title: Enable HTTPS for InfluxDB Enterprise
+title: Enable HTTPS over TLS for InfluxDB Enterprise
 description: >
-  Enabling HTTPS encrypts the communication between clients and the InfluxDB Enterprise server, and between nodes in the cluster.
+  Enabling HTTPS over TLS encrypts the communication between clients and the InfluxDB Enterprise server, and between nodes in the cluster.
 menu:
   enterprise_influxdb_1_9:
-    name: Enable HTTPS
+    name: Enable TLS
     weight: 100
     parent: Guides
+aliases:
+  - /enterprise_influxdb/v1.9/guides/https_setup/
 ---
 
-Enabling HTTPS encrypts the communication between clients and the InfluxDB Enterprise server, and between nodes in the cluster.
-When configured with a signed certificate, HTTPS can also verify the authenticity of the InfluxDB Enterprise server to connecting clients.
+Enabling HTTPS over TLS encrypts the communication between clients and the InfluxDB Enterprise server, and between nodes in the cluster.
+When configured with a signed certificate, HTTPS over TLS can also verify the authenticity of the InfluxDB Enterprise server to connecting clients.
 
 This pages outlines how to set up HTTPS with InfluxDB Enterprise using either a signed or self-signed certificate.
 

--- a/content/enterprise_influxdb/v1.9/introduction/install-and-deploy/installation/data_node_installation.md
+++ b/content/enterprise_influxdb/v1.9/introduction/install-and-deploy/installation/data_node_installation.md
@@ -297,9 +297,6 @@ If not, there may be artifacts of a previous cluster in the metastore.
 If you do not see your data nodes in the output, please retry adding them
 to the cluster.
 
-Once your data nodes are part of your cluster move on to [the final step
-to set up Chronograf](/enterprise_influxdb/v1.9/install-and-deploy/installation/chrono_install).
-
 ## Step 4: Create an admin user
 
 In [Step 2](#b-edit-the-data-node-configuration-files), you enabled authentication.
@@ -309,3 +306,13 @@ To create an admin user, use the [`influx` CLI](/enterprise_influxdb/v1.9/tools/
 ```sql
 CREATE USER admin WITH PASSWORD '<password>' WITH ALL PRIVILEGES
 ```
+
+---
+
+## Next steps
+
+Once your data nodes are part of your cluster:
+
+- [Set up Chronograf](/enterprise_influxdb/v1.9/install-and-deploy/installation/chrono_install)
+  for UI visualization, dashboards, and management.
+- [Enable TLS](/enterprise_influxdb/v1.9/guides/enable-tls/) for increased security (recommended).


### PR DESCRIPTION
Closes #3270.

Including TLS setup in the main meta/data installation docs would introduce significant complexity for initial users. Here we recommend enabling TLS after installing data nodes.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
