### PR TITLE
adjust influxdb1.8 and telegraf to be consistent; add repo instructions for 2.2

### DIFF
--- a/content/influxdb/v1.8/introduction/install.md
+++ b/content/influxdb/v1.8/introduction/install.md
@@ -68,17 +68,19 @@ For Ubuntu/Debian users, add the InfluxData repository with the following comman
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```sh
-wget -qO- https://repos.influxdata.com/influxdb.key | gpg --dearmor > /etc/apt/trusted.gpg.d/influxdb.gpg
-export DISTRIB_ID=$(lsb_release -si); export DISTRIB_CODENAME=$(lsb_release -sc)
-echo "deb [signed-by=/etc/apt/trusted.gpg.d/influxdb.gpg] https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" > /etc/apt/sources.list.d/influxdb.list
+# influxdb.key GPG Fingerprint: 05CE15085FC09D18E99EFB22684A14CF2582E0C5
+wget -q https://repos.influxdata.com/influxdb.key
+echo '23a1c8836f0afc5ed24e0486339d7cc8f6790b83886c4c96995b88a061c5bb5d influxdb.key' | sha256sum -c && cat influxdb.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdb.gpg > /dev/null
+echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdb.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
 ```
 {{% /code-tab-content %}}
 
 {{% code-tab-content %}}
 ```sh
-curl -s https://repos.influxdata.com/influxdb.key | gpg --dearmor > /etc/apt/trusted.gpg.d/influxdb.gpg
-export DISTRIB_ID=$(lsb_release -si); export DISTRIB_CODENAME=$(lsb_release -sc)
-echo "deb [signed-by=/etc/apt/trusted.gpg.d/influxdb.gpg] https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" > /etc/apt/sources.list.d/influxdb.list
+# influxdb.key GPG Fingerprint: 05CE15085FC09D18E99EFB22684A14CF2582E0C5
+curl -s https://repos.influxdata.com/influxdb.key > influxdb.key
+echo '23a1c8836f0afc5ed24e0486339d7cc8f6790b83886c4c96995b88a061c5bb5d influxdb.key' | sha256sum -c && cat influxdb.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdb.gpg > /dev/null
+echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdb.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}

--- a/content/influxdb/v2.2/install.md
+++ b/content/influxdb/v2.2/install.md
@@ -212,20 +212,40 @@ For information about installing the `influx` CLI, see
 
 ### Install InfluxDB as a service with systemd
 
-1.  Download and install the appropriate `.deb` or `.rpm` file using a URL from the
-    [InfluxData downloads page](https://portal.influxdata.com/downloads/)
+1.  Download and install the appropriate `.deb` or `.rpm` file using either:
+    * `apt` or `yum` with the following commands:
+        ```sh
+        # influxdb.key GPG Fingerprint: 05CE15085FC09D18E99EFB22684A14CF2582E0C5
+
+        # Ubuntu/Debian
+        wget -q https://repos.influxdata.com/influxdb.key
+        echo '23a1c8836f0afc5ed24e0486339d7cc8f6790b83886c4c96995b88a061c5bb5d influxdb.key' | sha256sum -c && cat influxdb.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdb.gpg > /dev/null
+        echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdb.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
+        sudo apt-get update && sudo apt-get install influxdb2
+
+        # Red Hat/CentOS/Fedora
+        cat <<EOF | sudo tee /etc/yum.repos.d/influxdb.repo
+        [influxdb]
+        name = InfluxDB Repository - RHEL \$releasever
+        baseurl = https://repos.influxdata.com/rhel/\$releasever/\$basearch/stable
+        enabled = 1
+        gpgcheck = 1
+        gpgkey = https://repos.influxdata.com/influxdb.key
+        EOF
+        sudo yum install influxdb2
+        ```
+    * or via a URL from the [InfluxData downloads page](https://portal.influxdata.com/downloads/)
     with the following commands:
+        ```sh
+        # Ubuntu/Debian
+        wget https://dl.influxdata.com/influxdb/releases/influxdb2-{{< latest-patch >}}-xxx.deb
+        sudo dpkg -i influxdb2-{{< latest-patch >}}-xxx.deb
 
