### PR TITLE
Fixes repeated typo on all pages (ouput)

### DIFF
--- a/content/flux/v0.x/join-data/full-outer.md
+++ b/content/flux/v0.x/join-data/full-outer.md
@@ -167,7 +167,7 @@ join.full(
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and output" %}}
+{{% expand "View example input and output data" %}}
 
 ### Input
 

--- a/content/flux/v0.x/join-data/inner.md
+++ b/content/flux/v0.x/join-data/inner.md
@@ -127,7 +127,7 @@ join.inner(
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and output" %}}
+{{% expand "View example input and output data" %}}
 
 {{% note %}}
 _`_start` and `_stop` columns have been omitted from example input and output._

--- a/content/flux/v0.x/join-data/left-outer.md
+++ b/content/flux/v0.x/join-data/left-outer.md
@@ -130,7 +130,7 @@ join.left(
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and output" %}}
+{{% expand "View example input and output data" %}}
 
 {{% note %}}
 _`_start` and `_stop` columns have been omitted from example input and output._

--- a/content/flux/v0.x/join-data/right-outer.md
+++ b/content/flux/v0.x/join-data/right-outer.md
@@ -130,7 +130,7 @@ join.right(
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and output" %}}
+{{% expand "View example input and output data" %}}
 
 ### Input
 

--- a/content/flux/v0.x/join-data/time.md
+++ b/content/flux/v0.x/join-data/time.md
@@ -115,7 +115,7 @@ join.time(method: "left", left: left, right: right, as: (l, r) => ({l with targe
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and output" %}}
+{{% expand "View example input and output data" %}}
 
 ### Input
 

--- a/content/flux/v0.x/stdlib/bitwise/sand.md
+++ b/content/flux/v0.x/stdlib/bitwise/sand.md
@@ -81,7 +81,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/bitwise/sclear.md
+++ b/content/flux/v0.x/stdlib/bitwise/sclear.md
@@ -83,7 +83,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/bitwise/slshift.md
+++ b/content/flux/v0.x/stdlib/bitwise/slshift.md
@@ -83,7 +83,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/bitwise/snot.md
+++ b/content/flux/v0.x/stdlib/bitwise/snot.md
@@ -75,7 +75,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/bitwise/sor.md
+++ b/content/flux/v0.x/stdlib/bitwise/sor.md
@@ -81,7 +81,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/bitwise/srshift.md
+++ b/content/flux/v0.x/stdlib/bitwise/srshift.md
@@ -83,7 +83,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/bitwise/sxor.md
+++ b/content/flux/v0.x/stdlib/bitwise/sxor.md
@@ -81,7 +81,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/bitwise/uand.md
+++ b/content/flux/v0.x/stdlib/bitwise/uand.md
@@ -81,7 +81,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/bitwise/uclear.md
+++ b/content/flux/v0.x/stdlib/bitwise/uclear.md
@@ -81,7 +81,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/bitwise/ulshift.md
+++ b/content/flux/v0.x/stdlib/bitwise/ulshift.md
@@ -83,7 +83,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/bitwise/unot.md
+++ b/content/flux/v0.x/stdlib/bitwise/unot.md
@@ -75,7 +75,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/bitwise/uor.md
+++ b/content/flux/v0.x/stdlib/bitwise/uor.md
@@ -81,7 +81,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/bitwise/urshift.md
+++ b/content/flux/v0.x/stdlib/bitwise/urshift.md
@@ -83,7 +83,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/bitwise/uxor.md
+++ b/content/flux/v0.x/stdlib/bitwise/uxor.md
@@ -81,7 +81,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/contrib/anaisdg/anomalydetection/mad.md
+++ b/content/flux/v0.x/stdlib/contrib/anaisdg/anomalydetection/mad.md
@@ -73,7 +73,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/contrib/bonitoo-io/hex/string.md
+++ b/content/flux/v0.x/stdlib/contrib/bonitoo-io/hex/string.md
@@ -169,7 +169,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/groupby.md
+++ b/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/groupby.md
@@ -69,7 +69,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/select.md
+++ b/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/select.md
@@ -96,7 +96,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -154,7 +154,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -202,7 +202,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/selectwindow.md
+++ b/content/flux/v0.x/stdlib/contrib/bonitoo-io/tickscript/selectwindow.md
@@ -108,7 +108,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/contrib/rhajek/bigpanda/statusfromlevel.md
+++ b/content/flux/v0.x/stdlib/contrib/rhajek/bigpanda/statusfromlevel.md
@@ -83,7 +83,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/contrib/tomhollingworth/events/duration.md
+++ b/content/flux/v0.x/stdlib/contrib/tomhollingworth/events/duration.md
@@ -119,7 +119,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/aggregate/rate.md
+++ b/content/flux/v0.x/stdlib/experimental/aggregate/rate.md
@@ -86,7 +86,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/aligntime.md
+++ b/content/flux/v0.x/stdlib/experimental/aligntime.md
@@ -76,7 +76,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/sand.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/sand.md
@@ -84,7 +84,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/sclear.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/sclear.md
@@ -86,7 +86,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/slshift.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/slshift.md
@@ -86,7 +86,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/snot.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/snot.md
@@ -78,7 +78,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/sor.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/sor.md
@@ -84,7 +84,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/srshift.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/srshift.md
@@ -86,7 +86,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/sxor.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/sxor.md
@@ -84,7 +84,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/uand.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/uand.md
@@ -84,7 +84,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/uclear.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/uclear.md
@@ -84,7 +84,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/ulshift.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/ulshift.md
@@ -86,7 +86,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/unot.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/unot.md
@@ -78,7 +78,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/uor.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/uor.md
@@ -84,7 +84,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/urshift.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/urshift.md
@@ -86,7 +86,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/bitwise/uxor.md
+++ b/content/flux/v0.x/stdlib/experimental/bitwise/uxor.md
@@ -84,7 +84,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/count.md
+++ b/content/flux/v0.x/stdlib/experimental/count.md
@@ -74,7 +74,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/distinct.md
+++ b/content/flux/v0.x/stdlib/experimental/distinct.md
@@ -67,7 +67,7 @@ sampledata.int(includeNull: true)
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/fill.md
+++ b/content/flux/v0.x/stdlib/experimental/fill.md
@@ -79,7 +79,7 @@ sampledata.int(includeNull: true)
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -137,7 +137,7 @@ sampledata.int(includeNull: true)
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/first.md
+++ b/content/flux/v0.x/stdlib/experimental/first.md
@@ -65,7 +65,7 @@ sampledata.int(includeNull: true)
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/geo/astracks.md
+++ b/content/flux/v0.x/stdlib/experimental/geo/astracks.md
@@ -77,7 +77,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -119,7 +119,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/geo/gridfilter.md
+++ b/content/flux/v0.x/stdlib/experimental/geo/gridfilter.md
@@ -117,7 +117,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/geo/groupbyarea.md
+++ b/content/flux/v0.x/stdlib/experimental/geo/groupbyarea.md
@@ -89,7 +89,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/geo/s2cellidtoken.md
+++ b/content/flux/v0.x/stdlib/experimental/geo/s2cellidtoken.md
@@ -83,7 +83,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -128,7 +128,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/geo/st_linestring.md
+++ b/content/flux/v0.x/stdlib/experimental/geo/st_linestring.md
@@ -65,7 +65,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/geo/strictfilter.md
+++ b/content/flux/v0.x/stdlib/experimental/geo/strictfilter.md
@@ -69,7 +69,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/geo/torows.md
+++ b/content/flux/v0.x/stdlib/experimental/geo/torows.md
@@ -63,7 +63,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/group.md
+++ b/content/flux/v0.x/stdlib/experimental/group.md
@@ -74,7 +74,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/histogram.md
+++ b/content/flux/v0.x/stdlib/experimental/histogram.md
@@ -101,7 +101,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/histogramquantile.md
+++ b/content/flux/v0.x/stdlib/experimental/histogramquantile.md
@@ -97,7 +97,7 @@ histogramData
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/integral.md
+++ b/content/flux/v0.x/stdlib/experimental/integral.md
@@ -87,7 +87,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -139,7 +139,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/json/parse.md
+++ b/content/flux/v0.x/stdlib/experimental/json/parse.md
@@ -84,7 +84,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/kaufmansama.md
+++ b/content/flux/v0.x/stdlib/experimental/kaufmansama.md
@@ -72,7 +72,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/last.md
+++ b/content/flux/v0.x/stdlib/experimental/last.md
@@ -65,7 +65,7 @@ sampledata.int(includeNull: true)
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/max.md
+++ b/content/flux/v0.x/stdlib/experimental/max.md
@@ -65,7 +65,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/mean.md
+++ b/content/flux/v0.x/stdlib/experimental/mean.md
@@ -65,7 +65,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/min.md
+++ b/content/flux/v0.x/stdlib/experimental/min.md
@@ -65,7 +65,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/mode.md
+++ b/content/flux/v0.x/stdlib/experimental/mode.md
@@ -75,7 +75,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/polyline/rdp.md
+++ b/content/flux/v0.x/stdlib/experimental/polyline/rdp.md
@@ -101,7 +101,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -160,7 +160,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -218,7 +218,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/quantile.md
+++ b/content/flux/v0.x/stdlib/experimental/quantile.md
@@ -117,7 +117,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -165,7 +165,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/set.md
+++ b/content/flux/v0.x/stdlib/experimental/set.md
@@ -70,7 +70,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/skew.md
+++ b/content/flux/v0.x/stdlib/experimental/skew.md
@@ -65,7 +65,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/spread.md
+++ b/content/flux/v0.x/stdlib/experimental/spread.md
@@ -65,7 +65,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/stddev.md
+++ b/content/flux/v0.x/stdlib/experimental/stddev.md
@@ -83,7 +83,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/sum.md
+++ b/content/flux/v0.x/stdlib/experimental/sum.md
@@ -63,7 +63,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/table/fill.md
+++ b/content/flux/v0.x/stdlib/experimental/table/fill.md
@@ -67,7 +67,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/unique.md
+++ b/content/flux/v0.x/stdlib/experimental/unique.md
@@ -69,7 +69,7 @@ sampledata.int(includeNull: true)
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/unpivot.md
+++ b/content/flux/v0.x/stdlib/experimental/unpivot.md
@@ -75,7 +75,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/experimental/window.md
+++ b/content/flux/v0.x/stdlib/experimental/window.md
@@ -115,7 +115,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -178,7 +178,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/http/pathescape.md
+++ b/content/flux/v0.x/stdlib/http/pathescape.md
@@ -79,7 +79,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/influxdata/influxdb/monitor/deadman.md
+++ b/content/flux/v0.x/stdlib/influxdata/influxdb/monitor/deadman.md
@@ -86,7 +86,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/influxdata/influxdb/monitor/statechanges.md
+++ b/content/flux/v0.x/stdlib/influxdata/influxdb/monitor/statechanges.md
@@ -87,7 +87,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/influxdata/influxdb/monitor/statechangesonly.md
+++ b/content/flux/v0.x/stdlib/influxdata/influxdb/monitor/statechangesonly.md
@@ -77,7 +77,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/influxdata/influxdb/schema/fieldsascols.md
+++ b/content/flux/v0.x/stdlib/influxdata/influxdb/schema/fieldsascols.md
@@ -65,7 +65,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/influxdata/influxdb/v1/fieldsascols.md
+++ b/content/flux/v0.x/stdlib/influxdata/influxdb/v1/fieldsascols.md
@@ -69,7 +69,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/internal/promql/changes.md
+++ b/content/flux/v0.x/stdlib/internal/promql/changes.md
@@ -63,7 +63,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/internal/promql/timestamp.md
+++ b/content/flux/v0.x/stdlib/internal/promql/timestamp.md
@@ -63,7 +63,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/interpolate/linear.md
+++ b/content/flux/v0.x/stdlib/interpolate/linear.md
@@ -71,7 +71,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/abs.md
+++ b/content/flux/v0.x/stdlib/math/abs.md
@@ -70,7 +70,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/acos.md
+++ b/content/flux/v0.x/stdlib/math/acos.md
@@ -75,7 +75,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/acosh.md
+++ b/content/flux/v0.x/stdlib/math/acosh.md
@@ -73,7 +73,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/asin.md
+++ b/content/flux/v0.x/stdlib/math/asin.md
@@ -74,7 +74,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/asinh.md
+++ b/content/flux/v0.x/stdlib/math/asinh.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/atan.md
+++ b/content/flux/v0.x/stdlib/math/atan.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/atanh.md
+++ b/content/flux/v0.x/stdlib/math/atanh.md
@@ -75,7 +75,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/cbrt.md
+++ b/content/flux/v0.x/stdlib/math/cbrt.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/ceil.md
+++ b/content/flux/v0.x/stdlib/math/ceil.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/copysign.md
+++ b/content/flux/v0.x/stdlib/math/copysign.md
@@ -79,7 +79,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/dim.md
+++ b/content/flux/v0.x/stdlib/math/dim.md
@@ -80,7 +80,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/erf.md
+++ b/content/flux/v0.x/stdlib/math/erf.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/erfc.md
+++ b/content/flux/v0.x/stdlib/math/erfc.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/erfcinv.md
+++ b/content/flux/v0.x/stdlib/math/erfcinv.md
@@ -75,7 +75,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/erfinv.md
+++ b/content/flux/v0.x/stdlib/math/erfinv.md
@@ -75,7 +75,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/exp.md
+++ b/content/flux/v0.x/stdlib/math/exp.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/exp2.md
+++ b/content/flux/v0.x/stdlib/math/exp2.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/expm1.md
+++ b/content/flux/v0.x/stdlib/math/expm1.md
@@ -76,7 +76,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/float64bits.md
+++ b/content/flux/v0.x/stdlib/math/float64bits.md
@@ -77,7 +77,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/float64frombits.md
+++ b/content/flux/v0.x/stdlib/math/float64frombits.md
@@ -78,7 +78,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/floor.md
+++ b/content/flux/v0.x/stdlib/math/floor.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/frexp.md
+++ b/content/flux/v0.x/stdlib/math/frexp.md
@@ -82,7 +82,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/gamma.md
+++ b/content/flux/v0.x/stdlib/math/gamma.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/hypot.md
+++ b/content/flux/v0.x/stdlib/math/hypot.md
@@ -82,7 +82,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/ilogb.md
+++ b/content/flux/v0.x/stdlib/math/ilogb.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/isinf.md
+++ b/content/flux/v0.x/stdlib/math/isinf.md
@@ -82,7 +82,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/isnan.md
+++ b/content/flux/v0.x/stdlib/math/isnan.md
@@ -74,7 +74,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/j0.md
+++ b/content/flux/v0.x/stdlib/math/j0.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/j1.md
+++ b/content/flux/v0.x/stdlib/math/j1.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/jn.md
+++ b/content/flux/v0.x/stdlib/math/jn.md
@@ -81,7 +81,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/ldexp.md
+++ b/content/flux/v0.x/stdlib/math/ldexp.md
@@ -80,7 +80,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/lgamma.md
+++ b/content/flux/v0.x/stdlib/math/lgamma.md
@@ -81,7 +81,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/log1p.md
+++ b/content/flux/v0.x/stdlib/math/log1p.md
@@ -78,7 +78,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/log2.md
+++ b/content/flux/v0.x/stdlib/math/log2.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/logb.md
+++ b/content/flux/v0.x/stdlib/math/logb.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/minf.md
+++ b/content/flux/v0.x/stdlib/math/minf.md
@@ -77,7 +77,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/mmax.md
+++ b/content/flux/v0.x/stdlib/math/mmax.md
@@ -80,7 +80,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/mmin.md
+++ b/content/flux/v0.x/stdlib/math/mmin.md
@@ -80,7 +80,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/mod.md
+++ b/content/flux/v0.x/stdlib/math/mod.md
@@ -84,7 +84,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/modf.md
+++ b/content/flux/v0.x/stdlib/math/modf.md
@@ -81,7 +81,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/nextafter.md
+++ b/content/flux/v0.x/stdlib/math/nextafter.md
@@ -80,7 +80,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/pow.md
+++ b/content/flux/v0.x/stdlib/math/pow.md
@@ -80,7 +80,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/pow10.md
+++ b/content/flux/v0.x/stdlib/math/pow10.md
@@ -75,7 +75,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/remainder.md
+++ b/content/flux/v0.x/stdlib/math/remainder.md
@@ -80,7 +80,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/round.md
+++ b/content/flux/v0.x/stdlib/math/round.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/roundtoeven.md
+++ b/content/flux/v0.x/stdlib/math/roundtoeven.md
@@ -78,7 +78,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/signbit.md
+++ b/content/flux/v0.x/stdlib/math/signbit.md
@@ -74,7 +74,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/sin.md
+++ b/content/flux/v0.x/stdlib/math/sin.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/sincos.md
+++ b/content/flux/v0.x/stdlib/math/sincos.md
@@ -81,7 +81,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/sinh.md
+++ b/content/flux/v0.x/stdlib/math/sinh.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/sqrt.md
+++ b/content/flux/v0.x/stdlib/math/sqrt.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/tan.md
+++ b/content/flux/v0.x/stdlib/math/tan.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/tanh.md
+++ b/content/flux/v0.x/stdlib/math/tanh.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/trunc.md
+++ b/content/flux/v0.x/stdlib/math/trunc.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/y0.md
+++ b/content/flux/v0.x/stdlib/math/y0.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/y1.md
+++ b/content/flux/v0.x/stdlib/math/y1.md
@@ -75,7 +75,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/math/yn.md
+++ b/content/flux/v0.x/stdlib/math/yn.md
@@ -80,7 +80,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/pagerduty/dedupkey.md
+++ b/content/flux/v0.x/stdlib/pagerduty/dedupkey.md
@@ -74,7 +74,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/regexp/findstring.md
+++ b/content/flux/v0.x/stdlib/regexp/findstring.md
@@ -83,7 +83,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/regexp/replaceallstring.md
+++ b/content/flux/v0.x/stdlib/regexp/replaceallstring.md
@@ -89,7 +89,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/compare.md
+++ b/content/flux/v0.x/stdlib/strings/compare.md
@@ -71,7 +71,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/containsany.md
+++ b/content/flux/v0.x/stdlib/strings/containsany.md
@@ -67,7 +67,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/containsstr.md
+++ b/content/flux/v0.x/stdlib/strings/containsstr.md
@@ -67,7 +67,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/countstr.md
+++ b/content/flux/v0.x/stdlib/strings/countstr.md
@@ -67,7 +67,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/equalfold.md
+++ b/content/flux/v0.x/stdlib/strings/equalfold.md
@@ -66,7 +66,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/hasprefix.md
+++ b/content/flux/v0.x/stdlib/strings/hasprefix.md
@@ -67,7 +67,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/hassuffix.md
+++ b/content/flux/v0.x/stdlib/strings/hassuffix.md
@@ -67,7 +67,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/index-fn.md
+++ b/content/flux/v0.x/stdlib/strings/index-fn.md
@@ -69,7 +69,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/indexany.md
+++ b/content/flux/v0.x/stdlib/strings/indexany.md
@@ -69,7 +69,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/isdigit.md
+++ b/content/flux/v0.x/stdlib/strings/isdigit.md
@@ -60,7 +60,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/isletter.md
+++ b/content/flux/v0.x/stdlib/strings/isletter.md
@@ -60,7 +60,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/islower.md
+++ b/content/flux/v0.x/stdlib/strings/islower.md
@@ -60,7 +60,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/isupper.md
+++ b/content/flux/v0.x/stdlib/strings/isupper.md
@@ -60,7 +60,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/lastindex.md
+++ b/content/flux/v0.x/stdlib/strings/lastindex.md
@@ -69,7 +69,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/lastindexany.md
+++ b/content/flux/v0.x/stdlib/strings/lastindexany.md
@@ -71,7 +71,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/repeat.md
+++ b/content/flux/v0.x/stdlib/strings/repeat.md
@@ -66,7 +66,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/replace.md
+++ b/content/flux/v0.x/stdlib/strings/replace.md
@@ -81,7 +81,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/replaceall.md
+++ b/content/flux/v0.x/stdlib/strings/replaceall.md
@@ -73,7 +73,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/strlen.md
+++ b/content/flux/v0.x/stdlib/strings/strlen.md
@@ -63,7 +63,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -113,7 +113,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/substring.md
+++ b/content/flux/v0.x/stdlib/strings/substring.md
@@ -76,7 +76,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/title.md
+++ b/content/flux/v0.x/stdlib/strings/title.md
@@ -61,7 +61,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/tolower.md
+++ b/content/flux/v0.x/stdlib/strings/tolower.md
@@ -61,7 +61,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/toupper.md
+++ b/content/flux/v0.x/stdlib/strings/toupper.md
@@ -70,7 +70,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/trim.md
+++ b/content/flux/v0.x/stdlib/strings/trim.md
@@ -66,7 +66,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/trimleft.md
+++ b/content/flux/v0.x/stdlib/strings/trimleft.md
@@ -66,7 +66,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/trimprefix.md
+++ b/content/flux/v0.x/stdlib/strings/trimprefix.md
@@ -67,7 +67,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/trimright.md
+++ b/content/flux/v0.x/stdlib/strings/trimright.md
@@ -66,7 +66,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/trimspace.md
+++ b/content/flux/v0.x/stdlib/strings/trimspace.md
@@ -60,7 +60,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/strings/trimsuffix.md
+++ b/content/flux/v0.x/stdlib/strings/trimsuffix.md
@@ -66,7 +66,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/types/isnumeric.md
+++ b/content/flux/v0.x/stdlib/types/isnumeric.md
@@ -63,7 +63,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/types/istype.md
+++ b/content/flux/v0.x/stdlib/types/istype.md
@@ -79,7 +79,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -139,7 +139,7 @@ union(tables: [nonNumericData, numericData])
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/aggregatewindow.md
+++ b/content/flux/v0.x/stdlib/universe/aggregatewindow.md
@@ -149,7 +149,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -207,7 +207,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -256,7 +256,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -316,7 +316,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/bool.md
+++ b/content/flux/v0.x/stdlib/universe/bool.md
@@ -104,7 +104,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/bottom.md
+++ b/content/flux/v0.x/stdlib/universe/bottom.md
@@ -76,7 +76,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/columns.md
+++ b/content/flux/v0.x/stdlib/universe/columns.md
@@ -74,7 +74,7 @@ sampledata.string()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/contains.md
+++ b/content/flux/v0.x/stdlib/universe/contains.md
@@ -68,7 +68,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/count.md
+++ b/content/flux/v0.x/stdlib/universe/count.md
@@ -100,7 +100,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/covariance.md
+++ b/content/flux/v0.x/stdlib/universe/covariance.md
@@ -78,7 +78,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/cumulativesum.md
+++ b/content/flux/v0.x/stdlib/universe/cumulativesum.md
@@ -68,7 +68,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/derivative.md
+++ b/content/flux/v0.x/stdlib/universe/derivative.md
@@ -113,7 +113,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -168,7 +168,7 @@ sampledata.int(includeNull: true)
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/difference.md
+++ b/content/flux/v0.x/stdlib/universe/difference.md
@@ -112,7 +112,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -167,7 +167,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -222,7 +222,7 @@ sampledata.int(includeNull: true)
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -277,7 +277,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/distinct.md
+++ b/content/flux/v0.x/stdlib/universe/distinct.md
@@ -73,7 +73,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -129,7 +129,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -176,7 +176,7 @@ sampledata.int(includeNull: true)
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/doubleema.md
+++ b/content/flux/v0.x/stdlib/universe/doubleema.md
@@ -78,7 +78,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/drop.md
+++ b/content/flux/v0.x/stdlib/universe/drop.md
@@ -81,7 +81,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -135,7 +135,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/duplicate.md
+++ b/content/flux/v0.x/stdlib/universe/duplicate.md
@@ -75,7 +75,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/duration.md
+++ b/content/flux/v0.x/stdlib/universe/duration.md
@@ -90,7 +90,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/elapsed.md
+++ b/content/flux/v0.x/stdlib/universe/elapsed.md
@@ -82,7 +82,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/exponentialmovingaverage.md
+++ b/content/flux/v0.x/stdlib/universe/exponentialmovingaverage.md
@@ -81,7 +81,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -134,7 +134,7 @@ sampledata.int(includeNull: true)
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/fill.md
+++ b/content/flux/v0.x/stdlib/universe/fill.md
@@ -85,7 +85,7 @@ sampledata.int(includeNull: true)
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -142,7 +142,7 @@ sampledata.int(includeNull: true)
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/filter.md
+++ b/content/flux/v0.x/stdlib/universe/filter.md
@@ -95,7 +95,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -142,7 +142,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/first.md
+++ b/content/flux/v0.x/stdlib/universe/first.md
@@ -68,7 +68,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/float.md
+++ b/content/flux/v0.x/stdlib/universe/float.md
@@ -96,7 +96,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/group.md
+++ b/content/flux/v0.x/stdlib/universe/group.md
@@ -83,7 +83,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -170,7 +170,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -255,7 +255,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/highestaverage.md
+++ b/content/flux/v0.x/stdlib/universe/highestaverage.md
@@ -82,7 +82,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/highestcurrent.md
+++ b/content/flux/v0.x/stdlib/universe/highestcurrent.md
@@ -82,7 +82,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/highestmax.md
+++ b/content/flux/v0.x/stdlib/universe/highestmax.md
@@ -82,7 +82,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/histogram.md
+++ b/content/flux/v0.x/stdlib/universe/histogram.md
@@ -117,7 +117,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -170,7 +170,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/histogramquantile.md
+++ b/content/flux/v0.x/stdlib/universe/histogramquantile.md
@@ -118,7 +118,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/holtwinters.md
+++ b/content/flux/v0.x/stdlib/universe/holtwinters.md
@@ -157,7 +157,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -214,7 +214,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -267,7 +267,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/hourselection.md
+++ b/content/flux/v0.x/stdlib/universe/hourselection.md
@@ -90,7 +90,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/increase.md
+++ b/content/flux/v0.x/stdlib/universe/increase.md
@@ -71,7 +71,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/int.md
+++ b/content/flux/v0.x/stdlib/universe/int.md
@@ -97,7 +97,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/integral.md
+++ b/content/flux/v0.x/stdlib/universe/integral.md
@@ -97,7 +97,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -142,7 +142,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/kaufmansama.md
+++ b/content/flux/v0.x/stdlib/universe/kaufmansama.md
@@ -77,7 +77,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/kaufmanser.md
+++ b/content/flux/v0.x/stdlib/universe/kaufmanser.md
@@ -72,7 +72,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/keep.md
+++ b/content/flux/v0.x/stdlib/universe/keep.md
@@ -81,7 +81,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -135,7 +135,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/keys.md
+++ b/content/flux/v0.x/stdlib/universe/keys.md
@@ -72,7 +72,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -132,7 +132,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/keyvalues.md
+++ b/content/flux/v0.x/stdlib/universe/keyvalues.md
@@ -71,7 +71,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/last.md
+++ b/content/flux/v0.x/stdlib/universe/last.md
@@ -70,7 +70,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/limit.md
+++ b/content/flux/v0.x/stdlib/universe/limit.md
@@ -79,7 +79,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/lowestaverage.md
+++ b/content/flux/v0.x/stdlib/universe/lowestaverage.md
@@ -82,7 +82,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/lowestcurrent.md
+++ b/content/flux/v0.x/stdlib/universe/lowestcurrent.md
@@ -82,7 +82,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/lowestmin.md
+++ b/content/flux/v0.x/stdlib/universe/lowestmin.md
@@ -82,7 +82,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/map.md
+++ b/content/flux/v0.x/stdlib/universe/map.md
@@ -109,7 +109,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -168,7 +168,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -225,7 +225,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/max.md
+++ b/content/flux/v0.x/stdlib/universe/max.md
@@ -70,7 +70,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/mean.md
+++ b/content/flux/v0.x/stdlib/universe/mean.md
@@ -70,7 +70,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/median.md
+++ b/content/flux/v0.x/stdlib/universe/median.md
@@ -103,7 +103,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -150,7 +150,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/min.md
+++ b/content/flux/v0.x/stdlib/universe/min.md
@@ -70,7 +70,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/mode.md
+++ b/content/flux/v0.x/stdlib/universe/mode.md
@@ -73,7 +73,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/movingaverage.md
+++ b/content/flux/v0.x/stdlib/universe/movingaverage.md
@@ -78,7 +78,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -131,7 +131,7 @@ sampledata.int(includeNull: true)
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/pivot.md
+++ b/content/flux/v0.x/stdlib/universe/pivot.md
@@ -110,7 +110,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -150,7 +150,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/quantile.md
+++ b/content/flux/v0.x/stdlib/universe/quantile.md
@@ -119,7 +119,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -166,7 +166,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/reduce.md
+++ b/content/flux/v0.x/stdlib/universe/reduce.md
@@ -96,7 +96,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -146,7 +146,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -193,7 +193,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -248,7 +248,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/relativestrengthindex.md
+++ b/content/flux/v0.x/stdlib/universe/relativestrengthindex.md
@@ -85,7 +85,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/rename.md
+++ b/content/flux/v0.x/stdlib/universe/rename.md
@@ -79,7 +79,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -136,7 +136,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -199,7 +199,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/sample.md
+++ b/content/flux/v0.x/stdlib/universe/sample.md
@@ -81,7 +81,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/set.md
+++ b/content/flux/v0.x/stdlib/universe/set.md
@@ -76,7 +76,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/skew.md
+++ b/content/flux/v0.x/stdlib/universe/skew.md
@@ -68,7 +68,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/sort.md
+++ b/content/flux/v0.x/stdlib/universe/sort.md
@@ -80,7 +80,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/spread.md
+++ b/content/flux/v0.x/stdlib/universe/spread.md
@@ -70,7 +70,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/statecount.md
+++ b/content/flux/v0.x/stdlib/universe/statecount.md
@@ -79,7 +79,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/stateduration.md
+++ b/content/flux/v0.x/stdlib/universe/stateduration.md
@@ -111,7 +111,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/statetracking.md
+++ b/content/flux/v0.x/stdlib/universe/statetracking.md
@@ -109,7 +109,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -164,7 +164,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -219,7 +219,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/stddev.md
+++ b/content/flux/v0.x/stdlib/universe/stddev.md
@@ -79,7 +79,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/string.md
+++ b/content/flux/v0.x/stdlib/universe/string.md
@@ -85,7 +85,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/sum.md
+++ b/content/flux/v0.x/stdlib/universe/sum.md
@@ -68,7 +68,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/tail.md
+++ b/content/flux/v0.x/stdlib/universe/tail.md
@@ -81,7 +81,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -132,7 +132,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/time.md
+++ b/content/flux/v0.x/stdlib/universe/time.md
@@ -87,7 +87,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/timedmovingaverage.md
+++ b/content/flux/v0.x/stdlib/universe/timedmovingaverage.md
@@ -91,7 +91,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/timeshift.md
+++ b/content/flux/v0.x/stdlib/universe/timeshift.md
@@ -78,7 +78,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -135,7 +135,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/timeweightedavg.md
+++ b/content/flux/v0.x/stdlib/universe/timeweightedavg.md
@@ -68,7 +68,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/tobool.md
+++ b/content/flux/v0.x/stdlib/universe/tobool.md
@@ -66,7 +66,7 @@ sampledata.numericBool()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/tofloat.md
+++ b/content/flux/v0.x/stdlib/universe/tofloat.md
@@ -69,7 +69,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -126,7 +126,7 @@ sampledata.bool()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/toint.md
+++ b/content/flux/v0.x/stdlib/universe/toint.md
@@ -76,7 +76,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -133,7 +133,7 @@ sampledata.bool()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -190,7 +190,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/top.md
+++ b/content/flux/v0.x/stdlib/universe/top.md
@@ -76,7 +76,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/tostring.md
+++ b/content/flux/v0.x/stdlib/universe/tostring.md
@@ -62,7 +62,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/totime.md
+++ b/content/flux/v0.x/stdlib/universe/totime.md
@@ -65,7 +65,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/touint.md
+++ b/content/flux/v0.x/stdlib/universe/touint.md
@@ -76,7 +76,7 @@ sampledata.float()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -133,7 +133,7 @@ sampledata.bool()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -190,7 +190,7 @@ sampledata.uint()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/tripleema.md
+++ b/content/flux/v0.x/stdlib/universe/tripleema.md
@@ -82,7 +82,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/truncatetimecolumn.md
+++ b/content/flux/v0.x/stdlib/universe/truncatetimecolumn.md
@@ -90,7 +90,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/uint.md
+++ b/content/flux/v0.x/stdlib/universe/uint.md
@@ -97,7 +97,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/unique.md
+++ b/content/flux/v0.x/stdlib/universe/unique.md
@@ -69,7 +69,7 @@ sampledata.int()
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/flux/v0.x/stdlib/universe/window.md
+++ b/content/flux/v0.x/stdlib/universe/window.md
@@ -136,7 +136,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -197,7 +197,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 
@@ -282,7 +282,7 @@ data
 ```
 
 {{< expand-wrapper >}}
-{{% expand "View example input and ouput" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input data
 

--- a/content/influxdb/v2.4/query-data/flux/join.md
+++ b/content/influxdb/v2.4/query-data/flux/join.md
@@ -365,7 +365,7 @@ union(tables: [f1, f2])
     |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
 ```
 {{< expand-wrapper >}}
-{{% expand "View example input and output" %}}
+{{% expand "View example input and output data" %}}
 
 #### Input
 {{< flex >}}


### PR DESCRIPTION
Closes #

Fixes a typo repeated in 258 locations in the docs (expand sample data in docs).

![image](https://user-images.githubusercontent.com/654416/196517951-5790c5c8-a467-4bc5-889d-c631737ed274.png)


_Describe your proposed changes here._

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
