### PR TITLE
Correct /write and /query endpoints

### DIFF
--- a/content/influxdb/cloud/write-data/best-practices/optimize-writes.md
+++ b/content/influxdb/cloud/write-data/best-practices/optimize-writes.md
@@ -91,7 +91,7 @@ For specific instructions, see the [InfluxDB client libraries documentation](/in
 {{% tab-content %}}
 ### Use gzip compression with the InfluxDB API
 
-When using the InfluxDB API `/write` endpoint to write data,
+When using the InfluxDB API `/api/v2/write` endpoint to write data,
 compress the data with `gzip` and set the `Content-Encoding` header to `gzip`.
 
 ```sh

--- a/content/influxdb/cloud/write-data/developer-tools/api.md
+++ b/content/influxdb/cloud/write-data/developer-tools/api.md
@@ -2,13 +2,13 @@
 title: Write data with the InfluxDB API
 weight: 206
 description: >
-  Use the `/write` endpoint of the InfluxDB API to write data to InfluxDB.
+  Use the `/api/v2/write` endpoint of the InfluxDB API to write data to InfluxDB.
 menu:
   influxdb_cloud:
     parent: Developer tools
     name: Write API
 ---
-Write data to InfluxDB using an HTTP request to the InfluxDB API `/write` endpoint.
+Write data to InfluxDB using an HTTP request to the InfluxDB API `/api/v2/write` endpoint.
 Use the `POST` request method and include the following in your request:
 
 | Requirement          | Include by                                               |
@@ -43,7 +43,7 @@ The URL in the examples depends on your [InfluxDB Cloud region](/influxdb/cloud/
 {{% note %}}
 ##### Use gzip compression with the InfluxDB API
 
-When using the InfluxDB API `/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
+When using the InfluxDB API `/api/v2/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
 header to `gzip`.
 Compression reduces network bandwidth, but increases server-side load.
 

--- a/content/influxdb/v2.0/api-guide/api_intro.md
+++ b/content/influxdb/v2.0/api-guide/api_intro.md
@@ -68,8 +68,8 @@ Before writing data you'll need to create a Bucket in InfluxDB.
 
 ## Write API
 
-[Write data to InfluxDB](/influxdb/v2.0/write-data/developer-tools/api/) using an HTTP request to the InfluxDB API `/write` endpoint.
+[Write data to InfluxDB](/influxdb/v2.0/write-data/developer-tools/api/) using an HTTP request to the InfluxDB API `/api/v2/write` endpoint.
 
 ## Query API
 
-[Query from InfluxDB](/influxdb/v2.0/query-data/execute-queries/influx-api/) using an HTTP request to the `/query` endpoint.
+[Query from InfluxDB](/influxdb/v2.0/query-data/execute-queries/influx-api/) using an HTTP request to the `/api/v2/query` endpoint.

--- a/content/influxdb/v2.0/reference/internals/storage-engine.md
+++ b/content/influxdb/v2.0/reference/internals/storage-engine.md
@@ -30,7 +30,7 @@ The storage engine includes the following components:
 ## Writing data from API to disk
 
 The storage engine handles data from the point an API write request is received through writing data to the physical disk.
-Data is written to InfluxDB using [line protocol](/influxdb/v2.0/reference/syntax/line-protocol/) sent via HTTP POST request to the `/write` endpoint.
+Data is written to InfluxDB using [line protocol](/influxdb/v2.0/reference/syntax/line-protocol/) sent via HTTP POST request to the `/api/v2/write` endpoint or the [`/write` 1.x compatibility endpoint](/influxdb/v2.0/reference/api/influxdb-1x/).
 Batches of [points](/influxdb/v2.0/reference/glossary/#point) are sent to InfluxDB, compressed, and written to a WAL for immediate durability.
 Points are also written to an in-memory cache and become immediately queryable.
 The in-memory cache is periodically written to disk in the form of [TSM](#time-structured-merge-tree-tsm) files.

--- a/content/influxdb/v2.0/write-data/best-practices/optimize-writes.md
+++ b/content/influxdb/v2.0/write-data/best-practices/optimize-writes.md
@@ -93,8 +93,8 @@ For specific instructions, see the [InfluxDB client libraries documentation](/in
 
 ### Use gzip compression with the InfluxDB API
 
-When using the InfluxDB API `/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
-header to `gzip`. 
+When using the InfluxDB API `/api/v2/write` endpoint to write data, compress the
+data with `gzip` and set the `Content-Encoding` header to `gzip`. 
 
 ```sh
 {{% get-shared-text "api/v2.0/write/write-compress.sh" %}}

--- a/content/influxdb/v2.0/write-data/developer-tools/api.md
+++ b/content/influxdb/v2.0/write-data/developer-tools/api.md
@@ -2,13 +2,13 @@
 title: Write data with the InfluxDB API
 weight: 206
 description: >
-  Use the `/write` endpoint of the InfluxDB API to write data to InfluxDB.
+  Use the `/api/v2/write` endpoint of the InfluxDB API to write data to InfluxDB.
 menu:
   influxdb_2_0:
     name: InfluxDB API
     parent: Developer tools
 ---
-Write data to InfluxDB using an HTTP request to the InfluxDB API `/write` endpoint.
+Write data to InfluxDB using an HTTP request to the InfluxDB API `/api/v2/write` endpoint.
 Use the `POST` request method and include the following in your request:
 
 | Requirement          | Include by                                               |
@@ -44,7 +44,7 @@ The URL in the examples depends on the version and location of your InfluxDB 2.0
 {{% note %}}
 ##### Use gzip compression with the InfluxDB API
 
-When using the InfluxDB API `/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
+When using the InfluxDB API `/api/v2/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
 header to `gzip`.
 Compression reduces network bandwidth, but increases server-side load.
 

--- a/content/influxdb/v2.1/api-guide/api_intro.md
+++ b/content/influxdb/v2.1/api-guide/api_intro.md
@@ -68,8 +68,8 @@ Before writing data you'll need to create a Bucket in InfluxDB.
 
 ## Write API
 
-[Write data to InfluxDB](/influxdb/v2.1/write-data/developer-tools/api/) using an HTTP request to the InfluxDB API `/write` endpoint.
+[Write data to InfluxDB](/influxdb/v2.1/write-data/developer-tools/api/) using an HTTP request to the InfluxDB API `/api/v2/write` endpoint.
 
 ## Query API
 
-[Query from InfluxDB](/influxdb/v2.1/query-data/execute-queries/influx-api/) using an HTTP request to the `/query` endpoint.
+[Query from InfluxDB](/influxdb/v2.1/query-data/execute-queries/influx-api/) using an HTTP request to the `/api/v2/query` endpoint.

--- a/content/influxdb/v2.1/reference/internals/storage-engine.md
+++ b/content/influxdb/v2.1/reference/internals/storage-engine.md
@@ -32,7 +32,7 @@ The storage engine includes the following components:
 ## Writing data from API to disk
 
 The storage engine handles data from the point an API write request is received through writing data to the physical disk.
-Data is written to InfluxDB using [line protocol](/influxdb/v2.1/reference/syntax/line-protocol/) sent via HTTP POST request to the `/write` endpoint.
+Data is written to InfluxDB using [line protocol](/influxdb/v2.1/reference/syntax/line-protocol/) sent via HTTP POST request to the `/api/v2/write` endpoint or the [`/write` 1.x compatibility endpoint](/influxdb/v2.1/reference/api/influxdb-1x/).
 Batches of [points](/influxdb/v2.1/reference/glossary/#point) are sent to InfluxDB, compressed, and written to a WAL for immediate durability.
 Points are also written to an in-memory cache and become immediately queryable.
 The in-memory cache is periodically written to disk in the form of [TSM](#time-structured-merge-tree-tsm) files.

--- a/content/influxdb/v2.1/write-data/best-practices/optimize-writes.md
+++ b/content/influxdb/v2.1/write-data/best-practices/optimize-writes.md
@@ -93,7 +93,7 @@ For specific instructions, see the [InfluxDB client libraries documentation](/in
 
 ### Use gzip compression with the InfluxDB API
 
-When using the InfluxDB API `/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
+When using the InfluxDB API `/api/v2/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
 header to `gzip`. 
 
 ```sh

--- a/content/influxdb/v2.1/write-data/developer-tools/api.md
+++ b/content/influxdb/v2.1/write-data/developer-tools/api.md
@@ -2,13 +2,13 @@
 title: Write data with the InfluxDB API
 weight: 206
 description: >
-  Use the `/write` endpoint of the InfluxDB API to write data to InfluxDB.
+  Use the `/api/v2/write` endpoint of the InfluxDB API to write data to InfluxDB.
 menu:
   influxdb_2_1:
     name: InfluxDB API
     parent: Developer tools
 ---
-Write data to InfluxDB using an HTTP request to the InfluxDB API `/write` endpoint.
+Write data to InfluxDB using an HTTP request to the InfluxDB API `/api/v2/write` endpoint.
 Use the `POST` request method and include the following in your request:
 
 | Requirement          | Include by                                               |
@@ -44,7 +44,7 @@ The URL in the examples depends on the version and location of your InfluxDB {{<
 {{% note %}}
 ##### Use gzip compression with the InfluxDB API
 
-When using the InfluxDB API `/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
+When using the InfluxDB API `/api/v2/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
 header to `gzip`.
 Compression reduces network bandwidth, but increases server-side load.
 

--- a/content/influxdb/v2.2/api-guide/api_intro.md
+++ b/content/influxdb/v2.2/api-guide/api_intro.md
@@ -68,8 +68,8 @@ Before writing data you'll need to create a Bucket in InfluxDB.
 
 ## Write API
 
-[Write data to InfluxDB](/influxdb/v2.2/write-data/developer-tools/api/) using an HTTP request to the InfluxDB API `/write` endpoint.
+[Write data to InfluxDB](/influxdb/v2.2/write-data/developer-tools/api/) using an HTTP request to the InfluxDB API `/api/v2/write` endpoint.
 
 ## Query API
 
-[Query from InfluxDB](/influxdb/v2.2/query-data/execute-queries/influx-api/) using an HTTP request to the `/query` endpoint.
+[Query from InfluxDB](/influxdb/v2.2/query-data/execute-queries/influx-api/) using an HTTP request to the `/api/v2/query` endpoint.

--- a/content/influxdb/v2.2/reference/internals/storage-engine.md
+++ b/content/influxdb/v2.2/reference/internals/storage-engine.md
@@ -32,7 +32,7 @@ The storage engine includes the following components:
 ## Writing data from API to disk
 
 The storage engine handles data from the point an API write request is received through writing data to the physical disk.
-Data is written to InfluxDB using [line protocol](/influxdb/v2.2/reference/syntax/line-protocol/) sent via HTTP POST request to the `/write` endpoint.
+Data is written to InfluxDB using [line protocol](/influxdb/v2.2/reference/syntax/line-protocol/) sent via HTTP POST request to the `/api/v2/write` endpoint or the [`/write` 1.x compatibility endpoint](/influxdb/v2.2/reference/api/influxdb-1x/).
 Batches of [points](/influxdb/v2.2/reference/glossary/#point) are sent to InfluxDB, compressed, and written to a WAL for immediate durability.
 Points are also written to an in-memory cache and become immediately queryable.
 The in-memory cache is periodically written to disk in the form of [TSM](#time-structured-merge-tree-tsm) files.

--- a/content/influxdb/v2.2/write-data/best-practices/optimize-writes.md
+++ b/content/influxdb/v2.2/write-data/best-practices/optimize-writes.md
@@ -93,8 +93,8 @@ For specific instructions, see the [InfluxDB client libraries documentation](/in
 
 ### Use gzip compression with the InfluxDB API
 
-When using the InfluxDB API `/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
-header to `gzip`. 
+When using the InfluxDB API `/api/v2/write` endpoint to write data, compress the
+data with `gzip` and set the `Content-Encoding` header to `gzip`. 
 
 ```sh
 {{% get-shared-text "api/v2.0/write/write-compress.sh" %}}

--- a/content/influxdb/v2.2/write-data/developer-tools/api.md
+++ b/content/influxdb/v2.2/write-data/developer-tools/api.md
@@ -2,13 +2,13 @@
 title: Write data with the InfluxDB API
 weight: 206
 description: >
-  Use the `/write` endpoint of the InfluxDB API to write data to InfluxDB.
+  Use the `/api/v2/write` endpoint of the InfluxDB API to write data to InfluxDB.
 menu:
   influxdb_2_2:
     name: InfluxDB API
     parent: Developer tools
 ---
-Write data to InfluxDB using an HTTP request to the InfluxDB API `/write` endpoint.
+Write data to InfluxDB using an HTTP request to the InfluxDB API `/api/v2/write` endpoint.
 Use the `POST` request method and include the following in your request:
 
 | Requirement          | Include by                                               |
@@ -44,7 +44,7 @@ The URL in the examples depends on the version and location of your InfluxDB {{<
 {{% note %}}
 ##### Use gzip compression with the InfluxDB API
 
-When using the InfluxDB API `/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
+When using the InfluxDB API `/api/v2/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
 header to `gzip`.
 Compression reduces network bandwidth, but increases server-side load.
 

--- a/content/influxdb/v2.3/api-guide/api_intro.md
+++ b/content/influxdb/v2.3/api-guide/api_intro.md
@@ -68,8 +68,8 @@ Before writing data you'll need to create a Bucket in InfluxDB.
 
 ## Write API
 
-[Write data to InfluxDB](/influxdb/v2.3/write-data/developer-tools/api/) using an HTTP request to the InfluxDB API `/write` endpoint.
+[Write data to InfluxDB](/influxdb/v2.3/write-data/developer-tools/api/) using an HTTP request to the InfluxDB API `/api/v2/write` endpoint.
 
 ## Query API
 
-[Query from InfluxDB](/influxdb/v2.3/query-data/execute-queries/influx-api/) using an HTTP request to the `/query` endpoint.
+[Query from InfluxDB](/influxdb/v2.3/query-data/execute-queries/influx-api/) using an HTTP request to the `/api/v2/query` endpoint.

--- a/content/influxdb/v2.3/reference/internals/storage-engine.md
+++ b/content/influxdb/v2.3/reference/internals/storage-engine.md
@@ -32,7 +32,7 @@ The storage engine includes the following components:
 ## Writing data from API to disk
 
 The storage engine handles data from the point an API write request is received through writing data to the physical disk.
-Data is written to InfluxDB using [line protocol](/influxdb/v2.3/reference/syntax/line-protocol/) sent via HTTP POST request to the `/write` endpoint.
+Data is written to InfluxDB using [line protocol](/influxdb/v2.3/reference/syntax/line-protocol/) sent via HTTP POST request to the `/api/v2/write` endpoint or the [`/write` 1.x compatibility endpoint](/influxdb/v2.3/reference/api/influxdb-1x/).
 Batches of [points](/influxdb/v2.3/reference/glossary/#point) are sent to InfluxDB, compressed, and written to a WAL for immediate durability.
 Points are also written to an in-memory cache and become immediately queryable.
 The in-memory cache is periodically written to disk in the form of [TSM](#time-structured-merge-tree-tsm) files.

--- a/content/influxdb/v2.3/write-data/best-practices/optimize-writes.md
+++ b/content/influxdb/v2.3/write-data/best-practices/optimize-writes.md
@@ -93,7 +93,7 @@ For specific instructions, see the [InfluxDB client libraries documentation](/in
 
 ### Use gzip compression with the InfluxDB API
 
-When using the InfluxDB API `/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
+When using the InfluxDB API `/api/v2/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
 header to `gzip`. 
 
 ```sh

--- a/content/influxdb/v2.3/write-data/developer-tools/api.md
+++ b/content/influxdb/v2.3/write-data/developer-tools/api.md
@@ -2,13 +2,13 @@
 title: Write data with the InfluxDB API
 weight: 206
 description: >
-  Use the `/write` endpoint of the InfluxDB API to write data to InfluxDB.
+  Use the `/api/v2/write` endpoint of the InfluxDB API to write data to InfluxDB.
 menu:
   influxdb_2_3:
     name: InfluxDB API
     parent: Developer tools
 ---
-Write data to InfluxDB using an HTTP request to the InfluxDB API `/write` endpoint.
+Write data to InfluxDB using an HTTP request to the InfluxDB API `/api/v2/write` endpoint.
 Use the `POST` request method and include the following in your request:
 
 | Requirement          | Include by                                               |
@@ -44,7 +44,7 @@ The URL in the examples depends on the version and location of your InfluxDB {{<
 {{% note %}}
 ##### Use gzip compression with the InfluxDB API
 
-When using the InfluxDB API `/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
+When using the InfluxDB API `/api/v2/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
 header to `gzip`.
 Compression reduces network bandwidth, but increases server-side load.
 

--- a/content/influxdb/v2.4/api-guide/api_intro.md
+++ b/content/influxdb/v2.4/api-guide/api_intro.md
@@ -68,8 +68,8 @@ Before writing data you'll need to create a Bucket in InfluxDB.
 
 ## Write API
 
-[Write data to InfluxDB](/influxdb/v2.4/write-data/developer-tools/api/) using an HTTP request to the InfluxDB API `/write` endpoint.
+[Write data to InfluxDB](/influxdb/v2.4/write-data/developer-tools/api/) using an HTTP request to the InfluxDB API `/api/v2/write` endpoint.
 
 ## Query API
 
-[Query from InfluxDB](/influxdb/v2.4/query-data/execute-queries/influx-api/) using an HTTP request to the `/query` endpoint.
+[Query from InfluxDB](/influxdb/v2.4/query-data/execute-queries/influx-api/) using an HTTP request to the `/api/v2/query` endpoint.

--- a/content/influxdb/v2.4/reference/internals/storage-engine.md
+++ b/content/influxdb/v2.4/reference/internals/storage-engine.md
@@ -32,7 +32,7 @@ The storage engine includes the following components:
 ## Writing data from API to disk
 
 The storage engine handles data from the point an API write request is received through writing data to the physical disk.
-Data is written to InfluxDB using [line protocol](/influxdb/v2.4/reference/syntax/line-protocol/) sent via HTTP POST request to the `/write` endpoint.
+Data is written to InfluxDB using [line protocol](/influxdb/v2.4/reference/syntax/line-protocol/) sent via HTTP POST request to the `/api/v2/write` endpoint or the [`/write` 1.x compatibility endpoint](/influxdb/v2.4/reference/api/influxdb-1x/).
 Batches of [points](/influxdb/v2.4/reference/glossary/#point) are sent to InfluxDB, compressed, and written to a WAL for immediate durability.
 Points are also written to an in-memory cache and become immediately queryable.
 The in-memory cache is periodically written to disk in the form of [TSM](#time-structured-merge-tree-tsm) files.

--- a/content/influxdb/v2.4/write-data/best-practices/optimize-writes.md
+++ b/content/influxdb/v2.4/write-data/best-practices/optimize-writes.md
@@ -93,7 +93,7 @@ For specific instructions, see the [InfluxDB client libraries documentation](/in
 
 ### Use gzip compression with the InfluxDB API
 
-When using the InfluxDB API `/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
+When using the InfluxDB API `/api/v2/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
 header to `gzip`. 
 
 ```sh

--- a/content/influxdb/v2.4/write-data/developer-tools/api.md
+++ b/content/influxdb/v2.4/write-data/developer-tools/api.md
@@ -2,13 +2,13 @@
 title: Write data with the InfluxDB API
 weight: 206
 description: >
-  Use the `/write` endpoint of the InfluxDB API to write data to InfluxDB.
+  Use the `/api/v2/write` endpoint of the InfluxDB API to write data to InfluxDB.
 menu:
   influxdb_2_4:
     name: InfluxDB API
     parent: Developer tools
 ---
-Write data to InfluxDB using an HTTP request to the InfluxDB API `/write` endpoint.
+Write data to InfluxDB using an HTTP request to the InfluxDB API `/api/v2/write` endpoint.
 Use the `POST` request method and include the following in your request:
 
 | Requirement          | Include by                                               |
@@ -44,7 +44,7 @@ The URL in the examples depends on the version and location of your InfluxDB {{<
 {{% note %}}
 ##### Use gzip compression with the InfluxDB API
 
-When using the InfluxDB API `/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
+When using the InfluxDB API `/api/v2/write` endpoint to write data, compress the data with `gzip` and set the `Content-Encoding`
 header to `gzip`.
 Compression reduces network bandwidth, but increases server-side load.
 


### PR DESCRIPTION
Closes influxdata/DAR#325

Before the 1.x compatibility API was introduced, some API endpoint references didn't include the `/api/v2` prefix. With the inclusion of the 1.x compatibility API, we need to be very specific about which endpoint to use. This PR updates the mention of these endpoints appropriately.

- [x] Rebased/mergeable
