### PR TITLE
Wrong function in docs

### DIFF
--- a/content/flux/v0.x/stdlib/universe/sum.md
+++ b/content/flux/v0.x/stdlib/universe/sum.md
@@ -63,7 +63,7 @@ Input data. Default is piped-forward data (`<-`).
 import "sampledata"
 
 sampledata.int()
-    |> stddev()
+    |> sum()
 
 ```
 
@@ -93,13 +93,14 @@ sampledata.int()
 
 #### Output data
 
-| *tag | _value            |
-| ---- | ----------------- |
-| t1   | 7.063993204979744 |
+| *tag | _value  |
+| ---- | ------- |
+| t1   | 51      |
 
-| *tag | _value            |
-| ---- | ----------------- |
-| t2   | 9.474527252938094 |
+| *tag | _value  |
+| ---- | ------- |
+| t2   | 53      |
+
 
 {{% /expand %}}
 {{< /expand-wrapper >}}


### PR DESCRIPTION
sum() function has an incorrect example.
Pointed out by community user : https://community.influxdata.com/t/sum-function-documentation/25631

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
