### PR TITLE
Fix wrong usage of CLI's config command

### DIFF
--- a/content/influxdb/v2.5/get-started/setup.md
+++ b/content/influxdb/v2.5/get-started/setup.md
@@ -278,9 +278,9 @@ to create a new CLI connection configuration. Include the following flags:
 
 ```sh
 influx config create \
-  --name get-started
-  --host-url http://localhost:8086
-  --org <YOUR_INFLUXDB_ORG_NAME>
+  --config-name get-started \
+  --host-url http://localhost:8086 \
+  --org <YOUR_INFLUXDB_ORG_NAME> \
   --token <YOUR_INFLUXDB_API_TOKEN>
 ```
 


### PR DESCRIPTION
Closes no issue I am aware of

Use the proper command line args for the cli's create command.

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
