### PR TITLE
Correct replication instructions to use bucket id

### DIFF
--- a/content/influxdb/v2.2/write-data/replication.md
+++ b/content/influxdb/v2.2/write-data/replication.md
@@ -76,8 +76,8 @@ Use InfluxDB replication streams (InfluxDB Edge Data Replication) to replicate t
     influx replication create \
       --name example-replication-stream-name \
       --remote-id 00xoXXXo0X0x \
-      --local-bucket Xxxo00Xx000o \
-      --remote-bucket 0xXXx00oooXx
+      --local-bucket-id Xxxo00Xx000o \
+      --remote-bucket-id 0xXXx00oooXx
     ```
 
 Once a replication stream is created, InfluxDB {{% oss-only %}}OSS{{% /oss-only %}}


### PR DESCRIPTION

Correct mistake in docs that use a command line argument that does not exist.
