### PR TITLE
Fix Telegraf plugin anchors and links

### DIFF
--- a/content/chronograf/v1.7/administration/prebuilt-dashboards.md
+++ b/content/chronograf/v1.7/administration/prebuilt-dashboards.md
@@ -30,12 +30,12 @@ The Docker dashboard displays the following information:
 
 ### Plugins
 
-- [`docker` plugin](/{{< latest "telegraf" >}}/plugins/#docker)
-- [`disk` plugin](/{{< latest "telegraf" >}}/plugins/#disk)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
-- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#cpu)
+- [`docker` plugin](/{{< latest "telegraf" >}}/plugins/#input-docker)
+- [`disk` plugin](/{{< latest "telegraf" >}}/plugins/#input-disk)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
+- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#input-cpu)
 
 ## Kubernetes Node
 The Kubernetes Node dashboard displays the following information:
@@ -53,7 +53,7 @@ The Kubernetes Node dashboard displays the following information:
 - K8s - Kubelet Memory Bytes
 
 ### Plugins
-- [kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)
+- [kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)
 
 ## Kubernetes Overview
 The Kubernetes Node dashboard displays the following information:
@@ -72,7 +72,7 @@ The Kubernetes Node dashboard displays the following information:
 
 ### Plugins
 
-- [kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)
+- [kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)
 
 ## Kubernetes Pod
 The Kubernetes Pod dashboard displays the following information:
@@ -87,7 +87,7 @@ The Kubernetes Pod dashboard displays the following information:
 - K8s - Pod TX Bytes/Second
 
 ### Plugins
-- [kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)
+- [kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)
 
 ## Riak
 The Riak dashboard displays the following information:
@@ -101,7 +101,7 @@ The Riak dashboard displays the following information:
 - Riak - Read Repairs/Minute
 
 ### Plugins
-- [`riak` plugin](/{{< latest "telegraf" >}}/plugins/#riak)
+- [`riak` plugin](/{{< latest "telegraf" >}}/plugins/#input-riak)
 
 ## Consul
 The Consul dashboard displays the following information:
@@ -110,7 +110,7 @@ The Consul dashboard displays the following information:
 - Consul - Number of Warning Health Checks
 
 ### Plugins
-- [`consul` plugin](/{{< latest "telegraf" >}}/plugins/#consul)
+- [`consul` plugin](/{{< latest "telegraf" >}}/plugins/#input-consul)
 
 ## Consul Telemetry
 The Consul Telemetry dashboard displays the following information:
@@ -125,7 +125,7 @@ The Consul Telemetry dashboard displays the following information:
 - Consul - Number of Serf Events
 
 ### Plugins
-[`consul` plugin](/{{< latest "telegraf" >}}/plugins/#consul)
+[`consul` plugin](/{{< latest "telegraf" >}}/plugins/#input-consul)
 
 
 ## Mesos
@@ -140,7 +140,7 @@ The Mesos dashboard displays the following information:
 - Mesos Master Uptime
 
 ### Plugins
-- [`mesos` plugin](/{{< latest "telegraf" >}}/plugins/#mesos)
+- [`mesos` plugin](/{{< latest "telegraf" >}}/plugins/#input-mesos)
 
 ## RabbitMQ
 The RabbitMQ dashboard displays the following information:
@@ -151,7 +151,7 @@ The RabbitMQ dashboard displays the following information:
 
 ### Plugins
 
-- [`rabbitmq` plugin](/{{< latest "telegraf" >}}/plugins/#rabbitmq)
+- [`rabbitmq` plugin](/{{< latest "telegraf" >}}/plugins/#input-rabbitmq)
 
 ## System
 
@@ -170,14 +170,14 @@ The System dashboard displays the following information:
 
 ### Plugins
 
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
-- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#cpu)
-- [`disk` plugin](/{{< latest "telegraf" >}}/plugins/#disk)
-- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
-- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#net)
-- [`processes` plugin](/{{< latest "telegraf" >}}/plugins/#processes)
-- [`swap` plugin](/{{< latest "telegraf" >}}/plugins/#swap)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
+- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#input-cpu)
+- [`disk` plugin](/{{< latest "telegraf" >}}/plugins/#input-disk)
+- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
+- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#input-net)
+- [`processes` plugin](/{{< latest "telegraf" >}}/plugins/#input-processes)
+- [`swap` plugin](/{{< latest "telegraf" >}}/plugins/#input-swap)
 
 
 
@@ -198,7 +198,7 @@ The VMware vSphere Overview dashboard gives an overview of your VMware vSphere C
   - VM CPU % Ready for :clustername:
 
 ### Plugins
-- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#vmware-vsphere)
+- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#input-vmware-vsphere)
 
 ## Apache
 The Apache dashboard displays the following information:
@@ -221,12 +221,12 @@ The Apache dashboard displays the following information:
 
 ### Plugins
 
-- [`apache` plugin](/{{< latest "telegraf" >}}/plugins/#apache)
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
-- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
-- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#net)
-- [`logparser` plugin](/{{< latest "telegraf" >}}/plugins/#logparser)
+- [`apache` plugin](/{{< latest "telegraf" >}}/plugins/#input-apache)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
+- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
+- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#input-net)
+- [`logparser` plugin](/{{< latest "telegraf" >}}/plugins/#input-logparser)
 
 ## ElasticSearch
 The ElasticSearch dashboard displays the following information:
@@ -243,7 +243,7 @@ The ElasticSearch dashboard displays the following information:
 - ElasticSearch - JVM Heap Usage
 
 ### Plugins
-- [`elasticsearch` plugin](/{{< latest "telegraf" >}}/plugins/#elasticsearch)
+- [`elasticsearch` plugin](/{{< latest "telegraf" >}}/plugins/#input-elasticsearch)
 
 
 ## InfluxDB
@@ -272,12 +272,12 @@ The InfluxDB dashboard displays the following information:
 
 ### Plugins
 
-- [`influxdb` plugin](/{{< latest "telegraf" >}}/plugins/#influxdb)
-- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#cpu)
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
-- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
-- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#net)
+- [`influxdb` plugin](/{{< latest "telegraf" >}}/plugins/#input-influxdb)
+- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#input-cpu)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
+- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
+- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#input-net)
 
 
 
@@ -299,7 +299,7 @@ The Memcached dashboard displays the following information:
 - Memcached - Evictions/10 Seconds
 
 ### Plugins
-- [`memcached` plugin](/{{< latest "telegraf" >}}/plugins/#memcached)
+- [`memcached` plugin](/{{< latest "telegraf" >}}/plugins/#input-memcached)
 
 
 ## NSQ
@@ -315,7 +315,7 @@ The NSQ dashboard displays the following information:
 - NSQ - Topic Egress
 
 ### Plugins
-- [`nsq` plugin](/{{< latest "telegraf" >}}/plugins/#nsq)
+- [`nsq` plugin](/{{< latest "telegraf" >}}/plugins/#input-nsq)
 
 ## PostgreSQL
 The PostgreSQL dashboard displays the following information:
@@ -340,11 +340,11 @@ The PostgreSQL dashboard displays the following information:
 
 ### Plugins
 
-- [`postgresql` plugin](/{{< latest "telegraf" >}}/plugins/#postgresql)
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
-- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#cpu)
-- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
+- [`postgresql` plugin](/{{< latest "telegraf" >}}/plugins/#input-postgresql)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
+- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#input-cpu)
+- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
 
 
 ## HAProxy
@@ -367,7 +367,7 @@ The HAProxy dashboard displays the following information:
 - HAProxy - Backend Error Responses/Second
 
 ### Plugins
-- [`haproxy` plugin](/{{< latest "telegraf" >}}/plugins/#haproxy)
+- [`haproxy` plugin](/{{< latest "telegraf" >}}/plugins/#input-haproxy)
 
 
 ## NGINX
@@ -379,7 +379,7 @@ The NGINX dashboard displays the following information:
 - NGINX - Active Client State
 
 ### Plugins
-- [`nginx` plugin](/{{< latest "telegraf" >}}/plugins/#nginx)
+- [`nginx` plugin](/{{< latest "telegraf" >}}/plugins/#input-nginx)
 
 ## Redis
 The Redis dashboard displays the following information:
@@ -390,7 +390,7 @@ The Redis dashboard displays the following information:
 - Redis - Memory
 
 ### Plugins
-- [`redis` plugin](/{{< latest "telegraf" >}}/plugins/#redis)
+- [`redis` plugin](/{{< latest "telegraf" >}}/plugins/#input-redis)
 
 
 ## VMware vSphere VMs
@@ -406,7 +406,7 @@ The VMWare vSphere VMs dashboard gives an overview of your VMware vSphere virtua
 - Total Disk Latency for :vmname:
 
 ### Plugins
-- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#vsphere)
+- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#input-vsphere)
 
 ## VMware vSphere Hosts
 
@@ -422,7 +422,7 @@ The VMWare vSphere Hosts dashboard displays the following information:
 - Total Disk Latency for :esxhostname:
 
 ### Plugins
-- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#vsphere)
+- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#input-vsphere)
 
 ## PHPfpm
 The PHPfpm dashboard displays the following information:
@@ -433,7 +433,7 @@ The PHPfpm dashboard displays the following information:
 - PHPfpm - Max Children Reached
 
 ### Plugins
-- [`phpfpm` plugin](/{{< latest "telegraf" >}}/plugins/#nginx)
+- [`phpfpm` plugin](/{{< latest "telegraf" >}}/plugins/#input-nginx)
 
 ## Win System
 The Win System dashboard displays the following information:
@@ -445,7 +445,7 @@ The Win System dashboard displays the following information:
 - System - Load
 
 ### Plugins
-- [`win_services` plugin](/{{< latest "telegraf" >}}/plugins/#windows-services)
+- [`win_services` plugin](/{{< latest "telegraf" >}}/plugins/#input-windows-services)
 
 
 ## MySQL
@@ -472,9 +472,9 @@ The MySQL dashboard displays the following information:
 - InnoDB Data
 
 ### Plugins
-- [`mySQL` plugin](/{{< latest "telegraf" >}}/plugins/#mysql)
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
+- [`mySQL` plugin](/{{< latest "telegraf" >}}/plugins/#input-mysql)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
 
 ## Ping
 The Ping dashboard displays the following information:
@@ -483,4 +483,4 @@ The Ping dashboard displays the following information:
 - Ping - Response Times (ms)
 
 ### Plugins
-- [`ping` plugin](/{{< latest "telegraf" >}}/plugins/#ping)
+- [`ping` plugin](/{{< latest "telegraf" >}}/plugins/#input-ping)

--- a/content/chronograf/v1.7/guides/using-precreated-dashboards.md
+++ b/content/chronograf/v1.7/guides/using-precreated-dashboards.md
@@ -65,7 +65,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## apache
 
-**Required Telegraf plugin:** [Apache input plugin](/{{< latest "telegraf" >}}/plugins/#apache)
+**Required Telegraf plugin:** [Apache input plugin](/{{< latest "telegraf" >}}/plugins/#input-apache)
 
 `apache.json`
 
@@ -75,7 +75,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## consul
 
-**Required Telegraf plugin:** [Consul input plugin](/{{< latest "telegraf" >}}/plugins/#consul)
+**Required Telegraf plugin:** [Consul input plugin](/{{< latest "telegraf" >}}/plugins/#input-consul)
 
 `consul_http.json`
 
@@ -95,7 +95,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## docker
 
-**Required Telegraf plugin:** [Docker input plugin](/{{< latest "telegraf" >}}/plugins/#docker)
+**Required Telegraf plugin:** [Docker input plugin](/{{< latest "telegraf" >}}/plugins/#input-docker)
 
 `docker.json`
 
@@ -115,7 +115,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## elasticsearch
 
-**Required Telegraf plugin:** [Elasticsearch input plugin](/{{< latest "telegraf" >}}/plugins/#elasticsearch)
+**Required Telegraf plugin:** [Elasticsearch input plugin](/{{< latest "telegraf" >}}/plugins/#input-elasticsearch)
 
 `elasticsearch.json`
 
@@ -132,7 +132,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## haproxy
 
-**Required Telegraf plugin:** [HAProxy input plugin](/{{< latest "telegraf" >}}/plugins/#haproxy)
+**Required Telegraf plugin:** [HAProxy input plugin](/{{< latest "telegraf" >}}/plugins/#input-haproxy)
 
 `haproxy.json`
 
@@ -154,7 +154,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## iis
 
-**Required Telegraf plugin:** [Windows Performance Counters input plugin](/{{< latest "telegraf" >}}/plugins/#win_perf_counters)
+**Required Telegraf plugin:** [Windows Performance Counters input plugin](/{{< latest "telegraf" >}}/plugins/#input-win_perf_counters)
 
 `win_websvc.json`
 
@@ -162,7 +162,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## influxdb
 
-**Required Telegraf plugin:** [InfluxDB input plugin](/{{< latest "telegraf" >}}/plugins/#influxdb)
+**Required Telegraf plugin:** [InfluxDB input plugin](/{{< latest "telegraf" >}}/plugins/#input-influxdb)
 
 `influxdb_database.json`
 
@@ -207,7 +207,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## Memcached (`memcached`)
 
-**Required Telegraf plugin:** [Memcached input plugin](/{{< latest "telegraf" >}}/plugins/#memcached)
+**Required Telegraf plugin:** [Memcached input plugin](/{{< latest "telegraf" >}}/plugins/#input-memcached)
 
 `memcached.json`
 
@@ -227,7 +227,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## mesos
 
-**Required Telegraf plugin:** [Mesos input plugin](/{{< latest "telegraf" >}}/plugins/#mesos)
+**Required Telegraf plugin:** [Mesos input plugin](/{{< latest "telegraf" >}}/plugins/#input-mesos)
 
 `mesos.json`
 
@@ -242,7 +242,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## mongodb
 
-**Required Telegraf plugin:** [MongoDB input plugin](/{{< latest "telegraf" >}}/plugins/#mongodb)
+**Required Telegraf plugin:** [MongoDB input plugin](/{{< latest "telegraf" >}}/plugins/#input-mongodb)
 
 `mongodb.json`
 
@@ -254,7 +254,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## mysql
 
-**Required Telegraf plugin:** [MySQL input plugin](/{{< latest "telegraf" >}}/plugins/#mysql)
+**Required Telegraf plugin:** [MySQL input plugin](/{{< latest "telegraf" >}}/plugins/#input-mysql)
 
 `mysql.json`
 
@@ -265,7 +265,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## nginx
 
-**Required Telegraf plugin:** [NGINX input plugin](/{{< latest "telegraf" >}}/plugins/#nginx)
+**Required Telegraf plugin:** [NGINX input plugin](/{{< latest "telegraf" >}}/plugins/#input-nginx)
 
 `nginx.json`
 
@@ -276,7 +276,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## nsq
 
-**Required Telegraf plugin:** [NSQ input plugin](/{{< latest "telegraf" >}}/plugins/#nsq)
+**Required Telegraf plugin:** [NSQ input plugin](/{{< latest "telegraf" >}}/plugins/#input-nsq)
 
 `nsq_channel.json`
 
@@ -297,7 +297,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## phpfpm
 
-**Required Telegraf plugin:** [PHPfpm input plugin](/{{< latest "telegraf" >}}/plugins/#phpfpm)
+**Required Telegraf plugin:** [PHPfpm input plugin](/{{< latest "telegraf" >}}/plugins/#input-phpfpm)
 
 `phpfpm.json`
 
@@ -309,7 +309,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## ping
 
-**Required Telegraf plugin:** [Ping input plugin](/{{< latest "telegraf" >}}/plugins/#ping)
+**Required Telegraf plugin:** [Ping input plugin](/{{< latest "telegraf" >}}/plugins/#input-ping)
 
 `ping.json`
 
@@ -318,7 +318,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## postgresql
 
-**Required Telegraf plugin:** [PostgreSQL input plugin](/{{< latest "telegraf" >}}/plugins/#postgresql)
+**Required Telegraf plugin:** [PostgreSQL input plugin](/{{< latest "telegraf" >}}/plugins/#input-postgresql)
 
 `postgresql.json`
 
@@ -329,7 +329,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## rabbitmq
 
-**Required Telegraf plugin:** [RabbitMQ input plugin](/{{< latest "telegraf" >}}/plugins/#rabbitmq)
+**Required Telegraf plugin:** [RabbitMQ input plugin](/{{< latest "telegraf" >}}/plugins/#input-rabbitmq)
 
 `rabbitmq.json`
 
@@ -340,7 +340,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## redis
 
-**Required Telegraf plugin:** [Redis input plugin](/{{< latest "telegraf" >}}/plugins/#redis)
+**Required Telegraf plugin:** [Redis input plugin](/{{< latest "telegraf" >}}/plugins/#input-redis)
 
 
 `redis.json`
@@ -352,7 +352,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## riak
 
-**Required Telegraf plugin:** [Riak input plugin](/{{< latest "telegraf" >}}/plugins/#riak)
+**Required Telegraf plugin:** [Riak input plugin](/{{< latest "telegraf" >}}/plugins/#input-riak)
 
 
 `riak.json`
@@ -371,7 +371,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ### cpu
 
-**Required Telegraf plugin:** [CPU input plugin](/{{< latest "telegraf" >}}/plugins/#cpu)
+**Required Telegraf plugin:** [CPU input plugin](/{{< latest "telegraf" >}}/plugins/#input-cpu)
 
 `cpu.json`
 
@@ -381,13 +381,13 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 `disk.json`
 
-**Required Telegraf plugin:** [Disk input plugin](/{{< latest "telegraf" >}}/plugins/#disk)
+**Required Telegraf plugin:** [Disk input plugin](/{{< latest "telegraf" >}}/plugins/#input-disk)
 
   * "System - Disk used %"
 
 ### diskio
 
-**Required Telegraf plugin:** [DiskIO input plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
+**Required Telegraf plugin:** [DiskIO input plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
 
 `diskio.json`
 
@@ -396,7 +396,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ### mem
 
-**Required Telegraf plugin:** [Mem input plugin](/{{< latest "telegraf" >}}/plugins/#mem)
+**Required Telegraf plugin:** [Mem input plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
 
 `mem.json`
 
@@ -404,7 +404,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ### net
 
-**Required Telegraf plugin:** [Net input plugin](/{{< latest "telegraf" >}}/plugins/#net)
+**Required Telegraf plugin:** [Net input plugin](/{{< latest "telegraf" >}}/plugins/#input-net)
 
 `net.json`
 
@@ -413,7 +413,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ### netstat
 
-**Required Telegraf plugin:** [Netstat input plugin](/{{< latest "telegraf" >}}/plugins/#netstat)
+**Required Telegraf plugin:** [Netstat input plugin](/{{< latest "telegraf" >}}/plugins/#input-netstat)
 
 `netstat.json`
 
@@ -422,7 +422,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ### processes
 
-**Required Telegraf plugin:** [Processes input plugin](/{{< latest "telegraf" >}}/plugins/#processes)
+**Required Telegraf plugin:** [Processes input plugin](/{{< latest "telegraf" >}}/plugins/#input-processes)
 
 `processes.json`
 
@@ -430,7 +430,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ### procstat
 
-**Required Telegraf plugin:** [Procstat input plugin](/{{< latest "telegraf" >}}/plugins/#procstat)
+**Required Telegraf plugin:** [Procstat input plugin](/{{< latest "telegraf" >}}/plugins/#input-procstat)
 
 `procstat.json`
 
@@ -439,7 +439,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ### system
 
-**Required Telegraf plugin:** [Procstat input plugin](/{{< latest "telegraf" >}}/plugins/#procstat)
+**Required Telegraf plugin:** [Procstat input plugin](/{{< latest "telegraf" >}}/plugins/#input-procstat)
 
 `load.json`
 
@@ -447,7 +447,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## varnish
 
-**Required Telegraf plugin:** [Varnish](/{{< latest "telegraf" >}}/plugins/#varnish)
+**Required Telegraf plugin:** [Varnish](/{{< latest "telegraf" >}}/plugins/#input-varnish)
 
 `varnish.json`
 
@@ -456,7 +456,7 @@ See [Telegraf configuration](https://github.com/influxdata/telegraf/blob/master/
 
 ## win_system
 
-**Required Telegraf plugin:** [Windows Performance Counters input plugin](/{{< latest "telegraf" >}}/plugins/#win_perf_counters)
+**Required Telegraf plugin:** [Windows Performance Counters input plugin](/{{< latest "telegraf" >}}/plugins/#input-win_perf_counters)
 
 `win_cpu.json`
 

--- a/content/chronograf/v1.8/administration/prebuilt-dashboards.md
+++ b/content/chronograf/v1.8/administration/prebuilt-dashboards.md
@@ -30,12 +30,12 @@ The Docker dashboard displays the following information:
 
 ### Plugins
 
-- [`docker` plugin](/{{< latest "telegraf" >}}/plugins/#docker)
-- [`disk` plugin](/{{< latest "telegraf" >}}/plugins/#disk)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
-- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#cpu)
+- [`docker` plugin](/{{< latest "telegraf" >}}/plugins/#input-docker)
+- [`disk` plugin](/{{< latest "telegraf" >}}/plugins/#input-disk)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
+- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#input-cpu)
 
 ## Kubernetes Node
 The Kubernetes Node dashboard displays the following information:
@@ -53,7 +53,7 @@ The Kubernetes Node dashboard displays the following information:
 - K8s - Kubelet Memory Bytes
 
 ### Plugins
-- [kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)
+- [kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)
 
 ## Kubernetes Overview
 The Kubernetes Node dashboard displays the following information:
@@ -72,7 +72,7 @@ The Kubernetes Node dashboard displays the following information:
 
 ### Plugins
 
-- [kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)
+- [kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)
 
 ## Kubernetes Pod
 The Kubernetes Pod dashboard displays the following information:
@@ -87,7 +87,7 @@ The Kubernetes Pod dashboard displays the following information:
 - K8s - Pod TX Bytes/Second
 
 ### Plugins
-- [kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)
+- [kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)
 
 ## Riak
 The Riak dashboard displays the following information:
@@ -101,7 +101,7 @@ The Riak dashboard displays the following information:
 - Riak - Read Repairs/Minute
 
 ### Plugins
-- [`riak` plugin](/{{< latest "telegraf" >}}/plugins/#riak)
+- [`riak` plugin](/{{< latest "telegraf" >}}/plugins/#input-riak)
 
 ## Consul
 The Consul dashboard displays the following information:
@@ -110,7 +110,7 @@ The Consul dashboard displays the following information:
 - Consul - Number of Warning Health Checks
 
 ### Plugins
-- [`consul` plugin](/{{< latest "telegraf" >}}/plugins/#consul)
+- [`consul` plugin](/{{< latest "telegraf" >}}/plugins/#input-consul)
 
 ## Consul Telemetry
 The Consul Telemetry dashboard displays the following information:
@@ -125,7 +125,7 @@ The Consul Telemetry dashboard displays the following information:
 - Consul - Number of Serf Events
 
 ### Plugins
-[`consul` plugin](/{{< latest "telegraf" >}}/plugins/#consul)
+[`consul` plugin](/{{< latest "telegraf" >}}/plugins/#input-consul)
 
 
 ## Mesos
@@ -140,7 +140,7 @@ The Mesos dashboard displays the following information:
 - Mesos Master Uptime
 
 ### Plugins
-- [`mesos` plugin](/{{< latest "telegraf" >}}/plugins/#mesos)
+- [`mesos` plugin](/{{< latest "telegraf" >}}/plugins/#input-mesos)
 
 ## RabbitMQ
 The RabbitMQ dashboard displays the following information:
@@ -151,7 +151,7 @@ The RabbitMQ dashboard displays the following information:
 
 ### Plugins
 
-- [`rabbitmq` plugin](/{{< latest "telegraf" >}}/plugins/#rabbitmq)
+- [`rabbitmq` plugin](/{{< latest "telegraf" >}}/plugins/#input-rabbitmq)
 
 ## System
 
@@ -170,14 +170,14 @@ The System dashboard displays the following information:
 
 ### Plugins
 
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
-- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#cpu)
-- [`disk` plugin](/{{< latest "telegraf" >}}/plugins/#disk)
-- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
-- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#net)
-- [`processes` plugin](/{{< latest "telegraf" >}}/plugins/#processes)
-- [`swap` plugin](/{{< latest "telegraf" >}}/plugins/#swap)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
+- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#input-cpu)
+- [`disk` plugin](/{{< latest "telegraf" >}}/plugins/#input-disk)
+- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
+- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#input-net)
+- [`processes` plugin](/{{< latest "telegraf" >}}/plugins/#input-processes)
+- [`swap` plugin](/{{< latest "telegraf" >}}/plugins/#input-swap)
 
 
 
@@ -198,7 +198,7 @@ The VMware vSphere Overview dashboard gives an overview of your VMware vSphere C
   - VM CPU % Ready for :clustername:
 
 ### Plugins
-- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#vmware-vsphere)
+- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#input-vmware-vsphere)
 
 ## Apache
 The Apache dashboard displays the following information:
@@ -221,12 +221,12 @@ The Apache dashboard displays the following information:
 
 ### Plugins
 
-- [`apache` plugin](/{{< latest "telegraf" >}}/plugins/#apache)
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
-- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
-- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#net)
-- [`logparser` plugin](/{{< latest "telegraf" >}}/plugins/#logparser)
+- [`apache` plugin](/{{< latest "telegraf" >}}/plugins/#input-apache)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
+- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
+- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#input-net)
+- [`logparser` plugin](/{{< latest "telegraf" >}}/plugins/#input-logparser)
 
 ## ElasticSearch
 The ElasticSearch dashboard displays the following information:
@@ -243,7 +243,7 @@ The ElasticSearch dashboard displays the following information:
 - ElasticSearch - JVM Heap Usage
 
 ### Plugins
-- [`elasticsearch` plugin](/{{< latest "telegraf" >}}/plugins/#elasticsearch)
+- [`elasticsearch` plugin](/{{< latest "telegraf" >}}/plugins/#input-elasticsearch)
 
 
 ## InfluxDB
@@ -272,12 +272,12 @@ The InfluxDB dashboard displays the following information:
 
 ### Plugins
 
-- [`influxdb` plugin](/{{< latest "telegraf" >}}/plugins/#influxdb)
-- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#cpu)
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
-- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
-- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#net)
+- [`influxdb` plugin](/{{< latest "telegraf" >}}/plugins/#input-influxdb)
+- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#input-cpu)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
+- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
+- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#input-net)
 
 
 
@@ -299,7 +299,7 @@ The Memcached dashboard displays the following information:
 - Memcached - Evictions/10 Seconds
 
 ### Plugins
-- [`memcached` plugin](/{{< latest "telegraf" >}}/plugins/#memcached)
+- [`memcached` plugin](/{{< latest "telegraf" >}}/plugins/#input-memcached)
 
 
 ## NSQ
@@ -315,7 +315,7 @@ The NSQ dashboard displays the following information:
 - NSQ - Topic Egress
 
 ### Plugins
-- [`nsq` plugin](/{{< latest "telegraf" >}}/plugins/#nsq)
+- [`nsq` plugin](/{{< latest "telegraf" >}}/plugins/#input-nsq)
 
 ## PostgreSQL
 The PostgreSQL dashboard displays the following information:
@@ -340,11 +340,11 @@ The PostgreSQL dashboard displays the following information:
 
 ### Plugins
 
-- [`postgresql` plugin](/{{< latest "telegraf" >}}/plugins/#postgresql)
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
-- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#cpu)
-- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
+- [`postgresql` plugin](/{{< latest "telegraf" >}}/plugins/#input-postgresql)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
+- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#input-cpu)
+- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
 
 
 ## HAProxy
@@ -367,7 +367,7 @@ The HAProxy dashboard displays the following information:
 - HAProxy - Backend Error Responses/Second
 
 ### Plugins
-- [`haproxy` plugin](/{{< latest "telegraf" >}}/plugins/#haproxy)
+- [`haproxy` plugin](/{{< latest "telegraf" >}}/plugins/#input-haproxy)
 
 
 ## NGINX
@@ -379,7 +379,7 @@ The NGINX dashboard displays the following information:
 - NGINX - Active Client State
 
 ### Plugins
-- [`nginx` plugin](/{{< latest "telegraf" >}}/plugins/#nginx)
+- [`nginx` plugin](/{{< latest "telegraf" >}}/plugins/#input-nginx)
 
 ## Redis
 The Redis dashboard displays the following information:
@@ -390,7 +390,7 @@ The Redis dashboard displays the following information:
 - Redis - Memory
 
 ### Plugins
-- [`redis` plugin](/{{< latest "telegraf" >}}/plugins/#redis)
+- [`redis` plugin](/{{< latest "telegraf" >}}/plugins/#input-redis)
 
 
 ## VMware vSphere VMs
@@ -406,7 +406,7 @@ The VMWare vSphere VMs dashboard gives an overview of your VMware vSphere virtua
 - Total Disk Latency for :vmname:
 
 ### Plugins
-- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#vsphere)
+- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#input-vsphere)
 
 ## VMware vSphere Hosts
 
@@ -422,7 +422,7 @@ The VMWare vSphere Hosts dashboard displays the following information:
 - Total Disk Latency for :esxhostname:
 
 ### Plugins
-- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#vsphere)
+- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#input-vsphere)
 
 ## PHPfpm
 The PHPfpm dashboard displays the following information:
@@ -433,7 +433,7 @@ The PHPfpm dashboard displays the following information:
 - PHPfpm - Max Children Reached
 
 ### Plugins
-- [`phpfpm` plugin](/{{< latest "telegraf" >}}/plugins/#nginx)
+- [`phpfpm` plugin](/{{< latest "telegraf" >}}/plugins/#input-nginx)
 
 ## Win System
 The Win System dashboard displays the following information:
@@ -445,7 +445,7 @@ The Win System dashboard displays the following information:
 - System - Load
 
 ### Plugins
-- [`win_services` plugin](/{{< latest "telegraf" >}}/plugins/#windows-services)
+- [`win_services` plugin](/{{< latest "telegraf" >}}/plugins/#input-windows-services)
 
 
 ## MySQL
@@ -472,9 +472,9 @@ The MySQL dashboard displays the following information:
 - InnoDB Data
 
 ### Plugins
-- [`mySQL` plugin](/{{< latest "telegraf" >}}/plugins/#mysql)
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
+- [`mySQL` plugin](/{{< latest "telegraf" >}}/plugins/#input-mysql)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
 
 ## Ping
 The Ping dashboard displays the following information:
@@ -483,4 +483,4 @@ The Ping dashboard displays the following information:
 - Ping - Response Times (ms)
 
 ### Plugins
-- [`ping` plugin](/{{< latest "telegraf" >}}/plugins/#ping)
+- [`ping` plugin](/{{< latest "telegraf" >}}/plugins/#input-ping)

--- a/content/chronograf/v1.8/guides/using-precreated-dashboards.md
+++ b/content/chronograf/v1.8/guides/using-precreated-dashboards.md
@@ -69,7 +69,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## apache
 
-**Required Telegraf plugin:** [Apache input plugin](/{{< latest "telegraf" >}}/plugins/#apache-http-server)
+**Required Telegraf plugin:** [Apache input plugin](/{{< latest "telegraf" >}}/plugins/#input-apache)
 
 `apache.json`
 
@@ -79,7 +79,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## consul
 
-**Required Telegraf plugin:** [Consul input plugin](/{{< latest "telegraf" >}}/plugins/#consul)
+**Required Telegraf plugin:** [Consul input plugin](/{{< latest "telegraf" >}}/plugins/#input-consul)
 
 `consul_http.json`
 
@@ -99,7 +99,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## docker
 
-**Required Telegraf plugin:** [Docker input plugin](/{{< latest "telegraf" >}}/plugins/#docker)
+**Required Telegraf plugin:** [Docker input plugin](/{{< latest "telegraf" >}}/plugins/#input-docker)
 
 `docker.json`
 
@@ -119,7 +119,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## elasticsearch
 
-**Required Telegraf plugin:** [Elasticsearch input plugin](/{{< latest "telegraf" >}}/plugins/#elasticsearch)
+**Required Telegraf plugin:** [Elasticsearch input plugin](/{{< latest "telegraf" >}}/plugins/#input-elasticsearch)
 
 `elasticsearch.json`
 
@@ -136,7 +136,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## haproxy
 
-**Required Telegraf plugin:** [HAProxy input plugin](/{{< latest "telegraf" >}}/plugins/#haproxy)
+**Required Telegraf plugin:** [HAProxy input plugin](/{{< latest "telegraf" >}}/plugins/#input-haproxy)
 
 `haproxy.json`
 
@@ -158,7 +158,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## iis
 
-**Required Telegraf plugin:** [Windows Performance Counters input plugin](/{{< latest "telegraf" >}}/plugins/#windows-performance-counters)
+**Required Telegraf plugin:** [Windows Performance Counters input plugin](/{{< latest "telegraf" >}}/plugins/#input-windows-performance-counters)
 
 `win_websvc.json`
 
@@ -166,7 +166,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## influxdb
 
-**Required Telegraf plugin:** [InfluxDB input plugin](/{{< latest "telegraf" >}}/plugins/#influxdb)
+**Required Telegraf plugin:** [InfluxDB input plugin](/{{< latest "telegraf" >}}/plugins/#input-influxdb)
 
 `influxdb_database.json`
 
@@ -211,7 +211,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## Memcached (`memcached`)
 
-**Required Telegraf plugin:** [Memcached input plugin](/{{< latest "telegraf" >}}/plugins/#memcached)
+**Required Telegraf plugin:** [Memcached input plugin](/{{< latest "telegraf" >}}/plugins/#input-memcached)
 
 `memcached.json`
 
@@ -231,7 +231,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## mesos
 
-**Required Telegraf plugin:** [Mesos input plugin](/{{< latest "telegraf" >}}/plugins/#mesos)
+**Required Telegraf plugin:** [Mesos input plugin](/{{< latest "telegraf" >}}/plugins/#input-mesos)
 
 `mesos.json`
 
@@ -246,7 +246,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## mongodb
 
-**Required Telegraf plugin:** [MongoDB input plugin](/{{< latest "telegraf" >}}/plugins/#mongodb)
+**Required Telegraf plugin:** [MongoDB input plugin](/{{< latest "telegraf" >}}/plugins/#input-mongodb)
 
 `mongodb.json`
 
@@ -258,7 +258,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## mysql
 
-**Required Telegraf plugin:** [MySQL input plugin](/{{< latest "telegraf" >}}/plugins/#mysql)
+**Required Telegraf plugin:** [MySQL input plugin](/{{< latest "telegraf" >}}/plugins/#input-mysql)
 
 `mysql.json`
 
@@ -269,7 +269,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## nginx
 
-**Required Telegraf plugin:** [NGINX input plugin](/{{< latest "telegraf" >}}/plugins/#nginx)
+**Required Telegraf plugin:** [NGINX input plugin](/{{< latest "telegraf" >}}/plugins/#input-nginx)
 
 `nginx.json`
 
@@ -280,7 +280,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## nsq
 
-**Required Telegraf plugin:** [NSQ input plugin](/{{< latest "telegraf" >}}/plugins/#nsq)
+**Required Telegraf plugin:** [NSQ input plugin](/{{< latest "telegraf" >}}/plugins/#input-nsq)
 
 `nsq_channel.json`
 
@@ -301,7 +301,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## phpfpm
 
-**Required Telegraf plugin:** [PHPfpm input plugin](/{{< latest "telegraf" >}}/plugins/#php-fpm)
+**Required Telegraf plugin:** [PHPfpm input plugin](/{{< latest "telegraf" >}}/plugins/#input-php-fpm)
 
 `phpfpm.json`
 
@@ -313,7 +313,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## ping
 
-**Required Telegraf plugin:** [Ping input plugin](/{{< latest "telegraf" >}}/plugins/#ping)
+**Required Telegraf plugin:** [Ping input plugin](/{{< latest "telegraf" >}}/plugins/#input-ping)
 
 `ping.json`
 
@@ -322,7 +322,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## postgresql
 
-**Required Telegraf plugin:** [PostgreSQL input plugin](/{{< latest "telegraf" >}}/plugins/#postgresql)
+**Required Telegraf plugin:** [PostgreSQL input plugin](/{{< latest "telegraf" >}}/plugins/#input-postgresql)
 
 `postgresql.json`
 
@@ -333,7 +333,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## rabbitmq
 
-**Required Telegraf plugin:** [RabbitMQ input plugin](/{{< latest "telegraf" >}}/plugins/#rabbitmq)
+**Required Telegraf plugin:** [RabbitMQ input plugin](/{{< latest "telegraf" >}}/plugins/#input-rabbitmq)
 
 `rabbitmq.json`
 
@@ -344,7 +344,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## redis
 
-**Required Telegraf plugin:** [Redis input plugin](/{{< latest "telegraf" >}}/plugins/#redis)
+**Required Telegraf plugin:** [Redis input plugin](/{{< latest "telegraf" >}}/plugins/#input-redis)
 
 
 `redis.json`
@@ -356,7 +356,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## riak
 
-**Required Telegraf plugin:** [Riak input plugin](/{{< latest "telegraf" >}}/plugins/#riak)
+**Required Telegraf plugin:** [Riak input plugin](/{{< latest "telegraf" >}}/plugins/#input-riak)
 
 
 `riak.json`
@@ -375,7 +375,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ### cpu
 
-**Required Telegraf plugin:** [CPU input plugin](/{{< latest "telegraf" >}}/plugins/#cpu)
+**Required Telegraf plugin:** [CPU input plugin](/{{< latest "telegraf" >}}/plugins/#input-cpu)
 
 `cpu.json`
 
@@ -385,13 +385,13 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 `disk.json`
 
-**Required Telegraf plugin:** [Disk input plugin](/{{< latest "telegraf" >}}/plugins/#disk)
+**Required Telegraf plugin:** [Disk input plugin](/{{< latest "telegraf" >}}/plugins/#input-disk)
 
   * "System - Disk used %"
 
 ### diskio
 
-**Required Telegraf plugin:** [DiskIO input plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
+**Required Telegraf plugin:** [DiskIO input plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
 
 `diskio.json`
 
@@ -400,7 +400,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ### mem
 
-**Required Telegraf plugin:** [Mem input plugin](/{{< latest "telegraf" >}}/plugins/#mem)
+**Required Telegraf plugin:** [Mem input plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
 
 `mem.json`
 
@@ -408,7 +408,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ### net
 
-**Required Telegraf plugin:** [Net input plugin](/{{< latest "telegraf" >}}/plugins/#net)
+**Required Telegraf plugin:** [Net input plugin](/{{< latest "telegraf" >}}/plugins/#input-net)
 
 `net.json`
 
@@ -417,7 +417,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ### netstat
 
-**Required Telegraf plugin:** [Netstat input plugin](/{{< latest "telegraf" >}}/plugins/#netstat)
+**Required Telegraf plugin:** [Netstat input plugin](/{{< latest "telegraf" >}}/plugins/#input-netstat)
 
 `netstat.json`
 
@@ -426,7 +426,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ### processes
 
-**Required Telegraf plugin:** [Processes input plugin](/{{< latest "telegraf" >}}/plugins/#processes)
+**Required Telegraf plugin:** [Processes input plugin](/{{< latest "telegraf" >}}/plugins/#input-processes)
 
 `processes.json`
 
@@ -434,7 +434,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ### procstat
 
-**Required Telegraf plugin:** [Procstat input plugin](/{{< latest "telegraf" >}}/plugins/#procstat)
+**Required Telegraf plugin:** [Procstat input plugin](/{{< latest "telegraf" >}}/plugins/#input-procstat)
 
 `procstat.json`
 
@@ -443,7 +443,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ### system
 
-**Required Telegraf plugin:** [Procstat input plugin](/{{< latest "telegraf" >}}/plugins/#procstat)
+**Required Telegraf plugin:** [Procstat input plugin](/{{< latest "telegraf" >}}/plugins/#input-procstat)
 
 `load.json`
 
@@ -451,7 +451,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## varnish
 
-**Required Telegraf plugin:** [Varnish](/{{< latest "telegraf" >}}/plugins/#varnish)
+**Required Telegraf plugin:** [Varnish](/{{< latest "telegraf" >}}/plugins/#input-varnish)
 
 `varnish.json`
 
@@ -460,7 +460,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## win_system
 
-**Required Telegraf plugin:** [Windows Performance Counters input plugin](/{{< latest "telegraf" >}}/plugins/#windows-performance-counters)
+**Required Telegraf plugin:** [Windows Performance Counters input plugin](/{{< latest "telegraf" >}}/plugins/#input-windows-performance-counters)
 
 `win_cpu.json`
 

--- a/content/chronograf/v1.9/administration/prebuilt-dashboards.md
+++ b/content/chronograf/v1.9/administration/prebuilt-dashboards.md
@@ -30,12 +30,12 @@ The Docker dashboard displays the following information:
 
 ### Plugins
 
-- [`docker` plugin](/{{< latest "telegraf" >}}/plugins/#docker)
-- [`disk` plugin](/{{< latest "telegraf" >}}/plugins/#disk)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
-- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#cpu)
+- [`docker` plugin](/{{< latest "telegraf" >}}/plugins/#input-docker)
+- [`disk` plugin](/{{< latest "telegraf" >}}/plugins/#input-disk)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
+- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#input-cpu)
 
 ## Kubernetes Node
 The Kubernetes Node dashboard displays the following information:
@@ -53,7 +53,7 @@ The Kubernetes Node dashboard displays the following information:
 - K8s - Kubelet Memory Bytes
 
 ### Plugins
-- [kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)
+- [kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)
 
 ## Kubernetes Overview
 The Kubernetes Node dashboard displays the following information:
@@ -72,7 +72,7 @@ The Kubernetes Node dashboard displays the following information:
 
 ### Plugins
 
-- [kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)
+- [kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)
 
 ## Kubernetes Pod
 The Kubernetes Pod dashboard displays the following information:
@@ -87,7 +87,7 @@ The Kubernetes Pod dashboard displays the following information:
 - K8s - Pod TX Bytes/Second
 
 ### Plugins
-- [kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)
+- [kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)
 
 ## Riak
 The Riak dashboard displays the following information:
@@ -101,7 +101,7 @@ The Riak dashboard displays the following information:
 - Riak - Read Repairs/Minute
 
 ### Plugins
-- [`riak` plugin](/{{< latest "telegraf" >}}/plugins/#riak)
+- [`riak` plugin](/{{< latest "telegraf" >}}/plugins/#input-riak)
 
 ## Consul
 The Consul dashboard displays the following information:
@@ -110,7 +110,7 @@ The Consul dashboard displays the following information:
 - Consul - Number of Warning Health Checks
 
 ### Plugins
-- [`consul` plugin](/{{< latest "telegraf" >}}/plugins/#consul)
+- [`consul` plugin](/{{< latest "telegraf" >}}/plugins/#input-consul)
 
 ## Consul Telemetry
 The Consul Telemetry dashboard displays the following information:
@@ -125,7 +125,7 @@ The Consul Telemetry dashboard displays the following information:
 - Consul - Number of Serf Events
 
 ### Plugins
-[`consul` plugin](/{{< latest "telegraf" >}}/plugins/#consul)
+[`consul` plugin](/{{< latest "telegraf" >}}/plugins/#input-consul)
 
 
 ## Mesos
@@ -140,7 +140,7 @@ The Mesos dashboard displays the following information:
 - Mesos Master Uptime
 
 ### Plugins
-- [`mesos` plugin](/{{< latest "telegraf" >}}/plugins/#mesos)
+- [`mesos` plugin](/{{< latest "telegraf" >}}/plugins/#input-mesos)
 
 ## RabbitMQ
 The RabbitMQ dashboard displays the following information:
@@ -151,7 +151,7 @@ The RabbitMQ dashboard displays the following information:
 
 ### Plugins
 
-- [`rabbitmq` plugin](/{{< latest "telegraf" >}}/plugins/#rabbitmq)
+- [`rabbitmq` plugin](/{{< latest "telegraf" >}}/plugins/#input-rabbitmq)
 
 ## System
 
@@ -170,14 +170,14 @@ The System dashboard displays the following information:
 
 ### Plugins
 
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
-- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#cpu)
-- [`disk` plugin](/{{< latest "telegraf" >}}/plugins/#disk)
-- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
-- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#net)
-- [`processes` plugin](/{{< latest "telegraf" >}}/plugins/#processes)
-- [`swap` plugin](/{{< latest "telegraf" >}}/plugins/#swap)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
+- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#input-cpu)
+- [`disk` plugin](/{{< latest "telegraf" >}}/plugins/#input-disk)
+- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
+- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#input-net)
+- [`processes` plugin](/{{< latest "telegraf" >}}/plugins/#input-processes)
+- [`swap` plugin](/{{< latest "telegraf" >}}/plugins/#input-swap)
 
 
 
@@ -198,7 +198,7 @@ The VMware vSphere Overview dashboard gives an overview of your VMware vSphere C
   - VM CPU % Ready for :clustername:
 
 ### Plugins
-- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#vmware-vsphere)
+- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#input-vmware-vsphere)
 
 ## Apache
 The Apache dashboard displays the following information:
@@ -221,12 +221,12 @@ The Apache dashboard displays the following information:
 
 ### Plugins
 
-- [`apache` plugin](/{{< latest "telegraf" >}}/plugins/#apache)
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
-- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
-- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#net)
-- [`logparser` plugin](/{{< latest "telegraf" >}}/plugins/#logparser)
+- [`apache` plugin](/{{< latest "telegraf" >}}/plugins/#input-apache)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
+- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
+- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#input-net)
+- [`logparser` plugin](/{{< latest "telegraf" >}}/plugins/#input-logparser)
 
 ## ElasticSearch
 The ElasticSearch dashboard displays the following information:
@@ -243,7 +243,7 @@ The ElasticSearch dashboard displays the following information:
 - ElasticSearch - JVM Heap Usage
 
 ### Plugins
-- [`elasticsearch` plugin](/{{< latest "telegraf" >}}/plugins/#elasticsearch)
+- [`elasticsearch` plugin](/{{< latest "telegraf" >}}/plugins/#input-elasticsearch)
 
 
 ## InfluxDB
@@ -272,12 +272,12 @@ The InfluxDB dashboard displays the following information:
 
 ### Plugins
 
-- [`influxdb` plugin](/{{< latest "telegraf" >}}/plugins/#influxdb)
-- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#cpu)
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
-- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
-- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#net)
+- [`influxdb` plugin](/{{< latest "telegraf" >}}/plugins/#input-influxdb)
+- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#input-cpu)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
+- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
+- [`net` plugin](/{{< latest "telegraf" >}}/plugins/#input-net)
 
 
 
@@ -299,7 +299,7 @@ The Memcached dashboard displays the following information:
 - Memcached - Evictions/10 Seconds
 
 ### Plugins
-- [`memcached` plugin](/{{< latest "telegraf" >}}/plugins/#memcached)
+- [`memcached` plugin](/{{< latest "telegraf" >}}/plugins/#input-memcached)
 
 
 ## NSQ
@@ -315,7 +315,7 @@ The NSQ dashboard displays the following information:
 - NSQ - Topic Egress
 
 ### Plugins
-- [`nsq` plugin](/{{< latest "telegraf" >}}/plugins/#nsq)
+- [`nsq` plugin](/{{< latest "telegraf" >}}/plugins/#input-nsq)
 
 ## PostgreSQL
 The PostgreSQL dashboard displays the following information:
@@ -340,11 +340,11 @@ The PostgreSQL dashboard displays the following information:
 
 ### Plugins
 
-- [`postgresql` plugin](/{{< latest "telegraf" >}}/plugins/#postgresql)
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
-- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#cpu)
-- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
+- [`postgresql` plugin](/{{< latest "telegraf" >}}/plugins/#input-postgresql)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
+- [`cpu` plugin](/{{< latest "telegraf" >}}/plugins/#input-cpu)
+- [`diskio` plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
 
 
 ## HAProxy
@@ -367,7 +367,7 @@ The HAProxy dashboard displays the following information:
 - HAProxy - Backend Error Responses/Second
 
 ### Plugins
-- [`haproxy` plugin](/{{< latest "telegraf" >}}/plugins/#haproxy)
+- [`haproxy` plugin](/{{< latest "telegraf" >}}/plugins/#input-haproxy)
 
 
 ## NGINX
@@ -379,7 +379,7 @@ The NGINX dashboard displays the following information:
 - NGINX - Active Client State
 
 ### Plugins
-- [`nginx` plugin](/{{< latest "telegraf" >}}/plugins/#nginx)
+- [`nginx` plugin](/{{< latest "telegraf" >}}/plugins/#input-nginx)
 
 ## Redis
 The Redis dashboard displays the following information:
@@ -390,7 +390,7 @@ The Redis dashboard displays the following information:
 - Redis - Memory
 
 ### Plugins
-- [`redis` plugin](/{{< latest "telegraf" >}}/plugins/#redis)
+- [`redis` plugin](/{{< latest "telegraf" >}}/plugins/#input-redis)
 
 
 ## VMware vSphere VMs
@@ -406,7 +406,7 @@ The VMWare vSphere VMs dashboard gives an overview of your VMware vSphere virtua
 - Total Disk Latency for :vmname:
 
 ### Plugins
-- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#vsphere)
+- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#input-vsphere)
 
 ## VMware vSphere Hosts
 
@@ -422,7 +422,7 @@ The VMWare vSphere Hosts dashboard displays the following information:
 - Total Disk Latency for :esxhostname:
 
 ### Plugins
-- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#vsphere)
+- [`vsphere` plugin](/{{< latest "telegraf" >}}/plugins/#input-vsphere)
 
 ## PHPfpm
 The PHPfpm dashboard displays the following information:
@@ -433,7 +433,7 @@ The PHPfpm dashboard displays the following information:
 - PHPfpm - Max Children Reached
 
 ### Plugins
-- [`phpfpm` plugin](/{{< latest "telegraf" >}}/plugins/#nginx)
+- [`phpfpm` plugin](/{{< latest "telegraf" >}}/plugins/#input-nginx)
 
 ## Win System
 The Win System dashboard displays the following information:
@@ -445,7 +445,7 @@ The Win System dashboard displays the following information:
 - System - Load
 
 ### Plugins
-- [`win_services` plugin](/{{< latest "telegraf" >}}/plugins/#windows-services)
+- [`win_services` plugin](/{{< latest "telegraf" >}}/plugins/#input-windows-services)
 
 
 ## MySQL
@@ -472,9 +472,9 @@ The MySQL dashboard displays the following information:
 - InnoDB Data
 
 ### Plugins
-- [`mySQL` plugin](/{{< latest "telegraf" >}}/plugins/#mysql)
-- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#system)
-- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#mem)
+- [`mySQL` plugin](/{{< latest "telegraf" >}}/plugins/#input-mysql)
+- [`system` plugin](/{{< latest "telegraf" >}}/plugins/#input-system)
+- [`mem` plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
 
 ## Ping
 The Ping dashboard displays the following information:
@@ -483,4 +483,4 @@ The Ping dashboard displays the following information:
 - Ping - Response Times (ms)
 
 ### Plugins
-- [`ping` plugin](/{{< latest "telegraf" >}}/plugins/#ping)
+- [`ping` plugin](/{{< latest "telegraf" >}}/plugins/#input-ping)

--- a/content/chronograf/v1.9/guides/using-precreated-dashboards.md
+++ b/content/chronograf/v1.9/guides/using-precreated-dashboards.md
@@ -71,7 +71,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## apache
 
-**Required Telegraf plugin:** [Apache input plugin](/{{< latest "telegraf" >}}/plugins/#apache-http-server)
+**Required Telegraf plugin:** [Apache input plugin](/{{< latest "telegraf" >}}/plugins/#input-apache)
 
 `apache.json`
 
@@ -81,7 +81,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## consul
 
-**Required Telegraf plugin:** [Consul input plugin](/{{< latest "telegraf" >}}/plugins/#consul)
+**Required Telegraf plugin:** [Consul input plugin](/{{< latest "telegraf" >}}/plugins/#input-consul)
 
 `consul_http.json`
 
@@ -101,7 +101,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## docker
 
-**Required Telegraf plugin:** [Docker input plugin](/{{< latest "telegraf" >}}/plugins/#docker)
+**Required Telegraf plugin:** [Docker input plugin](/{{< latest "telegraf" >}}/plugins/#input-docker)
 
 `docker.json`
 
@@ -121,7 +121,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## elasticsearch
 
-**Required Telegraf plugin:** [Elasticsearch input plugin](/{{< latest "telegraf" >}}/plugins/#elasticsearch)
+**Required Telegraf plugin:** [Elasticsearch input plugin](/{{< latest "telegraf" >}}/plugins/#input-elasticsearch)
 
 `elasticsearch.json`
 
@@ -138,7 +138,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## haproxy
 
-**Required Telegraf plugin:** [HAProxy input plugin](/{{< latest "telegraf" >}}/plugins/#haproxy)
+**Required Telegraf plugin:** [HAProxy input plugin](/{{< latest "telegraf" >}}/plugins/#input-haproxy)
 
 `haproxy.json`
 
@@ -160,7 +160,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## iis
 
-**Required Telegraf plugin:** [Windows Performance Counters input plugin](/{{< latest "telegraf" >}}/plugins/#windows-performance-counters)
+**Required Telegraf plugin:** [Windows Performance Counters input plugin](/{{< latest "telegraf" >}}/plugins/#input-windows-performance-counters)
 
 `win_websvc.json`
 
@@ -168,7 +168,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## influxdb
 
-**Required Telegraf plugin:** [InfluxDB input plugin](/{{< latest "telegraf" >}}/plugins/#influxdb)
+**Required Telegraf plugin:** [InfluxDB input plugin](/{{< latest "telegraf" >}}/plugins/#input-influxdb)
 
 `influxdb_database.json`
 
@@ -213,7 +213,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## Memcached (`memcached`)
 
-**Required Telegraf plugin:** [Memcached input plugin](/{{< latest "telegraf" >}}/plugins/#memcached)
+**Required Telegraf plugin:** [Memcached input plugin](/{{< latest "telegraf" >}}/plugins/#input-memcached)
 
 `memcached.json`
 
@@ -233,7 +233,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## mesos
 
-**Required Telegraf plugin:** [Mesos input plugin](/{{< latest "telegraf" >}}/plugins/#mesos)
+**Required Telegraf plugin:** [Mesos input plugin](/{{< latest "telegraf" >}}/plugins/#input-mesos)
 
 `mesos.json`
 
@@ -248,7 +248,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## mongodb
 
-**Required Telegraf plugin:** [MongoDB input plugin](/{{< latest "telegraf" >}}/plugins/#mongodb)
+**Required Telegraf plugin:** [MongoDB input plugin](/{{< latest "telegraf" >}}/plugins/#input-mongodb)
 
 `mongodb.json`
 
@@ -260,7 +260,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## mysql
 
-**Required Telegraf plugin:** [MySQL input plugin](/{{< latest "telegraf" >}}/plugins/#mysql)
+**Required Telegraf plugin:** [MySQL input plugin](/{{< latest "telegraf" >}}/plugins/#input-mysql)
 
 `mysql.json`
 
@@ -271,7 +271,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## nginx
 
-**Required Telegraf plugin:** [NGINX input plugin](/{{< latest "telegraf" >}}/plugins/#nginx)
+**Required Telegraf plugin:** [NGINX input plugin](/{{< latest "telegraf" >}}/plugins/#input-nginx)
 
 `nginx.json`
 
@@ -282,7 +282,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## nsq
 
-**Required Telegraf plugin:** [NSQ input plugin](/{{< latest "telegraf" >}}/plugins/#nsq)
+**Required Telegraf plugin:** [NSQ input plugin](/{{< latest "telegraf" >}}/plugins/#input-nsq)
 
 `nsq_channel.json`
 
@@ -303,7 +303,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## phpfpm
 
-**Required Telegraf plugin:** [PHPfpm input plugin](/{{< latest "telegraf" >}}/plugins/#php-fpm)
+**Required Telegraf plugin:** [PHPfpm input plugin](/{{< latest "telegraf" >}}/plugins/#input-php-fpm)
 
 `phpfpm.json`
 
@@ -315,7 +315,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## ping
 
-**Required Telegraf plugin:** [Ping input plugin](/{{< latest "telegraf" >}}/plugins/#ping)
+**Required Telegraf plugin:** [Ping input plugin](/{{< latest "telegraf" >}}/plugins/#input-ping)
 
 `ping.json`
 
@@ -324,7 +324,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## postgresql
 
-**Required Telegraf plugin:** [PostgreSQL input plugin](/{{< latest "telegraf" >}}/plugins/#postgresql)
+**Required Telegraf plugin:** [PostgreSQL input plugin](/{{< latest "telegraf" >}}/plugins/#input-postgresql)
 
 `postgresql.json`
 
@@ -335,7 +335,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## rabbitmq
 
-**Required Telegraf plugin:** [RabbitMQ input plugin](/{{< latest "telegraf" >}}/plugins/#rabbitmq)
+**Required Telegraf plugin:** [RabbitMQ input plugin](/{{< latest "telegraf" >}}/plugins/#input-rabbitmq)
 
 `rabbitmq.json`
 
@@ -346,7 +346,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## redis
 
-**Required Telegraf plugin:** [Redis input plugin](/{{< latest "telegraf" >}}/plugins/#redis)
+**Required Telegraf plugin:** [Redis input plugin](/{{< latest "telegraf" >}}/plugins/#input-redis)
 
 
 `redis.json`
@@ -358,7 +358,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## riak
 
-**Required Telegraf plugin:** [Riak input plugin](/{{< latest "telegraf" >}}/plugins/#riak)
+**Required Telegraf plugin:** [Riak input plugin](/{{< latest "telegraf" >}}/plugins/#input-riak)
 
 
 `riak.json`
@@ -377,7 +377,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ### cpu
 
-**Required Telegraf plugin:** [CPU input plugin](/{{< latest "telegraf" >}}/plugins/#cpu)
+**Required Telegraf plugin:** [CPU input plugin](/{{< latest "telegraf" >}}/plugins/#input-cpu)
 
 `cpu.json`
 
@@ -387,13 +387,13 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 `disk.json`
 
-**Required Telegraf plugin:** [Disk input plugin](/{{< latest "telegraf" >}}/plugins/#disk)
+**Required Telegraf plugin:** [Disk input plugin](/{{< latest "telegraf" >}}/plugins/#input-disk)
 
   * "System - Disk used %"
 
 ### diskio
 
-**Required Telegraf plugin:** [DiskIO input plugin](/{{< latest "telegraf" >}}/plugins/#diskio)
+**Required Telegraf plugin:** [DiskIO input plugin](/{{< latest "telegraf" >}}/plugins/#input-diskio)
 
 `diskio.json`
 
@@ -402,7 +402,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ### mem
 
-**Required Telegraf plugin:** [Mem input plugin](/{{< latest "telegraf" >}}/plugins/#mem)
+**Required Telegraf plugin:** [Mem input plugin](/{{< latest "telegraf" >}}/plugins/#input-mem)
 
 `mem.json`
 
@@ -410,7 +410,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ### net
 
-**Required Telegraf plugin:** [Net input plugin](/{{< latest "telegraf" >}}/plugins/#net)
+**Required Telegraf plugin:** [Net input plugin](/{{< latest "telegraf" >}}/plugins/#input-net)
 
 `net.json`
 
@@ -419,7 +419,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ### netstat
 
-**Required Telegraf plugin:** [Netstat input plugin](/{{< latest "telegraf" >}}/plugins/#netstat)
+**Required Telegraf plugin:** [Netstat input plugin](/{{< latest "telegraf" >}}/plugins/#input-netstat)
 
 `netstat.json`
 
@@ -428,7 +428,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ### processes
 
-**Required Telegraf plugin:** [Processes input plugin](/{{< latest "telegraf" >}}/plugins/#processes)
+**Required Telegraf plugin:** [Processes input plugin](/{{< latest "telegraf" >}}/plugins/#input-processes)
 
 `processes.json`
 
@@ -436,7 +436,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ### procstat
 
-**Required Telegraf plugin:** [Procstat input plugin](/{{< latest "telegraf" >}}/plugins/#procstat)
+**Required Telegraf plugin:** [Procstat input plugin](/{{< latest "telegraf" >}}/plugins/#input-procstat)
 
 `procstat.json`
 
@@ -445,7 +445,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ### system
 
-**Required Telegraf plugin:** [Procstat input plugin](/{{< latest "telegraf" >}}/plugins/#procstat)
+**Required Telegraf plugin:** [Procstat input plugin](/{{< latest "telegraf" >}}/plugins/#input-procstat)
 
 `load.json`
 
@@ -453,7 +453,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## varnish
 
-**Required Telegraf plugin:** [Varnish](/{{< latest "telegraf" >}}/plugins/#varnish)
+**Required Telegraf plugin:** [Varnish](/{{< latest "telegraf" >}}/plugins/#input-varnish)
 
 `varnish.json`
 
@@ -462,7 +462,7 @@ Enable and disable apps in your Telegraf configuration file (by default, `/etc/t
 
 ## win_system
 
-**Required Telegraf plugin:** [Windows Performance Counters input plugin](/{{< latest "telegraf" >}}/plugins/#windows-performance-counters)
+**Required Telegraf plugin:** [Windows Performance Counters input plugin](/{{< latest "telegraf" >}}/plugins/#input-windows-performance-counters)
 
 `win_cpu.json`
 

--- a/content/influxdb/cloud/reference/prometheus-metrics.md
+++ b/content/influxdb/cloud/reference/prometheus-metrics.md
@@ -12,7 +12,7 @@ related:
   - https://prometheus.io/docs/concepts/data_model/, Prometheus data model
   - /influxdb/cloud/write-data/developer-tools/scrape-prometheus-metrics/
   - /{{< latest "flux" >}}/prometheus/, Work with Prometheus in Flux
-  - /{{< latest "telegraf" >}}/plugins/#prometheus, Telegraf Prometheus input plugin
+  - /{{< latest "telegraf" >}}/input-prometheus, Telegraf Prometheus input plugin
   - /{{< latest "flux" >}}/stdlib/experimental/prometheus/scrape/
 ---
 

--- a/content/influxdb/cloud/visualize-data/variables/common-variables.md
+++ b/content/influxdb/cloud/visualize-data/variables/common-variables.md
@@ -67,7 +67,7 @@ v1.tagValues(bucket: "bucket-name", tag: "host")
 ## List Docker containers
 List all Docker containers when using the Docker Telegraf plugin.
 
-_**Telegraf plugin:** [Docker](/{{< latest "telegraf" >}}/plugins/#docker)_  
+_**Telegraf plugin:** [Docker](/{{< latest "telegraf" >}}/plugins/#input-docker)_  
 _**Flux package:** [InfluxDB v1](/influxdb/cloud/reference/flux/stdlib/influxdb-v1/)_  
 _**Flux functions:** [v1.tagValues()](/influxdb/cloud/reference/flux/stdlib/influxdb-v1/tagvalues/)_
 
@@ -80,7 +80,7 @@ v1.tagValues(bucket: "bucket-name", tag: "container_name")
 ## List Kubernetes pods
 List all Kubernetes pods when using the Kubernetes Telegraf plugin.
 
-_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)_  
+_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)_  
 _**Flux package:** [InfluxDB v1](/influxdb/cloud/reference/flux/stdlib/influxdb-v1/)_  
 _**Flux functions:** [v1.measurementTagValues()](/influxdb/cloud/reference/flux/stdlib/influxdb-v1/measurementtagvalues/)_
 
@@ -97,7 +97,7 @@ v1.measurementTagValues(
 ## List Kubernetes nodes
 List all Kubernetes nodes when using the Kubernetes Telegraf plugin.
 
-_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)_  
+_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)_  
 _**Flux package:** [InfluxDB v1](/influxdb/cloud/reference/flux/stdlib/influxdb-v1/)_  
 _**Flux functions:** [v1.measurementTagValues()](/influxdb/cloud/reference/flux/stdlib/influxdb-v1/measurementtagvalues/)_
 

--- a/content/influxdb/cloud/write-data/developer-tools/scrape-prometheus-metrics.md
+++ b/content/influxdb/cloud/write-data/developer-tools/scrape-prometheus-metrics.md
@@ -10,7 +10,7 @@ menu:
     name: Scrape Prometheus metrics
     parent: Developer tools
 related:
-  - /{{< latest "telegraf" >}}/plugins/#prometheus, Telegraf Prometheus input plugin
+  - /{{< latest "telegraf" >}}/plugins/#input-prometheus, Telegraf Prometheus input plugin
   - /{{< latest "flux" >}}/prometheus/scrape-prometheus/
   - /{{< latest "flux" >}}/stdlib/experimental/prometheus/scrape/
   - /{{< latest "flux" >}}/prometheus/metric-types/

--- a/content/influxdb/v2.0/reference/prometheus-metrics.md
+++ b/content/influxdb/v2.0/reference/prometheus-metrics.md
@@ -12,7 +12,7 @@ related:
   - https://prometheus.io/docs/concepts/data_model/, Prometheus data model
   - /influxdb/v2.0/write-data/developer-tools/scrape-prometheus-metrics/
   - /{{< latest "flux" >}}/prometheus/, Work with Prometheus in Flux
-  - /{{< latest "telegraf" >}}/plugins/#prometheus, Telegraf Prometheus input plugin
+  - /{{< latest "telegraf" >}}/plugins/#input-prometheus, Telegraf Prometheus input plugin
   - /influxdb/v2.0/write-data/no-code/scrape-data/
   - /{{< latest "flux" >}}/stdlib/experimental/prometheus/scrape/
 ---
@@ -28,7 +28,7 @@ are parsed and written to InfluxDB in one of two formats, depending on the scrap
 
 | Scraping tool                                                                              |                               InfluxDB Metric version |
 | :----------------------------------------------------------------------------------------- | ----------------------------------------------------: |
-| [Telegraf Prometheus plugin](/{{< latest "telegraf" >}}/plugins/#prometheus)               | _Determined by `metric_version` configuration option_ |
+| [Telegraf Prometheus plugin](/{{< latest "telegraf" >}}/plugins/#input-prometheus)         | _Determined by `metric_version` configuration option_ |
 | [InfluxDB scraper](/influxdb/v2.0/write-data/no-code/scrape-data/)                         |                                                     1 |
 | Flux [`prometheus.scrape()`]({{< latest "flux" >}}/stdlib/experimental/prometheus/scrape/) |                                                     2 |
 
@@ -37,7 +37,7 @@ are parsed and written to InfluxDB in one of two formats, depending on the scrap
 
 | Scraping tool                                                                              |                               InfluxDB Metric version |
 | :----------------------------------------------------------------------------------------- | ----------------------------------------------------: |
-| [Telegraf Prometheus plugin](/{{< latest "telegraf" >}}/plugins/#prometheus)               | _Determined by `metric_version` configuration option_ |
+| [Telegraf Prometheus plugin](/{{< latest "telegraf" >}}/plugins/#input-prometheus)         | _Determined by `metric_version` configuration option_ |
 | Flux [`prometheus.scrape()`]({{< latest "flux" >}}/stdlib/experimental/prometheus/scrape/) |                                                     2 |
 
 {{% /cloud-only %}}

--- a/content/influxdb/v2.0/tools/kapacitor.md
+++ b/content/influxdb/v2.0/tools/kapacitor.md
@@ -95,7 +95,7 @@ see [Write back to InfluxDB](#write-back-to-influxdb) below.
 InfluxDB Cloud and OSS 2.0 do not have subscription APIs and do not support Kapacitor stream tasks directly.
 To use Kapacitor stream tasks, write data directly to Kapacitor using the [Kapcitior `write` API](/{{< latest "kapacitor" >}}/working/api/#writing-data).
 
-We recommend using [Telegraf InfluxDB output plugin](/{{< latest "telegraf" >}}/plugins/#influxdb)
+We recommend using [Telegraf InfluxDB output plugin](/{{< latest "telegraf" >}}/plugins/#output-influxdb)
 to write data to both InfluxDB Cloud or OSS and Kapacitor.
 The following example Telegraf configuration writes data to both InfluxDB and Kapacitor:
 

--- a/content/influxdb/v2.0/upgrade/v1-to-v2/automatic-upgrade.md
+++ b/content/influxdb/v2.0/upgrade/v1-to-v2/automatic-upgrade.md
@@ -77,8 +77,8 @@ You can continue to use Kapacitor with InfluxDB OSS 2.0 under the following scen
   Existing Kapacitor user credentials should continue to work using the [1.x compatibility API](/influxdb/v2.0/reference/api/influxdb-1x/).
 - InfluxDB 2.0 has no subscriptions API and does not support Kapacitor stream tasks.
   To continue using stream tasks, write data directly to both InfluxDB and Kapacitor.
-  Use **Telegraf** and its [InfluxDB output plugin](/{{< latest "telegraf" >}}/plugins/#influxdb)
-  to write to Kapacitor and the [InfluxDB v2 output plugin](/{{< latest "telegraf" >}}/plugins/#influxdb_v2) to write to InfluxDB v2.
+  Use **Telegraf** and its [InfluxDB output plugin](/{{< latest "telegraf" >}}/plugins/#output-influxdb)
+  to write to Kapacitor and the [InfluxDB v2 output plugin](/{{< latest "telegraf" >}}/plugins/#output-influxdb_v2) to write to InfluxDB v2.
 
 ##### Example Telegraf configuration
 ```toml

--- a/content/influxdb/v2.0/visualize-data/variables/common-variables.md
+++ b/content/influxdb/v2.0/visualize-data/variables/common-variables.md
@@ -67,7 +67,7 @@ schema.tagValues(bucket: "bucket-name", tag: "host")
 ## List Docker containers
 List all Docker containers when using the Docker Telegraf plugin.
 
-_**Telegraf plugin:** [Docker](/{{< latest "telegraf" >}}/plugins/#docker)_  
+_**Telegraf plugin:** [Docker](/{{< latest "telegraf" >}}/plugins/#input-docker)_  
 _**Flux package:** [InfluxDB schema](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/)_  
 _**Flux functions:** [schema.tagValues()](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/tagvalues/)_
 
@@ -80,7 +80,7 @@ schema.tagValues(bucket: "bucket-name", tag: "container_name")
 ## List Kubernetes pods
 List all Kubernetes pods when using the Kubernetes Telegraf plugin.
 
-_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)_  
+_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)_  
 _**Flux package:** [InfluxDB schema](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/)_  
 _**Flux functions:** [schema.measurementTagValues()](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/measurementtagvalues/)_
 
@@ -97,7 +97,7 @@ schema.measurementTagValues(
 ## List Kubernetes nodes
 List all Kubernetes nodes when using the Kubernetes Telegraf plugin.
 
-_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)_  
+_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)_  
 _**Flux package:** [InfluxDB schema](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/)_  
 _**Flux functions:** [schema.measurementTagValues()](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/measurementtagvalues/)_
 

--- a/content/influxdb/v2.0/write-data/developer-tools/scrape-prometheus-metrics.md
+++ b/content/influxdb/v2.0/write-data/developer-tools/scrape-prometheus-metrics.md
@@ -11,7 +11,7 @@ menu:
     name: Scrape Prometheus metrics
     parent: Developer tools
 related:
-  - /{{< latest "telegraf" >}}/plugins/#prometheus, Telegraf Prometheus input plugin
+  - /{{< latest "telegraf" >}}/plugins/#input-prometheus, Telegraf Prometheus input plugin
   - /{{< latest "flux" >}}/prometheus/scrape-prometheus/, Scrape Prometheus metrics with Flux
   - /{{< latest "flux" >}}/stdlib/experimental/prometheus/scrape/
   - /{{< latest "flux" >}}/prometheus/metric-types/
@@ -42,12 +42,12 @@ to scrape Prometheus-formatted metrics from an HTTP-accessible endpoint and stor
 To use Telegraf to scrape Prometheus-formatted metrics from an HTTP-accessible
 endpoint and write them to InfluxDB{{% cloud-only %}} Cloud{{% /cloud-only %}}, follow these steps:
 
-1. Add the [Prometheus input plugin](/{{< latest "telegraf" >}}/plugins/#prometheus) to your Telegraf configuration file.
+1. Add the [Prometheus input plugin](/{{< latest "telegraf" >}}/plugins/#input-prometheus) to your Telegraf configuration file.
     1. Set the `urls` to scrape metrics from.
     2. Set the `metric_version` configuration option to specify which
       [metric parsing version](/influxdb/v2.0/reference/prometheus-metrics/) to use
       _(version `2` is recommended)_.
-2. Add the [InfluxDB v2 output plugin](/{{< latest "telegraf" >}}/plugins/#influxdb_v2)
+2. Add the [InfluxDB v2 output plugin](/{{< latest "telegraf" >}}/plugins/#output-influxdb_v2)
    to your Telegraf configuration file and configure it to to write to
    InfluxDB{{% cloud-only %}} Cloud{{% /cloud-only %}}.
   

--- a/content/influxdb/v2.1/reference/prometheus-metrics.md
+++ b/content/influxdb/v2.1/reference/prometheus-metrics.md
@@ -12,7 +12,7 @@ related:
   - https://prometheus.io/docs/concepts/data_model/, Prometheus data model
   - /influxdb/v2.1/write-data/developer-tools/scrape-prometheus-metrics/
   - /{{< latest "flux" >}}/prometheus/, Work with Prometheus in Flux
-  - /{{< latest "telegraf" >}}/plugins/#prometheus, Telegraf Prometheus input plugin
+  - /{{< latest "telegraf" >}}/plugins/#input-prometheus, Telegraf Prometheus input plugin
   - /influxdb/v2.1/write-data/no-code/scrape-data/
   - /{{< latest "flux" >}}/stdlib/experimental/prometheus/scrape/
 ---
@@ -28,7 +28,7 @@ are parsed and written to InfluxDB in one of two formats, depending on the scrap
 
 | Scraping tool                                                                              |                               InfluxDB Metric version |
 | :----------------------------------------------------------------------------------------- | ----------------------------------------------------: |
-| [Telegraf Prometheus plugin](/{{< latest "telegraf" >}}/plugins/#prometheus)               | _Determined by `metric_version` configuration option_ |
+| [Telegraf Prometheus plugin](/{{< latest "telegraf" >}}/plugins/#input-prometheus)               | _Determined by `metric_version` configuration option_ |
 | [InfluxDB scraper](/influxdb/v2.1/write-data/no-code/scrape-data/)                         |                                                     1 |
 | Flux [`prometheus.scrape()`]({{< latest "flux" >}}/stdlib/experimental/prometheus/scrape/) |                                                     2 |
 
@@ -37,7 +37,7 @@ are parsed and written to InfluxDB in one of two formats, depending on the scrap
 
 | Scraping tool                                                                              |                               InfluxDB Metric version |
 | :----------------------------------------------------------------------------------------- | ----------------------------------------------------: |
-| [Telegraf Prometheus plugin](/{{< latest "telegraf" >}}/plugins/#prometheus)               | _Determined by `metric_version` configuration option_ |
+| [Telegraf Prometheus plugin](/{{< latest "telegraf" >}}/plugins/#input-prometheus)               | _Determined by `metric_version` configuration option_ |
 | Flux [`prometheus.scrape()`]({{< latest "flux" >}}/stdlib/experimental/prometheus/scrape/) |                                                     2 |
 
 {{% /cloud-only %}}

--- a/content/influxdb/v2.1/tools/kapacitor.md
+++ b/content/influxdb/v2.1/tools/kapacitor.md
@@ -95,7 +95,7 @@ see [Write back to InfluxDB](#write-back-to-influxdb) below.
 InfluxDB Cloud and OSS {{< current-version >}} do not have subscription APIs and do not support Kapacitor stream tasks directly.
 To use Kapacitor stream tasks, write data directly to Kapacitor using the [Kapcitior `write` API](/{{< latest "kapacitor" >}}/working/api/#writing-data).
 
-We recommend using [Telegraf InfluxDB output plugin](/{{< latest "telegraf" >}}/plugins/#influxdb)
+We recommend using [Telegraf InfluxDB output plugin](/{{< latest "telegraf" >}}/plugins/#output-influxdb)
 to write data to both InfluxDB Cloud or OSS and Kapacitor.
 The following example Telegraf configuration writes data to both InfluxDB and Kapacitor:
 

--- a/content/influxdb/v2.1/upgrade/v1-to-v2/automatic-upgrade.md
+++ b/content/influxdb/v2.1/upgrade/v1-to-v2/automatic-upgrade.md
@@ -77,8 +77,8 @@ You can continue to use Kapacitor with InfluxDB OSS {{< current-version >}} unde
   Existing Kapacitor user credentials should continue to work using the [1.x compatibility API](/influxdb/v2.1/reference/api/influxdb-1x/).
 - InfluxDB {{< current-version >}} has no subscriptions API and does not support Kapacitor stream tasks.
   To continue using stream tasks, write data directly to both InfluxDB and Kapacitor.
-  Use **Telegraf** and its [InfluxDB output plugin](/{{< latest "telegraf" >}}/plugins/#influxdb)
-  to write to Kapacitor and the [InfluxDB v2 output plugin](/{{< latest "telegraf" >}}/plugins/#influxdb_v2) to write to InfluxDB v2.
+  Use **Telegraf** and its [InfluxDB output plugin](/{{< latest "telegraf" >}}/plugins/#output-influxdb)
+  to write to Kapacitor and the [InfluxDB v2 output plugin](/{{< latest "telegraf" >}}/plugins/#output-influxdb_v2) to write to InfluxDB v2.
 
 ##### Example Telegraf configuration
 ```toml

--- a/content/influxdb/v2.1/visualize-data/variables/common-variables.md
+++ b/content/influxdb/v2.1/visualize-data/variables/common-variables.md
@@ -67,7 +67,7 @@ schema.tagValues(bucket: "bucket-name", tag: "host")
 ## List Docker containers
 List all Docker containers when using the Docker Telegraf plugin.
 
-_**Telegraf plugin:** [Docker](/{{< latest "telegraf" >}}/plugins/#docker)_  
+_**Telegraf plugin:** [Docker](/{{< latest "telegraf" >}}/plugins/#input-docker)_  
 _**Flux package:** [InfluxDB schema](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/)_  
 _**Flux functions:** [schema.tagValues()](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/tagvalues/)_
 
@@ -80,7 +80,7 @@ schema.tagValues(bucket: "bucket-name", tag: "container_name")
 ## List Kubernetes pods
 List all Kubernetes pods when using the Kubernetes Telegraf plugin.
 
-_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)_  
+_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)_  
 _**Flux package:** [InfluxDB schema](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/)_  
 _**Flux functions:** [schema.measurementTagValues()](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/measurementtagvalues/)_
 
@@ -97,7 +97,7 @@ schema.measurementTagValues(
 ## List Kubernetes nodes
 List all Kubernetes nodes when using the Kubernetes Telegraf plugin.
 
-_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)_  
+_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)_  
 _**Flux package:** [InfluxDB schema](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/)_  
 _**Flux functions:** [schema.measurementTagValues()](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/measurementtagvalues/)_
 

--- a/content/influxdb/v2.1/write-data/developer-tools/scrape-prometheus-metrics.md
+++ b/content/influxdb/v2.1/write-data/developer-tools/scrape-prometheus-metrics.md
@@ -11,7 +11,7 @@ menu:
     name: Scrape Prometheus metrics
     parent: Developer tools
 related:
-  - /{{< latest "telegraf" >}}/plugins/#prometheus, Telegraf Prometheus input plugin
+  - /{{< latest "telegraf" >}}/plugins/#input-prometheus, Telegraf Prometheus input plugin
   - /{{< latest "flux" >}}/prometheus/scrape-prometheus/, Scrape Prometheus metrics with Flux
   - /{{< latest "flux" >}}/stdlib/experimental/prometheus/scrape/
   - /{{< latest "flux" >}}/prometheus/metric-types/
@@ -42,12 +42,12 @@ to scrape Prometheus-formatted metrics from an HTTP-accessible endpoint and stor
 To use Telegraf to scrape Prometheus-formatted metrics from an HTTP-accessible
 endpoint and write them to InfluxDB{{% cloud-only %}} Cloud{{% /cloud-only %}}, follow these steps:
 
-1. Add the [Prometheus input plugin](/{{< latest "telegraf" >}}/plugins/#prometheus) to your Telegraf configuration file.
+1. Add the [Prometheus input plugin](/{{< latest "telegraf" >}}/plugins/#input-prometheus) to your Telegraf configuration file.
     1. Set the `urls` to scrape metrics from.
     2. Set the `metric_version` configuration option to specify which
       [metric parsing version](/influxdb/v2.1/reference/prometheus-metrics/) to use
       _(version `2` is recommended)_.
-2. Add the [InfluxDB v2 output plugin](/{{< latest "telegraf" >}}/plugins/#influxdb_v2)
+2. Add the [InfluxDB v2 output plugin](/{{< latest "telegraf" >}}/plugins/#output-influxdb_v2)
    to your Telegraf configuration file and configure it to to write to
    InfluxDB{{% cloud-only %}} Cloud{{% /cloud-only %}}.
 

--- a/content/influxdb/v2.2/reference/prometheus-metrics.md
+++ b/content/influxdb/v2.2/reference/prometheus-metrics.md
@@ -12,7 +12,7 @@ related:
   - https://prometheus.io/docs/concepts/data_model/, Prometheus data model
   - /influxdb/v2.2/write-data/developer-tools/scrape-prometheus-metrics/
   - /{{< latest "flux" >}}/prometheus/, Work with Prometheus in Flux
-  - /{{< latest "telegraf" >}}/plugins/#prometheus, Telegraf Prometheus input plugin
+  - /{{< latest "telegraf" >}}/plugins/#input-prometheus, Telegraf Prometheus input plugin
   - /influxdb/v2.2/write-data/no-code/scrape-data/
   - /{{< latest "flux" >}}/stdlib/experimental/prometheus/scrape/
 ---
@@ -28,7 +28,7 @@ are parsed and written to InfluxDB in one of two formats, depending on the scrap
 
 | Scraping tool                                                                              |                               InfluxDB Metric version |
 | :----------------------------------------------------------------------------------------- | ----------------------------------------------------: |
-| [Telegraf Prometheus plugin](/{{< latest "telegraf" >}}/plugins/#prometheus)               | _Determined by `metric_version` configuration option_ |
+| [Telegraf Prometheus plugin](/{{< latest "telegraf" >}}/plugins/#input-prometheus)         | _Determined by `metric_version` configuration option_ |
 | [InfluxDB scraper](/influxdb/v2.2/write-data/no-code/scrape-data/)                         |                                                     1 |
 | Flux [`prometheus.scrape()`]({{< latest "flux" >}}/stdlib/experimental/prometheus/scrape/) |                                                     2 |
 
@@ -37,7 +37,7 @@ are parsed and written to InfluxDB in one of two formats, depending on the scrap
 
 | Scraping tool                                                                              |                               InfluxDB Metric version |
 | :----------------------------------------------------------------------------------------- | ----------------------------------------------------: |
-| [Telegraf Prometheus plugin](/{{< latest "telegraf" >}}/plugins/#prometheus)               | _Determined by `metric_version` configuration option_ |
+| [Telegraf Prometheus plugin](/{{< latest "telegraf" >}}/plugins/#input-prometheus)         | _Determined by `metric_version` configuration option_ |
 | Flux [`prometheus.scrape()`]({{< latest "flux" >}}/stdlib/experimental/prometheus/scrape/) |                                                     2 |
 
 {{% /cloud-only %}}

--- a/content/influxdb/v2.2/tools/kapacitor.md
+++ b/content/influxdb/v2.2/tools/kapacitor.md
@@ -95,7 +95,7 @@ see [Write back to InfluxDB](#write-back-to-influxdb) below.
 InfluxDB Cloud and OSS {{< current-version >}} do not have subscription APIs and do not support Kapacitor stream tasks directly.
 To use Kapacitor stream tasks, write data directly to Kapacitor using the [Kapcitior `write` API](/{{< latest "kapacitor" >}}/working/api/#writing-data).
 
-We recommend using [Telegraf InfluxDB output plugin](/{{< latest "telegraf" >}}/plugins/#influxdb)
+We recommend using [Telegraf InfluxDB output plugin](/{{< latest "telegraf" >}}/plugins/#output-influxdb)
 to write data to both InfluxDB Cloud or OSS and Kapacitor.
 The following example Telegraf configuration writes data to both InfluxDB and Kapacitor:
 

--- a/content/influxdb/v2.2/upgrade/v1-to-v2/automatic-upgrade.md
+++ b/content/influxdb/v2.2/upgrade/v1-to-v2/automatic-upgrade.md
@@ -77,8 +77,8 @@ You can continue to use Kapacitor with InfluxDB OSS {{< current-version >}} unde
   Existing Kapacitor user credentials should continue to work using the [1.x compatibility API](/influxdb/v2.2/reference/api/influxdb-1x/).
 - InfluxDB {{< current-version >}} has no subscriptions API and does not support Kapacitor stream tasks.
   To continue using stream tasks, write data directly to both InfluxDB and Kapacitor.
-  Use **Telegraf** and its [InfluxDB output plugin](/{{< latest "telegraf" >}}/plugins/#influxdb)
-  to write to Kapacitor and the [InfluxDB v2 output plugin](/{{< latest "telegraf" >}}/plugins/#influxdb_v2) to write to InfluxDB v2.
+  Use **Telegraf** and its [InfluxDB output plugin](/{{< latest "telegraf" >}}/plugins/#output-influxdb)
+  to write to Kapacitor and the [InfluxDB v2 output plugin](/{{< latest "telegraf" >}}/plugins/#output-influxdb_v2) to write to InfluxDB v2.
 
 ##### Example Telegraf configuration
 ```toml

--- a/content/influxdb/v2.2/visualize-data/variables/common-variables.md
+++ b/content/influxdb/v2.2/visualize-data/variables/common-variables.md
@@ -67,7 +67,7 @@ schema.tagValues(bucket: "bucket-name", tag: "host")
 ## List Docker containers
 List all Docker containers when using the Docker Telegraf plugin.
 
-_**Telegraf plugin:** [Docker](/{{< latest "telegraf" >}}/plugins/#docker)_  
+_**Telegraf plugin:** [Docker](/{{< latest "telegraf" >}}/plugins/#input-docker)_  
 _**Flux package:** [InfluxDB schema](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/)_  
 _**Flux functions:** [schema.tagValues()](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/tagvalues/)_
 
@@ -80,7 +80,7 @@ schema.tagValues(bucket: "bucket-name", tag: "container_name")
 ## List Kubernetes pods
 List all Kubernetes pods when using the Kubernetes Telegraf plugin.
 
-_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)_  
+_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)_  
 _**Flux package:** [InfluxDB schema](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/)_  
 _**Flux functions:** [schema.measurementTagValues()](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/measurementtagvalues/)_
 
@@ -97,7 +97,7 @@ schema.measurementTagValues(
 ## List Kubernetes nodes
 List all Kubernetes nodes when using the Kubernetes Telegraf plugin.
 
-_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#kubernetes)_  
+_**Telegraf plugin:** [Kubernetes](/{{< latest "telegraf" >}}/plugins/#input-kubernetes)_  
 _**Flux package:** [InfluxDB schema](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/)_  
 _**Flux functions:** [schema.measurementTagValues()](/{{< latest "flux" >}}/stdlib/influxdata/influxdb/schema/measurementtagvalues/)_
 

--- a/content/influxdb/v2.2/write-data/developer-tools/scrape-prometheus-metrics.md
+++ b/content/influxdb/v2.2/write-data/developer-tools/scrape-prometheus-metrics.md
@@ -11,7 +11,7 @@ menu:
     name: Scrape Prometheus metrics
     parent: Developer tools
 related:
-  - /{{< latest "telegraf" >}}/plugins/#prometheus, Telegraf Prometheus input plugin
+  - /{{< latest "telegraf" >}}/plugins/#input-prometheus, Telegraf Prometheus input plugin
   - /{{< latest "flux" >}}/prometheus/scrape-prometheus/, Scrape Prometheus metrics with Flux
   - /{{< latest "flux" >}}/stdlib/experimental/prometheus/scrape/
   - /{{< latest "flux" >}}/prometheus/metric-types/
@@ -42,12 +42,12 @@ to scrape Prometheus-formatted metrics from an HTTP-accessible endpoint and stor
 To use Telegraf to scrape Prometheus-formatted metrics from an HTTP-accessible
 endpoint and write them to InfluxDB{{% cloud-only %}} Cloud{{% /cloud-only %}}, follow these steps:
 
-1. Add the [Prometheus input plugin](/{{< latest "telegraf" >}}/plugins/#prometheus) to your Telegraf configuration file.
+1. Add the [Prometheus input plugin](/{{< latest "telegraf" >}}/plugins/#input-prometheus) to your Telegraf configuration file.
     1. Set the `urls` to scrape metrics from.
     2. Set the `metric_version` configuration option to specify which
       [metric parsing version](/influxdb/v2.2/reference/prometheus-metrics/) to use
       _(version `2` is recommended)_.
-2. Add the [InfluxDB v2 output plugin](/{{< latest "telegraf" >}}/plugins/#influxdb_v2)
+2. Add the [InfluxDB v2 output plugin](/{{< latest "telegraf" >}}/plugins/#output-influxdb_v2)
    to your Telegraf configuration file and configure it to to write to
    InfluxDB{{% cloud-only %}} Cloud{{% /cloud-only %}}.
   

--- a/content/telegraf/v1.10/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.10/about_the_project/release-notes-changelog.md
@@ -1240,7 +1240,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser](https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.10/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.10/about_the_project/release-notes-changelog.md
@@ -452,14 +452,14 @@ menu:
 
 ### New input data formats (parsers)
 
-- [csv](/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
-- [grok](/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
-- [logfmt](/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
-- [wavefront](/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
+- [csv](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
+- [grok](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
+- [logfmt](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
+- [wavefront](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
 
 ### New output data formats (serializers)
 
-- [splunkmetric](/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
+- [splunkmetric](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
 
 ### Features
 
@@ -1240,7 +1240,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser](/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.10/data_formats/output/graphite.md
+++ b/content/telegraf/v1.10/data_formats/output/graphite.md
@@ -10,7 +10,7 @@ menu:
 
 The Graphite data format is serialized from Telegraf metrics using either the
 template pattern or tag support method.  You can select between the two
-methods using the [`graphite_tag_support`](#graphite-tag-support) option.  When set, the tag support method is used,
+methods using the [`graphite_tag_support`](#graphite_tag_support) option.  When set, the tag support method is used,
 otherwise the [template pattern][templates]) option is used.
 
 ## Configuration

--- a/content/telegraf/v1.10/plugins/inputs.md
+++ b/content/telegraf/v1.10/plugins/inputs.md
@@ -1063,7 +1063,7 @@ The [HTTP Listener input plugin](https://github.com/influxdata/telegraf/blob/rel
 Line Protocol input data format](/telegraf/v1.10/data_formats/input/influx) ONLY (other [Telegraf input data formats](/telegraf/v1.10/data_formats/input/) are not supported).
 This plugin allows Telegraf to serve as a proxy or router for the `/write` endpoint of the InfluxDB HTTP API.
 
-> DEPRECATED as of version 1.9. Use either [HTTP Listener v2](#http-listener-v2) or the [InfluxDB Listener](#influxdb-v1-x)
+> DEPRECATED as of version 1.9. Use either [HTTP Listener v2](#http-listener-v2) or the [InfluxDB Listener](#influxdb-v1x)
 
 
 ### Jolokia

--- a/content/telegraf/v1.11/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.11/about_the_project/release-notes-changelog.md
@@ -1481,7 +1481,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser](https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.11/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.11/about_the_project/release-notes-changelog.md
@@ -693,14 +693,14 @@ menu:
 
 ### New input data formats (parsers)
 
-- [csv](/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
-- [grok](/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
-- [logfmt](/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
-- [wavefront](/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
+- [csv](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
+- [grok](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
+- [logfmt](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
+- [wavefront](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
 
 ### New output data formats (serializers)
 
-- [splunkmetric](/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
+- [splunkmetric](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
 
 ### Features
 
@@ -1481,7 +1481,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser](/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.11/data_formats/output/graphite.md
+++ b/content/telegraf/v1.11/data_formats/output/graphite.md
@@ -10,7 +10,7 @@ menu:
 
 The Graphite data format is serialized from Telegraf metrics using either the
 template pattern or tag support method.  You can select between the two
-methods using the [`graphite_tag_support`](#graphite-tag-support) option.  When set, the tag support method is used,
+methods using the [`graphite_tag_support`](#graphite_tag_support) option.  When set, the tag support method is used,
 otherwise the [template pattern][templates]) option is used.
 
 ## Configuration

--- a/content/telegraf/v1.12/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.12/about_the_project/release-notes-changelog.md
@@ -1647,7 +1647,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser](https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.12/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.12/about_the_project/release-notes-changelog.md
@@ -859,14 +859,14 @@ menu:
 
 ### New input data formats (parsers)
 
-- [csv](/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
-- [grok](/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
-- [logfmt](/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
-- [wavefront](/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
+- [csv](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
+- [grok](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
+- [logfmt](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
+- [wavefront](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
 
 ### New output data formats (serializers)
 
-- [splunkmetric](/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
+- [splunkmetric](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
 
 ### Features
 
@@ -1647,7 +1647,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser](/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.12/data_formats/output/graphite.md
+++ b/content/telegraf/v1.12/data_formats/output/graphite.md
@@ -10,7 +10,7 @@ menu:
 
 The Graphite data format is serialized from Telegraf metrics using either the
 template pattern or tag support method.  You can select between the two
-methods using the [`graphite_tag_support`](#graphite-tag-support) option.  When set, the tag support method is used,
+methods using the [`graphite_tag_support`](#graphite_tag_support) option.  When set, the tag support method is used,
 otherwise the [template pattern][templates]) option is used.
 
 ## Configuration

--- a/content/telegraf/v1.13/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.13/about_the_project/release-notes-changelog.md
@@ -1795,7 +1795,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser](https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.13/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.13/about_the_project/release-notes-changelog.md
@@ -1007,14 +1007,14 @@ for details about the mapping.
 
 ### New input data formats (parsers)
 
-- [csv](/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
-- [grok](/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
-- [logfmt](/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
-- [wavefront](/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
+- [csv](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
+- [grok](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
+- [logfmt](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
+- [wavefront](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
 
 ### New output data formats (serializers)
 
-- [splunkmetric](/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
+- [splunkmetric](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
 
 ### Features
 
@@ -1795,7 +1795,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser](/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.13/data_formats/output/graphite.md
+++ b/content/telegraf/v1.13/data_formats/output/graphite.md
@@ -10,7 +10,7 @@ menu:
 
 The Graphite data format is serialized from Telegraf metrics using either the
 template pattern or tag support method.  You can select between the two
-methods using the [`graphite_tag_support`](#graphite-tag-support) option.  When set, the tag support method is used,
+methods using the [`graphite_tag_support`](#graphite_tag_support) option.  When set, the tag support method is used,
 otherwise the [template pattern][templates]) option is used.
 
 ## Configuration

--- a/content/telegraf/v1.14/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.14/about_the_project/release-notes-changelog.md
@@ -1957,7 +1957,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser](https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.14/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.14/about_the_project/release-notes-changelog.md
@@ -1169,14 +1169,14 @@ for details about the mapping.
 
 ### New input data formats (parsers)
 
-- [csv](/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
-- [grok](/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
-- [logfmt](/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
-- [wavefront](/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
+- [csv](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
+- [grok](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
+- [logfmt](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
+- [wavefront](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
 
 ### New output data formats (serializers)
 
-- [splunkmetric](/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
+- [splunkmetric](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
 
 ### Features
 
@@ -1957,7 +1957,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser](/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.14/data_formats/output/graphite.md
+++ b/content/telegraf/v1.14/data_formats/output/graphite.md
@@ -10,7 +10,7 @@ menu:
 
 The Graphite data format is serialized from Telegraf metrics using either the
 template pattern or tag support method.  You can select between the two
-methods using the [`graphite_tag_support`](#graphite-tag-support) option.  When set, the tag support method is used,
+methods using the [`graphite_tag_support`](#graphite_tag_support) option.  When set, the tag support method is used,
 otherwise the [template pattern][templates]) option is used.
 
 ## Configuration

--- a/content/telegraf/v1.15/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.15/about_the_project/release-notes-changelog.md
@@ -1362,14 +1362,14 @@ for details about the mapping.
 
 ### New input data formats (parsers)
 
-- [csv](/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
-- [grok](/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
-- [logfmt](/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
-- [wavefront](/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
+- [csv](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
+- [grok](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
+- [logfmt](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
+- [wavefront](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
 
 ### New output data formats (serializers)
 
-- [splunkmetric](/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
+- [splunkmetric](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
 
 ### Features
 
@@ -2150,7 +2150,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser](/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.15/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.15/about_the_project/release-notes-changelog.md
@@ -2150,7 +2150,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser](https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.15/data_formats/output/graphite.md
+++ b/content/telegraf/v1.15/data_formats/output/graphite.md
@@ -10,7 +10,7 @@ menu:
 
 The Graphite data format is serialized from Telegraf metrics using either the
 template pattern or tag support method.  You can select between the two
-methods using the [`graphite_tag_support`](#graphite-tag-support) option.  When set, the tag support method is used,
+methods using the [`graphite_tag_support`](#graphite_tag_support) option.  When set, the tag support method is used,
 otherwise the [template pattern][templates]) option is used.
 
 ## Configuration

--- a/content/telegraf/v1.15/guides/using_http.md
+++ b/content/telegraf/v1.15/guides/using_http.md
@@ -10,7 +10,7 @@ menu:
 
 This example walks through using the Telegraf HTTP input plugin to collect live metrics on Citi Bike stations in New York City. Live station data is available in JSON format from [NYC OpenData](https://data.cityofnewyork.us/NYC-BigApps/Citi-Bike-Live-Station-Feed-JSON-/p94q-8hxh).
 
-For the following example to work, configure [`influxdb` output plugin](/telegraf/v1.15/plugins/#influxdb_v2). This plugin is what allows Telegraf to write the metrics to your InfluxDB.
+For the following example to work, configure [`influxdb` output plugin](/telegraf/v1.15/plugins/#output-influxdb_v2). This plugin is what allows Telegraf to write the metrics to your InfluxDB.
 
 ## Configure the HTTP Input plugin in your Telegraf configuration file
 

--- a/content/telegraf/v1.15/introduction/installation.md
+++ b/content/telegraf/v1.15/introduction/installation.md
@@ -337,7 +337,7 @@ Compare the output from this command to the hash listed on the downloads page to
 ### Configure an input plugin
 
 The Telegraf ZIP archive contains a default configuration file (`telegraf.conf`).
-In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.15/plugins/#win_perf_counters) is already activated.
+In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.15/plugins/#input-win_perf_counters) is already activated.
 With this plugin, Telegraf monitors the following defined Windows Operating System objects:
 
 - Processor
@@ -357,8 +357,8 @@ Before you start the Telegraf agent, configure an output plugin to send data to 
 Choose the appropriate plugin based on the version of InfluxDB you are using.
 
 The `telegraf.conf` file included in the ZIP archive contains sections for configuring
-both the [InfluxDB v1](/telegraf/v1.15/plugins/#influxdb) and
-[InfluxDB v2](/telegraf/v1.15/plugins/#influxdb_v2) output plugins.
+both the [InfluxDB v1](/telegraf/v1.15/plugins/#output-influxdb) and
+[InfluxDB v2](/telegraf/v1.15/plugins/#output-influxdb_v2) output plugins.
 
 #### Writing data to InfluxDB 1.x
 

--- a/content/telegraf/v1.16/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.16/about_the_project/release-notes-changelog.md
@@ -2272,7 +2272,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser](https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.16/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.16/about_the_project/release-notes-changelog.md
@@ -1484,14 +1484,14 @@ for details about the mapping.
 
 ### New input data formats (parsers)
 
-- [csv](/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
-- [grok](/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
-- [logfmt](/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
-- [wavefront](/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
+- [csv](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
+- [grok](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
+- [logfmt](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
+- [wavefront](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
 
 ### New output data formats (serializers)
 
-- [splunkmetric](/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
+- [splunkmetric](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
 
 ### Features
 
@@ -2272,7 +2272,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser](/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.16/data_formats/output/graphite.md
+++ b/content/telegraf/v1.16/data_formats/output/graphite.md
@@ -10,7 +10,7 @@ menu:
 
 The Graphite data format is serialized from Telegraf metrics using either the
 template pattern or tag support method.  You can select between the two
-methods using the [`graphite_tag_support`](#graphite-tag-support) option.  When set, the tag support method is used,
+methods using the [`graphite_tag_support`](#graphite_tag_support) option.  When set, the tag support method is used,
 otherwise the [template pattern][templates]) option is used.
 
 ## Configuration

--- a/content/telegraf/v1.16/guides/using_http.md
+++ b/content/telegraf/v1.16/guides/using_http.md
@@ -10,7 +10,7 @@ menu:
 
 This example walks through using the Telegraf HTTP input plugin to collect live metrics on Citi Bike stations in New York City. Live station data is available in JSON format from [NYC OpenData](https://data.cityofnewyork.us/NYC-BigApps/Citi-Bike-Live-Station-Feed-JSON-/p94q-8hxh).
 
-For the following example to work, configure [`influxdb` output plugin](/telegraf/v1.15/plugins/#influxdb). This plugin is what allows Telegraf to write the metrics to your InfluxDB.
+For the following example to work, configure [`influxdb` output plugin](/telegraf/v1.15/plugins/#output-influxdb). This plugin is what allows Telegraf to write the metrics to your InfluxDB.
 
 ## Configure the HTTP Input plugin in your Telegraf configuration file
 

--- a/content/telegraf/v1.16/introduction/installation.md
+++ b/content/telegraf/v1.16/introduction/installation.md
@@ -337,7 +337,7 @@ Compare the output from this command to the hash listed on the downloads page to
 ### Configure an input plugin
 
 The Telegraf ZIP archive contains a default configuration file (`telegraf.conf`).
-In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.15/plugins/#win_perf_counters) is already activated.
+In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.15/plugins/#input-win_perf_counters) is already activated.
 With this plugin, Telegraf monitors the following defined Windows Operating System objects:
 
 - Processor
@@ -357,8 +357,8 @@ Before you start the Telegraf agent, configure an output plugin to send data to 
 Choose the appropriate plugin based on the version of InfluxDB you are using.
 
 The `telegraf.conf` file included in the ZIP archive contains sections for configuring
-both the [InfluxDB v1](/telegraf/v1.15/plugins/#influxdb) and
-[InfluxDB v2](/telegraf/v1.15/plugins/#influxdb_v2) output plugins.
+both the [InfluxDB v1](/telegraf/v1.15/plugins/#output-influxdb) and
+[InfluxDB v2](/telegraf/v1.15/plugins/#output-influxdb_v2) output plugins.
 
 #### Writing data to InfluxDB 1.x
 

--- a/content/telegraf/v1.17/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.17/about_the_project/release-notes-changelog.md
@@ -2417,7 +2417,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser](https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.17/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.17/about_the_project/release-notes-changelog.md
@@ -1629,14 +1629,14 @@ for details about the mapping.
 
 ### New input data formats (parsers)
 
-- [csv](/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
-- [grok](/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
-- [logfmt](/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
-- [wavefront](/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
+- [csv](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
+- [grok](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
+- [logfmt](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
+- [wavefront](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
 
 ### New output data formats (serializers)
 
-- [splunkmetric](/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
+- [splunkmetric](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
 
 ### Features
 
@@ -2417,7 +2417,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser](/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.17/data_formats/output/graphite.md
+++ b/content/telegraf/v1.17/data_formats/output/graphite.md
@@ -10,7 +10,7 @@ menu:
 
 The Graphite data format is serialized from Telegraf metrics using either the
 template pattern or tag support method.  You can select between the two
-methods using the [`graphite_tag_support`](#graphite-tag-support) option.  When set, the tag support method is used,
+methods using the [`graphite_tag_support`](#graphite_tag_support) option.  When set, the tag support method is used,
 otherwise the [template pattern][templates]) option is used.
 
 ## Configuration

--- a/content/telegraf/v1.17/guides/using_http.md
+++ b/content/telegraf/v1.17/guides/using_http.md
@@ -10,7 +10,7 @@ menu:
 
 This example walks through using the Telegraf HTTP input plugin to collect live metrics on Citi Bike stations in New York City. Live station data is available in JSON format from [NYC OpenData](https://data.cityofnewyork.us/NYC-BigApps/Citi-Bike-Live-Station-Feed-JSON-/p94q-8hxh).
 
-For the following example to work, configure [`influxdb` output plugin](/telegraf/v1.15/plugins/#influxdb). This plugin is what allows Telegraf to write the metrics to your InfluxDB.
+For the following example to work, configure [`influxdb` output plugin](/telegraf/v1.15/plugins/#output-influxdb). This plugin is what allows Telegraf to write the metrics to your InfluxDB.
 
 ## Configure the HTTP Input plugin in your Telegraf configuration file
 

--- a/content/telegraf/v1.17/introduction/installation.md
+++ b/content/telegraf/v1.17/introduction/installation.md
@@ -338,7 +338,7 @@ Compare the output from this command to the hash listed on the downloads page to
 ### Configure an input plugin
 
 The Telegraf ZIP archive contains a default configuration file (`telegraf.conf`).
-In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.17/plugins/#win_perf_counters) is already activated.
+In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.17/plugins/#input-win_perf_counters) is already activated.
 With this plugin, Telegraf monitors the following defined Windows Operating System objects:
 
 - Processor
@@ -358,8 +358,8 @@ Before you start the Telegraf agent, configure an output plugin to send data to 
 Choose the appropriate plugin based on the version of InfluxDB you are using.
 
 The `telegraf.conf` file included in the ZIP archive contains sections for configuring
-both the [InfluxDB v1](/telegraf/v1.17/plugins/#influxdb) and
-[InfluxDB v2](/telegraf/v1.17/plugins/#influxdb_v2) output plugins.
+both the [InfluxDB v1](/telegraf/v1.17/plugins/#output-influxdb) and
+[InfluxDB v2](/telegraf/v1.17/plugins/#output-influxdb_v2) output plugins.
 
 #### Writing data to InfluxDB 1.x
 

--- a/content/telegraf/v1.18/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.18/about_the_project/release-notes-changelog.md
@@ -1761,14 +1761,14 @@ for details about the mapping.
 
 ### New input data formats (parsers)
 
-- [csv](/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
-- [grok](/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
-- [logfmt](/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
-- [wavefront](/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
+- [csv](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
+- [grok](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
+- [logfmt](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
+- [wavefront](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
 
 ### New output data formats (serializers)
 
-- [splunkmetric](/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
+- [splunkmetric](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
 
 ### Features
 
@@ -2549,7 +2549,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser](/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.18/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.18/about_the_project/release-notes-changelog.md
@@ -2549,7 +2549,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser](https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.18/data_formats/output/graphite.md
+++ b/content/telegraf/v1.18/data_formats/output/graphite.md
@@ -10,7 +10,7 @@ menu:
 
 The Graphite data format is serialized from Telegraf metrics using either the
 template pattern or tag support method.  You can select between the two
-methods using the [`graphite_tag_support`](#graphite-tag-support) option.  When set, the tag support method is used,
+methods using the [`graphite_tag_support`](#graphite_tag_support) option.  When set, the tag support method is used,
 otherwise the [template pattern][templates]) option is used.
 
 ## Configuration

--- a/content/telegraf/v1.18/guides/using_http.md
+++ b/content/telegraf/v1.18/guides/using_http.md
@@ -10,7 +10,7 @@ menu:
 
 This example walks through using the Telegraf HTTP input plugin to collect live metrics on Citi Bike stations in New York City. Live station data is available in JSON format from [NYC OpenData](https://data.cityofnewyork.us/NYC-BigApps/Citi-Bike-Live-Station-Feed-JSON-/p94q-8hxh).
 
-For the following example to work, configure [`influxdb` output plugin](/telegraf/v1.15/plugins/#influxdb). This plugin is what allows Telegraf to write the metrics to your InfluxDB.
+For the following example to work, configure [`influxdb` output plugin](/telegraf/v1.15/plugins/#output-influxdb). This plugin is what allows Telegraf to write the metrics to your InfluxDB.
 
 ## Configure the HTTP Input plugin in your Telegraf configuration file
 

--- a/content/telegraf/v1.18/introduction/installation.md
+++ b/content/telegraf/v1.18/introduction/installation.md
@@ -338,7 +338,7 @@ Compare the output from this command to the hash listed on the downloads page to
 ### Configure an input plugin
 
 The Telegraf ZIP archive contains a default configuration file (`telegraf.conf`).
-In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.18/plugins/#win_perf_counters) is already activated.
+In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.18/plugins/#input-win_perf_counters) is already activated.
 With this plugin, Telegraf monitors the following defined Windows Operating System objects:
 
 - Processor
@@ -358,8 +358,8 @@ Before you start the Telegraf agent, configure an output plugin to send data to 
 Choose the appropriate plugin based on the version of InfluxDB you are using.
 
 The `telegraf.conf` file included in the ZIP archive contains sections for configuring
-both the [InfluxDB v1](/telegraf/v1.18/plugins/#influxdb) and
-[InfluxDB v2](/telegraf/v1.18/plugins/#influxdb_v2) output plugins.
+both the [InfluxDB v1](/telegraf/v1.18/plugins/#output-influxdb) and
+[InfluxDB v2](/telegraf/v1.18/plugins/#output-influxdb_v2) output plugins.
 
 #### Writing data to InfluxDB 1.x
 

--- a/content/telegraf/v1.19/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.19/about_the_project/release-notes-changelog.md
@@ -2726,7 +2726,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser](https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.19/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.19/about_the_project/release-notes-changelog.md
@@ -1938,14 +1938,14 @@ for details about the mapping.
 
 ### New input data formats (parsers)
 
-- [csv](/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
-- [grok](/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
-- [logfmt](/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
-- [wavefront](/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
+- [csv](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
+- [grok](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
+- [logfmt](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
+- [wavefront](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
 
 ### New output data formats (serializers)
 
-- [splunkmetric](/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
+- [splunkmetric](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
 
 ### Features
 
@@ -2726,7 +2726,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser](/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.19/data_formats/input/prometheus-remote-write.md
+++ b/content/telegraf/v1.19/data_formats/input/prometheus-remote-write.md
@@ -19,7 +19,7 @@ For the metrics to completely align with the 1.x endpoint, add a Starlark proces
 
 ### Configuration
 
-Use the [`inputs.http_listener_v2`](/telegraf/v1.19/plugins/#http_listener_v2) plug and set `data_format = "prometheusremotewrite"`
+Use the [`inputs.http_listener_v2`](/telegraf/v1.19/plugins/#input-http_listener_v2) plug and set `data_format = "prometheusremotewrite"`
 
 ```toml
 [[inputs.http_listener_v2]]

--- a/content/telegraf/v1.19/data_formats/output/graphite.md
+++ b/content/telegraf/v1.19/data_formats/output/graphite.md
@@ -10,7 +10,7 @@ menu:
 
 The Graphite data format is serialized from Telegraf metrics using either the
 template pattern or tag support method.  You can select between the two
-methods using the [`graphite_tag_support`](#graphite-tag-support) option.  When set, the tag support method is used,
+methods using the [`graphite_tag_support`](#graphite_tag_support) option.  When set, the tag support method is used,
 otherwise the [template pattern][templates]) option is used.
 
 ## Configuration

--- a/content/telegraf/v1.19/external_plugins/write_external_plugin.md
+++ b/content/telegraf/v1.19/external_plugins/write_external_plugin.md
@@ -19,7 +19,7 @@ and feature development of external plugins.
    - [Processor plugins](https://github.com/influxdata/telegraf/blob/master/docs/PROCESSORS.md)
    - [Aggregator plugins](https://github.com/influxdata/telegraf/blob/master/docs/AGGREGATORS.md)
    - [Output plugins](https://github.com/influxdata/telegraf/blob/master/docs/OUTPUTS.md)
-2. If your plugin is written in Go, follow the steps for the [Execd Go Shim](/telegraf/latest/external_plugins/shim).
+2. If your plugin is written in Go, follow the steps for the [Execd Go Shim](/telegraf/v1.19/external_plugins/shim).
 3. Add usage and development instructions in the homepage of your repository for running your plugin with its respective `execd` plugin. Refer to [openvpn](https://github.com/danielnelson/telegraf-execd-openvpn#usage) and [awsalarms](https://github.com/vipinvkmenon/awsalarms#installation) for examples.
 Include the following steps:
      - How to download the release package for your platform or how to clone the binary for your external plugin

--- a/content/telegraf/v1.19/guides/using_http.md
+++ b/content/telegraf/v1.19/guides/using_http.md
@@ -10,7 +10,7 @@ menu:
 
 This example walks through using the Telegraf HTTP input plugin to collect live metrics on Citi Bike stations in New York City. Live station data is available in JSON format from [NYC OpenData](https://data.cityofnewyork.us/NYC-BigApps/Citi-Bike-Live-Station-Feed-JSON-/p94q-8hxh).
 
-For the following example to work, configure [`influxdb` output plugin](/telegraf/v1.15/plugins/#influxdb). This plugin is what allows Telegraf to write the metrics to your InfluxDB.
+For the following example to work, configure [`influxdb` output plugin](/telegraf/v1.15/plugins/#output-influxdb). This plugin is what allows Telegraf to write the metrics to your InfluxDB.
 
 ## Configure the HTTP Input plugin in your Telegraf configuration file
 

--- a/content/telegraf/v1.19/introduction/installation.md
+++ b/content/telegraf/v1.19/introduction/installation.md
@@ -347,7 +347,7 @@ Compare the output from this command to the hash listed on the downloads page to
 ### Configure an input plugin
 
 The Telegraf ZIP archive contains a default configuration file (`telegraf.conf`).
-In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.19/plugins/#win_perf_counters) is already activated.
+In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.19/plugins/#input-win_perf_counters) is already activated.
 With this plugin, Telegraf monitors the following defined Windows Operating System objects:
 
 - Processor
@@ -367,8 +367,8 @@ Before you start the Telegraf agent, configure an output plugin to send data to 
 Choose the appropriate plugin based on the version of InfluxDB you are using.
 
 The `telegraf.conf` file included in the ZIP archive contains sections for configuring
-both the [InfluxDB v1](/telegraf/v1.19/plugins/#influxdb) and
-[InfluxDB v2](/telegraf/v1.19/plugins/#influxdb_v2) output plugins.
+both the [InfluxDB v1](/telegraf/v1.19/plugins/#output-influxdb) and
+[InfluxDB v2](/telegraf/v1.19/plugins/#output-influxdb_v2) output plugins.
 
 #### Writing data to InfluxDB 1.x
 

--- a/content/telegraf/v1.20/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.20/about_the_project/release-notes-changelog.md
@@ -2098,14 +2098,14 @@ for details about the mapping.
 
 ### New input data formats (parsers)
 
-- [csv](/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
-- [grok](/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
-- [logfmt](/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
-- [wavefront](/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
+- [csv](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
+- [grok](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
+- [logfmt](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
+- [wavefront](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
 
 ### New output data formats (serializers)
 
-- [splunkmetric](/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
+- [splunkmetric](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
 
 ### Features
 
@@ -2886,7 +2886,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser](/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.20/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.20/about_the_project/release-notes-changelog.md
@@ -2886,7 +2886,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser](https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.20/data_formats/input/prometheus-remote-write.md
+++ b/content/telegraf/v1.20/data_formats/input/prometheus-remote-write.md
@@ -19,7 +19,7 @@ For the metrics to completely align with the 1.x endpoint, add a Starlark proces
 
 ### Configuration
 
-Use the [`inputs.http_listener_v2`](/telegraf/v1.20/plugins/#http_listener_v2) plug and set `data_format = "prometheusremotewrite"`
+Use the [`inputs.http_listener_v2`](/telegraf/v1.20/plugins/#input-http_listener_v2) plug and set `data_format = "prometheusremotewrite"`
 
 ```toml
 [[inputs.http_listener_v2]]

--- a/content/telegraf/v1.20/data_formats/output/graphite.md
+++ b/content/telegraf/v1.20/data_formats/output/graphite.md
@@ -10,7 +10,7 @@ menu:
 
 The Graphite data format is serialized from Telegraf metrics using either the
 template pattern or tag support method.  You can select between the two
-methods using the [`graphite_tag_support`](#graphite-tag-support) option.  When set, the tag support method is used,
+methods using the [`graphite_tag_support`](#graphite_tag_support) option.  When set, the tag support method is used,
 otherwise the [template pattern][templates]) option is used.
 
 ## Configuration

--- a/content/telegraf/v1.20/external_plugins/_index.md
+++ b/content/telegraf/v1.20/external_plugins/_index.md
@@ -14,7 +14,7 @@ more flexibility compared to internal Telegraf plugins. Benefits to using extern
 - Using licensed software (not available to open source community)
 - Including large dependencies that would otherwise bloat Telegraf
 - Using your external plugin immediately without waiting for the Telegraf team to publish
-- Easily convert plugins between internal and external using the [shim](/telegraf/latest/external_plugins/shim/)
+- Easily convert plugins between internal and external using the [shim](/telegraf/v1.20/external_plugins/shim/)
 
 
 

--- a/content/telegraf/v1.20/external_plugins/write_external_plugin.md
+++ b/content/telegraf/v1.20/external_plugins/write_external_plugin.md
@@ -19,7 +19,7 @@ and feature development of external plugins.
    - [Processor plugins](https://github.com/influxdata/telegraf/blob/master/docs/PROCESSORS.md)
    - [Aggregator plugins](https://github.com/influxdata/telegraf/blob/master/docs/AGGREGATORS.md)
    - [Output plugins](https://github.com/influxdata/telegraf/blob/master/docs/OUTPUTS.md)
-2. If your plugin is written in Go, follow the steps for the [Execd Go Shim](/telegraf/latest/external_plugins/shim).
+2. If your plugin is written in Go, follow the steps for the [Execd Go Shim](/telegraf/v1.20/external_plugins/shim).
 3. Add usage and development instructions in the homepage of your repository for running your plugin with its respective `execd` plugin. Refer to [openvpn](https://github.com/danielnelson/telegraf-execd-openvpn#usage) and [awsalarms](https://github.com/vipinvkmenon/awsalarms#installation) for examples.
 Include the following steps:
      - How to download the release package for your platform or how to clone the binary for your external plugin

--- a/content/telegraf/v1.20/guides/using_http.md
+++ b/content/telegraf/v1.20/guides/using_http.md
@@ -10,7 +10,7 @@ menu:
 
 This example walks through using the Telegraf HTTP input plugin to collect live metrics on Citi Bike stations in New York City. Live station data is available in JSON format from [NYC OpenData](https://data.cityofnewyork.us/NYC-BigApps/Citi-Bike-Live-Station-Feed-JSON-/p94q-8hxh).
 
-For the following example to work, configure [`influxdb` output plugin](/telegraf/v1.15/plugins/#influxdb). This plugin is what allows Telegraf to write the metrics to your InfluxDB.
+For the following example to work, configure [`influxdb` output plugin](/telegraf/v1.15/plugins/#output-influxdb). This plugin is what allows Telegraf to write the metrics to your InfluxDB.
 
 ## Configure the HTTP Input plugin in your Telegraf configuration file
 

--- a/content/telegraf/v1.20/introduction/installation.md
+++ b/content/telegraf/v1.20/introduction/installation.md
@@ -278,7 +278,7 @@ Compare the output from this command to the hash listed on the downloads page to
 ### Configure an input plugin
 
 The Telegraf ZIP archive contains a default configuration file (`telegraf.conf`).
-In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.20/plugins/#win_perf_counters) is already activated.
+In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.20/plugins/#input-win_perf_counters) is already activated.
 With this plugin, Telegraf monitors the following defined Windows Operating System objects:
 
 - Processor
@@ -298,8 +298,8 @@ Before you start the Telegraf agent, configure an output plugin to send data to 
 Choose the appropriate plugin based on the version of InfluxDB you are using.
 
 The `telegraf.conf` file included in the ZIP archive contains sections for configuring
-both the [InfluxDB v1](/telegraf/v1.20/plugins/#influxdb) and
-[InfluxDB v2](/telegraf/v1.20/plugins/#influxdb_v2) output plugins.
+both the [InfluxDB v1](/telegraf/v1.20/plugins/#output-influxdb) and
+[InfluxDB v2](/telegraf/v1.20/plugins/#output-influxdb_v2) output plugins.
 
 #### Writing data to InfluxDB 1.x
 

--- a/content/telegraf/v1.21/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.21/about_the_project/release-notes-changelog.md
@@ -3118,7 +3118,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser](https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.21/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.21/about_the_project/release-notes-changelog.md
@@ -2330,14 +2330,14 @@ for details about the mapping.
 
 ### New input data formats (parsers)
 
-- [csv](/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
-- [grok](/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
-- [logfmt](/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
-- [wavefront](/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
+- [csv](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
+- [grok](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
+- [logfmt](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
+- [wavefront](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
 
 ### New output data formats (serializers)
 
-- [splunkmetric](/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
+- [splunkmetric](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
 
 ### Features
 
@@ -3118,7 +3118,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser](/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.21/data_formats/input/prometheus-remote-write.md
+++ b/content/telegraf/v1.21/data_formats/input/prometheus-remote-write.md
@@ -21,7 +21,7 @@ For the metrics to completely align with the 1.x endpoint, add a Starlark proces
 
 ### Configuration
 
-Use the [`inputs.http_listener_v2`](/telegraf/v1.21/plugins/#http_listener_v2) plug and set `data_format = "prometheusremotewrite"`
+Use the [`inputs.http_listener_v2`](/telegraf/v1.21/plugins/#input-http_listener_v2) plug and set `data_format = "prometheusremotewrite"`
 
 ```toml
 [[inputs.http_listener_v2]]

--- a/content/telegraf/v1.21/data_formats/output/graphite.md
+++ b/content/telegraf/v1.21/data_formats/output/graphite.md
@@ -11,7 +11,7 @@ menu:
 
 The Graphite data format is serialized from Telegraf metrics using either the
 template pattern or tag support method.  You can select between the two
-methods using the [`graphite_tag_support`](#graphite-tag-support) option.  When set, the tag support method is used,
+methods using the [`graphite_tag_support`](#graphite_tag_support) option.  When set, the tag support method is used,
 otherwise the [template pattern][templates]) option is used.
 
 ## Configuration

--- a/content/telegraf/v1.21/external_plugins/_index.md
+++ b/content/telegraf/v1.21/external_plugins/_index.md
@@ -15,7 +15,7 @@ more flexibility compared to internal Telegraf plugins. Benefits to using extern
 - Using licensed software (not available to open source community)
 - Including large dependencies that would otherwise bloat Telegraf
 - Using your external plugin immediately without waiting for the Telegraf team to publish
-- Easily convert plugins between internal and external using the [shim](/{{< latest "telegraf" >}}/external_plugins/shim/)
+- Easily convert plugins between internal and external using the [shim](/telegraf/v1.21/external_plugins/shim/)
 
 
 

--- a/content/telegraf/v1.21/external_plugins/write_external_plugin.md
+++ b/content/telegraf/v1.21/external_plugins/write_external_plugin.md
@@ -20,7 +20,7 @@ and feature development of external plugins.
    - [Processor plugins](https://github.com/influxdata/telegraf/blob/master/docs/PROCESSORS.md)
    - [Aggregator plugins](https://github.com/influxdata/telegraf/blob/master/docs/AGGREGATORS.md)
    - [Output plugins](https://github.com/influxdata/telegraf/blob/master/docs/OUTPUTS.md)
-2. If your plugin is written in Go, follow the steps for the [Execd Go Shim](/telegraf/latest/external_plugins/shim).
+2. If your plugin is written in Go, follow the steps for the [Execd Go Shim](/telegraf/v1.21/external_plugins/shim).
 3. Add usage and development instructions in the homepage of your repository for running your plugin with its respective `execd` plugin. Refer to [openvpn](https://github.com/danielnelson/telegraf-execd-openvpn#usage) and [awsalarms](https://github.com/vipinvkmenon/awsalarms#installation) for examples.
 Include the following steps:
      - How to download the release package for your platform or how to clone the binary for your external plugin

--- a/content/telegraf/v1.21/guides/using_http.md
+++ b/content/telegraf/v1.21/guides/using_http.md
@@ -11,7 +11,7 @@ menu:
 
 This example walks through using the Telegraf HTTP input plugin to collect live metrics on Citi Bike stations in New York City. Live station data is available in JSON format directly from [Citi Bike](https://ride.citibikenyc.com/system-data).
 
-For the following example to work, configure [`influxdb_v2` output plugin](/telegraf/latest/plugins/#influxdb_v2). This plugin is what allows Telegraf to write the metrics to InfluxDB.
+For the following example to work, configure [`influxdb_v2` output plugin](/telegraf/v1.21/plugins/#output-influxdb_v2). This plugin is what allows Telegraf to write the metrics to InfluxDB.
 
 ## Configure the HTTP Input plugin in your Telegraf configuration file
 
@@ -85,7 +85,7 @@ The format used to interpret the designated `timestamp_key`. The `last_reported`
 
 ## Start Telegraf and verify data appears
 
-[Start the Telegraf service](/{{< latest "telegraf" >}}/introduction/getting-started/#start-telegraf-service).
+[Start the Telegraf service](/telegraf/v1.21/introduction/getting-started/#start-telegraf-service).
 
 To test that the data is being sent to InfluxDB, run the following (replacing `telegraf.conf` with the path to your configuration file):
 

--- a/content/telegraf/v1.21/introduction/installation.md
+++ b/content/telegraf/v1.21/introduction/installation.md
@@ -279,7 +279,7 @@ Compare the output from this command to the hash listed on the downloads page to
 ### Configure an input plugin
 
 The Telegraf ZIP archive contains a default configuration file (`telegraf.conf`).
-In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.21/plugins/#win_perf_counters) is already activated.
+In this file, the input plugin for capturing basic [Windows system metrics](/telegraf/v1.21/plugins/#input-win_perf_counters) is already activated.
 With this plugin, Telegraf monitors the following defined Windows Operating System objects:
 
 - Processor
@@ -299,8 +299,8 @@ Before you start the Telegraf agent, configure an output plugin to send data to 
 Choose the appropriate plugin based on the version of InfluxDB you are using.
 
 The `telegraf.conf` file included in the ZIP archive contains sections for configuring
-both the [InfluxDB v1](/telegraf/v1.21/plugins/#influxdb) and
-[InfluxDB v2](/telegraf/v1.21/plugins/#influxdb_v2) output plugins.
+both the [InfluxDB v1](/telegraf/v1.21/plugins/#output-influxdb) and
+[InfluxDB v2](/telegraf/v1.21/plugins/#output-influxdb_v2) output plugins.
 
 #### Writing data to InfluxDB 1.x
 

--- a/content/telegraf/v1.22/configure_plugins/external_plugins/_index.md
+++ b/content/telegraf/v1.22/configure_plugins/external_plugins/_index.md
@@ -4,7 +4,6 @@ description: |
   External plugins are external programs that are built outside of Telegraf that can run through an `execd` plugin.
 menu:
   telegraf_1_22:
-
      name: External plugins
      weight: 50
      parent: Configure plugins

--- a/content/telegraf/v1.22/configure_plugins/external_plugins/write_external_plugin.md
+++ b/content/telegraf/v1.22/configure_plugins/external_plugins/write_external_plugin.md
@@ -20,7 +20,7 @@ and feature development of external plugins.
    - [Processor plugins](https://github.com/influxdata/telegraf/blob/master/docs/PROCESSORS.md)
    - [Aggregator plugins](https://github.com/influxdata/telegraf/blob/master/docs/AGGREGATORS.md)
    - [Output plugins](https://github.com/influxdata/telegraf/blob/master/docs/OUTPUTS.md)
-2. If your plugin is written in Go, follow the steps for the [Execd Go Shim](/{{< latest "telegraf" >}}/external_plugins/shim).
+2. If your plugin is written in Go, follow the steps for the [Execd Go Shim](/{{< latest "telegraf" >}}/configure_plugins/external_plugins/shim).
 3. Add usage and development instructions in the homepage of your repository for running your plugin with its respective `execd` plugin. Refer to [openvpn](https://github.com/danielnelson/telegraf-execd-openvpn#usage) and [awsalarms](https://github.com/vipinvkmenon/awsalarms#installation) for examples.
 Include the following steps:
      - How to download the release package for your platform or how to clone the binary for your external plugin

--- a/content/telegraf/v1.22/configure_plugins/input_plugins/using_http.md
+++ b/content/telegraf/v1.22/configure_plugins/input_plugins/using_http.md
@@ -11,7 +11,7 @@ menu:
 
 This example walks through using the Telegraf HTTP input plugin to collect live metrics on Citi Bike stations in New York City. Live station data is available in JSON format directly from [Citi Bike](https://ride.citibikenyc.com/system-data).
 
-For the following example to work, configure [`influxdb_v2` output plugin](/{{< latest "telegraf" >}}/plugins/#influxdb_v2). This plugin is what allows Telegraf to write the metrics to InfluxDB.
+For the following example to work, configure [`influxdb_v2` output plugin](/telegraf/v1.22/plugins/#output-influxdb_v2). This plugin is what allows Telegraf to write the metrics to InfluxDB.
 
 ## Configure the HTTP Input plugin in your Telegraf configuration file
 
@@ -85,7 +85,7 @@ The format used to interpret the designated `timestamp_key`. The `last_reported`
 
 ## Start Telegraf and verify data appears
 
-[Start the Telegraf service](/{{< latest "telegraf" >}}/introduction/getting-started/#start-telegraf-service).
+[Start the Telegraf service](/telegraf/v1.22/get_started/#start-telegraf).
 
 To test that the data is being sent to InfluxDB, run the following (replacing `telegraf.conf` with the path to your configuration file):
 

--- a/content/telegraf/v1.22/data_formats/input/prometheus-remote-write.md
+++ b/content/telegraf/v1.22/data_formats/input/prometheus-remote-write.md
@@ -21,7 +21,7 @@ For the metrics to completely align with the 1.x endpoint, add a Starlark proces
 
 ### Configuration
 
-Use the [`inputs.http_listener_v2`](/telegraf/v1.22/plugins/#http_listener_v2) plug and set `data_format = "prometheusremotewrite"`
+Use the [`inputs.http_listener_v2`](/telegraf/v1.22/plugins/#input-http_listener_v2) plug and set `data_format = "prometheusremotewrite"`
 
 ```toml
 [[inputs.http_listener_v2]]

--- a/content/telegraf/v1.22/data_formats/output/graphite.md
+++ b/content/telegraf/v1.22/data_formats/output/graphite.md
@@ -11,7 +11,7 @@ menu:
 
 The Graphite data format is serialized from Telegraf metrics using either the
 template pattern or tag support method.  You can select between the two
-methods using the [`graphite_tag_support`](#graphite-tag-support) option.  When set, the tag support method is used,
+methods using the [`graphite_tag_support`](#graphite_tag_support) option.  When set, the tag support method is used,
 otherwise the [template pattern][templates]) option is used.
 
 ## Configuration

--- a/content/telegraf/v1.22/get_started.md
+++ b/content/telegraf/v1.22/get_started.md
@@ -3,23 +3,25 @@ title: Get started
 description: Configure and start Telegraf
 menu:
   telegraf_1_22:
-
     name: Get started
     weight: 25
 ---
 
-After you've [downloaded and installed Telegraf](/{{< latest "telegraf" >}}/install/), you're ready to begin collecting and sending data. To collect and send data, do the following:
+After you've [downloaded and installed Telegraf](/telegraf/v1.22/install/), you're ready to begin collecting and sending data. To collect and send data, do the following:
 
 1. [Configure Telegraf](#configure-telegraf)
 2. [Start Telegraf](#start-telegraf)
-3. Use [plugins available in Telegraf](/{{< latest "telegraf" >}}/plugins/) to gather, transform, and output data.
+3. Use [plugins available in Telegraf](/telegraf/v1.22/plugins/) to gather, transform, and output data.
 
 ## Configure Telegraf
 
-Define which plugins Telegraf will use in the configuration file. Each configuration file needs at least one enabled [input plugin](/{{< latest "telegraf" >}}/plugins/inputs/) (where the metrics come from) and at least one enabled [output plugin](/{{< latest "telegraf" >}}/plugins/outputs/) (where the metrics go).
+Define which plugins Telegraf will use in the configuration file. Each configuration file needs at least one enabled [input plugin](/telegraf/v1.22/plugins/inputs/) (where the metrics come from) and at least one enabled [output plugin](/telegraf/v1.22/plugins/outputs/) (where the metrics go).
 
 The following example generates a sample configuration file with all available plugins, then uses `filter` flags to enable specific plugins.
-{{% note %}} For details on `filter` and other flags, see [Telegraf commands and flags](/{{< latest "telegraf" >}}/commands/). {{% /note %}}
+
+{{% note %}}
+For details on `filter` and other flags, see [Telegraf commands and flags](/telegraf/v1.22/commands/).
+{{% /note %}}
 
 1. Run the following command to create a configuration file:
    ```bash

--- a/content/telegraf/v1.22/release-notes-changelog.md
+++ b/content/telegraf/v1.22/release-notes-changelog.md
@@ -3420,7 +3420,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser](https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.22/release-notes-changelog.md
+++ b/content/telegraf/v1.22/release-notes-changelog.md
@@ -2632,14 +2632,14 @@ for details about the mapping.
 
 ### New input data formats (parsers)
 
-- [csv](/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
-- [grok](/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
-- [logfmt](/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
-- [wavefront](/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
+- [csv](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
+- [grok](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
+- [logfmt](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
+- [wavefront](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
 
 ### New output data formats (serializers)
 
-- [splunkmetric](/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
+- [splunkmetric](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
 
 ### Features
 
@@ -3420,7 +3420,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser](/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.9/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.9/about_the_project/release-notes-changelog.md
@@ -260,14 +260,14 @@ menu:
 
 ### New input data formats (parsers)
 
-- [csv](/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
-- [grok](/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
-- [logfmt](/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
-- [wavefront](/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
+- [csv](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/csv) - Contributed by @maxunt
+- [grok](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/grok/) - Contributed by @maxunt
+- [logfmt](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/logfmt/) - Contributed by @Ayrdrie & @maxunt
+- [wavefront](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/input/wavefront/) - Contributed by @puckpuck
 
 ### New output data formats (serializers)
 
-- [splunkmetric](/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
+- [splunkmetric](https://archive.docs.influxdata.com/telegraf/v1.8/data_formats/output/splunkmetric/) - Contributed by @ronnocol
 
 ### Features
 
@@ -1048,7 +1048,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser](/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.9/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.9/about_the_project/release-notes-changelog.md
@@ -1048,7 +1048,7 @@ These plugins will replace [udp_listener](https://github.com/influxdata/telegraf
 - Add [DMCache input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache).
 - Add support for precision in [HTTP Listener input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener).
 - Add `message_len_max` option to the [Kafka consumer input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer).
-- Add [collectd parser]((https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
+- Add [collectd parser](https://archive.docs.influxdata.com/telegraf/v1.3/concepts/data_formats_input/#collectd).
 - Simplify plugin testing without outputs.
 - Check signature in the [GitHub webhook input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/github).
 - Add [papertrail](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/papertrail) support to webhooks.

--- a/content/telegraf/v1.9/data_formats/output/graphite.md
+++ b/content/telegraf/v1.9/data_formats/output/graphite.md
@@ -10,7 +10,7 @@ menu:
 
 The Graphite data format is serialized from Telegraf metrics using either the
 template pattern or tag support method.  You can select between the two
-methods using the [`graphite_tag_support`](#graphite-tag-support) option.  When set, the tag support method is used,
+methods using the [`graphite_tag_support`](#graphite_tag_support) option.  When set, the tag support method is used,
 otherwise the [template pattern][templates]) option is used.
 
 ## Configuration

--- a/content/telegraf/v1.9/plugins/inputs.md
+++ b/content/telegraf/v1.9/plugins/inputs.md
@@ -1000,7 +1000,7 @@ The [HTTP Listener input plugin](https://github.com/influxdata/telegraf/blob/rel
 Line Protocol input data format](/telegraf/v1.9/data_formats/input/influx) ONLY (other [Telegraf input data formats](/telegraf/v1.9/data_formats/input/) are not supported).
 This plugin allows Telegraf to serve as a proxy or router for the `/write` endpoint of the InfluxDB HTTP API.
 
-> DEPRECATED as of version 1.9. Use either [HTTP Listener v2](#http-listener-v2) or the [InfluxDB Listener](#influxdb-v1-x)
+> DEPRECATED as of version 1.9. Use either [HTTP Listener v2](#http-listener-v2) or the [InfluxDB Listener](#influxdb-v1x)
 
 
 ### Jolokia

--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -277,7 +277,7 @@ input:
     description: |
       > The `inputs.cisco_telementry_gnmi` plugin was renamed to `inputs.gmni`
       in **Telegraf 1.15.0** to better reflect its general support for gNMI devices.
-      See the [gNMI plugin](#gnmi).
+      See the [gNMI plugin](#input-cisco_telemetry_gnmi).
 
       Cisco GNMI Telemetry input plugin consumes telemetry data similar to the GNMI specification.
       This GRPC-based protocol can utilize TLS for authentication and encryption.
@@ -2210,7 +2210,7 @@ output:
     tags: [linux, macos, windows, systems]
 
   - name: Execd
-    id: exec
+    id: execd
     description: |
         The Execd output plugin runs an external program as a daemon.
     introduced: 1.15.0

--- a/layouts/shortcodes/telegraf/plugins.html
+++ b/layouts/shortcodes/telegraf/plugins.html
@@ -13,7 +13,7 @@
   {{ if $supported }}
     <div class="plugin-card filter-item visible{{ if eq $minorVer $currentTelegrafVersion }} new{{ end }}" id="{{ .id }}" data-tags="{{ $type }} {{ lower $pluginTags }} {{ if eq $minorVer $currentTelegrafVersion }}new{{ end }} {{ if .deprecated }}deprecated{{ end }} ">
       <div class="info">
-        <h3 id="{{ .id }}">{{ .name }}</h3>
+        <h3 id="{{ $type }}-{{ .id }}">{{ .name }}</h3>
         {{ if in .tags "external"}}<p class="external">External</p>{{ end }}
         <p class="meta">
           Plugin ID: <code>{{ $type }}s.{{ .id }}</code><br/>


### PR DESCRIPTION
Closes #3863

- Updated the Telegraf plugin heading IDs to include the plugin type. So instead of `#exec`, it would be `#input-exec`
- Updated all links in the documentation that go to Telegraf plugins
- Fixed the link for the execd output plugin
- Fixed all Telegraf 404s and missing anchor link errors

---

- [x] Rebased/mergeable
