### PR TITLE
FGA location trusted change

### DIFF
--- a/content/enterprise_influxdb/v1.9/administration/manage/users-and-permissions/fine-grained-authorization.md
+++ b/content/enterprise_influxdb/v1.9/administration/manage/users-and-permissions/fine-grained-authorization.md
@@ -135,7 +135,7 @@ The following examples create two new roles:
 
 ```sh
 # Create east role
-curl -s -L -XPOST "http://localhost:8091/role" \
+curl -s --location-trusted -XPOST "http://localhost:8091/role" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -146,7 +146,7 @@ curl -s -L -XPOST "http://localhost:8091/role" \
   }'
 
 # Create west role
-curl -s -L -XPOST "http://localhost:8091/role" \
+curl -s --location-trusted -XPOST "http://localhost:8091/role" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -165,7 +165,7 @@ Specify the [permissions](/chronograf/v1.8/administration/managing-influxdb-user
 The following example sets read and write permissions on `db1` for both `east` and `west` roles.
 
 ```sh
-curl -s -L -XPOST "http://localhost:8091/role" \
+curl -s --location-trusted -XPOST "http://localhost:8091/role" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -178,7 +178,7 @@ curl -s -L -XPOST "http://localhost:8091/role" \
     }
   }'
 
-curl -s -L -XPOST "http://localhost:8091/role" \
+curl -s --location-trusted -XPOST "http://localhost:8091/role" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -200,7 +200,7 @@ Specify the [permissions](/{{< latest "chronograf" >}}/administration/managing-i
 The following example removes read and write permissions from `db1` for the `east` role.
 
 ```sh
-curl -s -L -XPOST "http://localhost:8091/role" \
+curl -s --location-trusted -XPOST "http://localhost:8091/role" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -222,7 +222,7 @@ The following examples add user1, user2 and the ops user to the `east` and `west
 
 ```sh
 # Add user1 and ops to the east role
-curl -s -L -XPOST "http://localhost:8091/role" \
+curl -s --location-trusted -XPOST "http://localhost:8091/role" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -234,7 +234,7 @@ curl -s -L -XPOST "http://localhost:8091/role" \
   }'
 
 # Add user1 and ops to the west role
-curl -s -L -XPOST "http://localhost:8091/role" \
+curl -s --location-trusted -XPOST "http://localhost:8091/role" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -251,7 +251,7 @@ To view existing roles with their assigned permissions and users, use the `GET`
 request method with the InfluxDB Meta API `/role` endpoint.
 
 ```sh
-curl -L -XGET http://localhost:8091/role | jq
+curl --location-trusted -XGET http://localhost:8091/role | jq
 ```
 
 ### Delete a role
@@ -259,7 +259,7 @@ To delete a role, the InfluxDB Meta API `/role` endpoint and set the `action`
 field to `delete` and include the name of the role to delete.
 
 ```sh
-curl -s -L -XPOST "http://localhost:8091/role" \
+curl -s --location-trusted -XPOST "http://localhost:8091/role" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -285,7 +285,7 @@ Restrictions apply to all non-admin users.
 Manage restrictions using the InfluxDB Meta API `acl/restrictions` endpoint.
 
 ```sh
-curl -L -XGET "http://localhost:8091/influxdb/v2/acl/restrictions"
+curl --location-trusted -XGET "http://localhost:8091/influxdb/v2/acl/restrictions"
 ```
 
 - [Restrict by database](#restrict-by-database)
@@ -302,7 +302,7 @@ In most cases, restricting the database is the simplest option, and has minimal 
 The following example restricts reads and writes on the `my_database` database.
 
 ```sh
-curl -L -XPOST "http://localhost:8091/influxdb/v2/acl/restrictions" \
+curl --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/restrictions" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -317,7 +317,7 @@ measurement in the `my_database` database.
 _This restriction does not apply to other measurements in the `my_database` database._
 
 ```sh
-curl -L -XPOST "http://localhost:8091/influxdb/v2/acl/restrictions" \
+curl --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/restrictions" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -334,7 +334,7 @@ The following example restricts read and write permissions on the `datacenter=ea
 _This restriction does not apply to other tags or tag values in the `network` measurement._
 
 ```sh
-curl -L -XPOST "http://localhost:8091/influxdb/v2/acl/restrictions" \
+curl --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/restrictions" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -350,7 +350,7 @@ writes to `network` with a tag key of `datacenter` and a tag value of anything b
 
 ##### Apply restrictions to a series defined by multiple tags
 ```sh
-curl -L -XPOST "http://localhost:8091/influxdb/v2/acl/restrictions" \
+curl --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/restrictions" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -371,7 +371,7 @@ To create multiple restrictions for a list of values, use a bash `for` loop:
 
 ```sh
 for value in val1 val2 val3 val4; do
-  curl -L -XPOST "http://localhost:8091/influxdb/v2/acl/restrictions" \
+  curl --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/restrictions" \
     -u "admin-username:admin-password" \
     -H "Content-Type: application/json" \
     --data-binary '{
@@ -388,7 +388,7 @@ done
 To view existing restrictions, use the `GET` request method with the `acl/restrictions` endpoint.
 
 ```sh
-curl -L -u "admin-username:admin-password" -XGET "http://localhost:8091/influxdb/v2/acl/restrictions" | jq
+curl --location-trusted -u "admin-username:admin-password" -XGET "http://localhost:8091/influxdb/v2/acl/restrictions" | jq
 ```
 
 ### Update a restriction
@@ -402,11 +402,11 @@ Use the `DELETE` request method to delete a restriction by ID.
 
 ```sh
 # Obtain the restriction ID from the list of restrictions
-curl -L -u "admin-username:admin-password" \
+curl --location-trusted -u "admin-username:admin-password" \
   -XGET "http://localhost:8091/influxdb/v2/acl/restrictions" | jq
 
 # Delete the restriction using the restriction ID
-curl -L -u "admin-username:admin-password" \
+curl --location-trusted -u "admin-username:admin-password" \
   -XDELETE "http://localhost:8091/influxdb/v2/acl/restrictions/<restriction_id>"
 ```
 
@@ -417,7 +417,7 @@ permissions on InfluxDB assets.
 Manage grants using the InfluxDB Meta API `acl/grants` endpoint.
 
 ```sh
-curl -L -u "admin-username:admin-password" \
+curl --location-trusted -u "admin-username:admin-password" \
   -XGET "http://localhost:8091/influxdb/v2/acl/grants"
 ```
 
@@ -435,7 +435,7 @@ The following examples grant read and write permissions on the `my_database` dat
 
 ##### Grant database-level permissions to users
 ```sh
-curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
+curl -s --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -450,7 +450,7 @@ curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
 
 ##### Grant database-level permissions to roles
 ```sh
-curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
+curl -s --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -470,7 +470,7 @@ guarantee that users will use the correct tags.
 
 ##### Grant measurement-level permissions to users
 ```sh
-curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
+curl -s --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -487,7 +487,7 @@ curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
 To grant access for roles, run:
 
 ```sh
-curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
+curl -s --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -509,7 +509,7 @@ _Neither guarantees the users will use the `network` measurement._
 ##### Grant series-level permissions to users
 ```sh
 # Grant user1 read/write permissions on data with the 'datacenter=east' tag set.
-curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
+curl -s --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -520,7 +520,7 @@ curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
   }'
 
 # Grant user2 read/write permissions on data with the 'datacenter=west' tag set.
-curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
+curl -s --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -534,7 +534,7 @@ curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
 ##### Grant series-level permissions to roles
 ```sh
 # Grant role1 read/write permissions on data with the 'datacenter=east' tag set.
-curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
+curl -s --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -545,7 +545,7 @@ curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
   }'
 
 # Grant role2 read/write permissions on data with the 'datacenter=west' tag set.
-curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
+curl -s --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -565,7 +565,7 @@ _They each specify the measurement in the request body._
 ```sh
 # Grant user1 read/write permissions on data with the 'datacenter=west' tag set
 # inside the 'network' measurement.
-curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
+curl -s --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -578,7 +578,7 @@ curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
 
 # Grant user2 read/write permissions on data with the 'datacenter=west' tag set
 # inside the 'network' measurement.
-curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
+curl -s --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -594,7 +594,7 @@ curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
 ```sh
 # Grant role1 read/write permissions on data with the 'datacenter=west' tag set
 # inside the 'network' measurement.
-curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
+curl -s --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -607,7 +607,7 @@ curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
 
 # Grant role2 read/write permissions on data with the 'datacenter=west' tag set
 # inside the 'network' measurement.
-curl -s -L -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
+curl -s --location-trusted -XPOST "http://localhost:8091/influxdb/v2/acl/grants" \
   -u "admin-username:admin-password" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -635,7 +635,7 @@ Note that this is only the requirement of the presence of that tag;
 To view existing grants, use the `GET` request method with the `acl/grants` endpoint.
 
 ```sh
-curl -L -u "admin-username:admin-password" \
+curl --location-trusted -u "admin-username:admin-password" \
   -XGET "http://localhost:8091/influxdb/v2/acl/grants" | jq
 ```
 
@@ -650,10 +650,10 @@ Use the `DELETE` request method to delete a grant by ID.
 
 ```sh
 # Obtain the grant ID from the list of grants
-curl -L -u "admin-username:admin-password" \
+curl --location-trusted -u "admin-username:admin-password" \
   -XGET "http://localhost:8091/influxdb/v2/acl/grants" | jq
 
 # Delete the grant using the grant ID
-curl -L -u "admin-username:admin-password" \
+curl --location-trusted -u "admin-username:admin-password" \
   -XDELETE "http://localhost:8091/influxdb/v2/acl/grants/<grant_id>"
 ```

--- a/content/enterprise_influxdb/v1.9/guides/migration.md
+++ b/content/enterprise_influxdb/v1.9/guides/migration.md
@@ -30,21 +30,25 @@ to migrate data from OSS to an InfluxDB Enterprise cluster without downtime or m
    add the IP and hostname of your OSS instance to the `/etc/hosts` file.
    This will allow the nodes to communicate with the OSS instance.
 
-3. On the OSS instance, take a portable backup from OSS:
+3. On the OSS instance, take a portable backup from OSS using the **influxd backup** command 
+with the `-portable` flag:
 
    ```sh
-   influxd-ctl backup -portable -host <IP address>:8088 /tmp/mysnapshot
+   influxd backup -portable -host <IP address>:8088 /tmp/mysnapshot
    ```
 
    Note the current date and time when you take the backup.
-   For more information, see [`-backup`](/enterprise_influxdb/v1.9/administration/backup-and-restore/#backup).
+   For more information, see [influxd backup](/influxdb/v1.8/tools/influxd/backup/).
 
 4. Restore the backup on the cluster by running the following:
 
    ```sh
-   influxd-ctl restore -portable  [ -host <host:port> ] <path-to-backup-files>
+   influxd-ctl restore [ -host <host:port> ] <path-to-backup-files>
    ```
-   For more information, see [`-restore`](/enterprise_influxdb/v1.9/administration/backup-and-restore/#restore).
+   
+    > NOTE:  InfluxDB Enterprise uses the **influxd-ctl utility** to backup and restore data.  For more information, 
+see [influxd-ctl](/enterprise_influxdb/v1.9/tools/influxd-ctl) 
+and [`restore`](/enterprise_influxdb/v1.9/administration/backup-and-restore/#restore).
 
 5. To avoid data loss, dual write to both OSS and Enterprise while completing the remaining steps.
    This keeps the OSS and cluster active for testing and acceptance work. For more information, see [Write data with the InfluxDB API](/enterprise_influxdb/v1.9/guides/write_data/).


### PR DESCRIPTION
Closes DAR https://github.com/influxdata/DAR/issues/262

As part of the curl command, -L changed to --location-trusted throughout the doc to address username/password redirect
