### PR TITLE
fix: caption shortcode

### DIFF
--- a/assets/styles/layouts/article/_captions.scss
+++ b/assets/styles/layouts/article/_captions.scss
@@ -4,14 +4,9 @@
   font-size: .95rem;
   font-style: italic;
   opacity: .8;
+  color: $article-text;
 
   p { line-height: 1.25rem; }
-}
-
-.code-tabs-wrapper, .code-tab-content {
-  & + .caption {
-    margin-top: -2.75rem;
-  }
 }
 
 p {


### PR DESCRIPTION
Caption shouldn't overlap code-tabs. Removes extra negative margin from captions below code tabs. 
Caption text color should adapt to dark theme. Uses $article-text var for caption text.

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
