### PR TITLE
feat/3866: document new InfluxDB OSS --hardening-enabled feature

### DIFF
--- a/content/influxdb/v2.1/reference/config-options.md
+++ b/content/influxdb/v2.1/reference/config-options.md
@@ -159,6 +159,9 @@ To configure InfluxDB, use the following configuration options when starting the
 - [vault-skip-verify](#vault-skip-verify)
 - [vault-tls-server-name](#vault-tls-server-name)
 - [vault-token](#vault-token)
+<!-- TODO: when 2.2 is released and/or 2.1 is patched, move this above
+- [hardening-enabled](#hardening-enabled)
+-->
 
 ---
 
@@ -466,7 +469,55 @@ flux-log-enabled = "true"
 {{< /code-tabs-wrapper >}}
 
 ---
+<!-- uncomment when 2.2 is released and/or 2.1 is patched
+### hardening-enabled
+Enable [additional security features](/influxdb/v2.1/security/enable-hardening/)
+in InfluxDB.
 
+**Default:** `false`
+
+| influxd flag          | Environment variable        | Configuration key   |
+| :-------------------- | :-------------------------- | :------------------ |
+| `--hardening-enabled` | `INFLUXD_HARDENING_ENABLED` | `hardening-enabled` |
+
+###### influxd flag
+```sh
+influxd --hardening-enabled
+```
+
+###### Environment variable
+```sh
+export INFLUXD_HARDENING_ENABLED=true
+```
+
+###### Configuration file
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[YAML](#)
+[TOML](#)
+[JSON](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+```yml
+hardening-enabled: true
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+```toml
+hardening-enabled = true
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+```json
+{
+  "hardening-enabled": true
+}
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+
+---
+-->
 ### http-bind-address
 Bind address for the InfluxDB HTTP API.
 Customize the URL and port for the InfluxDB API and UI.

--- a/content/influxdb/v2.1/security/enable-hardening.md
+++ b/content/influxdb/v2.1/security/enable-hardening.md
@@ -12,14 +12,12 @@ influxdb/v2.1/tags: [security, hardening]
 draft: true
 ---
 
-InfluxDB is used in many environments and depending on your environment, enabling additional security features may be appropriate.
-To enable all security hardening options now and in the future,
-start InfluxDB with the `--hardening-enabled` command line flag:
+InfluxDB {{< current-version >}} provides optional security features that ensure your
+InfluxDB instance is secure in whatever environment it's used in.
 
-    ```bash
-    influxd \
-    --hardening-enabled
-    ```
+To enable all [additional security features](#security-features), use the
+[`hardening-enabled` configuration option](/influxdb/v2.1/reference/config-options/#hardening-enabled)
+when starting InfluxDB.
 
 ## Security features
 

--- a/content/influxdb/v2.1/security/enable-hardening.md
+++ b/content/influxdb/v2.1/security/enable-hardening.md
@@ -2,7 +2,8 @@
 title: Enable security features
 seotitle: Enable security and hardening features in InfluxDB
 description: >
-  Enable additional security features in InfluxDB.
+  Enable a collection of additional security and hardening features in InfluxDB OSS to better
+  secure your InfluxDB instance.
 weight: 102
 menu:
   influxdb_2_1:

--- a/content/influxdb/v2.1/security/enable-hardening.md
+++ b/content/influxdb/v2.1/security/enable-hardening.md
@@ -27,15 +27,20 @@ start InfluxDB with the `--hardening-enabled` command line flag:
 
 ### Private IP Validation
 
-Certain flux functions (eg, `to()`, `from()`, etc) and [template fetching](/influxdb/v2.1/influxdb-templates/) cause InfluxDB to make HTTP requests over the network.
-When private IP validation is enabled, InfluxDB will first verify that the IP address of the URL is not a private IP address.
+Some Flux functions ([`to()`](/flux/v0.x/stdlib/influxdata/influxdb/to/),
+[`from()`](/flux/v0.x/stdlib/influxdata/influxdb/from/), [`http.post()`](/flux/v0.x/stdlib/http/post/), etc.)
+and [template fetching](/influxdb/v2.1/influxdb-templates/) can require InfluxDB to make
+HTTP requests over the network.
+With private IP validation enabled, InfluxDB first verifies that the IP address of the URL is not a private IP address.
+
 IP addresses are considered private if they fall into one of the following categories:
-* IPv4 loopback (`127.0.0.0/8`)
-* RFC1918 (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`)
-* RFC3927 (`169.254.0.0/16`)
-* IPv6 loopback (`::1/128`)
-* IPv6 link-local (`fe80::/10`)
-* IPv6 unique local (`fc00::/7`)
+
+- IPv4 loopback (`127.0.0.0/8`)
+- RFC1918 (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`)
+- RFC3927 (`169.254.0.0/16`)
+- IPv6 loopback (`::1/128`)
+- IPv6 link-local (`fe80::/10`)
+- IPv6 unique local (`fc00::/7`)
 
 {{% note %}}
 #### Private IP considerations

--- a/content/influxdb/v2.1/security/enable-hardening.md
+++ b/content/influxdb/v2.1/security/enable-hardening.md
@@ -1,0 +1,43 @@
+---
+title: Enable security features
+seotitle: Enable security/hardening features
+description: >
+  Enable additional security features in InfluxDB.
+weight: 102
+menu:
+  influxdb_2_1:
+    parent: Security & authorization
+influxdb/v2.1/tags: [security, hardening]
+products: [oss]
+---
+
+InfluxDB is used in many environments and depending on your environment, enabling additional security features may be appropriate.
+To enable all security hardening options now and in the future,
+start InfluxDB with the `--hardening-enabled` command line flag:
+
+    ```bash
+    influxd \
+    --hardening-enabled
+    ```
+
+## Security features
+
+- [Private IP Validation](#private-ip-validation)
+
+### Private IP Validation
+
+Certain flux functions (eg, `to()`, `from()`, etc) and [template fetching](/influxdb/v2.1/influxdb-templates/) cause InfluxDB to make HTTP requests over the network.
+When private IP validation is enabled, InfluxDB will first verify that the IP address of the URL is not a private IP address.
+IP addresses are considered private if they fall into one of the following categories:
+* IPv4 loopback (`127.0.0.0/8`)
+* RFC1918 (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`)
+* RFC3927 (`169.254.0.0/16`)
+* IPv6 loopback (`::1/128`)
+* IPv6 link-local (`fe80::/10`)
+* IPv6 unique local (`fc00::/7`)
+
+{{% note %}}
+#### Private IP considerations
+If your environment requires that these authenticated HTTP requests be made to private IP addresses,
+omit the use of `--hardening-enabled` and
+consider instead setting up egress firewalling to limit which hosts InfluxDB is allowed to connect.

--- a/content/influxdb/v2.1/security/enable-hardening.md
+++ b/content/influxdb/v2.1/security/enable-hardening.md
@@ -1,6 +1,6 @@
 ---
 title: Enable security features
-seotitle: Enable security/hardening features
+seotitle: Enable security and hardening features in InfluxDB
 description: >
   Enable additional security features in InfluxDB.
 weight: 102

--- a/content/influxdb/v2.1/security/enable-hardening.md
+++ b/content/influxdb/v2.1/security/enable-hardening.md
@@ -47,3 +47,4 @@ IP addresses are considered private if they fall into one of the following categ
 If your environment requires that these authenticated HTTP requests be made to private IP addresses,
 omit the use of `--hardening-enabled` and
 consider instead setting up egress firewalling to limit which hosts InfluxDB is allowed to connect.
+{{% /note %}}

--- a/content/influxdb/v2.1/security/enable-hardening.md
+++ b/content/influxdb/v2.1/security/enable-hardening.md
@@ -9,7 +9,7 @@ menu:
   influxdb_2_1:
     parent: Security & authorization
 influxdb/v2.1/tags: [security, hardening]
-products: [oss]
+draft: true
 ---
 
 InfluxDB is used in many environments and depending on your environment, enabling additional security features may be appropriate.

--- a/content/influxdb/v2.1/security/secrets/_index.md
+++ b/content/influxdb/v2.1/security/secrets/_index.md
@@ -5,7 +5,7 @@ influxdb/v2.1/tags: [secrets, security]
 menu:
   influxdb_2_1:
     parent: Security & authorization
-weight: 102
+weight: 103
 aliases:
   - /influxdb/v2.1/security/secrets/manage-secrets/
 ---

--- a/content/influxdb/v2.1/security/tokens/_index.md
+++ b/content/influxdb/v2.1/security/tokens/_index.md
@@ -9,7 +9,7 @@ menu:
   influxdb_2_1:
     name: Manage tokens
     parent: Security & authorization
-weight: 103
+weight: 104
 ---
 
 InfluxDB **API tokens** ensure secure interaction between InfluxDB and external tools such as clients or applications.

--- a/data/influxd_flags.yml
+++ b/data/influxd_flags.yml
@@ -24,6 +24,9 @@
 - flag: "--flux-log-enabled"
   added: 2.0
 
+- flag: "--hardening-enabled"
+  added: 2.2
+
 - flag: "-h, --help"
   added: 2.0
   nolink: true


### PR DESCRIPTION
Closes #3866

Document new InfluxDB OSS --hardening-enabled feature by adding a new page under security/ and between enabling TLS and secrets.

Note, these are suggested changes that you're free to rewrite. I did it against InfluxDB OSS 2.1 since 2.2 hasn't been cut yet. ~~This feature will be backported to 2.1, but that hasn't happened just yet.~~

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
