### PR TITLE
Update token variable naming and other typos

### DIFF
--- a/content/influxdb/cloud/reference/api/_index.md
+++ b/content/influxdb/cloud/reference/api/_index.md
@@ -20,7 +20,7 @@ Include your API token as an `Authorization` header in each request.
 
 ```sh
 curl --request POST https://cloud2.influxdata.com/api/v2/write \
-  --header "Authorization: Token YOURAUTHTOKEN" \
+  --header "Authorization: Token YOUR_API_TOKEN" \
   --data-urlencode "org=myorg" \
   --data-urlencode "bucket=example-bucket"
 ```

--- a/content/influxdb/cloud/reference/cli/influx/_index.md
+++ b/content/influxdb/cloud/reference/cli/influx/_index.md
@@ -37,7 +37,7 @@ to create an `influx` CLI config and set it as active:
 influx config create --config-name <config-name> \
   --host-url http://localhost:8086 \
   --org <your-org> \
-  --token <your-auth-token> \
+  --token <your-api-token> \
   --active
 ```
 

--- a/content/influxdb/cloud/security/secrets/add.md
+++ b/content/influxdb/cloud/security/secrets/add.md
@@ -64,7 +64,7 @@ add a new secret to your organization.
 <!-- -->
 ```sh
 curl -XPATCH https://cloud2.influxdata.com/api/v2/orgs/<org-id>/secrets \
-  -H 'Authorization: Token YOURAUTHTOKEN' \
+  -H 'Authorization: Token YOUR_API_TOKEN' \
   -H 'Content-type: application/json' \
   --data '{
 	"<secret-key>": "<secret-value>"

--- a/content/influxdb/cloud/security/secrets/delete.md
+++ b/content/influxdb/cloud/security/secrets/delete.md
@@ -51,7 +51,7 @@ to delete one or more secrets.
 <!-- -->
 ```bash
 curl -XGET https://cloud2.influxdata.com/api/v2/orgs/<org-id>/secrets/delete \
-  --H 'Authorization: Token YOURAUTHTOKEN'
+  --H 'Authorization: Token YOUR_API_TOKEN'
   --data '{
   "secrets": [
     "<secret-key>"

--- a/content/influxdb/cloud/security/secrets/update.md
+++ b/content/influxdb/cloud/security/secrets/update.md
@@ -59,7 +59,7 @@ to update a secret in your organization.
 <!-- -->
 ```sh
 curl -XPATCH https://cloud2.influxdata.com/api/v2/orgs/<org-id>/secrets \
-  -H 'Authorization: Token YOURAUTHTOKEN' \
+  -H 'Authorization: Token YOUR_API_TOKEN' \
   -H 'Content-type: application/json' \
   --data '{
 	"<secret-key>": "<secret-value>"

--- a/content/influxdb/cloud/security/secrets/view.md
+++ b/content/influxdb/cloud/security/secrets/view.md
@@ -50,5 +50,5 @@ to view your organization's secrets keys.
 <!-- -->
 ```sh
 curl -XGET https://cloud2.influxdata.com/api/v2/orgs/<org-id>/secrets \
-  -H 'Authorization: Token YOURAUTHTOKEN'
+  -H 'Authorization: Token YOUR_API_TOKEN'
 ```

--- a/content/influxdb/v2.0/process-data/manage-tasks/create-task.md
+++ b/content/influxdb/v2.0/process-data/manage-tasks/create-task.md
@@ -151,7 +151,7 @@ curl --request POST 'https://us-west-2-1.aws.cloud2.influxdata.com/api/v2/tasks'
 }'
 ```
 Replace the following:
-- *`INFLUX_API_TOKEN`*: your [InfluxDB API token](/influxdb/v2.0/security/tokens/)
+- *`INFLUX_TOKEN`*: your [InfluxDB API token](/influxdb/v2.0/security/tokens/)
 - *`INFLUX_ORG`*: your [InfluxDB organization name](influxdb/2.0/organizations/view-orgs/)
 - *`INFLUX_ORG_ID`*: your [InfluxDB organization ID](/influxdb/v2.0/organizations/view-orgs/#view-your-organization-id)
 

--- a/content/influxdb/v2.0/query-data/execute-queries/influx-api.md
+++ b/content/influxdb/v2.0/query-data/execute-queries/influx-api.md
@@ -43,7 +43,7 @@ Below is an example `curl` request that sends a Flux query to InfluxDB 2.0:
 ```bash
 curl --request POST \
   http://localhost:8086/api/v2/query?org=my-org  \
