### PR TITLE
remove TLS 1.0 and 1.1 references

### DIFF
--- a/content/kapacitor/v1.6/administration/configuration.md
+++ b/content/kapacitor/v1.6/administration/configuration.md
@@ -263,8 +263,6 @@ Use the query `SHOW DIAGNOSTICS` to see the version of Go used to build Kapacito
 Minimum version of the TLS protocol that will be negotiated.
 Valid values include: 
 
-- `tls1.0`
-- `tls1.1`
 - `tls1.2`
 - `tls1.3` _(default)_
 
@@ -273,8 +271,6 @@ Valid values include:
 Maximum version of the TLS protocol that will be negotiated. 
 Valid values include: 
 
-- `tls1.0`
-- `tls1.1`
 - `tls1.2`
 - `tls1.3` _(default)_
 


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/3881

Removed TLS 1.0 and 1.1 version references from Kapa config doc.  Confirmed OK to remove by Emerys.
