### PR TITLE
corrected to influx server-config command

### DIFF
--- a/content/influxdb/v2.5/install.md
+++ b/content/influxdb/v2.5/install.md
@@ -554,7 +554,7 @@ To mount an InfluxDB configuration file and use it from within Docker:
     ```sh
     docker run \
       --rm influxdb:{{< latest-patch >}} \
-      influxd print-config > config.yml
+      influx server-config > config.yml
     ```
 
 3. Modify the default configuration, which will now be available under `$PWD`.


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/4631

changed to influx server-config - influxd print-config is deprecated

