### PR TITLE
update 1.24 changelog titles

### DIFF
--- a/content/telegraf/v1.24/release-notes-changelog.md
+++ b/content/telegraf/v1.24/release-notes-changelog.md
@@ -1,9 +1,9 @@
 ---
-title: Telegraf 1.23 release notes
+title: Telegraf 1.24 release notes
 description: Important features and changes in the latest version of Telegraf.
 aliases:
-  - /telegraf/v1.23/reference/release-notes/influxdb/
-  - /telegraf/v1.23/about_the_project/release-notes-changelog/
+  - /telegraf/v1.24/reference/release-notes/influxdb/
+  - /telegraf/v1.24/about_the_project/release-notes-changelog/
 menu:
   telegraf_1_24_ref:
 


### PR DESCRIPTION
Some of the titles for the 1.24 changelog are still routing to 1.23 which i think is what is causing  https://docs.influxdata.com/telegraf/latest/release-notes-changelog/ to still go to 1.23
