### PR TITLE
Missing 's' for the user's right params in the documentation

### DIFF
--- a/content/influxdb/v2.1/reference/cli/influx/auth/create.md
+++ b/content/influxdb/v2.1/reference/cli/influx/auth/create.md
@@ -41,7 +41,7 @@ influx auth create [flags]
 |      | `--read-orgs`                   | Grant permission to read organizations                                |             |                       |
 |      | `--read-tasks`                  | Grant permission to read tasks                                        |             |                       |
 |      | `--read-telegrafs`              | Grant permission to read Telegraf configurations                      |             |                       |
-|      | `--read-user`                   | Grant permission to read organization users                           |             |                       |
+|      | `--read-users`                  | Grant permission to read organization users                           |             |                       |
 |      | `--skip-verify`                 | Skip TLS certificate verification                                     |             | `INFLUX_SKIP_VERIFY`  |
 | `-t` | `--token`                       | API token                                                             | string      | `INFLUX_TOKEN`        |
 | `-u` | `--user`                        | Username                                                              | string      |                       |
@@ -55,7 +55,7 @@ influx auth create [flags]
 |      | `--write-orgs`                  | Grant permission to create and update organizations                   |             |                       |
 |      | `--write-tasks`                 | Grant permission to create and update tasks                           |             |                       |
 |      | `--write-telegrafs`             | Grant permission to create and update Telegraf configurations         |             |                       |
-|      | `--write-user`                  | Grant permission to create and update organization users              |             |                       |
+|      | `--write-users`                  | Grant permission to create and update organization users              |             |                       |
 
 ## Examples
 
@@ -100,7 +100,7 @@ influx auth create \
   --read-orgs \
   --read-tasks \
   --read-telegrafs \
-  --read-user \
+  --read-users \
   --write-buckets \
   --write-checks \
   --write-dashboards \
@@ -110,7 +110,7 @@ influx auth create \
   --write-orgs \
   --write-tasks \
   --write-telegrafs \
-  --write-user
+  --write-users
 ```
 
 ### Create an API token with read and write access to specific buckets
@@ -136,5 +136,5 @@ influx auth create \
   --read-orgs \
   --read-tasks \
   --read-telegrafs \
-  --read-user
+  --read-users
 ```


### PR DESCRIPTION
At [https://docs.influxdata.com/influxdb/v2.1/reference/cli/influx/auth/create](https://docs.influxdata.com/influxdb/v2.1/reference/cli/influx/auth/create)
This doc says that '--read-user' and '--write-user' should work for the _influx auth create_ command
But this command knows '--read-user**s**' and '--write-user**s**' not '--read-user' and '--write-user'

Closes #

Merge proposed fix

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
