### PR TITLE
Updates to Install page Windows download

### DIFF
--- a/content/influxdb/v2.3/install.md
+++ b/content/influxdb/v2.3/install.md
@@ -411,13 +411,13 @@ For information about installing the `influx` CLI, see
 [Install and use the influx CLI](/influxdb/v2.3/tools/influx-cli/).
 {{% /note %}}
 
-<a class="btn download" href="https://dl.influxdata.com/influxdb/releases/influxdb2-{{< latest-patch >}}.x86_64.rpm" download >InfluxDB v{{< current-version >}} (Windows)</a>
+<a class="btn download" href="https://dl.influxdata.com/influxdb/releases/influxdb2-2.3.0-windows-amd64.zip" download >InfluxDB v{{< current-version >}} (Windows)</a>
 
 Expand the downloaded archive into `C:\Program Files\InfluxData\` and rename the files if desired.
 
 ```powershell
-> Expand-Archive .\influxdb2-{{< latest-patch >}}.x86_64.rpm -DestinationPath 'C:\Program Files\InfluxData\'
-> mv 'C:\Program Files\InfluxData\influxdb2-{{< latest-patch >}}.x86_64' 'C:\Program Files\InfluxData\influxdb'
+> Expand-Archive .\influxdb2-{{< latest-patch >}}-windows-amd64.zip -DestinationPath 'C:\Program Files\InfluxData\'
+> mv 'C:\Program Files\InfluxData\influxdb2-{{< latest-patch >}}-windows-amd64' 'C:\Program Files\InfluxData\influxdb'
 ```
 
 ## Networking ports

--- a/content/influxdb/v2.3/install.md
+++ b/content/influxdb/v2.3/install.md
@@ -411,13 +411,13 @@ For information about installing the `influx` CLI, see
 [Install and use the influx CLI](/influxdb/v2.3/tools/influx-cli/).
 {{% /note %}}
 
-<a class="btn download" href="https://dl.influxdata.com/influxdb/releases/influxdb2-{{< latest-patch >}}-windows-amd64.zip" download >InfluxDB v{{< current-version >}} (Windows)</a>
+<a class="btn download" href="https://dl.influxdata.com/influxdb/releases/influxdb2-{{< latest-patch >}}.x86_64.rpm" download >InfluxDB v{{< current-version >}} (Windows)</a>
 
 Expand the downloaded archive into `C:\Program Files\InfluxData\` and rename the files if desired.
 
 ```powershell
-> Expand-Archive .\influxdb2-{{< latest-patch >}}-windows-amd64.zip -DestinationPath 'C:\Program Files\InfluxData\'
-> mv 'C:\Program Files\InfluxData\influxdb2-{{< latest-patch >}}-windows-amd64' 'C:\Program Files\InfluxData\influxdb'
+> Expand-Archive .\influxdb2-{{< latest-patch >}}.x86_64.rpm -DestinationPath 'C:\Program Files\InfluxData\'
+> mv 'C:\Program Files\InfluxData\influxdb2-{{< latest-patch >}}.x86_64' 'C:\Program Files\InfluxData\influxdb'
 ```
 
 ## Networking ports


### PR DESCRIPTION
Closes #4056

This updates the Install InfluxDB Windows download button and the related links below it.

Should it be a concern that the Install page Windows download link does not exactly mirror the Windows link on the Download portal? 

Install page: https://dl.influxdata.com/influxdb/releases/influxdb2-2.3.0.x86_64.rpm
Downloads portal: https://dl.influxdata.com/influxdb/releases/influxdb2-2.3.0-windows-amd64.zip