### PR TITLE
Fix JSON syntax error in bucket create example

### DIFF
--- a/shared/text/api/v2.0/buckets/oss/create.sh
+++ b/shared/text/api/v2.0/buckets/oss/create.sh
@@ -14,5 +14,5 @@ curl --request POST \
         "everySeconds": 86400,
         "shardGroupDurationSeconds": 0
       }
-    ],
+    ]
   }'


### PR DESCRIPTION
Closes influxdata/DAR#261

- [x] Rebased/mergeable
