### PR TITLE
fix: correct debian/ubuntu install instructions

### DIFF
--- a/content/telegraf/v1.20/introduction/installation.md
+++ b/content/telegraf/v1.20/introduction/installation.md
@@ -124,7 +124,7 @@ gpgkey = https://repos.influxdata.com/influxdb.key
 EOF
 ```
 
-Install telegraf once repository is added to the `yum` configuration:
+Install telegraf once the repository is added to the `yum` configuration:
 
 ```bash
 sudo yum install telegraf


### PR DESCRIPTION
This consolidates the Debian and Ubutnu install instructions into one
section. The install instructions can be the same for both as they use
the same package manager (i.e. apt).

This removes the use of the now deprecated pipe to apt-key.

This removes references to starting the service, as the service starts
on install and does not require an extra step. Also all supported
operating systems are using systemd at this point so no need to call
that out seperatly.

Removes an extra 'sudo' in deb instructions.

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [x] Rebased/mergeable