-  --header 'Authorization: Token YOURAUTHTOKEN' \
+  --header 'Authorization: Token YOUR_API_TOKEN' \
   --header 'Accept: application/csv' \
   --header 'Content-type: application/vnd.flux' \
   --data 'from(bucket:"example-bucket")
@@ -57,7 +57,7 @@ curl --request POST \
 ```bash
 curl --request POST \
   http://localhost:8086/api/v2/query?org=my-org \
-  --header 'Authorization: Token YOURAUTHTOKEN' \
+  --header 'Authorization: Token YOUR_API_TOKEN' \
   --header 'Accept: application/csv' \
   --header 'Content-type: application/vnd.flux' \
   --header 'Accept-Encoding: gzip' \
@@ -82,7 +82,7 @@ Below is an example `curl` request that sends an InfluxQL query to InfluxDB 2.0:
 {{% code-tab-content %}}
 ```bash
 curl --request -G http://localhost:8086/query?org=my-org?database=MyDB&retention_policy=MyRP \
-  --header 'Authorization: Token YOURAUTHTOKEN' \
+  --header 'Authorization: Token YOUR_API_TOKEN' \
   --header 'Accept: application/csv' \
   --header 'Content-type: application/json' \
   --data-urlencode "q=SELECT used_percent FROM example-db.example-rp.example-measurement WHERE host=host1"
@@ -92,7 +92,7 @@ curl --request -G http://localhost:8086/query?org=my-org?database=MyDB&retention
 {{% code-tab-content %}}
 ```bash
 curl --request -G http://localhost:8086/query?org=my-org?database=MyDB&retention_policy=MyRP \
-  --header 'Authorization: Token YOURAUTHTOKEN' \
+  --header 'Authorization: Token YOUR_API_TOKEN' \
   --header 'Accept: application/csv' \
   --header 'Content-type: application/json' \
   --header 'Accept-Encoding: gzip' \

--- a/content/influxdb/v2.0/query-data/flux/sql.md
+++ b/content/influxdb/v2.0/query-data/flux/sql.md
@@ -234,7 +234,7 @@ to store your database credentials as secrets.
 {{% tab-content %}}
 ```sh
 curl --request PATCH http://localhost:8086/api/v2/orgs/<org-id>/secrets \
-  --header 'Authorization: Token YOURAUTHTOKEN' \
+  --header 'Authorization: Token YOUR_API_TOKEN' \
   --header 'Content-type: application/json' \
   --data '{
   "POSTGRES_HOST": "http://example.com",

--- a/content/influxdb/v2.0/reference/cli/influx/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/_index.md
@@ -35,7 +35,7 @@ to create an `influx` CLI config and set it as active:
 influx config create --config-name <config-name> \
   --host-url http://localhost:8086 \
   --org <your-org> \
-  --token <your-auth-token> \
+  --token <your-api-token> \
   --active
 ```
 

--- a/content/influxdb/v2.0/security/secrets/add.md
+++ b/content/influxdb/v2.0/security/secrets/add.md
@@ -50,7 +50,7 @@ add a new secret to your organization.
 <!-- -->
 ```sh
 curl --request PATCH http://localhost:8086/api/v2/orgs/<org-id>/secrets \
-  --header 'Authorization: Token YOURAUTHTOKEN' \
+  --header 'Authorization: Token YOUR_API_TOKEN' \
   --header 'Content-type: application/json' \
   --data '{
 	"<secret-key>": "<secret-value>"

