### PR TITLE
comment out passive node until 1.9.8

### DIFF
--- a/content/enterprise_influxdb/v1.9/concepts/glossary.md
+++ b/content/enterprise_influxdb/v1.9/concepts/glossary.md
@@ -181,10 +181,10 @@ Related entries: [server](#server)
 
 The local server's nanosecond timestamp.
 
-## passive node (experimental)
+<!-- ## passive node (experimental)
 
 Passive nodes act as load balancers--they accept write calls, perform shard lookup and RPC calls (on active data nodes), and distribute writes to active data nodes. They do not own shards or accept writes. 
-**Note:**  This is an experimental feature.  
+**Note:**  This is an experimental feature.   -->
 
 <!--
 ## permission

--- a/content/enterprise_influxdb/v1.9/features/clustering-features.md
+++ b/content/enterprise_influxdb/v1.9/features/clustering-features.md
@@ -134,7 +134,7 @@ version 0.7.1.
 See [Backup and restore](/enterprise_influxdb/v1.9/administration/backup-and-restore/) for
 more information.
 
-## Passive node setup (experimental)
+<!-- ## Passive node setup (experimental)
 
 Passive nodes act as load balancers--they accept write calls, perform shard lookup and RPC calls (on active data nodes), and distribute writes to active data nodes. They do not own shards or accept writes.
 
@@ -149,4 +149,4 @@ For more inforrmation, see how to [add a passive node to a cluster](/enterprise_
 
 {{% note %}}
 **Note:**  This feature is experimental and available only in InfluxDB Enterprise.
-{{% /note %}}
+{{% /note %}} -->

--- a/content/enterprise_influxdb/v1.9/tools/influxd-ctl.md
+++ b/content/enterprise_influxdb/v1.9/tools/influxd-ctl.md
@@ -1097,7 +1097,7 @@ cluster-node-01:8091    1.9.x-c1.9.x    {}
 cluster-node-02:8091    1.9.x-c1.9.x    {}
 cluster-node-03:8091    1.9.x-c1.9.x    {}
 ```
-##### Show active and passive data nodes in a cluster
+<!-- ##### Show active and passive data nodes in a cluster
 
 In this example, the `show` command output displays that the cluster includes a passive data node.
 
@@ -1109,6 +1109,7 @@ ID	TCP Address               Version		    Labels	  Passive
 5	 cluster-node_1_1:8088		  1.9.6-c1.9.6  {}	      true
 6	 cluster-node_2_1:8088		  1.9.6-c1.9.6  {}	      false
 ```
+-->
 
 ### `show-shards`
 

--- a/content/enterprise_influxdb/v1.9/tools/influxd-ctl.md
+++ b/content/enterprise_influxdb/v1.9/tools/influxd-ctl.md
@@ -169,8 +169,8 @@ Resources: [Installation](/enterprise_influxdb/v1.9/installation/data_node_insta
 
 Optional arguments are in brackets.
 
-##### `[ -p ]`  
-Add a passive node to an Enterprise cluster.
+<!-- ##### `[ -p ]`  
+Add a passive node to an Enterprise cluster. -->
 
 ### Examples
 
@@ -196,12 +196,12 @@ $ influxd-ctl -bind cluster-meta-node-01:8091 add-data cluster-data-node:8088
 Added data node 3 at cluster-data-node:8088
 ```
 
-###### Add a passive node to a cluster
+<!-- ###### Add a passive node to a cluster
 **Passive nodes** act as load balancers--they accept write calls, perform shard lookup and RPC calls (on active data nodes), and distribute writes to active data nodes. They do not own shards or accept writes. If you are using passive nodes, they should be the write endpoint for all data ingest. A cluster can have multiple passive nodes.
 
 ```bash
 influxd-ctl add-data -p <passive-data-node-TCP-bind-address>
-```
+``` -->
 
 ### `add-meta`
 


### PR DESCRIPTION
See https://github.com/influxdata/docs-v2/issues/3926

commented out mentions of passive node due to v1.9.7 rollback:

https://docs.influxdata.com/enterprise_influxdb/features/clustering-features/

https://docs.influxdata.com/enterprise_influxdb/v1.9/tools/influxd-ctl/#add-data

https://docs.influxdata.com/enterprise_influxdb/v1.9/concepts/glossary/#passive-node-experimental

Uncomment once v1.9.8 is rolled out
