### PR TITLE
Deprecate nats configuration options

### DIFF
--- a/content/influxdb/v2.2/reference/config-options.md
+++ b/content/influxdb/v2.2/reference/config-options.md
@@ -108,8 +108,8 @@ To configure InfluxDB, use the following configuration options when starting the
 - [influxql-max-select-series](#influxql-max-select-series)
 - [log-level](#log-level)
 - [metrics-disabled](#metrics-disabled)
-- [nats-max-payload-bytes](#nats-max-payload-bytes)
-- [nats-port](#nats-port)
+- [nats-max-payload-bytes](#nats-max-payload-bytes) <em style="opacity:.65">- (deprecated)</em>
+- [nats-port](#nats-port) <em style="opacity:.65">- (deprecated)</em>
 - [no-tasks](#no-tasks)
 - [pprof-disabled](#pprof-disabled)
 - [query-concurrency](#query-concurrency)
@@ -965,6 +965,11 @@ metrics-disabled = true
 ---
 
 ### nats-max-payload-bytes
+
+{{% warn %}}
+`nats-max-payload-bytes` was **deprecated in InfluxDB 2.2** and no longer has any effect.
+{{% /warn %}}
+
 Maximum number of bytes allowed in a NATS message payload.
 
 **Default:** `1048576`
@@ -1012,6 +1017,11 @@ nats-max-payload-bytes = 1048576
 ---
 
 ### nats-port
+
+{{% warn %}}
+`nats-port` was **deprecated in InfluxDB 2.2** and no longer has any effect.
+{{% /warn %}}
+
 Port for the NATS streaming server. `-1` selects a random port.
 
 **Default:** `-1`

--- a/data/influxd_flags.yml
+++ b/data/influxd_flags.yml
@@ -3,6 +3,8 @@
 #
 # - flag: "--flag-name"
 #   added: InfluxDB minor version the flag was added
+#   deprecated: InfluxDB minor version the flag was deprecated
+#   removed: InfluxDB minor version the flag was removed
 #   nolink: Do not create a link to the config options doc for this flag
 # 
 
@@ -60,9 +62,13 @@
 
 - flag: "--nats-max-payload-bytes"
   added: 2.0
+  deprecated: 2.2
+  # removed: 2.2
 
 - flag: "--nats-port"
   added: 2.0
+  deprecated: 2.2
+  # removed: 2.2
 
 - flag: "--no-tasks"
   added: 2.0

--- a/layouts/shortcodes/cli/influxd-flags.html
+++ b/layouts/shortcodes/cli/influxd-flags.html
@@ -5,8 +5,14 @@
 <ul>
 {{- range $flags -}}
 {{- $flagAnchor := replaceRE "--" "#" .flag -}}
-{{- if ge (float $currentVersion) .added -}}
-  <li>{{ if .nolink }}{{ .flag }}{{ else }}<a href="/influxdb/v{{ $currentVersion }}/reference/config-options/{{ $flagAnchor }}">{{ .flag }}</a>{{ end }}</li>
+{{- $removed := cond (isset . "removed") .removed 1000.0 -}}
+{{- $deprecated := cond (isset . "deprecated") true false -}}
+{{- $deprecatedVersion := cond $deprecated .deprecated 0.0 -}}
+{{- if and (ge (float $currentVersion) .added) (lt (float $currentVersion) $removed) -}}
+  <li>
+    {{ if .nolink }}{{ .flag }}{{ else }}<a href="/influxdb/v{{ $currentVersion }}/reference/config-options/{{ $flagAnchor }}">{{ .flag }}</a>{{ end }} 
+    {{ if and $deprecated (ge (float $currentVersion) $deprecatedVersion) }}<em style="opacity:.65;"> - (deprecated in InfluxDB {{ $deprecatedVersion }})</em>{{ end }}
+  </li>
 {{- end -}}
 {{- end -}}
 </ul>


### PR DESCRIPTION
Related to #3766 

This deprecates the `nats-` configuration options in 2.2. To support future deprecation and removal of configuration options, I updated `data/influxd_flags.yml` and the shortcode that displays these flags per version of the `influxd` CLI doc.

- [x] Rebased/mergeable
