### PR TITLE
Fix for integer range issue

### DIFF
--- a/content/enterprise_influxdb/v1.10/troubleshooting/frequently-asked-questions.md
+++ b/content/enterprise_influxdb/v1.10/troubleshooting/frequently-asked-questions.md
@@ -390,7 +390,7 @@ my_field   boolean
 
 ## What are the minimum and maximum integers that InfluxDB can store?
 InfluxDB stores all integers as signed int64 data types.
-The minimum and maximum valid values for int64 are `-9023372036854775808` and `9023372036854775807`.
+The minimum and maximum valid values for int64 are `-9223372036854775808` and `9223372036854775807`.
 See [Go builtins](http://golang.org/pkg/builtin/#int64) for more information.
 
 Values close to but within those limits may lead to unexpected results; some functions and operators convert the int64 data type to float64 during calculation which can cause overflow issues.

--- a/content/enterprise_influxdb/v1.9/troubleshooting/frequently-asked-questions.md
+++ b/content/enterprise_influxdb/v1.9/troubleshooting/frequently-asked-questions.md
@@ -401,7 +401,7 @@ my_field   boolean
 
 #### What are the minimum and maximum integers that InfluxDB can store?
 InfluxDB stores all integers as signed int64 data types.
-The minimum and maximum valid values for int64 are `-9023372036854775808` and `9023372036854775807`.
+The minimum and maximum valid values for int64 are `-9223372036854775808` and `9223372036854775807`.
 See [Go builtins](http://golang.org/pkg/builtin/#int64) for more information.
 
 Values close to but within those limits may lead to unexpected results; some functions and operators convert the int64 data type to float64 during calculation which can cause overflow issues.

--- a/content/influxdb/v1.3/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.3/troubleshooting/frequently-asked-questions.md
@@ -345,7 +345,7 @@ my_field   boolean
 
 ## What are the minimum and maximum integers that InfluxDB can store?
 InfluxDB stores all integers as signed int64 data types.
-The minimum and maximum valid values for int64 are `-9023372036854775808` and `9023372036854775807`.
+The minimum and maximum valid values for int64 are `-9223372036854775808` and `9223372036854775807`.
 See [Go builtins](http://golang.org/pkg/builtin/#int64) for more information.
 
 Values close to but within those limits may lead to unexpected results; some functions and operators convert the int64 data type to float64 during calculation which can cause overflow issues.

--- a/content/influxdb/v1.4/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.4/troubleshooting/frequently-asked-questions.md
@@ -350,7 +350,7 @@ my_field   boolean
 
 ## What are the minimum and maximum integers that InfluxDB can store?
 InfluxDB stores all integers as signed int64 data types.
-The minimum and maximum valid values for int64 are `-9023372036854775808` and `9023372036854775807`.
+The minimum and maximum valid values for int64 are `-9223372036854775808` and `9223372036854775807`.
 See [Go builtins](http://golang.org/pkg/builtin/#int64) for more information.
 
 Values close to but within those limits may lead to unexpected results; some functions and operators convert the int64 data type to float64 during calculation which can cause overflow issues.

--- a/content/influxdb/v1.5/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.5/troubleshooting/frequently-asked-questions.md
@@ -350,7 +350,7 @@ my_field   boolean
 
 ## What are the minimum and maximum integers that InfluxDB can store?
 InfluxDB stores all integers as signed int64 data types.
-The minimum and maximum valid values for int64 are `-9023372036854775808` and `9023372036854775807`.
+The minimum and maximum valid values for int64 are `-9223372036854775808` and `9223372036854775807`.
 See [Go builtins](http://golang.org/pkg/builtin/#int64) for more information.
 
 Values close to but within those limits may lead to unexpected results; some functions and operators convert the int64 data type to float64 during calculation which can cause overflow issues.

--- a/content/influxdb/v1.6/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.6/troubleshooting/frequently-asked-questions.md
@@ -350,7 +350,7 @@ my_field   boolean
 
 ## What are the minimum and maximum integers that InfluxDB can store?
 InfluxDB stores all integers as signed int64 data types.
-The minimum and maximum valid values for int64 are `-9023372036854775808` and `9023372036854775807`.
+The minimum and maximum valid values for int64 are `-9223372036854775808` and `9223372036854775807`.
 See [Go builtins](http://golang.org/pkg/builtin/#int64) for more information.
 
 Values close to but within those limits may lead to unexpected results; some functions and operators convert the int64 data type to float64 during calculation which can cause overflow issues.

--- a/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
@@ -380,7 +380,7 @@ my_field   boolean
 
 ## What are the minimum and maximum integers that InfluxDB can store?
 InfluxDB stores all integers as signed int64 data types.
-The minimum and maximum valid values for int64 are `-9023372036854775808` and `9023372036854775807`.
+The minimum and maximum valid values for int64 are `-9223372036854775808` and `9223372036854775807`.
 See [Go builtins](http://golang.org/pkg/builtin/#int64) for more information.
 
 Values close to but within those limits may lead to unexpected results; some functions and operators convert the int64 data type to float64 during calculation which can cause overflow issues.

--- a/content/influxdb/v1.8/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.8/troubleshooting/frequently-asked-questions.md
@@ -372,7 +372,7 @@ my_field   boolean
 
 ## What are the minimum and maximum integers that InfluxDB can store?
 InfluxDB stores all integers as signed int64 data types.
-The minimum and maximum valid values for int64 are `-9023372036854775808` and `9023372036854775807`.
+The minimum and maximum valid values for int64 are `-9223372036854775808` and `9223372036854775807`.
 See [Go builtins](http://golang.org/pkg/builtin/#int64) for more information.
 
 Values close to but within those limits may lead to unexpected results; some functions and operators convert the int64 data type to float64 during calculation which can cause overflow issues.

--- a/content/influxdb/v2.2/reference/faq.md
+++ b/content/influxdb/v2.2/reference/faq.md
@@ -343,8 +343,8 @@ For more information, see [Data retention](/influxdb/v2.2/reference/internals/da
 #### What are the minimum and maximum integers that InfluxDB can store?
 InfluxDB stores all integers as signed 64bit integers.
 
-**Minimum integer**: `-9023372036854775808`  
-**Maximum integer**: `9023372036854775807`  
+**Minimum integer**: `-9223372036854775808`  
+**Maximum integer**: `9223372036854775807`  
 
 Values close to but within those limits may lead to unexpected behavior.
 Some query operations convert 64bit integers to 64bit float values 

--- a/content/influxdb/v2.3/reference/faq.md
+++ b/content/influxdb/v2.3/reference/faq.md
@@ -343,8 +343,8 @@ For more information, see [Data retention](/influxdb/v2.3/reference/internals/da
 #### What are the minimum and maximum integers that InfluxDB can store?
 InfluxDB stores all integers as signed 64bit integers.
 
-**Minimum integer**: `-9023372036854775808`  
-**Maximum integer**: `9023372036854775807`  
+**Minimum integer**: `-9223372036854775808`  
+**Maximum integer**: `9223372036854775807`  
 
 Values close to but within those limits may lead to unexpected behavior.
 Some query operations convert 64bit integers to 64bit float values 

--- a/content/influxdb/v2.4/reference/faq.md
+++ b/content/influxdb/v2.4/reference/faq.md
@@ -357,8 +357,8 @@ For more information, see [Data retention](/influxdb/v2.4/reference/internals/da
 #### What are the minimum and maximum integers that InfluxDB can store?
 InfluxDB stores all integers as signed 64bit integers.
 
-**Minimum integer**: `-9023372036854775808`  
-**Maximum integer**: `9023372036854775807`  
+**Minimum integer**: `-9223372036854775808`  
+**Maximum integer**: `9223372036854775807`  
 
 Values close to but within those limits may lead to unexpected behavior.
 Some query operations convert 64bit integers to 64bit float values 

--- a/content/influxdb/v2.5/reference/faq.md
+++ b/content/influxdb/v2.5/reference/faq.md
@@ -357,8 +357,8 @@ For more information, see [Data retention](/influxdb/v2.5/reference/internals/da
 #### What are the minimum and maximum integers that InfluxDB can store?
 InfluxDB stores all integers as signed 64bit integers.
 
-**Minimum integer**: `-9023372036854775808`  
-**Maximum integer**: `9023372036854775807`  
+**Minimum integer**: `-9223372036854775808`  
+**Maximum integer**: `9223372036854775807`  
 
 Values close to but within those limits may lead to unexpected behavior.
 Some query operations convert 64bit integers to 64bit float values 


### PR DESCRIPTION
Closes #4637

The minimum and maximum values for int64 are -9223372036854775808 through 9223372036854775807

As noted here:
https://pkg.go.dev/builtin#int64
