### PR TITLE
fix: mjs example path (#3305)

### DIFF
--- a/content/influxdb/cloud/write-data/developer-tools/api.md
+++ b/content/influxdb/cloud/write-data/developer-tools/api.md
@@ -35,7 +35,7 @@ The URL in the examples depends on your [InfluxDB Cloud region](/influxdb/cloud/
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```js
-{{< get-shared-text "api/v2.0/write/write.sh" >}}
+{{< get-shared-text "api/v2.0/write/write.mjs" >}}
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}

--- a/content/influxdb/v2.0/write-data/developer-tools/api.md
+++ b/content/influxdb/v2.0/write-data/developer-tools/api.md
@@ -36,7 +36,7 @@ The URL in the examples depends on the version and location of your InfluxDB 2.0
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```js
-{{< get-shared-text "api/v2.0/write/write.sh" >}}
+{{< get-shared-text "api/v2.0/write/write.mjs" >}}
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}


### PR DESCRIPTION
Replaces code example .sh path with .mjs path.
Part of #3305