### PR TITLE
Feat/oss 2 2 config

### DIFF
--- a/content/influxdb/v2.2/reference/cli/influx/server-config/_index.md
+++ b/content/influxdb/v2.2/reference/cli/influx/server-config/_index.md
@@ -1,6 +1,6 @@
 ---
 title: influx server-config
-description: The `influx server-config` command displays the run-time server configuration.
+description: The `influx server-config` command displays the runtime server configuration.
 menu:
   influxdb_2_2_ref:
     name: influx server-config
@@ -14,7 +14,7 @@ cascade:
   metadata: [influx CLI 2.0.0+, InfluxDB 2.0.0+]
 ---
 
-The `influx server-config` command displays the InfluxDB run-time [server configuration](/influxdb/v2.2/reference/config-options/).
+The `influx server-config` command displays the InfluxDB runtime [server configuration](/influxdb/v2.2/reference/config-options/).
 
 {{% note %}}
 To display the server configuration, you must use an [operator token](/influxdb/v2.2/security/tokens/#operator-token).

--- a/content/influxdb/v2.2/reference/cli/influx/server-config/_index.md
+++ b/content/influxdb/v2.2/reference/cli/influx/server-config/_index.md
@@ -43,7 +43,7 @@ influx server-config --yaml
 | `-h` | `--help`          | Help for the `list` command                                           |            |                       |
 |      | `--hide-headers`  | Hide table headers (default `false`)                                  |            | `INFLUX_HIDE_HEADERS` |
 |      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string     | `INFLUX_HOST`         |
-|      | `--http-debug`    | Inspect communication with InfluxDB servers.                          | string     |                       |
+|      | `--http-debug`    | Inspect communication with InfluxDB servers                          | string     |                       |
 | `-i` | `--id`            | Organization ID                                                       | string     | `INFLUX_ORG`          |
 |      | `--json`          | Output data as JSON (default `false`)                                 |            | `INFLUX_OUTPUT_JSON`  |
 | `-n` | `--name`          | Organization name                                                     | string     | `INFLUX_ORG_ID`       |

--- a/content/influxdb/v2.2/reference/cli/influx/server-config/_index.md
+++ b/content/influxdb/v2.2/reference/cli/influx/server-config/_index.md
@@ -1,0 +1,53 @@
+---
+title: influx server-config
+description: The `influx server-config` command displays the run-time server configuration.
+menu:
+  influxdb_2_2_ref:
+    name: influx server-config
+    parent: influx
+weight: 101
+influxdb/v2.2/tags: [config]
+cascade:
+  related:
+    - /influxdb/v2.2/reference/cli/influx/#provide-required-authentication-credentials, influx CLI—Provide required authentication credentials
+    - /influxdb/v2.2/reference/cli/influx/#flag-patterns-and-conventions, influx CLI—Flag patterns and conventions
+  metadata: [influx CLI 2.0.0+, InfluxDB 2.0.0+]
+---
+
+The `influx server-config` command displays the InfluxDB run-time [server configuration](/influxdb/v2.2/reference/config-options/).
+
+{{% note %}}
+To display the server configuration, you must use an [operator token](/influxdb/v2.2/security/tokens/#operator-token).
+{{% /note %}}
+
+## Usage
+```
+influx server-config [flags]
+influx server-config [command]
+```
+
+## Examples
+```sh
+# Show the server configuration.
+influx server-config
+
+# Show the server configuration as YAML.
+influx server-config --yaml
+```
+
+## Flags
+| Flag |          | Description                   |
+|:---- |:---      |:-----------                   |
+| `-c` | `--active-config` | CLI configuration to use for command                                  | string     |                       |
+|      | `--configs-path`  | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`) | string     | `INFLUX_CONFIGS_PATH` |
+| `-h` | `--help`          | Help for the `list` command                                           |            |                       |
+|      | `--hide-headers`  | Hide table headers (default `false`)                                  |            | `INFLUX_HIDE_HEADERS` |
+|      | `--host`          | HTTP address of InfluxDB (default `http://localhost:8086`)            | string     | `INFLUX_HOST`         |
+|      | `--http-debug`    | Inspect communication with InfluxDB servers.                          | string     |                       |
+| `-i` | `--id`            | Organization ID                                                       | string     | `INFLUX_ORG`          |
+|      | `--json`          | Output data as JSON (default `false`)                                 |            | `INFLUX_OUTPUT_JSON`  |
+| `-n` | `--name`          | Organization name                                                     | string     | `INFLUX_ORG_ID`       |
+|      | `--skip-verify`   | Skip TLS certificate verification                                     |            | `INFLUX_SKIP_VERIFY`  |
+| `-t` | `--token`         | API token                                                             | string     | `INFLUX_TOKEN`        |
+|      | `--toml` | Output configuration as TOML instead of JSON |
+|      | `--yaml` | Output configuration as YAML instead of JSON |

--- a/content/influxdb/v2.2/reference/cli/influxd/_index.md
+++ b/content/influxdb/v2.2/reference/cli/influxd/_index.md
@@ -33,7 +33,7 @@ For information about other available InfluxDB configuration methods, see
 | [downgrade](/influxdb/v2.2/reference/cli/influxd/downgrade/)       | Downgrade metadata schema to match an older release          |
 | help                                                               | Output help information for `influxd`                        |
 | [inspect](/influxdb/v2.2/reference/cli/influxd/inspect/)           | Inspect on-disk database data                                |
-| [print-config](/influxdb/v2.2/reference/cli/influxd/print-config/) | Print full influxd configuration for the current environment |
+| [print-config](/influxdb/v2.2/reference/cli/influxd/print-config/) | (**Deprecated**) Print full influxd configuration for the current environment |
 | [recovery](/influxdb/v2.2/reference/cli/influxd/recovery/)         | Recover operator access to InfluxDB                          |
 | [run](/influxdb/v2.2/reference/cli/influxd/run/)                   | Start the influxd server _**(default)**_                     |
 | [upgrade](/influxdb/v2.2/reference/cli/influxd/upgrade/)           | Upgrade a 1.x version of InfluxDB to {{< current-version >}} |

--- a/content/influxdb/v2.2/reference/cli/influxd/print-config.md
+++ b/content/influxdb/v2.2/reference/cli/influxd/print-config.md
@@ -23,12 +23,12 @@ The command formats output as YAML.
 
 `influxd print-config` is deprecated in InfluxDB v2.2.
 
-To display the run-time server configuration, use the [`influx server-config` command](/influxdb/v2.2/reference/cli/influx/server-config/)
+To display the runtime server configuration, use the [`influx server-config` command](/influxdb/v2.2/reference/cli/influx/server-config/)
 or the [`/api/v2/config`](/influxdb/v2.2/api/#operation/GetConfig) InfluxDB API endpoint.
-For more information, see [how to view your server configuration](/influxdb/v2.2/reference/config-options/#view-your-run-time-server-configuration).
+For more information, see [how to view your server configuration](/influxdb/v2.2/reference/config-options/#view-your-runtime-server-configuration).
 {{% /warn %}}
 
-`influxd print-config` does not output the configuration of the running server. Rather, it evaluates the current environment, config file, and _flags passed to the `influxd print-config` command_. It is unaware of configuration options passed to the `influxd` command at run-time.
+`influxd print-config` does not output the configuration of the running server. Rather, it evaluates the current environment, config file, and _flags passed to the `influxd print-config` command_. It is unaware of configuration options passed to the `influxd` command at runtime.
 
 For example, with the following configuration value:
 ```sh

--- a/content/influxdb/v2.2/reference/cli/influxd/print-config.md
+++ b/content/influxdb/v2.2/reference/cli/influxd/print-config.md
@@ -10,11 +10,55 @@ menu:
 weight: 201
 related:
   - /influxdb/v2.2/reference/config-options/
+  - /influxdb/v2.2/reference/cli/influx/server-config/
 ---
 
 The `influxd print-config` command prints a full InfluxDB configuration resolved
 from the current `influxd` environment.
 The command formats output as YAML.
+
+{{% warn %}}
+
+#### Use influx CLI server-config
+
+`influxd print-config` is deprecated in InfluxDB v2.2.
+
+To display the run-time server configuration, use the [`influx server-config` command](/influxdb/v2.2/reference/cli/influx/server-config/)
+or the [`/api/v2/config`](/influxdb/v2.2/api/#operation/GetConfig) InfluxDB API endpoint.
+For more information, see [how to view your server configuration](/influxdb/v2.2/reference/config-options/#view-your-run-time-server-configuration).
+{{% /warn %}}
+
+`influxd print-config` does not output the configuration of the running server. Rather, it evaluates the current environment, config file, and _flags passed to the `influxd print-config` command_. It is unaware of configuration options passed to the `influxd` command at run-time.
+
+For example, with the following configuration value:
+```sh
+# Configuration file
+...
+log-level: info
+...
+```
+
+and `--log-level` provided at startup:
+
+```
+influxd --log-level warn
+```
+
+`influxd print-config` displays
+
+```sh
+...
+log-level: info
+...
+```
+
+`influxd print-config log-level warn` displays
+
+```sh
+...
+log-level: warn
+...
+```
 
 ## Usage
 

--- a/content/influxdb/v2.2/reference/config-options.md
+++ b/content/influxdb/v2.2/reference/config-options.md
@@ -17,6 +17,27 @@ Customize your InfluxDB configuration by using [`influxd`](/influxdb/v2.2/refere
 configuration flags, setting environment variables, or defining configuration
 options in a configuration file.
 
+### View your run-time server configuration
+
+Use the `influx` CLI or the InfluxDB API to get the run-time server configuration of your InfluxDB instance.
+
+Server configuration commands require an [Operator token](/influxdb/v2.2/security/tokens/#operator-token).
+
+#### View your server configuration with the CLI
+
+Use the [`influx server-config` command](/influxdb/v2.2/reference/cli/influx/server-config/)
+to retrieve your run-time server configuration.
+
+```sh
+influx server-config
+```
+
+### View your server configuration with the API
+
+Use the `/api/v2/config` InfluxDB API endpoint to retrieve your run-time server configuration.
+
+[{{< api-endpoint method="GET" endpoint="http://localhost:8086/api/v2/config" >}}]((/influxdb/v2.2/api/#operation/GetConfig))
+
 ### Configuration precedence
 InfluxDB honors configuration settings using the following precedence:
 
@@ -42,27 +63,6 @@ export INFLUXD_CONFIG_PATH=/path/to/custom/config/directory
 ```
 
 On startup, `influxd` will check for a `config.*` in the `INFLUXD_CONFIG_PATH` directory.
-
-### View your run-time server configuration
-  Use the `influx` CLI or the InfluxDB API to get the run-time server configuration of your InfluxDB instance.
-
-  Server configuration commands require an API token with operator permissions.
-  See how to create an op token.
-
-#### View your server configuration with the CLI
-
-Use the [`influx server-config` command](/influxdb/v2.2/reference/cli/influx/server-config/)
-to get your run-time server configuration.
-
-```sh
-influx server-config
-```
-
-### View your server configuration with the API
-
-Use the `/api/v2/config` InfluxDB API endpoint to get your run-time server configuration.
-
-[{{< api-endpoint method="GET" endpoint="http://localhost:8086/api/v2/config" >}}]((/influxdb/v2.2/api/#operation/GetConfig))
 
 ##### Example configuration file
 {{< code-tabs-wrapper >}}
@@ -940,7 +940,7 @@ log-level = "info"
 ---
 
 ### metrics-disabled
-Disable the HTTP `/metrics` endpoint which exposes internal InfluxDB metrics.
+Disable the HTTP `/metrics` endpoint which exposes [internal InfluxDB metrics](/influxdb/v2.2/reference/internals/metrics/).
 
 **Default:** `false`  
 

--- a/content/influxdb/v2.2/reference/config-options.md
+++ b/content/influxdb/v2.2/reference/config-options.md
@@ -17,6 +17,11 @@ Customize your InfluxDB configuration by using [`influxd`](/influxdb/v2.2/refere
 configuration flags, setting environment variables, or defining configuration
 options in a configuration file.
 
+- [View your run-time server configuration](#view-your-run-time-server-configuration)
+- [Configuration precedence](#configuration-precedence)
+- [InfluxDB configuration file](#influxdb-configuration-file)
+- [Configuration options](#configuration-options)
+
 ### View your run-time server configuration
 
 Use the `influx` CLI or the InfluxDB API to get the run-time server configuration of your InfluxDB instance.

--- a/content/influxdb/v2.2/reference/config-options.md
+++ b/content/influxdb/v2.2/reference/config-options.md
@@ -25,6 +25,7 @@ InfluxDB honors configuration settings using the following precedence:
 3. Configuration file settings
 
 ### InfluxDB configuration file
+
 When `influxd` starts, it checks for a file named `config.*` **in the current working directory**.
 The file extension depends on the syntax of the configuration file.
 InfluxDB configuration files support the following syntaxes:
@@ -41,6 +42,27 @@ export INFLUXD_CONFIG_PATH=/path/to/custom/config/directory
 ```
 
 On startup, `influxd` will check for a `config.*` in the `INFLUXD_CONFIG_PATH` directory.
+
+### View your run-time server configuration
+  Use the `influx` CLI or the InfluxDB API to get the run-time server configuration of your InfluxDB instance.
+
+  Server configuration commands require an API token with operator permissions.
+  See how to create an op token.
+
+#### View your server configuration with the CLI
+
+Use the [`influx server-config` command](/influxdb/v2.2/reference/cli/influx/server-config/)
+to get your run-time server configuration.
+
+```sh
+influx server-config
+```
+
+### View your server configuration with the API
+
+Use the `/api/v2/config` InfluxDB API endpoint to get your run-time server configuration.
+
+[{{< api-endpoint method="GET" endpoint="http://localhost:8086/api/v2/config" >}}]((/influxdb/v2.2/api/#operation/GetConfig))
 
 ##### Example configuration file
 {{< code-tabs-wrapper >}}

--- a/content/influxdb/v2.2/reference/config-options.md
+++ b/content/influxdb/v2.2/reference/config-options.md
@@ -17,21 +17,21 @@ Customize your InfluxDB configuration by using [`influxd`](/influxdb/v2.2/refere
 configuration flags, setting environment variables, or defining configuration
 options in a configuration file.
 
-- [View your run-time server configuration](#view-your-run-time-server-configuration)
+- [View your runtime server configuration](#view-your-runtime-server-configuration)
 - [Configuration precedence](#configuration-precedence)
 - [InfluxDB configuration file](#influxdb-configuration-file)
 - [Configuration options](#configuration-options)
 
-### View your run-time server configuration
+### View your runtime server configuration
 
-Use the `influx` CLI or the InfluxDB API to get the run-time server configuration of your InfluxDB instance.
+Use the `influx` CLI or the InfluxDB API to get the runtime server configuration of your InfluxDB instance.
 
 Server configuration commands require an [Operator token](/influxdb/v2.2/security/tokens/#operator-token).
 
 #### View your server configuration with the CLI
 
 Use the [`influx server-config` command](/influxdb/v2.2/reference/cli/influx/server-config/)
-to retrieve your run-time server configuration.
+to retrieve your runtime server configuration.
 
 ```sh
 influx server-config
@@ -39,7 +39,7 @@ influx server-config
 
 ### View your server configuration with the API
 
-Use the `/api/v2/config` InfluxDB API endpoint to retrieve your run-time server configuration.
+Use the `/api/v2/config` InfluxDB API endpoint to retrieve your runtime server configuration.
 
 [{{< api-endpoint method="GET" endpoint="http://localhost:8086/api/v2/config" >}}]((/influxdb/v2.2/api/#operation/GetConfig))
 

--- a/content/influxdb/v2.2/security/tokens/_index.md
+++ b/content/influxdb/v2.2/security/tokens/_index.md
@@ -24,10 +24,12 @@ Learn how to create, view, update, or delete an API token.
 - [Read/Write token](#readwrite-token)
 
 #### Operator token
-Grants full read and write access to all resources in **all organizations in InfluxDB OSS 2.x**.
+Grants full read and write access to **all organizations and all organization resources in InfluxDB OSS 2.x**.
+Some operations, e.g. [retrieving the server configuration](/influxdb/v2.2/reference/config-options/), require operator permissions.
+Operator tokens are created in the InfluxDB setup process.
+To [create an operator token manually](/influxdb/v2.2/security/tokens/create-token/), you must use an existing operator token.
 
 {{% note %}}
-Operator tokens are created in the InfluxDB setup process and cannot be created manually.
 Because Operator tokens have full read and write access to all organizations in the database,
 we recommend [creating an All-Access token](/influxdb/v2.2/security/tokens/create-token/)
 for each organization and using those to manage InfluxDB.

--- a/content/influxdb/v2.2/security/tokens/create-token.md
+++ b/content/influxdb/v2.2/security/tokens/create-token.md
@@ -163,7 +163,7 @@ See the [`influx auth create` documentation](/{{< latest "influxdb" >}}/referenc
 
 ## Create a token using the InfluxDB API
 
-Use the `/authorizations` endpoint of the InfluxDB API to create a token.
+Use the `/api/v2/authorizations` InfluxDB API endpoint to create a token.
 
 [{{< api-endpoint method="POST" endpoint="http://localhost:8086/api/v2/authorizations" >}}]((/influxdb/v2.2/api/#operation/PostAuthorizations))
 

--- a/content/influxdb/v2.2/security/tokens/delete-token.md
+++ b/content/influxdb/v2.2/security/tokens/delete-token.md
@@ -62,7 +62,7 @@ influx auth delete -i 03a2bee5a9c9a000
 
 ## Delete a token using the InfluxDB API
 
-Use the `/authorizations` endpoint of the InfluxDB API to delete a token.
+Use the `/api/v2/authorizations` InfluxDB API endpoint to delete a token.
 
 [{{< api-endpoint method="DELETE" endpoint="http://localhost:8086/api/v2/authorizations/AUTH_ID" >}}](/influxdb/v2.2/api/#operation/DeleteAuthorizationsID)
 

--- a/content/influxdb/v2.2/security/tokens/update-tokens.md
+++ b/content/influxdb/v2.2/security/tokens/update-tokens.md
@@ -96,7 +96,7 @@ influx auth find --json
 
 ## Update a token using the InfluxDB API
 
-Use the `/authorizations` endpoint of the InfluxDB API to update the description and status of a token.
+Use the `/api/v2/authorizations` InfluxDB API endpoint to update the description and status of a token.
 
 [{{< api-endpoint method="PATCH" endpoint="http://localhost:8086/api/v2/authorizations/AUTH_ID" >}}](/influxdb/v2.2/api/#operation/PatchAuthorizationsID)
 

--- a/content/influxdb/v2.2/security/tokens/view-tokens.md
+++ b/content/influxdb/v2.2/security/tokens/view-tokens.md
@@ -71,7 +71,7 @@ for information about other available flags.
 
 ## View tokens using the InfluxDB API
 
-Use the `/authorizations` endpoint of the InfluxDB API to view tokens and permissions.
+Use the `/api/v2/authorizations` InfluxDB API endpoint to view tokens and permissions.
 
 [{{< api-endpoint method="GET" endpoint="/api/v2/authorizations" >}}](/influxdb/cloud/api/#operation/GetAuthorizations)
 


### PR DESCRIPTION
Closes #3523
For OSS v2.2:
- add new `influx server-config` command and `/api/v2/config` path.
- update Operator token doc
- deprecate `influxd print-config`