-    ```sh
-    # Ubuntu/Debian
-    wget https://dl.influxdata.com/influxdb/releases/influxdb2-{{< latest-patch >}}-xxx.deb
-    sudo dpkg -i influxdb2-{{< latest-patch >}}-xxx.deb
-
-    # Red Hat/CentOS/Fedora
-    wget https://dl.influxdata.com/influxdb/releases/influxdb2-{{< latest-patch >}}-xxx.rpm
-    sudo yum localinstall influxdb2-{{< latest-patch >}}-xxx.rpm
-    ```
-    _Use the exact filename of the download of `.rpm` package (for example, `influxdb2-{{< latest-patch >}}-amd64.rpm`)._
+        # Red Hat/CentOS/Fedora
+        wget https://dl.influxdata.com/influxdb/releases/influxdb2-{{< latest-patch >}}-xxx.rpm
+        sudo yum localinstall influxdb2-{{< latest-patch >}}-xxx.rpm
+        ```
+        _Use the exact filename of the download of `.rpm` package (for example, `influxdb2-{{< latest-patch >}}-amd64.rpm`)._
 
 2.  Start the InfluxDB service:
 

--- a/content/telegraf/v1.23/install.md
+++ b/content/telegraf/v1.23/install.md
@@ -68,16 +68,20 @@ Install Telegraf from the InfluxData repository with the following commands:
 
 {{% code-tab-content %}}
 ```bash
-wget -qO- https://repos.influxdata.com/influxdb.key | sudo tee /etc/apt/trusted.gpg.d/influxdb.asc >/dev/null
-echo "deb https://repos.influxdata.com/debian stable main" | sudo tee /etc/apt/sources.list.d/influxdb.list
+# influxdb.key GPG Fingerprint: 05CE15085FC09D18E99EFB22684A14CF2582E0C5
+wget -q https://repos.influxdata.com/influxdb.key
+echo '23a1c8836f0afc5ed24e0486339d7cc8f6790b83886c4c96995b88a061c5bb5d influxdb.key' | sha256sum -c && cat influxdb.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdb.gpg > /dev/null
+echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdb.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
 sudo apt-get update && sudo apt-get install telegraf
 ```
 {{% /code-tab-content %}}
 
 {{% code-tab-content %}}
 ```bash
-curl -s https://repos.influxdata.com/influxdb.key | sudo tee /etc/apt/trusted.gpg.d/influxdb.asc >/dev/null
-echo "deb https://repos.influxdata.com/debian stable main" | sudo tee /etc/apt/sources.list.d/influxdb.list
+# influxdb.key GPG Fingerprint: 05CE15085FC09D18E99EFB22684A14CF2582E0C5
+curl -s https://repos.influxdata.com/influxdb.key > influxdb.key
+echo '23a1c8836f0afc5ed24e0486339d7cc8f6790b83886c4c96995b88a061c5bb5d influxdb.key' | sha256sum -c && cat influxdb.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdb.gpg > /dev/null
+echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdb.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
 sudo apt-get update && sudo apt-get install telegraf
 ```
 {{% /code-tab-content %}}


### PR DESCRIPTION
The install instructions have been inconsistent within this repo as well as the downloads portal. In addition to being inconsistent, the instructions lacked security features with apt setup. The private https://github.com/influxdata/influxdb-customers/pull/919 PR adjusts the downloads portal to make all apt downloads consistent and secure. This PR:
* adjusts telegraf install to be like the downloads portal
* adjusts influxdb 1.8 install to be like the downloads portal
* adjusts influxdb 2.2 install to include apt/yum repo configuration (the preferred distribution method since it allows for users to get security updates easily). These instructions are consistent with the downloads portal

Tested all updates against Ubuntu 20.04 and CentOS 8.