### PR TITLE
2.3 security notes plus opt out of devel features

### DIFF
--- a/content/influxdb/v2.2/reference/release-notes/influxdb.md
+++ b/content/influxdb/v2.2/reference/release-notes/influxdb.md
@@ -8,6 +8,21 @@ menu:
 weight: 101
 ---
 
+## v2.3 [2022-06-17]
+
+...
+
+### Security updates
+
+Several security issues were fixed in dependencies and the toolchain used to build InfluxDB, including:
+- An issue in the `gopkg.in/yaml.v3` package import that could lead to a DoS in the templates service
+- An issue in the `github.com/buger/jsonparser` package import that could potentially lead to a DoS in storage authorization
+- The cumulative security fixes for [Go 1.18.3](https://go.dev/doc/devel/release#go1.18.minor) since Go 1.17.8 are included in this release.
+  This addresses the following issues that affect InfluxDB:
+  - An issue with processing large PEM files that could lead to a DoS in the templates service or flux connections using `to()`
+  - An issue in TLSv1.3 and a lack of ticket randomness
+  - A minor issue with `filepath.Clean()` on Windows
+
 ## v2.2 [2022-04-06]
 
 This release includes the following new [features](#features) and several [bug fixes](#bug-fixes).

--- a/content/influxdb/v2.2/security/disable-devel.md
+++ b/content/influxdb/v2.2/security/disable-devel.md
@@ -1,0 +1,19 @@
+---
+title: Disable development features
+seotitle: Disable development features in InfluxDB
+description: >
+  Disable development features that may not be desirable in production.
+weight: 105
+menu:
+  influxdb_2_2:
+    parent: Security & authorization
+influxdb/v2.2/tags: [security, development]
+---
+
+InfluxDB {{< current-version >}} defaults to enabling functionality that is
+particularly useful in developer environments but depending on
+site-requirements, may not be needed when running InfluxDB in production.
+
+- [Disable /debug/pprof](/influxdb/v2.2/reference/config-options/#pprof-disabled). This endpoint provides runtime profiling data.
+- [Disable /metrics](/influxdb/v2.2/reference/config-options/#metrics-disabled). This endpoint exposes [internal InfluxDB metrics](/influxdb/v2.2/reference/internals/metrics/).
+- [Disable UI](/influxdb/v2.2/reference/config-options/#ui-disabled). The user interface for InfluxDB.


### PR DESCRIPTION
* add placeholder 2.3 security section to the 2.2 release notes
* security/disable-devel.md: opt out of potentially unneeded features in prod

@kelseiv - since 2.3 isn't branched yet, here is what I propose doing for 2.3. Importantly, [content/influxdb/v2.2/reference/release-notes/influxdb.md](https://github.com/influxdata/docs-v2/compare/jdstrand/2.3-security-notes-plus-disable-devel?expand=1#diff-62b8b4b89648f2f0bf9968eb0d8fbe8510900e1c1179376368586f52cf230b84) just added a section at the top of the 2.2 page, so it is not mergeable as is. The other change is applicable to 2.2 and can be applied to master right away.