### PR TITLE
fix: replace download button with spec link.

### DIFF
--- a/api-docs/cloud/ref.yml
+++ b/api-docs/cloud/ref.yml
@@ -6038,7 +6038,15 @@ info:
   title: InfluxDB Cloud API Service
   description: >
     The InfluxDB v2 API provides a programmatic interface for all interactions
-    with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.
+    with InfluxDB.
+
+    Access the InfluxDB API using the `/api/v2/` endpoint.
+
+
+    This documentation is generated from the
+
+    [InfluxDB OpenAPI
+    specification](https://raw.githubusercontent.com/influxdata/openapi/master/contracts/ref/cloud.yml).
 openapi: 3.0.0
 paths:
   /api/v2:

--- a/api-docs/cloud/swaggerV1Compat.yml
+++ b/api-docs/cloud/swaggerV1Compat.yml
@@ -2,14 +2,20 @@ openapi: 3.0.0
 info:
   title: InfluxDB Cloud v1 compatibility API documentation
   version: 0.1.0
-  description: |
-    The InfluxDB 1.x compatibility `/write` and `/query` endpoints work with
-    InfluxDB 1.x client libraries and third-party integrations like Grafana
-    and others.
+  description: >
+    The InfluxDB 1.x compatibility /write and /query endpoints work with
+    InfluxDB 1.x client libraries and third-party integrations like Grafana and
+    others.
 
 
-    If you want to use the latest InfluxDB `/api/v2` API instead,
-    see the [InfluxDB v2 API documentation](/influxdb/cloud/api/).
+    If you want to use the latest InfluxDB /api/v2 API instead, see the
+    [InfluxDB v2 API documentation](/influxdb/cloud/api/).
+
+
+    This documentation is generated from the
+
+    [InfluxDB OpenAPI
+    specification](https://raw.githubusercontent.com/influxdata/openapi/master/contracts/swaggerV1Compat.yml).
 servers:
   - url: /
 paths:

--- a/api-docs/generate-api-docs.sh
+++ b/api-docs/generate-api-docs.sh
@@ -32,7 +32,7 @@ weight: 102
   v1frontmatter="---
 title: InfluxDB $titleVersion v1 compatibility API documentation
 description: >
-  The InfluxDB v1 compatibility API provides a programmatic interface for interactions with InfluxDB $titleVersion using InfluxDB v1.x compatibly endpoints.
+  The InfluxDB v1 compatibility API provides a programmatic interface for interactions with InfluxDB $titleVersion using InfluxDB v1.x compatibility endpoints.
 layout: api
 menu:
   $menu:
@@ -58,6 +58,7 @@ weight: 304
     --options.sortPropsAlphabetically \
     --options.menuToggle \
     --options.hideHostname \
+    --options.hideDownloadButton \
     --options.noAutoAuth \
     --templateOptions.version="$version" \
     --templateOptions.titleVersion="$titleVersion" \
@@ -69,6 +70,7 @@ weight: 304
     --title="InfluxDB $titleVersion v1 compatibility API documentation" \
     --options.sortPropsAlphabetically \
     --options.menuToggle \
+    --options.hideDownloadButton \
     --options.hideHostname \
     --options.noAutoAuth \
     --templateOptions.version="$version" \

--- a/api-docs/openapi/content/cloud/info.yml
+++ b/api-docs/openapi/content/cloud/info.yml
@@ -1,3 +1,7 @@
 title: InfluxDB Cloud API Service
 description: |
-    The InfluxDB v2 API provides a programmatic interface for all interactions with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.
+    The InfluxDB v2 API provides a programmatic interface for all interactions with InfluxDB.
+    Access the InfluxDB API using the `/api/v2/` endpoint.
+
+    This documentation is generated from the
+    [InfluxDB OpenAPI specification](https://raw.githubusercontent.com/influxdata/openapi/master/contracts/ref/cloud.yml).

--- a/api-docs/openapi/content/cloud/v1compat/info.yml
+++ b/api-docs/openapi/content/cloud/v1compat/info.yml
@@ -1,1 +1,8 @@
 title: InfluxDB Cloud v1 compatibility API documentation
+description: |
+  The InfluxDB 1.x compatibility /write and /query endpoints work with InfluxDB 1.x client libraries and third-party integrations like Grafana and others.
+
+  If you want to use the latest InfluxDB /api/v2 API instead, see the [InfluxDB v2 API documentation](/influxdb/cloud/api/).
+
+  This documentation is generated from the
+  [InfluxDB OpenAPI specification](https://raw.githubusercontent.com/influxdata/openapi/master/contracts/swaggerV1Compat.yml).

--- a/api-docs/openapi/content/v2.2/info.yml
+++ b/api-docs/openapi/content/v2.2/info.yml
@@ -1,4 +1,7 @@
 title: InfluxDB OSS API Service
-version: 2.0.0
+version: 2.2.0
 description: |
     The InfluxDB v2 API provides a programmatic interface for all interactions with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.
+
+    This documentation is generated from the
+    [InfluxDB OpenAPI specification](https://raw.githubusercontent.com/influxdata/openapi/docs-release/influxdb-oss/contracts/ref/oss.yml).

--- a/api-docs/openapi/content/v2.2/v1compat/info.yml
+++ b/api-docs/openapi/content/v2.2/v1compat/info.yml
@@ -1,1 +1,9 @@
 title: InfluxDB OSS v1 compatibility API documentation
+version: 2.2.0 v1 compatibility
+description: |
+  The InfluxDB 1.x compatibility /write and /query endpoints work with InfluxDB 1.x client libraries and third-party integrations like Grafana and others.
+
+  If you want to use the latest InfluxDB /api/v2 API instead, see the [InfluxDB v2 API documentation](/influxdb/v2.2/api/).
+
+  This documentation is generated from the
+  [InfluxDB OpenAPI specification](https://raw.githubusercontent.com/influxdata/openapi/docs-release/influxdb-oss/contracts/swaggerV1Compat.yml).

--- a/api-docs/v2.2/ref.yml
+++ b/api-docs/v2.2/ref.yml
@@ -6175,10 +6175,16 @@ components:
       type: apiKey
 info:
   title: InfluxDB OSS API Service
-  version: 2.0.0
+  version: 2.2.0
   description: >
     The InfluxDB v2 API provides a programmatic interface for all interactions
     with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.
+
+
+    This documentation is generated from the
+
+    [InfluxDB OpenAPI
+    specification](https://raw.githubusercontent.com/influxdata/openapi/docs-release/influxdb-oss/contracts/ref/oss.yml).
 openapi: 3.0.0
 paths:
   /api/v2:

--- a/api-docs/v2.2/swaggerV1Compat.yml
+++ b/api-docs/v2.2/swaggerV1Compat.yml
@@ -1,15 +1,21 @@
 openapi: 3.0.0
 info:
   title: InfluxDB OSS v1 compatibility API documentation
-  version: 0.1.0
-  description: |
-    The InfluxDB 1.x compatibility `/write` and `/query` endpoints work with
-    InfluxDB 1.x client libraries and third-party integrations like Grafana
-    and others.
+  version: 2.2.0 v1 compatibility
+  description: >
+    The InfluxDB 1.x compatibility /write and /query endpoints work with
+    InfluxDB 1.x client libraries and third-party integrations like Grafana and
+    others.
 
 
-    If you want to use the latest InfluxDB `/api/v2` API instead,
-    see the [InfluxDB v2 API documentation](/influxdb/cloud/api/).
+    If you want to use the latest InfluxDB /api/v2 API instead, see the
+    [InfluxDB v2 API documentation](/influxdb/v2.2/api/).
+
+
+    This documentation is generated from the
+
+    [InfluxDB OpenAPI
+    specification](https://raw.githubusercontent.com/influxdata/openapi/docs-release/influxdb-oss/contracts/swaggerV1Compat.yml).
 servers:
   - url: /
 paths:


### PR DESCRIPTION
- Closes #3810
- Remove download button and add a link to the spec source in Github.

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
