### PR TITLE
Update telegraf groundwork plugin description

### DIFF
--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -2196,9 +2196,9 @@ output:
   - name: GroundWork
     id: groundwork
     description: |
-      The  Graylog output plugin writes to a [GroundWork Monitor](https://www.gwos.com/product/groundwork-monitor/) instance.
+      The  GroundWork output plugin writes to a [GroundWork Monitor](https://www.gwos.com/product/groundwork-monitor/) instance.
     introduced: 1.21.0
-    tags: [linux, macos, windows, logging]
+    tags: [linux, macos, windows, applications, messaging]
 
   - name: HTTP
     id: http


### PR DESCRIPTION
The description of the GroundWork plugin wrongly mentioned Graylog.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
