### PR TITLE
Typo in INFLUXD_STORAGE_RETENTION_CHECK_INTERVAL

### DIFF
--- a/content/influxdb/v2.1/reference/config-options.md
+++ b/content/influxdb/v2.1/reference/config-options.md
@@ -2040,7 +2040,7 @@ influxd --storage-retention-check-interval=30m0s
 
 ###### Environment variable
 ```sh
-export INFLUXD_STORAGE_MAX_INDEX_LOG_FILE_SIZE=30m0s
+export INFLUXD_STORAGE_RETENTION_CHECK_INTERVAL=30m0s
 ```
 
 ###### Configuration file


### PR DESCRIPTION
Noticed by community user: https://influxcommunity.slack.com/archives/CH8TV3LJG/p1637592013183400

Closes #

_Describe your proposed changes here._
The environment variable used the wrong naming notation for the given command.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
