### PR TITLE
added 2.1 alias to IQL 1.8 spec

### DIFF
--- a/content/influxdb/v1.8/query_language/spec.md
+++ b/content/influxdb/v1.8/query_language/spec.md
@@ -8,6 +8,7 @@ menu:
     parent: InfluxQL
 aliases:
   - /influxdb/v2.0/query_language/spec/
+  - /influxdb/v2.1/query_language/spec/
 ---
 
 ## Introduction


### PR DESCRIPTION
Closes # https://github.com/influxdata/docs-v2/issues/3643

added the following alias:

/influxdb/v2.1/query_language/spec/

to /influxdb/v1.8/query_language/spec/
