### PR TITLE
chore: modify curl requests for listing scripts

### DIFF
--- a/shared/text/api/v2.0/api-invokable-scripts/list.sh
+++ b/shared/text/api/v2.0/api-invokable-scripts/list.sh
@@ -3,4 +3,6 @@ curl -X 'GET' \
   --header "Authorization: Token ${INFLUX_TOKEN}" \
   --header 'accept: application/json' \
   --header 'Content-Type: application/json' \
-  --data-urlencode "org=${INFLUX_ORG}&limit=10"
+  --data-urlencode "org=${INFLUX_ORG}" \
+  --data-urlencode "limit=10"
+


### PR DESCRIPTION
Closes #

The `curl` request was incorrect for listing scripts. This was noticed by @nathanielc as he was only getting back 10 scripts even though he requested more than 10.

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
