### PR TITLE
docs: update telegraf configuration.md

### DIFF
--- a/content/telegraf/v1.20/administration/configuration.md
+++ b/content/telegraf/v1.20/administration/configuration.md
@@ -150,7 +150,7 @@ The following config parameters are available for all inputs:
 * **alias**: Name an instance of a plugin.
 * **interval**: How often to gather this metric. Normal plugins use a single
 global interval, but if one particular input should be run less or more often,
-you can configure that here.
+you can configure that here. `interval` can be increased to reduce data-in rate limits. 
 * **precision**: Overrides the `precision` setting of the agent. Collected 
 metrics are rounded to the precision specified as an `interval`. When this value is 
 set on a service input (ex: `statsd`), multiple events occuring at the same 


### PR DESCRIPTION
- Added missing setting from GitHub configuration.md: https://github.com/influxdata/telegraf/blob/master/docs/CONFIGURATION.md
- Changed some of the heading sizes to hopefully make more sense

fyi this PR (https://github.com/influxdata/docs-v2/pull/2754) was added in July 2021 but the changes don't exist in the latest docs (1.20) 