### PR TITLE
fixed api quick start link

### DIFF
--- a/content/influxdb/v2.2/api-guide/_index.md
+++ b/content/influxdb/v2.2/api-guide/_index.md
@@ -14,7 +14,7 @@ Access the InfluxDB API using the `/api/v2/` endpoint.
 
 ## Developer guides
 
-- [API starter guide](/influxdb/v2.2/api-guide/starter/)
+- [API Quick Start](/influxdb/v2.2/api-guide/api_intro/)
 
 ## InfluxDB client libraries
 

--- a/content/influxdb/v2.3/api-guide/_index.md
+++ b/content/influxdb/v2.3/api-guide/_index.md
@@ -14,7 +14,7 @@ Access the InfluxDB API using the `/api/v2/` endpoint.
 
 ## Developer guides
 
-- [API starter guide](/influxdb/v2.3/api-guide/starter/)
+- [API Quick Start](/influxdb/v2.3/api-guide/api_intro/)
 
 ## InfluxDB client libraries
 

--- a/content/influxdb/v2.4/api-guide/_index.md
+++ b/content/influxdb/v2.4/api-guide/_index.md
@@ -14,7 +14,7 @@ Access the InfluxDB API using the `/api/v2/` endpoint.
 
 ## Developer guides
 
-- [API starter guide](/influxdb/v2.4/api-guide/starter/)
+- [API Quick Start](/influxdb/v2.4/api-guide/api_intro/)
 
 ## InfluxDB client libraries
 


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/4476

fixed the api quick start link in OSS v2.4, 2.3 and 2.2
