### PR TITLE
fix copy & paste mistake 

### DIFF
--- a/content/influxdb/v2.1/install.md
+++ b/content/influxdb/v2.1/install.md
@@ -244,7 +244,7 @@ For information about installing the `influx` CLI, see
     sudo cp influxdb2-{{< latest-patch >}}-linux-amd64/influxd /usr/local/bin/
 
     # arm
-    sudo cp influxdb2-{{< latest-patch >}}-linux-amd64/influxd /usr/local/bin/
+    sudo cp influxdb2-{{< latest-patch >}}-linux-arm64/influxd /usr/local/bin/
     ```
 
     If you do not move the `influxd` binary into your `$PATH`, prefix the executable


### PR DESCRIPTION
Fixed a mistake in the linux section of the installation instructions. The intructions for arm should not use the amd directory.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