--- a/content/influxdb/v2.0/security/secrets/delete.md
+++ b/content/influxdb/v2.0/security/secrets/delete.md
@@ -41,7 +41,7 @@ to delete one or more secrets.
 <!-- -->
 ```bash
 curl --request GET http://localhost:8086/api/v2/orgs/<org-id>/secrets/delete \
-  --header 'Authorization: Token YOURAUTHTOKEN' \
+  --header 'Authorization: Token YOUR_API_TOKEN' \
   --data '{
   "secrets": [
     "<secret-key>"

--- a/content/influxdb/v2.0/security/secrets/update.md
+++ b/content/influxdb/v2.0/security/secrets/update.md
@@ -49,7 +49,7 @@ to update a secret in your organization.
 <!-- -->
 ```sh
 curl --request PATCH http://localhost:8086/api/v2/orgs/<org-id>/secrets \
-  --header 'Authorization: Token YOURAUTHTOKEN' \
+  --header 'Authorization: Token YOUR_API_TOKEN' \
   --header 'Content-type: application/json' \
   --data '{
 	"<secret-key>": "<secret-value>"

--- a/content/influxdb/v2.0/security/secrets/view.md
+++ b/content/influxdb/v2.0/security/secrets/view.md
@@ -35,5 +35,5 @@ to view your organization's secrets keys.
 <!-- -->
 ```sh
 curl --request GET http://localhost:8086/api/v2/orgs/<org-id>/secrets \
-  --header 'Authorization: Token YOURAUTHTOKEN'
+  --header 'Authorization: Token YOUR_API_TOKEN'
 ```

--- a/shared/text/api/v2.0/api-invocable-scripts/create-flux-script.sh
+++ b/shared/text/api/v2.0/api-invocable-scripts/create-flux-script.sh
@@ -1,6 +1,6 @@
 curl -X 'POST' \
-  "http://cloud2.influxdata.com/api/v2/scripts" \
-  --header "Authorization: Token ${INFLUX_API_TOKEN}" \
+  "https://cloud2.influxdata.com/api/v2/scripts" \
+  --header "Authorization: Token ${INFLUX_TOKEN}" \
   --header 'accept: application/json' \
   --header 'Content-Type: application/json' \
   --data-binary @- << EOF | jq .

--- a/shared/text/api/v2.0/api-invocable-scripts/find.sh
+++ b/shared/text/api/v2.0/api-invocable-scripts/find.sh
@@ -1,5 +1,5 @@
 curl -X 'GET' \
   "${INFLUX_URL}/api/v2/scripts/${SCRIPT_ID}" \
-  --header "Authorization: Token ${INFLUX_API_TOKEN}" \
+  --header "Authorization: Token ${INFLUX_TOKEN}" \
   --header 'accept: application/json' \
   --header 'Content-Type: application/json'

