### PR TITLE
Fix parameter on 1.x import commands

### DIFF
--- a/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
+++ b/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
@@ -380,31 +380,35 @@ Use the InfluxDB `influx_inspect export` and `influx -import` commands to create
 
 ### Export data
 
-Use the [`influx_inspect export` command](/{{< latest "influxdb" "v1" >}}/tools/influx_inspect#export) to export data in line protocol format from your InfluxDB Enterprise cluster. Options include:
+Use the [`influx_inspect export` command](/influxdb/v1.7/tools/influx_inspect#export) to export data in line protocol format from your InfluxDB Enterprise cluster. Options include:
 
 - Exporting all, or specific, databases
 - Filtering with starting and ending timestamps
 - Using gzip compression for smaller files and faster exports
 
-For details on optional settings and usage, see [`influx_inspect export` command](/{{< latest "influxdb" "v1" >}}/tools/influx_inspect#export).
+For details on optional settings and usage, see [`influx_inspect export` command](/influxdb/v1.7/tools/influx_inspect#export).
 
 In the following example, the database is exported filtered to include only one day and compressed for optimal speed and file size.
 
 ```bash
-influx_inspect export -database myDB -compress -start 2019-05-19T00:00:00.000Z -end 2019-05-19T23:59:59.999Z
+influx_inspect export \
+  -database myDB \
+  -compress \
+  -start 2019-05-19T00:00:00.000Z \
+  -end 2019-05-19T23:59:59.999Z
 ```
 
 ### Import data
 
-After exporting the data in line protocol format, you can import the data using the [`influx -import` CLI command](/{{< latest "influxdb" "v1" >}}/tools/shell/#import).
+After exporting the data in line protocol format, you can import the data using the [`influx -import` CLI command](/influxdb/v1.7/tools/shell/#import).
 
 In the following example, the compressed data file is imported into the specified database.
 
 ```bash
-influx -import -database myDB -compress
+influx -import -database myDB -compressed
 ```
 
-For details on using the `influx -import` command, see [Import data from a file with -import](/{{< latest "influxdb" "v1" >}}/tools/shell/#import-data-from-a-file-with-import).
+For details on using the `influx -import` command, see [Import data from a file with -import](/influxdb/v1.7/tools/shell/#import-data-from-a-file-with-import).
 
 ## Take AWS snapshots as backup
 

--- a/content/enterprise_influxdb/v1.8/administration/backup-and-restore.md
+++ b/content/enterprise_influxdb/v1.8/administration/backup-and-restore.md
@@ -27,7 +27,7 @@ Depending on the volume of data to be protected and your application requirement
 - [Backup and restore utilities](#backup-and-restore-utilities) — For most applications
 - [Exporting and importing data](#exporting-and-importing-data) — For large datasets
 
-> **Note:** Use the [`backup` and `restore` utilities (InfluxDB OSS 1.5 and later)](/{{< latest "influxdb" "v1" >}}/administration/backup_and_restore/) to:
+> **Note:** Use the [`backup` and `restore` utilities (InfluxDB OSS 1.5 and later)](/influxdb/v1.8/administration/backup_and_restore/) to:
 >
 > - Restore InfluxDB Enterprise backup files to InfluxDB OSS instances.
 > - Back up InfluxDB OSS data that can be restored in InfluxDB Enterprise clusters.
@@ -434,31 +434,35 @@ As an alternative to the standard backup and restore utilities, use the InfluxDB
 
 ### Exporting data
 
-Use the [`influx_inspect export` command](/{{< latest "influxdb" "v1" >}}/tools/influx_inspect#export) to export data in line protocol format from your InfluxDB Enterprise cluster. Options include:
+Use the [`influx_inspect export` command](/influxdb/v1.8/tools/influx_inspect#export) to export data in line protocol format from your InfluxDB Enterprise cluster. Options include:
 
 - Exporting all, or specific, databases
 - Filtering with starting and ending timestamps
 - Using gzip compression for smaller files and faster exports
 
-For details on optional settings and usage, see [`influx_inspect export` command](/{{< latest "influxdb" "v1" >}}/tools/influx_inspect#export).
+For details on optional settings and usage, see [`influx_inspect export` command](/influxdb/v1.8/tools/influx_inspect#export).
 
 In the following example, the database is exported filtered to include only one day and compressed for optimal speed and file size.
 
 ```bash
-influx_inspect export -database myDB -compress -start 2019-05-19T00:00:00.000Z -end 2019-05-19T23:59:59.999Z
+influx_inspect export \
+  -database myDB \
+  -compress \
+  -start 2019-05-19T00:00:00.000Z \
+  -end 2019-05-19T23:59:59.999Z
 ```
 
 ### Importing data
 
-After exporting the data in line protocol format, you can import the data using the [`influx -import` CLI command](/{{< latest "influxdb" "v1" >}}/tools/shell/#import).
+After exporting the data in line protocol format, you can import the data using the [`influx -import` CLI command](/influxdb/v1.8/tools/shell/#import).
 
 In the following example, the compressed data file is imported into the specified database.
 
 ```bash
-influx -import -database myDB -compress
+influx -import -database myDB -compressed
 ```
 
-For details on using the `influx -import` command, see [Import data from a file with -import](/{{< latest "influxdb" "v1" >}}/tools/shell/#import-data-from-a-file-with-import).
+For details on using the `influx -import` command, see [Import data from a file with -import](/influxdb/v1.8/tools/shell/#import-data-from-a-file-with-import).
 
 ### Example
 

--- a/content/enterprise_influxdb/v1.9/administration/backup-and-restore.md
+++ b/content/enterprise_influxdb/v1.9/administration/backup-and-restore.md
@@ -469,7 +469,11 @@ For details on optional settings and usage, see [`influx_inspect export` command
 In the following example, the database is exported filtered to include only one day and compressed for optimal speed and file size.
 
 ```bash
-influx_inspect export -database myDB -compress -start 2019-05-19T00:00:00.000Z -end 2019-05-19T23:59:59.999Z
+influx_inspect export \
+  -database myDB \
+  -compress \
+  -start 2019-05-19T00:00:00.000Z \
+  -end 2019-05-19T23:59:59.999Z
 ```
 
 ### Importing data
@@ -479,7 +483,7 @@ After exporting the data in line protocol format, you can import the data using 
 In the following example, the compressed data file is imported into the specified database.
 
 ```bash
-influx -import -database myDB -compress
+influx -import -database myDB -compressed
 ```
 
 For details on using the `influx -import` command, see [Import data from a file with -import](/enterprise_influxdb/v1.9/tools/influx-cli/use-influx/#import-data-from-a-file-with--import).


### PR DESCRIPTION
Closes influxdata/DAR#287

- Updates the `-compress` flag to `-compressed` on 1.x `influx import' commands.
- Updates latest links to fixed-version links in 1.x import/export docs.

---

- [x] Rebased/mergeable
