### PR TITLE
feat: add authorization info to influxdb.api().

### DIFF
--- a/content/flux/v0.x/stdlib/experimental/influxdb/api.md
+++ b/content/flux/v0.x/stdlib/experimental/influxdb/api.md
@@ -18,6 +18,8 @@ The `influxdb.api()` function submits an HTTP request to the specified InfluxDB
 API path and returns a record containing the HTTP status code, response headers,
 and response body as a byte array.
 
+`influxdb.api()` requests use the authorization of the `token` (if provided) or the invoking user. InfluxDB applies the same access permissions and limits as when directly accessing the API.
+
 ```js
 import "experimental/influxdb"
 

--- a/content/flux/v0.x/stdlib/experimental/influxdb/api.md
+++ b/content/flux/v0.x/stdlib/experimental/influxdb/api.md
@@ -18,7 +18,9 @@ The `influxdb.api()` function submits an HTTP request to the specified InfluxDB
 API path and returns a record containing the HTTP status code, response headers,
 and response body as a byte array.
 
-`influxdb.api()` requests use the authorization of the `token` (if provided) or the invoking user. InfluxDB applies the same access permissions and limits as when directly accessing the API.
+`influxdb.api()` uses the authorization of the specified `token` or, if executed from
+the InfluxDB UI, the authorization of the InfluxDB user that invokes the script.
+Authorization permissions and limits apply to each request.
 
 ```js
 import "experimental/influxdb"


### PR DESCRIPTION
Closes #2833

Add note about authorization used in influxdb.api()

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
