### PR TITLE
fix: add note for how to close stdin pipe on windows

### DIFF
--- a/content/influxdb/v2.5/process-data/manage-tasks/create-task.md
+++ b/content/influxdb/v2.5/process-data/manage-tasks/create-task.md
@@ -122,7 +122,8 @@ option task = {
 
 # ... Task script ...
 
-# <ctrl-d> to close the pipe and submit the command
+# <ctrl-d> to close the pipe and submit the command (on Unix-like systems)
+# <enter>, then <ctrl-d>, then <enter> to close the pipe and submit the command (on Windows systems)
 ```
 
 ## Create a task using the InfluxDB API

--- a/content/influxdb/v2.5/process-data/manage-tasks/create-task.md
+++ b/content/influxdb/v2.5/process-data/manage-tasks/create-task.md
@@ -122,8 +122,8 @@ option task = {
 
 # ... Task script ...
 
-# <ctrl-d> to close the pipe and submit the command (on Unix-like systems)
-# <enter>, then <ctrl-d>, then <enter> to close the pipe and submit the command (on Windows systems)
+# Linux & macOS: <ctrl-d> to close the pipe and submit the command
+# Windows: <enter>, then <ctrl-d>, then <enter> to close the pipe and submit the command
 ```
 
 ## Create a task using the InfluxDB API

--- a/content/influxdb/v2.5/query-data/execute-queries/influx-query.md
+++ b/content/influxdb/v2.5/query-data/execute-queries/influx-query.md
@@ -26,7 +26,8 @@ influx query --file /path/to/query.flux
 influx query - # Return to open the pipe
 
 data = from(bucket: "example-bucket") |> range(start: -10m) # ...
-# ctrl-d to close the pipe and submit the query
+# ctrl-d to close the pipe and submit the query (on Unix-like systems)
+# enter, then ctrl-z, then enter to close the pipe and submit the query (on Windows systems)
 ```
 
 {{% note %}}

--- a/content/influxdb/v2.5/query-data/execute-queries/influx-query.md
+++ b/content/influxdb/v2.5/query-data/execute-queries/influx-query.md
@@ -26,8 +26,8 @@ influx query --file /path/to/query.flux
 influx query - # Return to open the pipe
 
 data = from(bucket: "example-bucket") |> range(start: -10m) # ...
-# ctrl-d to close the pipe and submit the query (on Unix-like systems)
-# enter, then ctrl-z, then enter to close the pipe and submit the query (on Windows systems)
+# Linux & macOS: <ctrl-d> to close the pipe and submit the command
+# Windows: <enter>, then <ctrl-d>, then <enter> to close the pipe and submit the command
 ```
 
 {{% note %}}


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/23178

_Describe your proposed changes here._
ctrl+d does not work on the Windows CLI, this adds documentation on how to close the stdin pipe for Windows.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
