### PR TITLE
added additional download instructions

### DIFF
--- a/content/chronograf/v1.10/introduction/downloading.md
+++ b/content/chronograf/v1.10/introduction/downloading.md
@@ -8,3 +8,6 @@ menu:
 ---
 
 Download the latest Chronograf release at the [InfluxData download page](https://portal.influxdata.com/downloads).
+Click **Are you interested in InfluxDB 1.x Open Source?** to expand the 1.x options. Scroll to the **Chronograf** section and select your desired Chronograf version and operating system. Execute the provided download commands.
+
+

--- a/content/chronograf/v1.10/introduction/installation.md
+++ b/content/chronograf/v1.10/introduction/installation.md
@@ -25,7 +25,7 @@ Chronograf is the user interface for InfluxData's [TICK stack](https://www.influ
 
 The latest Chronograf builds are available on InfluxData's [Downloads page](https://portal.influxdata.com/downloads).
 
-1. Choose the download link for your operating system.
+1. On the Downloads page, scroll to the bottom and click **Are you interested in InfluxDB 1.x Open Source?** to expand the 1.x options. Scroll to the **Chronograf** section and select your desired Chronograf version and operating system. Execute the provided download commands.
 
     {{% note %}}
 If your download includes a TAR package, save the underlying datastore `chronograf-v1.db` in directory outside of where you start Chronograf. This preserves and references your existing datastore, including configurations and dashboards, when you download future versions.


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/4481

For some reason, the augmented download chronograf instructions from v1.9 did not make it into 1.10, so I added them