### PR TITLE
Added directory info in data node section for enterprise 1.7 and 1.8

### DIFF
--- a/content/enterprise_influxdb/v1.7/install-and-deploy/production_installation/data_node_installation.md
+++ b/content/enterprise_influxdb/v1.7/install-and-deploy/production_installation/data_node_installation.md
@@ -72,16 +72,19 @@ Ultimately, use entries similar to the following (hostnames and domain IP addres
 | A           | ```enterprise-data-01.mydomain.com``` | ```<Data_1_IP>``` |
 | A           | ```enterprise-data-02.mydomain.com``` | ```<Data_2_IP>``` |
 
-> **Verification steps:**
->
+   {{% note %}}
+**Verification steps:**
+
 Before proceeding with the installation, verify on each meta and data server that the other
 servers are resolvable. Here is an example set of shell commands using `ping`:
->
+```bash
     ping -qc 1 enterprise-meta-01
     ping -qc 1 enterprise-meta-02
     ping -qc 1 enterprise-meta-03
     ping -qc 1 enterprise-data-01
     ping -qc 1 enterprise-data-02
+```
+   {{% /note %}}
 
 We highly recommend that each server be able to resolve the IP from the hostname alone as shown here.
 Resolve any connectivity issues before proceeding with the installation.
@@ -254,7 +257,7 @@ to the cluster.
 >
 Issue the following command on any meta node:
 ```bash
-    influxd-ctl show
+influxd-ctl show
 ```
 The expected output is:
 

--- a/content/enterprise_influxdb/v1.7/install-and-deploy/production_installation/data_node_installation.md
+++ b/content/enterprise_influxdb/v1.7/install-and-deploy/production_installation/data_node_installation.md
@@ -18,15 +18,15 @@ If you have not set up your meta nodes, please visit
 [Installing meta nodes](/enterprise_influxdb//v1.7/install-and-deploy/production_installation/meta_node_installation/).
 Bad things can happen if you complete the following steps without meta nodes.
 
-<br>
 # Data node setup description and requirements
 
 The Production Installation process sets up two [data nodes](/enterprise_influxdb/v1.7/concepts/glossary#data-node)
 and each data node runs on its own server.
 You **must** have a minimum of two data nodes in a cluster.
 InfluxDB Enterprise clusters require at least two data nodes for high availability and redundancy.
-<br>
-Note: that there is no requirement for each data node to run on its own
+`hh`, `wal`, `data`, and `meta` directories are required on all data nodes and are created as part of the installation process.
+
+**Note:** There is no requirement for each data node to run on its own
 server.  However, best practices are to deploy each data node on a dedicated server.
 
 See the
@@ -114,26 +114,26 @@ For added security, follow these steps to verify the signature of your InfluxDB 
 
 1. Download and import InfluxData's public key:
 
-    ```
+    ```bash
     curl -s https://repos.influxdata.com/influxdb.key | gpg --import
     ```
 
 2. Download the signature file for the release by adding `.asc` to the download URL.
    For example:
 
-    ```
+    ```bash
     wget https://dl.influxdata.com/enterprise/releases/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm.asc
     ```
 
 3. Verify the signature with `gpg --verify`:
 
-    ```
+    ```bash
     gpg --verify influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm.asc influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
     ```
 
     The output from this command should include the following:
 
-    ```
+    ```bash
     gpg: Good signature from "InfluxDB Packaging Service <support@influxdb.com>" [unknown]
     ```
 
@@ -207,16 +207,18 @@ On systemd systems, enter:
 sudo systemctl start influxdb
 ```
 
-> **Verification steps:**
->
-Check to see that the process is running by entering:
->
-    ps aux | grep -v grep | grep influxdb
->
-You should see output similar to:
->
-    influxdb  2706  0.2  7.0 571008 35376 ?        Sl   15:37   0:16 /usr/bin/influxd -config /etc/influxdb/influxdb.conf
+**Verification steps:**
 
+Check to see that the process is running by entering:
+
+```bash
+ps aux | grep -v grep | grep influxdb
+```
+
+You should see output similar to:
+```bash
+influxdb  2706  0.2  7.0 571008 35376 ?        Sl   15:37   0:16 /usr/bin/influxd -config /etc/influxdb/influxdb.conf
+```
 
 If you do not see the expected output, the process is either not launching or is exiting prematurely. Check the [logs](/enterprise_influxdb/v1.7/administration/logs/) for error messages and verify the previous setup steps are complete.
 
@@ -251,25 +253,27 @@ to the cluster.
 > **Verification steps:**
 >
 Issue the following command on any meta node:
->
+```bash
     influxd-ctl show
->
+```
 The expected output is:
->
-    Data Nodes
-    ==========
-    ID   TCP Address               Version
-    4    enterprise-data-01:8088   {{< latest-patch >}}-c{{< latest-patch >}}
-    5    enterprise-data-02:8088   {{< latest-patch >}}-c{{< latest-patch >}}
 
->
-    Meta Nodes
-    ==========
-    TCP Address               Version
-    enterprise-meta-01:8091   {{< latest-patch >}}-c{{< latest-patch >}}
-    enterprise-meta-02:8091   {{< latest-patch >}}-c{{< latest-patch >}}
-    enterprise-meta-03:8091   {{< latest-patch >}}-c{{< latest-patch >}}
+```bash
 
+Data Nodes
+==========
+ID  TCP Address             Version         Labels
+4  cluster-node-01:8088    1.7.x-c1.7.x    {}
+5  cluster-node-02:8088    1.7.x-c1.7.x    {}
+
+Meta Nodes
+==========
+TCP Address             Version         Labels
+cluster-node-01:8091    1.7.x-c1.7.x    {}
+cluster-node-02:8091    1.7.x-c1.7.x    {}
+cluster-node-03:8091    1.7.x-c1.7.x    {}
+
+```
 
 The output should include every data node that was added to the cluster.
 The first data node added should have `ID=N`, where `N` is equal to one plus the number of meta nodes.

--- a/content/enterprise_influxdb/v1.8/install-and-deploy/production_installation/data_node_installation.md
+++ b/content/enterprise_influxdb/v1.8/install-and-deploy/production_installation/data_node_installation.md
@@ -24,8 +24,9 @@ The Production Installation process sets up two [data nodes](/enterprise_influxd
 and each data node runs on its own server.
 You **must** have a minimum of two data nodes in a cluster.
 InfluxDB Enterprise clusters require at least two data nodes for high availability and redundancy.
-<br>
-Note: that there is no requirement for each data node to run on its own
+`hh`, `wal`, `data`, and `meta` directories are required on all data nodes and are created as part of the installation process.
+
+**Note:** There is no requirement for each data node to run on its own
 server.  However, best practices are to deploy each data node on a dedicated server.
 
 See the
@@ -211,19 +212,17 @@ On systemd systems, enter:
 sudo systemctl start influxdb
 ```
 
-   {{% note %}}
 **Verification steps:**
 
 Check to see that the process is running by entering:
-
-    ps aux | grep -v grep | grep influxdb
-
+```bash
+ps aux | grep -v grep | grep influxdb
+```
 You should see output similar to:
-
-    influxdb  2706  0.2  7.0 571008 35376 ?        Sl   15:37   0:16 /usr/bin/influxd -config /etc/influxdb/influxdb.conf
-
-   {{% /note %}}
-
+```bash
+influxdb  2706  0.2  7.0 571008 35376 ?        Sl   15:37   0:16 /usr/bin/influxd -config /etc/influxdb/influxdb.conf
+```
+ 
 If you do not see the expected output, the process is either not launching or is exiting prematurely. Check the [logs](/enterprise_influxdb/v1.8/administration/logs/) for error messages and verify the previous setup steps are complete.
 
 If you see the expected output, repeat for the remaining data nodes.
@@ -252,29 +251,28 @@ The expected output is:
 Added data node y at enterprise-data-0x:8088
 ```
 
-   {{% note %}}
 **Verification steps:**
 
 Issue the following command on any meta node:
-
-    influxd-ctl show
-
+```bash
+influxd-ctl show
+```
 The expected output is:
+```bash
 
-    Data Nodes
-    ==========
-    ID   TCP Address               Version
-    4    enterprise-data-01:8088   {{< latest-patch >}}-c{{< latest-patch >}}
-    5    enterprise-data-02:8088   {{< latest-patch >}}-c{{< latest-patch >}}
+Data Nodes
+==========
+ID  TCP Address             Version         Labels
+4  cluster-node-01:8088    1.8.x-c1.8.x    {}
+5  cluster-node-02:8088    1.8.x-c1.8.x    {}
 
-
-    Meta Nodes
-    ==========
-    TCP Address               Version
-    enterprise-meta-01:8091   {{< latest-patch >}}-c{{< latest-patch >}}
-    enterprise-meta-02:8091   {{< latest-patch >}}-c{{< latest-patch >}}
-    enterprise-meta-03:8091   {{< latest-patch >}}-c{{< latest-patch >}}
-       {{% /note %}}
+Meta Nodes
+==========
+TCP Address             Version         Labels
+cluster-node-01:8091    1.8.x-c1.8.x    {}
+cluster-node-02:8091    1.8.x-c1.8.x    {}
+cluster-node-03:8091    1.8.x-c1.8.x    {}
+  ```
 
 The output should include every data node that was added to the cluster.
 The first data node added should have `ID=N`, where `N` is equal to one plus the number of meta nodes.


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/1490

1. added verbiage regarding which directories are created as part of the installation process 
2. cleaned up the formatting issues for both enterprise 1.7 and 1.8