### PR TITLE
Update "node.js" tag to "nodejs"

### DIFF
--- a/content/influxdb/cloud/api-guide/client-libraries/nodejs/query.md
+++ b/content/influxdb/cloud/api-guide/client-libraries/nodejs/query.md
@@ -6,7 +6,7 @@ menu:
   influxdb_cloud:
     name: Query
     parent: Node.js
-influxdb/cloud/tags: [client libraries, Node.js, JavaScript]
+influxdb/cloud/tags: [client libraries, nodejs, JavaScript]
 weight: 201
 aliases:
   - /influxdb/cloud/reference/api/client-libraries/js/query

--- a/content/influxdb/cloud/api-guide/client-libraries/nodejs/write.md
+++ b/content/influxdb/cloud/api-guide/client-libraries/nodejs/write.md
@@ -6,7 +6,7 @@ menu:
   influxdb_cloud:
     name: Write
     parent: Node.js
-influxdb/cloud/tags: [client libraries, Node.js, JavaScript]
+influxdb/cloud/tags: [client libraries, nodejs, JavaScript]
 weight: 101
 aliases:
   - /influxdb/cloud/reference/api/client-libraries/js/write


### PR DESCRIPTION
The "Node.js" tag was causing 404s because of how the webserver handles URLs with the `.js` extension. Because Hugo creates a landing page using the name of each tag, the landing page for the Node.js tag was `/influxdb/cloud/tags/node.js` which the webserver and browser would parse as an extension.

This change simply updates the "Node.js" tag to `nodejs` to prevent this issue from happening.

- [x] Rebased/mergeable