--- a/shared/text/api/v2.0/api-invocable-scripts/invoke_with_params.sh
+++ b/shared/text/api/v2.0/api-invocable-scripts/invoke_with_params.sh
@@ -1,7 +1,7 @@
 new_script_id=$(
   curl -v -X 'POST' \
     "${INFLUX_URL}/api/v2/scripts" \
-    --header "Authorization: Token ${INFLUX_API_TOKEN}" \
+    --header "Authorization: Token ${INFLUX_TOKEN}" \
     --header 'Accept: application/json' \
     --header 'Content-Type: application/json' \
     --data-binary @- << EOF | jq -r '.id' 
@@ -20,7 +20,7 @@ EOF
 
 curl -vv -X 'POST' \
   "${INFLUX_URL}/api/v2/scripts/${new_script_id}/invoke" \
-  --header "Authorization: Token ${INFLUX_API_TOKEN}" \
+  --header "Authorization: Token ${INFLUX_TOKEN}" \
   --header 'Accept: application/csv' \
   --header 'Content-Type: application/json' \
   --data-binary @- << EOF

--- a/shared/text/api/v2.0/api-invocable-scripts/list.sh
+++ b/shared/text/api/v2.0/api-invocable-scripts/list.sh
@@ -1,6 +1,6 @@
 curl -X 'GET' \
   "${INFLUX_URL}/api/v2/scripts" \
-  --header "Authorization: Token ${INFLUX_API_TOKEN}" \
+  --header "Authorization: Token ${INFLUX_TOKEN}" \
   --header 'accept: application/json' \
   --header 'Content-Type: application/json' \
-  --data-urlencode 'org=jstirnamaninflux&limit=10'
+  --data-urlencode "org=${INFLUX_ORG}&limit=10"

--- a/shared/text/api/v2.0/api-invocable-scripts/update-flux-script.sh
+++ b/shared/text/api/v2.0/api-invocable-scripts/update-flux-script.sh
@@ -1,10 +1,10 @@
 find_and_update() {
   script=$(curl -X 'GET' \
-    "http://cloud2.influxdata.com/api/v2/scripts" \
-    --header "Authorization: Token ${INFLUX_API_TOKEN}" \
+    "https://cloud2.influxdata.com/api/v2/scripts" \
+    --header "Authorization: Token ${INFLUX_TOKEN}" \
     --header 'Accept: application/json' \
     --header 'Content-Type: application/json' \
-    --data-urlencode 'org=jstirnamaninflux&limit=10' \
+    --data-urlencode "org=${INFLUX_ORG}&limit=10" \
     | jq '[.scripts[] | select(.script | test("start: -?\\d\\w"))]' \
     | jq '.[0]')
   new_script=$(jq '.script |= sub("start: .*d"; "start: params.myrangestart")' <<< "${script}")
@@ -12,7 +12,7 @@ find_and_update() {
 
   curl -X 'PATCH' \
     "${INFLUX_URL}/api/v2/scripts/${script_id}" \
-    --header "Authorization: Token ${INFLUX_API_TOKEN}" \
+    --header "Authorization: Token ${INFLUX_TOKEN}" \
     --header 'Accept: application/json' \
     --header 'Content-Type: application/json' \
     --data "${new_script}" | jq .

--- a/shared/text/api/v2.0/auth/oss/token-create.sh
+++ b/shared/text/api/v2.0/auth/oss/token-create.sh
@@ -1,9 +1,9 @@
 INFLUX_ORG_ID=YOUR_ORG_ID
-INFLUX_API_TOKEN=YOUR_API_TOKEN
+INFLUX_TOKEN=YOUR_API_TOKEN
 
 curl -v --request POST \
   http://localhost:8086/api/v2/authorizations \
-  --header "Authorization: Token ${INFLUX_API_TOKEN}" \
+  --header "Authorization: Token ${INFLUX_TOKEN}" \
   --header 'Content-type: application/json' \
   --data '{
   "status": "active",

--- a/shared/text/api/v2.0/write/write.mjs
+++ b/shared/text/api/v2.0/write/write.mjs
@@ -7,7 +7,7 @@ import { InfluxDB, Point } from '@influxdata/influxdb-client'
 
 /** Environment variables **/
 const url = process.env.INFLUX_URL
-const token = process.env.INFLUX_API_TOKEN
+const token = process.env.INFLUX_TOKEN
 const org = process.env.INFLUX_ORG
 const bucket = process.env.INFLUX_BUCKET
 


### PR DESCRIPTION
Closes influxdata/DAR#244

This updates some issues found in the new invocable scripts docs. It also brought up some inconsistencies in how we reference tokens.

- "Auth token" is no longer used and should be replaced with "API token".
- One special use-case is when using environment variables to reference an InfluxDB API token. With the release of 2.0, we established the convention of using the `INFLUX_TOKEN` environment variable to reference tokens. The `influx` CLI checks for this environment variable. For any examples using environment variables, we should stick with `INFLUX_TOKEN`.

---

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
