### PR TITLE
Correct Flux `range` stop description

### DIFF
--- a/content/flux/v0.x/stdlib/universe/range.md
+++ b/content/flux/v0.x/stdlib/universe/range.md
@@ -61,7 +61,7 @@ Durations are relative to `now()`.
 
 Latest time to include in results. Default is `now()`.
 
-Results _exclude_ rows with `_time` values that match the specified start time.
+Results _exclude_ rows with `_time` values that match the specified stop time.
 Use a relative duration, absolute time, or integer (Unix timestamp in seconds).
 For example, `-1h`, `2019-08-28T22:00:00Z`, or `1567029600`.
 Durations are relative to `now()`.
@@ -75,9 +75,14 @@ Input data. Default is piped-forward data (`<-`).
 
 ## Examples
 
-- [Query a time range relative to now](#query-a-time-range-relative-to-now)
-- [Query an absolute time range](#query-an-absolute-time-range)
-- [Query an absolute time range using Unix timestamps](#query-an-absolute-time-range-using-unix-timestamps)
+- [Parameters](#parameters)
+  - [start](#start)
+  - [stop](#stop)
+  - [tables](#tables)
+- [Examples](#examples)
+  - [Query a time range relative to now](#query-a-time-range-relative-to-now)
+  - [Query an absolute time range](#query-an-absolute-time-range)
+  - [Query an absolute time range using Unix timestamps](#query-an-absolute-time-range-using-unix-timestamps)
 
 ### Query a time range relative to now
 


### PR DESCRIPTION
"start" in this sentence should be "stop".
> Results _exclude_ rows with `_time` values that match the specified start time.

https://docs.influxdata.com/flux/v0.x/stdlib/universe/range/#stop

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
