### PR TITLE
Update 'influx' CLI / Flux REPL examples 

### DIFF
--- a/content/enterprise_influxdb/v1.9/flux/guides/execute-queries.md
+++ b/content/enterprise_influxdb/v1.9/flux/guides/execute-queries.md
@@ -31,6 +31,69 @@ on your InfluxDB instance, use the `-username` flag to provide your InfluxDB use
 the `-password` flag to provide your password.
 {{% /note %}}
 
+## Influx CLI
+To start an interactive Flux read-eval-print-loop (REPL) with the InfluxDB Enterprise 1.9+
+`influx` CLI, run the `influx` command with the following flags:
+
+- `-type=flux`
+- `-path-prefix=/api/v2/query`
+
+{{% note %}}
+If [authentication is enabled](/enterprise_influxdb/v1.9/administration/authentication_and_authorization)
+on your InfluxDB instance, use the `-username` flag to provide your InfluxDB username and
+the `-password` flag to provide your password.
+{{% /note %}}
+
+##### Enter an interactive Flux REPL
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[No Auth](#)
+[Auth Enabled](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+```bash
+influx -type=flux -path-prefix=/api/v2/query
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+```bash
+influx -type=flux \
+  -path-prefix=/api/v2/query \
+  -username myuser \
+  -password PasSw0rd
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+
+Any Flux query can be executed within the REPL.
+
+### Submit a Flux query via parameter
+Flux queries can also be passed to the Flux REPL as a parameter using the `influx` CLI's `-type=flux` option and the `-execute` parameter.
+The accompanying string is executed as a Flux query and results are output in your terminal.
+
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[No Auth](#)
+[Auth Enabled](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+```bash
+influx -type=flux \
+  -path-prefix=/api/v2/query \
+  -execute '<flux query>'
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+```bash
+influx -type=flux \
+  -path-prefix=/api/v2/query \
+  -username myuser \
+  -password PasSw0rd \
+  -execute '<flux query>'
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+
 ### Submit a Flux query via via STDIN
 Flux queries an be piped into the `influx` CLI via STDIN.
 Query results are otuput in your terminal.
@@ -42,12 +105,15 @@ Query results are otuput in your terminal.
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```bash
-echo '<flux query>' | influx -type=flux
+echo '<flux query>' | influx -type=flux -path-prefix=/api/v2/query
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```bash
-echo '<flux query>' | influx -type=flux -username myuser -password PasSw0rd
+echo '<flux query>' | influx -type=flux \
+  -path-prefix=/api/v2/query \
+  -username myuser \
+  -password PasSw0rd
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}

--- a/content/influxdb/v1.7/flux/get-started/_index.md
+++ b/content/influxdb/v1.7/flux/get-started/_index.md
@@ -113,10 +113,11 @@ The Functions pane provides a list of functions available in your Flux queries.
 
 ### 2. influx CLI
 The `influx` CLI is an interactive shell for querying InfluxDB.
-With InfluxDB v1.7+, use the `-type=flux` option to open a Flux REPL where you write and run Flux queries.
+With InfluxDB v1.7+, use the `-type=flux` and `-path-prefix=/api/v2/query` options
+to open a Flux REPL where you write and run Flux queries.
 
 ```bash
-influx -type=flux
+influx -type=flux -path-prefix=/api/v2/query
 ```
 
 <div class="page-nav-btns">

--- a/content/influxdb/v1.7/flux/get-started/syntax-basics.md
+++ b/content/influxdb/v1.7/flux/get-started/syntax-basics.md
@@ -18,11 +18,12 @@ This guide walks through a handful of simple expressions and how they are handle
 
 ## Use the influx CLI
 Use the `influx` CLI in "Flux mode" as you follow this guide.
-When started with `-type=flux`, the `influx` CLI is an interactive read-eval-print-loop (REPL) that supports Flux syntax.
+When started with `-type=flux` and `-path-prefix=/api/v2/query`, the `influx`
+CLI is an interactive read-eval-print-loop (REPL) that supports Flux syntax.
 
 ##### Start in the influx CLI in Flux mode
 ```bash
-influx -type=flux
+influx -type=flux -path-prefix=/api/v2/query
 ```
 
 > If using the [InfluxData Sandbox](/platform/install-and-deploy/deploying/sandbox-install), use the `./sandbox enter`
@@ -32,7 +33,7 @@ influx -type=flux
 ```bash
 ./sandbox enter influxdb
 
-root@9bfc3c08579c:/# influx -host influxdb -type=flux
+root@9bfc3c08579c:/# influx -host influxdb -type=flux -path-prefix=/api/v2/query
 ```
 
 ## Basic Flux syntax

--- a/content/influxdb/v1.7/flux/guides/execute-queries.md
+++ b/content/influxdb/v1.7/flux/guides/execute-queries.md
@@ -26,9 +26,11 @@ Chronograf v1.7+ supports Flux in its Data Explorer.
 Flux queries can be built, executed, and visualized from within the Chronograf user interface.
 
 ## Influx CLI
-InfluxDB v1.7+'s `influx` CLI includes a `-type` option which allows you specify
-what type of interactive session to start.
-`-type=flux` will start an interactive read-eval-print-loop (REPL) that supports Flux.
+To start an interactive Flux read-eval-print-loop (REPL) with the InfluxDB 1.7+
+`influx` CLI, run the `influx` command with the following flags:
+
+- `-type=flux`
+- `-path-prefix=/api/v2/query`
 
 {{% note %}}
 If [authentication is enabled](/influxdb/v1.7/administration/authentication_and_authorization)
@@ -44,12 +46,15 @@ the `-password` flag to provide your password.
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```bash
-influx -type=flux
+influx -type=flux -path-prefix=/api/v2/query
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```bash
-influx -type=flux -username myuser -password PasSw0rd
+influx -type=flux \
+  -path-prefix=/api/v2/query \
+  -username myuser \
+  -password PasSw0rd
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
@@ -67,12 +72,18 @@ The accompanying string is executed as a Flux query and results are output in yo
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```bash
-influx -type=flux -execute '<flux query>'
+influx -type=flux \
+  -path-prefix=/api/v2/query \
+  -execute '<flux query>'
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```bash
-influx -type=flux -username myuser -password PasSw0rd -execute '<flux query>'
+influx -type=flux \
+  -path-prefix=/api/v2/query \
+  -username myuser \
+  -password PasSw0rd \
+  -execute '<flux query>'
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
@@ -88,12 +99,15 @@ Query results are otuput in your terminal.
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```bash
-echo '<flux query>' | influx -type=flux
+echo '<flux query>' | influx -type=flux -path-prefix=/api/v2/query
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```bash
-echo '<flux query>' | influx -type=flux -username myuser -password PasSw0rd
+echo '<flux query>' | influx -type=flux \
+  -path-prefix=/api/v2/query \
+  -username myuser \
+  -password PasSw0rd
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}

--- a/content/influxdb/v1.8/flux/get-started/_index.md
+++ b/content/influxdb/v1.8/flux/get-started/_index.md
@@ -114,10 +114,11 @@ The Functions pane provides a list of functions available in your Flux queries.
 
 ### 2. influx CLI
 The `influx` CLI is an interactive shell for querying InfluxDB.
-With InfluxDB v1.8+, use the `-type=flux` option to open a Flux REPL where you write and run Flux queries.
+With InfluxDB v1.8+, use the `-type=flux` and `-path-prefix=/api/v2/query` options
+to open a Flux REPL where you write and run Flux queries.
 
 ```bash
-influx -type=flux
+influx -type=flux -path-prefix=/api/v2/query
 ```
 
 <div class="page-nav-btns">

--- a/content/influxdb/v1.8/flux/get-started/syntax-basics.md
+++ b/content/influxdb/v1.8/flux/get-started/syntax-basics.md
@@ -18,11 +18,12 @@ This guide walks through a handful of simple expressions and how they are handle
 
 ## Use the influx CLI
 Use the `influx` CLI in "Flux mode" as you follow this guide.
-When started with `-type=flux`, the `influx` CLI is an interactive read-eval-print-loop (REPL) that supports Flux syntax.
+When started with `-type=flux` and `-path-prefix=/api/v2/query`, the `influx`
+CLI is an interactive read-eval-print-loop (REPL) that supports Flux syntax.
 
 ##### Start in the influx CLI in Flux mode
 ```bash
-influx -type=flux
+influx -type=flux -path-prefix=/api/v2/query
 ```
 
 > If using the [InfluxData Sandbox](/platform/install-and-deploy/deploying/sandbox-install), use the `./sandbox enter`
@@ -32,7 +33,7 @@ influx -type=flux
 ```bash
 ./sandbox enter influxdb
 
-root@9bfc3c08579c:/# influx -host influxdb -type=flux
+root@9bfc3c08579c:/# influx -host influxdb -type=flux -path-prefix=/api/v2/query
 ```
 
 ## Basic Flux syntax

--- a/content/influxdb/v1.8/flux/guides/execute-queries.md
+++ b/content/influxdb/v1.8/flux/guides/execute-queries.md
@@ -26,9 +26,11 @@ Chronograf v1.8+ supports Flux in its Data Explorer.
 Flux queries can be built, executed, and visualized from within the Chronograf user interface.
 
 ## Influx CLI
-InfluxDB v1.8+'s `influx` CLI includes a `-type` option which allows you specify
-what type of interactive session to start.
-`-type=flux` will start an interactive read-eval-print-loop (REPL) that supports Flux.
+To start an interactive Flux read-eval-print-loop (REPL) with the InfluxDB 1.8+
+`influx` CLI, run the `influx` command with the following flags:
+
+- `-type=flux`
+- `-path-prefix=/api/v2/query`
 
 {{% note %}}
 If [authentication is enabled](/influxdb/v1.8/administration/authentication_and_authorization)
@@ -44,12 +46,15 @@ the `-password` flag to provide your password.
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```bash
-influx -type=flux
+influx -type=flux -path-prefix=/api/v2/query
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```bash
-influx -type=flux -username myuser -password PasSw0rd
+influx -type=flux \
+  -path-prefix=/api/v2/query \
+  -username myuser \
+  -password PasSw0rd
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
@@ -67,12 +72,18 @@ The accompanying string is executed as a Flux query and results are output in yo
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```bash
-influx -type=flux -execute '<flux query>'
+influx -type=flux \
+  -path-prefix=/api/v2/query \
+  -execute '<flux query>'
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```bash
-influx -type=flux -username myuser -password PasSw0rd -execute '<flux query>'
+influx -type=flux \
+  -path-prefix=/api/v2/query \
+  -username myuser \
+  -password PasSw0rd \
+  -execute '<flux query>'
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
@@ -88,12 +99,15 @@ Query results are otuput in your terminal.
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```bash
-echo '<flux query>' | influx -type=flux
+echo '<flux query>' | influx -type=flux -path-prefix=/api/v2/query
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```bash
-echo '<flux query>' | influx -type=flux -username myuser -password PasSw0rd
+echo '<flux query>' | influx -type=flux \
+  -path-prefix=/api/v2/query \
+  -username myuser \
+  -password PasSw0rd
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}


### PR DESCRIPTION
Closes influxdata/DAR#288

This adds the `-path-prefix=/api/v2/query` flag to all examples of using the 1.x `influx` CLI to start a Flux REPL.

- [x] Rebased/mergeable
