### PR TITLE
Add research notification across all docs

### DIFF
--- a/assets/styles/layouts/_notifications.scss
+++ b/assets/styles/layouts/_notifications.scss
@@ -17,7 +17,7 @@
     box-shadow: 2px 2px 6px rgba($g2-kevlar, .35);
 
     .notification-content {
-      padding: 1.25rem 2.35rem .5rem 1.25rem;
+      padding: 1.5rem 2rem .75rem 1.5rem;
       margin-bottom: 10px;
       font-size: .95rem;
       color: $g20-white;
@@ -57,21 +57,65 @@
       &:first-child { margin-top: 0; }
     }
 
-    h1,h2 { font-size: 1.5rem; }
-    h3 { font-size: 1.25rem; }
-    h4 { font-size: 1.1rem; }
-    h5 { font-size: 1rem; }
+    h1,h2 { font-size: 1.6rem; }
+    h3 { font-size: 1.4rem; }
+    h4 { font-size: 1.3rem; }
+    h5 { font-size: 1.1rem; }
     h6 { font-size: .95rem; font-style: italic; }
 
-    p,li  { line-height: 1.4rem; }
+    p,li  {
+      font-size: 1.05rem;
+      line-height: 1.4rem;
+    }
 
-    p { margin: 0 0 .75rem; }
+    p {
+      margin: 0 0 .75rem;
+
+      &.right {
+        text-align: right;
+      }
+    }
 
     a {
       font-weight: bold;
       text-decoration: none;
       color: $g20-white;
       transition: color .2s;
+
+      &.btn {
+        position: relative;
+        display: inline-block;
+        margin: .5rem .25rem .5rem 0;
+        padding: 0.85rem 1.5rem;
+        color: $article-btn-text !important;
+        border-radius: $radius;
+        font-size: 1.05rem;
+        z-index: 1;
+        @include gradient($grad-burningDusk);
+      
+        &:after {
+          content: "";
+          position: absolute;
+          display: block;
+          top: 0;
+          right: 0;
+          width: 100%;
+          height: 100%;
+          border-radius: $radius;
+          @include gradient($grad-coolDusk, 270deg);
+          opacity: 0;
+          transition: opacity .2s;
+          z-index: -1;
+        }
+      
+        &:hover {
+          cursor: pointer;
+      
+          &:after {
+            opacity: 1;
+          }
+        }
+      }
     }
 
     ul,ol { padding-left: 1.5rem; }

--- a/data/notifications.yaml
+++ b/data/notifications.yaml
@@ -16,7 +16,7 @@
     **InfluxDB Cloud** and **InfluxDB OSS 2.0** ready for production.
 
     - [Upgrade to InfluxDB Cloud](/influxdb/cloud/upgrade/v1-to-cloud/)
-    - [Upgrade to InfluxDB OSS 2.0](/influxdb/v2.0/upgrade/v1-to-v2/)
+    - [Upgrade to InfluxDB OSS 2.x](/influxdb/latest/upgrade/v1-to-v2/)
 
 - id: docs-ux-research
   level: note
@@ -24,8 +24,8 @@
     - /
   message: |
     ### Help improve the InfluxData documentation
-    We are looking for volunteers to help us in our research to improve the
-    structure, layout, and user experience of the InfluxData documentation.
-    If you are interested in helping, let us know.
+    We're looking for volunteers to help in our research to improve the
+    structure, layout, and user experience in InfluxData documentation.
+    If you're interested, please let us know.
 
     <p class="right"><a class="btn" href="https://forms.gle/mkUPGmtBi6izNAfWA" target="_blank">I want to help!</a></p>

--- a/data/notifications.yaml
+++ b/data/notifications.yaml
@@ -17,3 +17,15 @@
 
     - [Upgrade to InfluxDB Cloud](/influxdb/cloud/upgrade/v1-to-cloud/)
     - [Upgrade to InfluxDB OSS 2.0](/influxdb/v2.0/upgrade/v1-to-v2/)
+
+- id: docs-ux-research
+  level: note
+  scope:
+    - /
+  message: |
+    ### Help improve the InfluxData documentation
+    We are looking for volunteers to help us in our research to improve the
+    structure, layout, and user experience of the InfluxData documentation.
+    If you are interested in helping, let us know.
+
+    <p class="right"><a class="btn" href="https://forms.gle/mkUPGmtBi6izNAfWA" target="_blank">I want to help!</a></p>


### PR DESCRIPTION
This adds a session-based notification visible on all pages for all users. It's an invitation to sign up and help with our user research.

<img width="1314" alt="image" src="https://user-images.githubusercontent.com/181484/196559919-032e8943-f13f-445e-b50c-57c17aca12a4.png">

"I want to help!" links to the following Google form:

<img width="500" alt="image" src="https://user-images.githubusercontent.com/181484/196559956-3a1ac682-d2d6-4e77-bca8-5862ac0a0dd8.png">

- [x] Rebased/mergeable
