### PR TITLE
Flux auto-gen updates

### DIFF
--- a/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/_index.md
+++ b/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/_index.md
@@ -2,7 +2,7 @@
 title: tickscript package
 description: >
   The `tickscript` package provides functions to help migrate
-  Kapacitor [TICKscripts](https://docs.influxdata.com/kapacitor/latest/tick/) to Flux tasks.
+  Kapacitor [TICKscripts](/kapacitor/latest/tick/) to Flux tasks.
 menu:
   flux_0_x_ref:
     name: tickscript 
@@ -31,7 +31,7 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 ------------------------------------------------------------------------------->
 
 The `tickscript` package provides functions to help migrate
-Kapacitor [TICKscripts](https://docs.influxdata.com/kapacitor/latest/tick/) to Flux tasks.
+Kapacitor [TICKscripts](/kapacitor/latest/tick/) to Flux tasks.
 Import the `contrib/bonitoo-io/tickscript` package:
 
 ```js

--- a/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/alert.md
+++ b/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/alert.md
@@ -34,7 +34,7 @@ and writes them to the `statuses` measurement in the InfluxDB `_monitoring`
 system bucket.
 
 This function is comparable to
-TICKscript [`alert()`](https://docs.influxdata.com/kapacitor/v1.6/nodes/alert_node/).
+TICKscript [`alert()`](/kapacitor/v1.6/nodes/alert_node/).
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/deadman.md
+++ b/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/deadman.md
@@ -34,7 +34,7 @@ the InfluxDB `_monitoring` system bucket.
 For each input table containing a number of rows less than or equal to the specified threshold,
 the function assigns a `crit` value to the` _level` column.
 
-This function is comparable to [Kapacitor AlertNode deadman](https://docs.influxdata.com/kapacitor/latest/nodes/stream_node/#deadman).
+This function is comparable to [Kapacitor AlertNode deadman](/kapacitor/latest/nodes/stream_node/#deadman).
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/groupby.md
+++ b/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/groupby.md
@@ -29,7 +29,7 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `tickscript.groupBy()` groups results by the `_measurement` column and other specified columns.
 
-This function is comparable to [Kapacitor QueryNode .groupBy](https://docs.influxdata.com/kapacitor/latest/nodes/query_node/#groupby).
+This function is comparable to [Kapacitor QueryNode .groupBy](/kapacitor/latest/nodes/query_node/#groupby).
 
 **Note**: To group by time intervals, use `window()` or `tickscript.selectWindow()`.
 

--- a/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/join.md
+++ b/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/join.md
@@ -31,7 +31,7 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 `tickscript.join()` merges two input streams into a single output stream
 based on specified columns with equal values and appends a new measurement name.
 
-This function is comparable to [Kapacitor JoinNode](https://docs.influxdata.com/kapacitor/latest/nodes/join_node/).
+This function is comparable to [Kapacitor JoinNode](/kapacitor/latest/nodes/join_node/).
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/contrib/jsternberg/influxdb/from.md
+++ b/content/flux/v0.x/stdlib/contrib/jsternberg/influxdb/from.md
@@ -84,8 +84,8 @@ Durations are relative to `now()`.
 
 URL of the InfluxDB instance to query.
 
-See [InfluxDB OSS URLs](https://docs.influxdata.com/influxdb/latest/reference/urls/)
-or [InfluxDB Cloud regions](https://docs.influxdata.com/influxdb/cloud/reference/regions/).
+See [InfluxDB OSS URLs](/influxdb/latest/reference/urls/)
+or [InfluxDB Cloud regions](/influxdb/cloud/reference/regions/).
 
 ### org
 
@@ -95,7 +95,7 @@ Organization name.
 
 ### token
 
-InfluxDB [API token](https://docs.influxdata.com/influxdb/latest/security/tokens/).
+InfluxDB [API token](/influxdb/latest/security/tokens/).
 
 
 

--- a/content/flux/v0.x/stdlib/contrib/jsternberg/influxdb/select.md
+++ b/content/flux/v0.x/stdlib/contrib/jsternberg/influxdb/select.md
@@ -117,8 +117,8 @@ Records that evaluate to _null_ or `false` are not included in the output tables
 
 URL of the InfluxDB instance to query.
 
-See [InfluxDB OSS URLs](https://docs.influxdata.com/influxdb/latest/reference/urls/)
-or [InfluxDB Cloud regions](https://docs.influxdata.com/influxdb/cloud/reference/regions/).
+See [InfluxDB OSS URLs](/influxdb/latest/reference/urls/)
+or [InfluxDB Cloud regions](/influxdb/cloud/reference/regions/).
 
 ### org
 
@@ -128,7 +128,7 @@ Organization name.
 
 ### token
 
-InfluxDB [API token](https://docs.influxdata.com/influxdb/latest/security/tokens/).
+InfluxDB [API token](/influxdb/latest/security/tokens/).
 
 
 

--- a/content/flux/v0.x/stdlib/contrib/sranka/opsgenie/sendalert.md
+++ b/content/flux/v0.x/stdlib/contrib/sranka/opsgenie/sendalert.md
@@ -77,7 +77,7 @@ Opsgenie API URL. Defaults to `https://api.opsgenie.com/v2/alerts`.
 
 Opsgenie alias usee to de-deduplicate alerts.
 250 characters or less.
-Defaults to [message](https://docs.influxdata.com/flux/v0.x/stdlib/contrib/sranka/opsgenie/sendalert/#message).
+Defaults to [message](/flux/v0.x/stdlib/contrib/sranka/opsgenie/sendalert/#message).
 
 
 

--- a/content/flux/v0.x/stdlib/contrib/sranka/sensu/event.md
+++ b/content/flux/v0.x/stdlib/contrib/sranka/sensu/event.md
@@ -85,7 +85,7 @@ Sensu handlers to execute. Default is `[]`.
 
 ### status
 
-Event status code that indicates [state](https://docs.influxdata.com/flux/v0.x/stdlib/contrib/sranka/sensu/event/#state).
+Event status code that indicates [state](/flux/v0.x/stdlib/contrib/sranka/sensu/event/#state).
 Default is `0`.
 
 | Status code     | State                   |
@@ -98,7 +98,7 @@ Default is `0`.
 ### state
 
 Event state.
-Default is `"passing"` for `0` [status](https://docs.influxdata.com/flux/v0.x/stdlib/contrib/sranka/sensu/event/#status) and `"failing"` for other statuses.
+Default is `"passing"` for `0` [status](/flux/v0.x/stdlib/contrib/sranka/sensu/event/#status) and `"failing"` for other statuses.
 
 **Accepted values**:
 - `"failing"`

--- a/content/flux/v0.x/stdlib/experimental/array/_index.md
+++ b/content/flux/v0.x/stdlib/experimental/array/_index.md
@@ -36,7 +36,10 @@ Import the `experimental/array` package:
 import "experimental/array"
 ```
 
-**Deprecated**: This package is deprecated in favor of [`array`](https://docs.influxdata.com/flux/v0.x/stdlib/array/).
+{{% warn %}}
+#### Deprecated
+This package is deprecated in favor of [`array`](/flux/v0.x/stdlib/array/).
+{{% /warn %}}
 
 
 ## Functions

--- a/content/flux/v0.x/stdlib/experimental/array/concat.md
+++ b/content/flux/v0.x/stdlib/experimental/array/concat.md
@@ -31,7 +31,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `array.concat()` appends two arrays and returns a new array.
 
-**Deprecated**: `concat()` is deprecated in favor of [`concat()`](https://docs.influxdata.com/flux/v0.x/stdlib/array/concat).
+{{% warn %}}
+#### Deprecated
+`concat()` is deprecated in favor of [`concat()`](/flux/v0.x/stdlib/array/concat).
+{{% /warn %}}
 
 Neither input array is mutated and a new array is returned.
 

--- a/content/flux/v0.x/stdlib/experimental/array/filter.md
+++ b/content/flux/v0.x/stdlib/experimental/array/filter.md
@@ -33,7 +33,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 `array.filter()` iterates over an array, evaluates each element with a predicate function, and then returns
 a new array with only elements that match the predicate.
 
-**Deprecated**: `filter()` is deprecated in favor of [`filter()`](https://docs.influxdata.com/flux/v0.x/stdlib/array/filter).
+{{% warn %}}
+#### Deprecated
+`filter()` is deprecated in favor of [`filter()`](/flux/v0.x/stdlib/array/filter).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/array/from.md
+++ b/content/flux/v0.x/stdlib/experimental/array/from.md
@@ -30,8 +30,11 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `array.from()` constructs a table from an array of records.
 
-**Deprecated**: `from()` is deprecated in favor of [`from()`](https://docs.influxdata.com/flux/v0.x/stdlib/array/from).
+{{% warn %}}
+#### Deprecated
+`from()` is deprecated in favor of [`from()`](/flux/v0.x/stdlib/array/from).
 This function is available for backwards compatibility, but we recommend using the `array` package instead.
+{{% /warn %}}
 
 
 Each record in the array is converted into an output row or record. All

--- a/content/flux/v0.x/stdlib/experimental/array/map.md
+++ b/content/flux/v0.x/stdlib/experimental/array/map.md
@@ -33,7 +33,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 `array.map()` iterates over an array, applies a function to each element to produce a new element,
 and then returns a new array.
 
-**Deprecated**: `map()` is deprecated in favor of [`map()`](https://docs.influxdata.com/flux/v0.x/stdlib/array/map).
+{{% warn %}}
+#### Deprecated
+`map()` is deprecated in favor of [`map()`](/flux/v0.x/stdlib/array/map).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/_index.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/_index.md
@@ -37,7 +37,10 @@ Import the `experimental/bitwise` package:
 import "experimental/bitwise"
 ```
 
-**Deprecated**: This package is deprecated in favor of [`bitwise`](https://docs.influxdata.com/flux/v0.x/stdlib/bitwise/).
+{{% warn %}}
+#### Deprecated
+This package is deprecated in favor of [`bitwise`](/flux/v0.x/stdlib/bitwise/).
+{{% /warn %}}
 
 All integers are 64 bit integers.
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/sand.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/sand.md
@@ -28,7 +28,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `bitwise.sand()` performs the bitwise operation, `a AND b`, with integers.
 
-**Deprecated**: `sand` is deprecated in favor of [`bitwise`](https://docs.influxdata.com/flux/v0.x/stdlib/bitwise/sand/).
+{{% warn %}}
+#### Deprecated
+`sand` is deprecated in favor of [`bitwise`](/flux/v0.x/stdlib/bitwise/sand/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/sclear.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/sclear.md
@@ -30,7 +30,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 `bitwise.sclear()` performs the bitwise operation `a AND NOT b`.
 Both `a` and `b` are integers.
 
-**Deprecated**: `sclear` is deprecated in favor of [`bitwise`](https://docs.influxdata.com/flux/v0.x/stdlib/bitwise/sclear/).
+{{% warn %}}
+#### Deprecated
+`sclear` is deprecated in favor of [`bitwise`](/flux/v0.x/stdlib/bitwise/sclear/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/slshift.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/slshift.md
@@ -30,7 +30,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 `bitwise.slshift()` shifts the bits in `a` left by `b` bits.
 Both `a` and `b` are integers.
 
-**Deprecated**: `slshift` is deprecated in favor of [`bitwise`](https://docs.influxdata.com/flux/v0.x/stdlib/bitwise/slshift/).
+{{% warn %}}
+#### Deprecated
+`slshift` is deprecated in favor of [`bitwise`](/flux/v0.x/stdlib/bitwise/slshift/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/snot.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/snot.md
@@ -28,7 +28,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `bitwise.snot()` inverts every bit in `a`, an integer.
 
-**Deprecated**: `snot` is deprecated in favor of [`bitwise`](https://docs.influxdata.com/flux/v0.x/stdlib/bitwise/snot/).
+{{% warn %}}
+#### Deprecated
+`snot` is deprecated in favor of [`bitwise`](/flux/v0.x/stdlib/bitwise/snot/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/sor.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/sor.md
@@ -28,7 +28,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `bitwise.sor()` performs the bitwise operation, `a OR b`, with integers.
 
-**Deprecated**: `sor` is deprecated in favor of [`bitwise`](https://docs.influxdata.com/flux/v0.x/stdlib/bitwise/sor/).
+{{% warn %}}
+#### Deprecated
+`sor` is deprecated in favor of [`bitwise`](/flux/v0.x/stdlib/bitwise/sor/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/srshift.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/srshift.md
@@ -30,7 +30,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 `bitwise.srshift()` shifts the bits in `a` right by `b` bits.
 Both `a` and `b` are integers.
 
-**Deprecated**: `srshift` is deprecated in favor of [`bitwise`](https://docs.influxdata.com/flux/v0.x/stdlib/bitwise/srshift/).
+{{% warn %}}
+#### Deprecated
+`srshift` is deprecated in favor of [`bitwise`](/flux/v0.x/stdlib/bitwise/srshift/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/sxor.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/sxor.md
@@ -28,7 +28,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `bitwise.sxor()` performs the bitwise operation, `a XOR b`, with integers.
 
-**Deprecated**: `sxor` is deprecated in favor of [`bitwise`](https://docs.influxdata.com/flux/v0.x/stdlib/bitwise/sxor/).
+{{% warn %}}
+#### Deprecated
+`sxor` is deprecated in favor of [`bitwise`](/flux/v0.x/stdlib/bitwise/sxor/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/uand.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/uand.md
@@ -28,7 +28,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `bitwise.uand()` performs the bitwise operation, `a AND b`, with unsigned integers.
 
-**Deprecated**: `uand` is deprecated in favor of [`bitwise`](https://docs.influxdata.com/flux/v0.x/stdlib/bitwise/uand/).
+{{% warn %}}
+#### Deprecated
+`uand` is deprecated in favor of [`bitwise`](/flux/v0.x/stdlib/bitwise/uand/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/uclear.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/uclear.md
@@ -28,7 +28,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `bitwise.uclear()` performs the bitwise operation `a AND NOT b`, with unsigned integers.
 
-**Deprecated**: `uclear` is deprecated in favor of [`bitwise`](https://docs.influxdata.com/flux/v0.x/stdlib/bitwise/uclear/).
+{{% warn %}}
+#### Deprecated
+`uclear` is deprecated in favor of [`bitwise`](/flux/v0.x/stdlib/bitwise/uclear/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/ulshift.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/ulshift.md
@@ -30,7 +30,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 `bitwise.ulshift()` shifts the bits in `a` left by `b` bits.
 Both `a` and `b` are unsigned integers.
 
-**Deprecated**: `ulshift` is deprecated in favor of [`bitwise`](https://docs.influxdata.com/flux/v0.x/stdlib/bitwise/ulshift/).
+{{% warn %}}
+#### Deprecated
+`ulshift` is deprecated in favor of [`bitwise`](/flux/v0.x/stdlib/bitwise/ulshift/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/unot.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/unot.md
@@ -28,7 +28,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `bitwise.unot()` inverts every bit in `a`, an unsigned integer.
 
-**Deprecated**: `unot` is deprecated in favor of [`bitwise`](https://docs.influxdata.com/flux/v0.x/stdlib/bitwise/unot/).
+{{% warn %}}
+#### Deprecated
+`unot` is deprecated in favor of [`bitwise`](/flux/v0.x/stdlib/bitwise/unot/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/uor.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/uor.md
@@ -28,7 +28,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `bitwise.uor()` performs the bitwise operation, `a OR b`, with unsigned integers.
 
-**Deprecated**: `uor` is deprecated in favor of [`bitwise`](https://docs.influxdata.com/flux/v0.x/stdlib/bitwise/uor/).
+{{% warn %}}
+#### Deprecated
+`uor` is deprecated in favor of [`bitwise`](/flux/v0.x/stdlib/bitwise/uor/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/urshift.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/urshift.md
@@ -30,7 +30,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 `bitwise.urshift()` shifts the bits in `a` right by `b` bits.
 Both `a` and `b` are unsigned integers.
 
-**Deprecated**: `urshift` is deprecated in favor of [`bitwise`](https://docs.influxdata.com/flux/v0.x/stdlib/bitwise/urshift/).
+{{% warn %}}
+#### Deprecated
+`urshift` is deprecated in favor of [`bitwise`](/flux/v0.x/stdlib/bitwise/urshift/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/uxor.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/uxor.md
@@ -28,7 +28,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `bitwise.uxor()` performs the bitwise operation, `a XOR b`, with unsigned integers.
 
-**Deprecated**: `uxor` is deprecated in favor of [`bitwise`](https://docs.influxdata.com/flux/v0.x/stdlib/bitwise/uxor/).
+{{% warn %}}
+#### Deprecated
+`uxor` is deprecated in favor of [`bitwise`](/flux/v0.x/stdlib/bitwise/uxor/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/csv/from.md
+++ b/content/flux/v0.x/stdlib/experimental/csv/from.md
@@ -1,7 +1,7 @@
 ---
 title: csv.from() function
 description: >
-  `csv.from()` retrieves [annotated CSV](https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/) **from a URL**.
+  `csv.from()` retrieves [annotated CSV](/influxdb/latest/reference/syntax/annotated-csv/) **from a URL**.
 menu:
   flux_0_x_ref:
     name: csv.from
@@ -26,9 +26,12 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 ------------------------------------------------------------------------------->
 
-`csv.from()` retrieves [annotated CSV](https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/) **from a URL**.
+`csv.from()` retrieves [annotated CSV](/influxdb/latest/reference/syntax/annotated-csv/) **from a URL**.
 
-**Deprecated**: `csv.from()` is deprecated in favor of a combination of [`requests.get()`](https://docs.influxdata.com/flux/v0.x/stdlib/http/requests/get/) and [`csv.from()`](https://docs.influxdata.com/flux/v0.x/stdlib/csv/from/).
+{{% warn %}}
+#### Deprecated
+`csv.from()` is deprecated in favor of a combination of [`requests.get()`](/flux/v0.x/stdlib/http/requests/get/) and [`csv.from()`](/flux/v0.x/stdlib/csv/from/).
+{{% /warn %}}
 
 **Note:** Experimental `csv.from()` is an alternative to the standard
 `csv.from()` function.

--- a/content/flux/v0.x/stdlib/experimental/geo/_index.md
+++ b/content/flux/v0.x/stdlib/experimental/geo/_index.md
@@ -63,7 +63,7 @@ Geometry Library to generate `s2_cell_id` tags.
 Specify your [S2 Cell ID level](https://s2geometry.io/resources/s2cell_statistics.html).
 
 **Note:** To filter more quickly, use higher S2 Cell ID levels, but know that
-higher levels increase [series cardinality](https://docs.influxdata.com/influxdb/latest/reference/glossary/#series-cardinality).
+higher levels increase [series cardinality](/influxdb/latest/reference/glossary/#series-cardinality).
 
 Language-specific implementations of the S2 Geometry Library provide methods for
 generating S2 Cell ID tokens. For example:

--- a/content/flux/v0.x/stdlib/experimental/http/_index.md
+++ b/content/flux/v0.x/stdlib/experimental/http/_index.md
@@ -37,7 +37,10 @@ Import the `experimental/http` package:
 import "experimental/http"
 ```
 
-**Deprecated**: This package is deprecated in favor of [`requests`](https://docs.influxdata.com/flux/v0.x/stdlib/http/requests/).
+{{% warn %}}
+#### Deprecated
+This package is deprecated in favor of [`requests`](/flux/v0.x/stdlib/http/requests/).
+{{% /warn %}}
 
 
 ## Functions

--- a/content/flux/v0.x/stdlib/experimental/http/get.md
+++ b/content/flux/v0.x/stdlib/experimental/http/get.md
@@ -31,7 +31,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 `http.get()` submits an HTTP GET request to the specified URL and returns the HTTP
 status code, response body, and response headers.
 
-**Deprecated**: `http.get()` is deprecated in favor of [`requests.get()`](https://docs.influxdata.com/flux/v0.x/stdlib/http/requests/get/).
+{{% warn %}}
+#### Deprecated
+`http.get()` is deprecated in favor of [`requests.get()`](/flux/v0.x/stdlib/http/requests/get/).
+{{% /warn %}}
 
 ## Response format
 `http.get()` returns a record with the following properties:

--- a/content/flux/v0.x/stdlib/experimental/http/requests/_index.md
+++ b/content/flux/v0.x/stdlib/experimental/http/requests/_index.md
@@ -37,9 +37,12 @@ Import the `experimental/http/requests` package:
 import "experimental/http/requests"
 ```
 
-**Deprecated**: This package is deprecated in favor of [`requests`](https://docs.influxdata.com/flux/v0.x/stdlib/http/requests/).
+{{% warn %}}
+#### Deprecated
+This package is deprecated in favor of [`requests`](/flux/v0.x/stdlib/http/requests/).
 Do not mix usage of this experimental package with the `requests` package as the `defaultConfig` is not shared between the two packages.
 This experimental package is completely superceded by the `requests` package so there should be no need to mix them.
+{{% /warn %}}
 
 ## Options
 
@@ -58,7 +61,7 @@ option requests.defaultConfig = {
 Changing this config will affect all other packages using the requests package.
 To change the config for a single request, pass a new config directly into the corresponding function.
 
-**Deprecated**: `defautlConfig` is deprecated in favor of [`requests`](https://docs.influxdata.com/flux/v0.x/stdlib/http/requests/#options).
+**Deprecated**: `defautlConfig` is deprecated in favor of [`requests`](/flux/v0.x/stdlib/http/requests/#options).
 Do not mix usage of this experimental package with the `requests` package as the `defaultConfig` is not shared between the two packages.
 
 

--- a/content/flux/v0.x/stdlib/experimental/http/requests/do.md
+++ b/content/flux/v0.x/stdlib/experimental/http/requests/do.md
@@ -29,7 +29,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `requests.do()` makes an http request.
 
-**Deprecated**: `do` is deprecated in favor of [`requests`](https://docs.influxdata.com/flux/v0.x/stdlib/http/requests/do/).
+{{% warn %}}
+#### Deprecated
+`do` is deprecated in favor of [`requests`](/flux/v0.x/stdlib/http/requests/do/).
+{{% /warn %}}
 
 The returned response contains the following properties:
 

--- a/content/flux/v0.x/stdlib/experimental/http/requests/get.md
+++ b/content/flux/v0.x/stdlib/experimental/http/requests/get.md
@@ -29,7 +29,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `requests.get()` makes a http GET request. This identical to calling `request.do(method: "GET", ...)`.
 
-**Deprecated**: `get` is deprecated in favor of [`requests`](https://docs.influxdata.com/flux/v0.x/stdlib/http/requests/get/).
+{{% warn %}}
+#### Deprecated
+`get` is deprecated in favor of [`requests`](/flux/v0.x/stdlib/http/requests/get/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/http/requests/peek.md
+++ b/content/flux/v0.x/stdlib/experimental/http/requests/peek.md
@@ -28,7 +28,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `requests.peek()` converts an HTTP response into a table for easy inspection.
 
-**Deprecated**: `peek` is deprecated in favor of [`requests`](https://docs.influxdata.com/flux/v0.x/stdlib/http/requests/peek/).
+{{% warn %}}
+#### Deprecated
+`peek` is deprecated in favor of [`requests`](/flux/v0.x/stdlib/http/requests/peek/).
+{{% /warn %}}
 
 The output table includes the following columns:
  - **body** with the response body as a string

--- a/content/flux/v0.x/stdlib/experimental/http/requests/post.md
+++ b/content/flux/v0.x/stdlib/experimental/http/requests/post.md
@@ -29,7 +29,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `requests.post()` makes a http POST request. This identical to calling `request.do(method: "POST", ...)`.
 
-**Deprecated**: `post` is deprecated in favor of [`requests`](https://docs.influxdata.com/flux/v0.x/stdlib/http/requests/post/).
+{{% warn %}}
+#### Deprecated
+`post` is deprecated in favor of [`requests`](/flux/v0.x/stdlib/http/requests/post/).
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/experimental/influxdb/api.md
+++ b/content/flux/v0.x/stdlib/experimental/influxdb/api.md
@@ -81,7 +81,7 @@ Default is `""`.
 
 ### token
 
-[InfluxDB API token](https://docs.influxdata.com/influxdb/cloud/security/tokens/)
+[InfluxDB API token](/influxdb/cloud/security/tokens/)
 _(Required when executed outside of InfluxDB)_.
 Default is `""`.
 

--- a/content/flux/v0.x/stdlib/experimental/join.md
+++ b/content/flux/v0.x/stdlib/experimental/join.md
@@ -31,9 +31,12 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `experimental.join()` joins two streams of tables on the **group key and `_time` column**.
 
-**Deprecated**: `experimental.join()` is deprecated in favor of [`join.time()`](https://docs.influxdata.com/flux/v0.x/stdlib/join/time/).
-The [`join` package](https://docs.influxdata.com/flux/v0.x/stdlib/join/) provides support
+{{% warn %}}
+#### Deprecated
+`experimental.join()` is deprecated in favor of [`join.time()`](/flux/v0.x/stdlib/join/time/).
+The [`join` package](/flux/v0.x/stdlib/join/) provides support
 for multiple join methods.
+{{% /warn %}}
 
 Use the `fn` parameter to map new output tables using values from input tables.
 

--- a/content/flux/v0.x/stdlib/experimental/prometheus/histogramquantile.md
+++ b/content/flux/v0.x/stdlib/experimental/prometheus/histogramquantile.md
@@ -29,7 +29,7 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `prometheus.histogramQuantile()` calculates a quantile on a set of Prometheus histogram values.
 
-This function supports [Prometheus metric parsing formats](https://docs.influxdata.com/influxdb/latest/reference/prometheus-metrics/)
+This function supports [Prometheus metric parsing formats](/influxdb/latest/reference/prometheus-metrics/)
 used by `prometheus.scrape()`, the Telegraf `promtheus` input plugin, and
 InfluxDB scrapers available in InfluxDB OSS.
 
@@ -51,7 +51,7 @@ Quantile to compute. Must be a float value between 0.0 and 1.0.
 
 ### metricVersion
 
-[Prometheus metric parsing format](https://docs.influxdata.com/influxdb/latest/reference/prometheus-metrics/)
+[Prometheus metric parsing format](/influxdb/latest/reference/prometheus-metrics/)
 used to parse queried Prometheus data.
 Available versions are `1` and `2`.
 Default is `2`.

--- a/content/flux/v0.x/stdlib/experimental/to.md
+++ b/content/flux/v0.x/stdlib/experimental/to.md
@@ -31,8 +31,11 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 `experimental.to()` writes _pivoted_ data to an InfluxDB 2.x or InfluxDB Cloud bucket.
 
-**Deprecated**: `experimental.to()` is deprecated in favor of [`wideTo()`](/flux/v0.x/stdlib/influxdata/influxdb/wideto/),
+{{% warn %}}
+#### Deprecated
+`experimental.to()` is deprecated in favor of [`wideTo()`](/flux/v0.x/stdlib/influxdata/influxdb/wideto/),
 which is an equivalent function.
+{{% /warn %}}
 
 #### Requirements and behavior
 - Requires both a `_time` and a `_measurement` column.
@@ -80,8 +83,8 @@ _`bucket` and `bucketID` are mutually exclusive_.
 
 URL of the InfluxDB instance to write to.
 
-See [InfluxDB Cloud regions](https://docs.influxdata.com/influxdb/cloud/reference/regions/)
-or [InfluxDB OSS URLs](https://docs.influxdata.com/influxdb/latest/reference/urls/).
+See [InfluxDB Cloud regions](/influxdb/cloud/reference/regions/)
+or [InfluxDB OSS URLs](/influxdb/latest/reference/urls/).
 `host` is required when writing to a remote InfluxDB instance.
 If specified, `token` is also required.
 

--- a/content/flux/v0.x/stdlib/experimental/usage/from.md
+++ b/content/flux/v0.x/stdlib/experimental/usage/from.md
@@ -77,7 +77,7 @@ Latest time to include in results.
 
 ### host
 
-[InfluxDB Cloud region URL](https://docs.influxdata.com/influxdb/cloud/reference/regions/).
+[InfluxDB Cloud region URL](/influxdb/cloud/reference/regions/).
 Default is `""`.
 
 _(Required if executed outside of your InfluxDB Cloud organization or region)_.
@@ -90,7 +90,7 @@ _(Required if executed outside of your InfluxDB Cloud organization or region)_.
 
 ### token
 
-InfluxDB Cloud [API token](https://docs.influxdata.com/influxdb/cloud/security/tokens/).
+InfluxDB Cloud [API token](/influxdb/cloud/security/tokens/).
 Default is `""`.
 
 _(Required if executed outside of your InfluxDB Cloud organization or region)_.

--- a/content/flux/v0.x/stdlib/experimental/usage/limits.md
+++ b/content/flux/v0.x/stdlib/experimental/usage/limits.md
@@ -60,7 +60,7 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 ### host
 
-[InfluxDB Cloud region URL](https://docs.influxdata.com/influxdb/cloud/reference/regions/).
+[InfluxDB Cloud region URL](/influxdb/cloud/reference/regions/).
 Default is `""`.
 
 _(Required if executed outside of your InfluxDB Cloud organization or region)_.
@@ -73,7 +73,7 @@ _(Required if executed outside of your InfluxDB Cloud organization or region)_.
 
 ### token
 
-InfluxDB Cloud [API token](https://docs.influxdata.com/influxdb/cloud/security/tokens/).
+InfluxDB Cloud [API token](/influxdb/cloud/security/tokens/).
 Default is `""`.
 
 _(Required if executed outside of your InfluxDB Cloud organization or region)_.

--- a/content/flux/v0.x/stdlib/influxdata/influxdb/buckets.md
+++ b/content/flux/v0.x/stdlib/influxdata/influxdb/buckets.md
@@ -69,8 +69,8 @@ _`org` and `orgID` are mutually exclusive_.
 
 URL of the InfluxDB instance.
 
-See [InfluxDB Cloud regions](https://docs.influxdata.com/influxdb/cloud/reference/regions/)
-or [InfluxDB OSS URLs](https://docs.influxdata.com/influxdb/latest/reference/urls/).
+See [InfluxDB Cloud regions](/influxdb/cloud/reference/regions/)
+or [InfluxDB OSS URLs](/influxdb/latest/reference/urls/).
 _`host` is required when `org` or `orgID` are specified._
 
 ### token

--- a/content/flux/v0.x/stdlib/influxdata/influxdb/cardinality.md
+++ b/content/flux/v0.x/stdlib/influxdata/influxdb/cardinality.md
@@ -80,8 +80,8 @@ String-encoded organization ID.
 
 URL of the InfluxDB instance to query.
 
-See [InfluxDB Cloud regions](https://docs.influxdata.com/influxdb/cloud/reference/regions/)
-or [InfluxDB OSS URLs](https://docs.influxdata.com/influxdb/latest/reference/urls/).
+See [InfluxDB Cloud regions](/influxdb/cloud/reference/regions/)
+or [InfluxDB OSS URLs](/influxdb/latest/reference/urls/).
 
 ### token
 

--- a/content/flux/v0.x/stdlib/influxdata/influxdb/from.md
+++ b/content/flux/v0.x/stdlib/influxdata/influxdb/from.md
@@ -78,8 +78,8 @@ _`bucket` and `bucketID` are mutually exclusive_.
 
 URL of the InfluxDB instance to query.
 
-See [InfluxDB Cloud regions](https://docs.influxdata.com/influxdb/cloud/reference/regions/)
-or [InfluxDB OSS URLs](https://docs.influxdata.com/influxdb/latest/reference/urls/).
+See [InfluxDB Cloud regions](/influxdb/cloud/reference/regions/)
+or [InfluxDB OSS URLs](/influxdb/latest/reference/urls/).
 
 ### org
 

--- a/content/flux/v0.x/stdlib/influxdata/influxdb/monitor/_index.md
+++ b/content/flux/v0.x/stdlib/influxdata/influxdb/monitor/_index.md
@@ -66,9 +66,11 @@ option monitor.write = (tables=<-) => tables |> experimental.to(bucket: bucket)
 
 `log` persists notification events to an InfluxDB bucket.
 
+
 ### write
 
 `write` persists check statuses to an InfluxDB bucket.
+
 
 
 ## Functions

--- a/content/flux/v0.x/stdlib/influxdata/influxdb/to.md
+++ b/content/flux/v0.x/stdlib/influxdata/influxdb/to.md
@@ -39,7 +39,7 @@ structure that includes, at a minimum, the following columns:
 - `_value`
 
 All other columns are written to InfluxDB as
-[tags](https://docs.influxdata.com/influxdb/cloud/reference/key-concepts/data-elements/#tags).
+[tags](/influxdb/cloud/reference/key-concepts/data-elements/#tags).
 
 **Note**: `to()` drops rows with null `_time` values and does not write them
 to InfluxDB.
@@ -88,8 +88,8 @@ _`bucket` and `bucketID` are mutually exclusive_.
 
 URL of the InfluxDB instance to write to.
 
-See [InfluxDB Cloud regions](https://docs.influxdata.com/influxdb/cloud/reference/regions/)
-or [InfluxDB OSS URLs](https://docs.influxdata.com/influxdb/latest/reference/urls/).
+See [InfluxDB Cloud regions](/influxdb/cloud/reference/regions/)
+or [InfluxDB OSS URLs](/influxdb/latest/reference/urls/).
 `host` is required when writing to a remote InfluxDB instance.
 If specified, `token` is also required.
 

--- a/content/flux/v0.x/stdlib/influxdata/influxdb/v1/fieldsascols.md
+++ b/content/flux/v0.x/stdlib/influxdata/influxdb/v1/fieldsascols.md
@@ -34,7 +34,10 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 on `_field` and `_time` columns to align fields within each input table that
 have the same timestamp.
 
-**Deprecated**: See influxdata/influxdata/schema.fieldsAsCols.
+{{% warn %}}
+#### Deprecated
+See influxdata/influxdata/schema.fieldsAsCols.
+{{% /warn %}}
 
 ##### Function type signature
 

--- a/content/flux/v0.x/stdlib/influxdata/influxdb/wideto.md
+++ b/content/flux/v0.x/stdlib/influxdata/influxdb/wideto.md
@@ -78,8 +78,8 @@ _`bucket` and `bucketID` are mutually exclusive_.
 
 URL of the InfluxDB instance to write to.
 
-See [InfluxDB Cloud regions](https://docs.influxdata.com/influxdb/cloud/reference/regions/)
-or [InfluxDB OSS URLs](https://docs.influxdata.com/influxdb/latest/reference/urls/).
+See [InfluxDB Cloud regions](/influxdb/cloud/reference/regions/)
+or [InfluxDB OSS URLs](/influxdb/latest/reference/urls/).
 `host` is required when writing to a remote InfluxDB instance.
 If specified, `token` is also required.
 

--- a/content/flux/v0.x/stdlib/join/full.md
+++ b/content/flux/v0.x/stdlib/join/full.md
@@ -86,7 +86,7 @@ the uncertainty of a full outer join.
 `v_left` and `v_right` still use values from `l` and `r` directly, because we expect
 them to sometimes be null in the output table.
 
-For more information about the behavior of outer joins, see the [Outer joins](https://docs.influxdata.com/flux/v0.x/stdlib/join/#outer-joins)
+For more information about the behavior of outer joins, see the [Outer joins](/flux/v0.x/stdlib/join/#outer-joins)
 section in the `join` package documentation.
 
 ```js

--- a/content/flux/v0.x/stdlib/join/left.md
+++ b/content/flux/v0.x/stdlib/join/left.md
@@ -79,7 +79,7 @@ default record. Because `r` is more likely to contain null values, the output re
 is built almost entirely from proprties of `l`, with the exception of `v_right`, which
 we expect to sometimes be null.
 
-For more information about the behavior of outer joins, see the [Outer joins](https://docs.influxdata.com/flux/v0.x/stdlib/join/#outer-joins)
+For more information about the behavior of outer joins, see the [Outer joins](/flux/v0.x/stdlib/join/#outer-joins)
 section in the `join` package documentation.
 
 ```js

--- a/content/flux/v0.x/stdlib/join/right.md
+++ b/content/flux/v0.x/stdlib/join/right.md
@@ -79,7 +79,7 @@ default record. Because `l` is more likely to contain null values, the output re
 is built almost entirely from proprties of `r`, with the exception of `v_left`, which
 we expect to sometimes be null.
 
-For more information about the behavior of outer joins, see the [Outer joins](https://docs.influxdata.com/flux/v0.x/stdlib/join/#outer-joins)
+For more information about the behavior of outer joins, see the [Outer joins](/flux/v0.x/stdlib/join/#outer-joins)
 section in the `join` package documentation.
 
 ```js

--- a/content/flux/v0.x/stdlib/join/tables.md
+++ b/content/flux/v0.x/stdlib/join/tables.md
@@ -146,7 +146,7 @@ the output record is constructed in the `as` function.
 Because of how flux handles outer joins, it's possible for either `l` or `r` to be a
 default record. This means any value in a non-group-key column could be null.
 
-For more information about the behavior of outer joins, see the [Outer joins](https://docs.influxdata.com/flux/v0.x/stdlib/join/#outer-joins)
+For more information about the behavior of outer joins, see the [Outer joins](/flux/v0.x/stdlib/join/#outer-joins)
 section in the `join` package documentation.
 
 In the case of a left outer join, `l` is guaranteed to not be a default record. To

--- a/content/flux/v0.x/stdlib/json/encode.md
+++ b/content/flux/v0.x/stdlib/json/encode.md
@@ -31,7 +31,7 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 This function encodes Flux types as follows:
 
-- **time** values in [RFC3339](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp) format
+- **time** values in [RFC3339](/influxdb/cloud/reference/glossary/#rfc3339-timestamp) format
 - **duration** values in number of milliseconds since the Unix epoch
 - **regexp** values as their string representation
 - **bytes** values as base64-encoded strings

--- a/content/flux/v0.x/stdlib/profiler/_index.md
+++ b/content/flux/v0.x/stdlib/profiler/_index.md
@@ -67,7 +67,7 @@ When enabled, results include a table with the following columns:
 
 ### operator
 The `operator` profiler output statistics about each operation in a query.
-[Operations executed in the storage tier](https://docs.influxdata.com/influxdb/cloud/query-data/optimize-queries/#start-queries-with-pushdown-functions)
+[Operations executed in the storage tier](/influxdb/cloud/query-data/optimize-queries/#start-queries-with-pushdown-functions)
 return as a single operation.
 When the `operator` profile is enabled, results include a table with a row
 for each operation and the following columns:

--- a/content/flux/v0.x/stdlib/testing/_index.md
+++ b/content/flux/v0.x/stdlib/testing/_index.md
@@ -50,6 +50,7 @@ option testing.tags = []
 
 `load` loads test data from a stream of tables.
 
+
 ### tags
 
 `tags` is a list of tags that will be applied to a test case.

--- a/content/flux/v0.x/stdlib/universe/_index.md
+++ b/content/flux/v0.x/stdlib/universe/_index.md
@@ -58,6 +58,7 @@ option now = system.time
 so all executions of `now()` in a Flux script return the same time value.
 `system.time()` returns the system time (UTC) at which `system.time()` is executed.
 Each instance of `system.time()` in a Flux script returns a unique value.
+
 ## Functions
 
 {{< children type="functions" show="pages" >}}

--- a/content/flux/v0.x/stdlib/universe/join.md
+++ b/content/flux/v0.x/stdlib/universe/join.md
@@ -37,9 +37,12 @@ Null values are not considered equal when comparing column values.
 The resulting schema is the union of the input schemas.
 The resulting group key is the union of the input group keys.
 
-**Deprecated**: `join()` is deprecated in favor of [`join.inner()`](https://docs.influxdata.com/flux/v0.x/stdlib/join/inner/).
-The [`join` package](https://docs.influxdata.com/flux/v0.x/stdlib/join/) provides support
+{{% warn %}}
+#### Deprecated
+`join()` is deprecated in favor of [`join.inner()`](/flux/v0.x/stdlib/join/inner/).
+The [`join` package](/flux/v0.x/stdlib/join/) provides support
 for multiple join methods.
+{{% /warn %}}
 
 #### Output data
 The schema and group keys of the joined output output data is the union of

--- a/content/flux/v0.x/stdlib/universe/time.md
+++ b/content/flux/v0.x/stdlib/universe/time.md
@@ -46,7 +46,7 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 ({{< req >}})
 Value to convert.
 
-Strings must be valid [RFC3339 timestamps](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp).
+Strings must be valid [RFC3339 timestamps](/influxdb/cloud/reference/glossary/#rfc3339-timestamp).
 Integer and unsigned integer values are parsed as nanosecond epoch timestamps.
 
 


### PR DESCRIPTION
- Reformats deprecation notices to be more noticeable.
- Removes `https://docs.influxdata.com` from links

---
- [x] Rebased/mergeable
