### PR TITLE
Fix typo in get.md

### DIFF
--- a/content/flux/v0.x/stdlib/experimental/record/get.md
+++ b/content/flux/v0.x/stdlib/experimental/record/get.md
@@ -67,7 +67,7 @@ Default value to return if the specified key does not exist in the record.
 
 ## Examples
 
-### Dynamically return a value from a recordd
+### Dynamically return a value from a record
 
 ```js
 import "experimental/record"
@@ -75,7 +75,7 @@ import "experimental/record"
 key = "foo"
 exampleRecord = {foo: 1.0, bar: "hello"}
 
-record.get(r: exampleRecord, key: key, default: "")// Returns 1.0
+record.get(r: exampleRecord, key: key, default: "") // Returns 1.0
 
 
 ```


### PR DESCRIPTION
Hi there! I was just reading this page and noticed an extra letter in the record word - not a big deal but I know this would bug me if I was writing these docs!

![image](https://user-images.githubusercontent.com/65625400/192907160-98bdd367-6e86-4252-b2ca-e856595082f0.png)

Relevant URLs

- https://docs.influxdata.com/flux/v0.x/stdlib/experimental/record/get/
