### PR TITLE
fix: add imports to query script

### DIFF
--- a/content/influxdb/v2.4/api-guide/client-libraries/python.md
+++ b/content/influxdb/v2.4/api-guide/client-libraries/python.md
@@ -114,11 +114,11 @@ write_api.write(bucket=bucket, org=org, record=p)
 2. Create a Flux query, and then format it as a Python string.
 
    ```python
-   query = ' from(bucket:"my-bucket")\
+   query = 'from(bucket:"my-bucket")\
    |> range(start: -10m)\
    |> filter(fn:(r) => r._measurement == "my_measurement")\
-   |> filter(fn: (r) => r.location == "Prague")\
-   |> filter(fn:(r) => r._field == "temperature" ) '
+   |> filter(fn:(r) => r.location == "Prague")\
+   |> filter(fn:(r) => r._field == "temperature")'
    ```
 
     The query client sends the Flux query to InfluxDB and returns a Flux object with a table structure.
@@ -178,8 +178,8 @@ query_api = client.query_api()
 query = 'from(bucket:"my-bucket")\
 |> range(start: -10m)\
 |> filter(fn:(r) => r._measurement == "my_measurement")\
-|> filter(fn: (r) => r.location == "Prague")\
-|> filter(fn:(r) => r._field == "temperature" )'
+|> filter(fn:(r) => r.location == "Prague")\
+|> filter(fn:(r) => r._field == "temperature")'
 result = query_api.query(org=org, query=query)
 results = []
 for table in result:

--- a/content/influxdb/v2.4/api-guide/client-libraries/python.md
+++ b/content/influxdb/v2.4/api-guide/client-libraries/python.md
@@ -97,6 +97,7 @@ client = influxdb_client.InfluxDBClient(
     org=org
 )
 
+# Write script
 write_api = client.write_api(write_options=SYNCHRONOUS)
 
 p = influxdb_client.Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)
@@ -157,12 +158,28 @@ write_api.write(bucket=bucket, org=org, record=p)
 ### Complete example query script
 
 ```python
+import influxdb_client
+from influxdb_client.client.write_api import SYNCHRONOUS
+
+bucket = "<my-bucket>"
+org = "<my-org>"
+token = "<my-token>"
+# Store the URL of your InfluxDB instance
+url="http://localhost:8086"
+
+client = influxdb_client.InfluxDBClient(
+    url=url,
+    token=token,
+    org=org
+)
+
+# Query script
 query_api = client.query_api()
-query = ‘ from(bucket:"my-bucket")\
+query = 'from(bucket:"my-bucket")\
 |> range(start: -10m)\
 |> filter(fn:(r) => r._measurement == "my_measurement")\
 |> filter(fn: (r) => r.location == "Prague")\
-|> filter(fn:(r) => r._field == "temperature" )‘
+|> filter(fn:(r) => r._field == "temperature" )'
 result = query_api.query(org=org, query=query)
 results = []
 for table in result:


### PR DESCRIPTION
Closes #
New user feedback!
Page: https://docs.influxdata.com/influxdb/cloud/api-guide/client-libraries/python/
Feedback: The code example doesn't work. I get an Atribute error

I ran through all the example code on the page and was not able to recreate the error the user found.
One possibility i saw was that our `query` code example doesn't include import statements so I added that into the script, but that shouldn't be the cause for the error the user is seeing themselves.

Additional information from the user would be needed on this feedback.  

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
