### PR TITLE
fix(api): expand URL replacement to descriptions in schema nodes

### DIFF
--- a/api-docs/openapi/plugins/decorators/replace-shortcodes.js
+++ b/api-docs/openapi/plugins/decorators/replace-shortcodes.js
@@ -14,78 +14,13 @@ function replaceDocsUrl(field) {
 /** @type {import('@redocly/openapi-cli').OasDecorator} */
 function docsUrl() {
   return {
-    DefinitionRoot: {
-      Example: {
-        leave(node, ctx) {
-          node.description = replaceDocsUrl(node.description);
-        },
-      },
-      ExternalDocs: {
-        leave(node, ctx) {
-          node.description = replaceDocsUrl(node.description);
-        },
-      },
-      Header: {
-        leave(node, ctx) {
-          node.description = replaceDocsUrl(node.description);
-        },
-      },
-      Info: {
-        leave(node, ctx) {
-          node.description = replaceDocsUrl(node.description);
-        },
-      },
-      Operation: {
-        leave(node, ctx) {
-          node.description = replaceDocsUrl(node.description);
-        },
-      },
-      Parameter: {
-        leave(node, ctx) {
-          node.description = replaceDocsUrl(node.description);
+    any: {
+      leave(node, ctx) {
+        if(node.description && typeof(node.description) === 'string') {
+            node.description = replaceDocsUrl(node.description);
         }
       },
-      PathItem: {
-        leave(node, ctx) {
-          node.description = replaceDocsUrl(node.description);
-        }
-      },
-      RequestBody: {
-        leave(node, ctx) {
-          node.description = replaceDocsUrl(node.description);
-        }
-      },
-      Response: {
-        leave(node, ctx) {
-          node.description = replaceDocsUrl(node.description);
-        }
-      },
-      Schema: {
-        leave(node, ctx) {
-          node.description = replaceDocsUrl(node.description);
-        }
-      },
-      SecurityScheme: {
-        leave(node, ctx) {
-          node.description = replaceDocsUrl(node.description);
-        }
-      },
-      Server: {
-        leave(node, ctx) {
-          node.description = replaceDocsUrl(node.description);
-        }
-      },
-      Tag: {
-        leave(node, ctx) {
-          node.description = replaceDocsUrl(node.description);
-        }
-      },
-      XCodeSample: {
-        leave(node, ctx) {
-          node.description = replaceDocsUrl(node.description);
-        }
-      }
-    }
+    },
   }
 }
 


### PR DESCRIPTION
Check every node in the spec for a description field:
- Replace named nodes in decorator with the `any` key.
- If the node description field is a string (and not an object named "description"), replace URLs in the description.


- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
