### PR TITLE
Fix incorrect reference to `derivative` function

### DIFF
--- a/content/flux/v0.x/stdlib/universe/increase.md
+++ b/content/flux/v0.x/stdlib/universe/increase.md
@@ -44,7 +44,7 @@ Input data.
 Default is piped-forward data ([`<-`](/flux/v0.x/spec/expressions/#pipe-expressions)).
 
 ## Output tables
-For each input table with `n` rows, `derivative()` outputs a table with `n - 1` rows.
+For each input table with `n` rows, `increase()` outputs a table with `n - 1` rows.
 
 ## Examples
 


### PR DESCRIPTION
Closes #

_Describe your proposed changes here._

In the documentation page of increase, section "Output tables", there is an incorrect reference to the `derivative` function.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
