### PR TITLE
removed kapa enterprise from 1.6

### DIFF
--- a/content/kapacitor/v1.6/administration/security.md
+++ b/content/kapacitor/v1.6/administration/security.md
@@ -15,8 +15,7 @@ weight: 12
 ## Overview
 
 This document covers the basics of securing the open-source distribution of
-Kapacitor.  For information about security with Enterprise Kapacitor see the
-[Enterprise Kapacitor](https://archive.docs.influxdata.com/enterprise_kapacitor/v1.6/) documentation.
+Kapacitor.  
 
 When seeking to secure Kapacitor it is assumed that the Kapacitor server will be
 communicating with an already secured InfluxDB server.  It will also make its

--- a/content/kapacitor/v1.6/administration/subscription-management.md
+++ b/content/kapacitor/v1.6/administration/subscription-management.md
@@ -54,7 +54,6 @@ Many persistence strategies are available and which to use depends on your
 specific architecture and containerization technology.
 {{% /note %}}
 
-
 ## Configure Kapacitor subscriptions
 Kapacitor subscription configuration options are available under the `[[influxdb]]` section in the [`kapacitor.conf`](/kapacitor/v1.6/administration/configuration/).
 Below is an example of subscription-specific configuration options followed by a description of each.
@@ -86,14 +85,9 @@ Defines the subscription mode of Kapacitor.
 Available options:
 
 - `"server"`
-- `"cluster"` _(See warning below)_
+- `"cluster"` 
 
-{{% warn %}}
-The default setting for `subscription-mode` is `cluster`, however this should
-not be used with [Kapacitor Enterprise](https://archive.docs.influxdata.com/enterprise_kapacitor/latest/).
-Multi-node Kapacitor Enterprise clusters should only use the `server` subscription-mode,
-otherwise subscription data will not be received.
-{{% /warn %}}
+The default setting is `cluster`.
 
 ### `subscription-protocol`
 Defines which protocol to use for subscriptions.
@@ -102,6 +96,8 @@ Available options:
 - `"udp"`
 - `"http"`
 - `"https"`
+
+The default setting is `http`.
 
 ### `[influxdb.subscriptions]`
 Defines a set of databases and retention policies to subscribe to.

--- a/content/platform/install-and-deploy/install/_index.md
+++ b/content/platform/install-and-deploy/install/_index.md
@@ -20,7 +20,6 @@ To get install and configure the **InfluxData 1.x** platform, use one of the fol
   - Install InfluxData 1.x Enterprise:
       1. [Install Telegraf](/{{< latest "telegraf" >}}/install/)
       2. [Install InfluxDB Enterprise](/{{< latest "enterprise_influxdb" >}}/install-and-deploy/)
-      3. [Install Kapacitor Enterprise](https://archive.docs.influxdata.com/enterprise_kapacitor/latest/introduction/installation_guide/)
 
 {{% note %}}
 Windows support is experimental.


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/4390

removed kapa enterprise from v1.6 - it's been EOL for quite a while, last version updates happened in 1.5

requested by Support
