### PR TITLE
Fixed issue in JSON sample

### DIFF
--- a/content/influxdb/v2.3/write-data/no-code/load-data.md
+++ b/content/influxdb/v2.3/write-data/no-code/load-data.md
@@ -168,7 +168,7 @@ Associate **JSON** key/value pairs with **InfluxDB elements** (measurements, tim
 "device_id":2036,
 "model_id":"KN24683",
 "temperature":25.0,
-"time":1653998899010000000
+"time":1653998899010000000,
 "error_state":"in_error"
 }
 ```


### PR DESCRIPTION
missing comma causes errors when reading in with new native subscriptions feature
