### PR TITLE
Add security section to influxdb/v2.2/reference/release-notes/influxdb.md

### DIFF
--- a/content/influxdb/v2.2/reference/release-notes/influxdb.md
+++ b/content/influxdb/v2.2/reference/release-notes/influxdb.md
@@ -105,6 +105,32 @@ See [InfluxDB OSS metrics](/influxdb/v2.1/reference/internals/metrics/) for addi
   - ``nats-port`` and ``nats-max-payload-bytes`` flags have been deprecated.
   -  NATS is no longer embedded in InfluxDB. Because InfluxDB no longer requires a port for NATS, port conflct issues are reduced.
 
+### Security
+
+Several security issues are fixed in this release:
+- Disable use of jsonnet with `/api/v2/templates/apply`.
+  This prevents crafted authenticated requests from exfiltrating files accessible to the user InfluxDB runs as.
+- Add read permissions check for querying data.
+  This prevents authenticated requests using a write-only token from reading data
+  via the InfluxQL `/query` compatibility API.
+- Add write permissions check for `DELETE` and `DROP MEASUREMENT`.
+  This prevents authenticated requests using a read-only token from deleting data
+  via the InfluxQL `/query` compatibility API.
+- Add the [`hardening-enabled`](/influxdb/v2.2/security/enable-hardening.md) option to limit flux/pkger HTTP requests.
+  By default, Flux HTTP and template fetching requests are allowed
+  to access localhost and private IP addresses.
+  The new `hardening-enabled` option makes InfluxDB first verify that the IP address of the URL is not a private IP address.
+
+Additionally, several security issues were fixed in dependencies and
+the toolchain used to build InfluxDB:
+- The cumulative security fixes for [Flux v0.161.0](/flux/v0.x/release-notes/) since 0.139.0 are included in this release:
+  - Quote db identifiers.
+    This addresses injection vulnerabilities in database connections using `to()`.
+  - Make substring check bounds correctly.
+    This prevents authenticated queries from crashing the Flux engine.
+- The cumulative security fixes for [Go 1.17.8](https://go.dev/doc/devel/release#go1.17.minor) since Go 1.17.2 are included in this release.
+  This addresses an issue in the InfluxDB testsuite.
+
 ## v2.1.1 [2021-11-08]
 
 {{% note %}}


### PR DESCRIPTION
The 2.2 release has several security fixes coming from fixes in InfluxDB OSS itself, flux and Go.

My hope is that the release notes we add here can be used as a template for security fixes in release notes for (at least) our open source products going forward. While I have experience writing security notices for open source software (eg, I used to write Ubuntu Security Notices), I want to be sure that we have a consistent voice for describing security issues in our products. Once we have the voice and outline right, we can just copy this forward for future releases and to other products.

I'm proposing we use the following outline:
```
### Security

<issues specific to this product>
- <issue 1 commit summary>. <high-level details>
- <issue 2 commit summary>. <high-level details>

<issues in dependencies or the toolchain that affect this product>
- Go
- Flux
    - <issue 1 commit summary>
    - <issue 2 commit summary>
- ...
```

The idea here is that we provide extra detail for how the issues affect the product and for dependencies, we also link out to more information (eg, upstream release notes). To best serve our users, IMO it's important to add some detail on security issues so that users have enough information to decide on whether or not to upgrade. This extra detail should not be too deep (to avoid confusion) but should have enough to give users a feel for how the issue might impact their environment. Some might feel that we shouldn't give the extra detail, but I strongly feel that omitting this type of detail only helps attackers (since they read source code commits, not release notes).

Notes for the text itself:
* the link for `hardening-enabled` is only in oss-2.2-base and not in the release notes so it is broken if you use hugo now
* the link in the security section for flux only links to `/flux/v0.x/release-notes/` since there isn't anything for 0.161.0 yet
* the "Flux updates" section (which I did not modify) is at v0.150.0 but OSS now has 0.161.0