### PR TITLE
fix: global write request limit is still 50 MB for the time being.

### DIFF
--- a/content/influxdb/cloud/account-management/limits.md
+++ b/content/influxdb/cloud/account-management/limits.md
@@ -77,7 +77,7 @@ InfluxDB Cloud applies global (non-adjustable) system limits to all accounts, wh
 Limits include:
 
 - Write request limits:
-  - 5 MB maximum HTTP request batch size (compressed or uncompressed--defined in the `Content-Encoding` header)
+  - 50 MB maximum HTTP request batch size (compressed or uncompressed--defined in the `Content-Encoding` header)
   - 250 MB maximum HTTP request batch size after decompression
 - Query processing time: 90 seconds
 - Task processing time: 150 seconds


### PR DESCRIPTION
May be reduced in the future (see https://github.com/influxdata/DAR/issues/226). (#1448)

Closes #1448

Revert 5 MB to 50 MB

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
