### PR TITLE
fix: add offset param description

### DIFF
--- a/content/flux/v0.x/stdlib/universe/aggregatewindow.md
+++ b/content/flux/v0.x/stdlib/universe/aggregatewindow.md
@@ -30,7 +30,8 @@ aggregateWindow(
     column: "_value",
     timeSrc: "_stop",
     timeDst: "_time",
-    location: {offset: 0h, zone="UTC"},
+    location: timezone.utc,
+    offset: 0s,
     createEmpty: true,
 )
 ```
@@ -134,6 +135,7 @@ Default is piped-forward data ([`<-`](/flux/v0.x/spec/expressions/#pipe-expressi
 - [Use an aggregate function with default parameters](#use-an-aggregate-function-with-default-parameters)
 - [Specify parameters of the aggregate function](#specify-parameters-of-the-aggregate-function)
 - [Window and aggregate by calendar month](#window-and-aggregate-by-calendar-month)
+- [Window and aggregate by calendar week starting on Monday](#window-and-aggregate-by-calendar-week-starting-on-monday)
 
 #### Use an aggregate function with default parameters
 The following example uses the default parameters of the
@@ -221,6 +223,7 @@ data
     |> aggregateWindow(every: 1mo, fn: mean)
 ```
 
+{{< expand-wrapper >}}
 {{% expand "View input and output" %}}
 ##### Input data
 {{% flux/sample set="float" includeRange=true %}}
@@ -234,3 +237,47 @@ data
 | :------------------- | :------------------- | :------------------- | :-- | ----------------: |
 | 2021-01-01T00:00:00Z | 2021-01-01T00:01:00Z | 2021-01-01T00:01:00Z | t2  | 9.426666666666668 |
 {{% /expand %}}
+{{< /expand-wrapper >}}
+
+#### Window and aggregate by calendar week starting on Monday
+
+Flux increments weeks from the Unix epoch, which was a Thursday.
+Because of this, by default, all `1w` windows begin on Thursday.
+Use the `offset` parameter to shift the start of weekly windows to the desired day.
+
+| Week start | Offset |
+| :--------- | :----: |
+| Monday     |  -3d   |
+| Tuesday    |  -2d   |
+| Wednesday  |  -1d   |
+| Thursday   |   0d   |
+| Friday     |   1d   |
+| Saturday   |   2d   |
+| Sunday     |   3d   |
+
+```js
+import "sampledata"
+
+data = sampledata.float()
+    |> range(start: sampledata.start, stop: sampledata.stop)
+
+data
+    |> aggregateWindow(every: 1w, offset: -3d, fn: mean)
+```
+
+{{< expand-wrapper >}}
+{{% expand "View input and output" %}}
+##### Input data
+{{% flux/sample set="float" includeRange=true %}}
+
+#### Output data
+| _start               | _stop                | _time                | tag | _value |
+| :------------------- | :------------------- | :------------------- | :-- | -----: |
+| 2021-01-01T00:00:00Z | 2021-01-01T00:01:00Z | 2021-01-01T00:01:00Z | t1  |   8.88 |
+
+| _start               | _stop                | _time                | tag |            _value |
+| :------------------- | :------------------- | :------------------- | :-- | ----------------: |
+| 2021-01-01T00:00:00Z | 2021-01-01T00:01:00Z | 2021-01-01T00:01:00Z | t2  | 9.426666666666668 |
+
+{{% /expand %}}
+{{< /expand-wrapper >}}

--- a/content/flux/v0.x/stdlib/universe/aggregatewindow.md
+++ b/content/flux/v0.x/stdlib/universe/aggregatewindow.md
@@ -100,11 +100,17 @@ The "time destination" column to which time is copied for the aggregate record.
 Defaults to `"_time"`.
 
 ### location {data-type="record"}
+
 Location used to determine timezone.
 Default is the [`location` option](/flux/v0.x/stdlib/universe/#location).
 
 _Flux uses the timezone database (commonly referred to as "tz" or "zoneinfo")
 provided by the operating system._
+
+### offset {data-type="duration"}
+
+Duration to shift the window boundaries by. Default is `0s`.
+`offset` can be negative, indicating that the offset goes backwards in time.
 
 ### createEmpty {data-type="bool"}
 


### PR DESCRIPTION
Closes #https://github.com/influxdata/DAR/issues/301

Add offset parameter description to aggregateWindow.

<img width="938" alt="image" src="https://user-images.githubusercontent.com/101659702/173474409-f30bf107-6fc3-4bff-a3b4-bee0e02614c2.png">


- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
