### PR TITLE
Chore/lint api defs

### DIFF
--- a/api-docs/.redocly.yaml
+++ b/api-docs/.redocly.yaml
@@ -1,5 +1,5 @@
-apiDefintions:
-lint:
+apis:
+styleguide:
   plugins:
     - './openapi/plugins/docs-plugin.js'
   extends:

--- a/api-docs/getswagger.sh
+++ b/api-docs/getswagger.sh
@@ -103,7 +103,7 @@ function postProcess() {
   # npm_config_yes=true npx overrides the prompt
   # and (vs. npx --yes) is compatible with npm@6 and npm@7.
   specPath=$1
-  version="$2"
+  platform="$2"
   apiVersion="$3"
 
   openapiCLI=" @redocly/cli"
@@ -111,12 +111,18 @@ function postProcess() {
   npx --version
 
   # Use Redoc's openapi-cli to regenerate the spec with custom decorations.
+  # If you want to lint the source contract (before bundling),
+  # pass `--lint` to the `bundle` command.
   INFLUXDB_API_VERSION=$apiVersion \
-  INFLUXDB_VERSION=$version \
+  INFLUXDB_PLATFORM=$platform \
   npm_config_yes=true \
   npx $openapiCLI bundle $specPath \
-    --config=./.redocly.yaml \
-    -o $specPath
+    -o $specPath \
+    --config=./.redocly.yaml
+
+  # Lint the bundle output.
+  npx $openapiCLI lint $specPath \
+    --max-problems 2
 }
 
 function updateCloud {

--- a/api-docs/openapi/content/cloud/info.yml
+++ b/api-docs/openapi/content/cloud/info.yml
@@ -5,3 +5,4 @@ description: |
 
     This documentation is generated from the
     [InfluxDB OpenAPI specification](https://raw.githubusercontent.com/influxdata/openapi/master/contracts/ref/cloud.yml).
+version: Cloud 2.x

--- a/api-docs/openapi/content/content.js
+++ b/api-docs/openapi/content/content.js
@@ -2,7 +2,7 @@ const path = require('path');
 const { toJSON } = require('../plugins/helpers/content-helper');
 
 function getVersion(filename) {
-  return path.join(__dirname, process.env.INFLUXDB_VERSION,
+  return path.join(__dirname, process.env.INFLUXDB_PLATFORM,
      (process.env.INFLUXDB_API_VERSION || ''), 
      filename);
 }

--- a/api-docs/openapi/plugins/decorators/replace-shortcodes.js
+++ b/api-docs/openapi/plugins/decorators/replace-shortcodes.js
@@ -6,7 +6,7 @@ function replaceDocsUrl(field) {
    * [^]* matches line breaks. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#using_regular_expression_on_multiple_lines
    */
   const shortcode = /\{\{%([^]|\s)*?INFLUXDB_DOCS_URL([^]|\s)*?%\}\}/g
-  let replacement = `/influxdb/${process.env.INFLUXDB_VERSION}`;
+  let replacement = `/influxdb/${process.env.INFLUXDB_PLATFORM}`;
   return field.replaceAll(shortcode, replacement)
               .replaceAll('https://docs.influxdata.com/influxdb/', '/influxdb/');
 }

--- a/api-docs/openapi/plugins/decorators/set-info.js
+++ b/api-docs/openapi/plugins/decorators/set-info.js
@@ -11,10 +11,9 @@ function SetInfo() {
       leave(info, ctx) {
         if(data) {
           if(data.hasOwnProperty('title')) {
-             info.title =  data.title;
+             info.title = data.title;
           }
 	        if(data.hasOwnProperty('version')) {
-
              info.version = data.version;
           }
           if(data.hasOwnProperty('description')) {


### PR DESCRIPTION
Quality of life improvements for API docs:
- Runs openapi-cli lint after generating the bundle output. This detects errors before pushing to openapi repo only to have the CI OATS validation fail. Only report the first 2 errors so we're not inundated with non-critical warnings.
- Renames INFLUXDB_VERSION to INFLUXDB_PLATFORM for clarity.
- Add a Cloud version to make the spec legal.


- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
