### PR TITLE
Fix oss 2.6 refs

### DIFF
--- a/content/influxdb/v2.6/upgrade/v1-to-v2/_index.md
+++ b/content/influxdb/v2.6/upgrade/v1-to-v2/_index.md
@@ -1,12 +1,12 @@
 ---
-title: Upgrade from InfluxDB 1.x to 2.5
+title: Upgrade from InfluxDB 1.x to 2.6
 description: >
-  Explore different methods for upgrading from InfluxDB 1.x to InfluxDB 2.5 and
+  Explore different methods for upgrading from InfluxDB 1.x to InfluxDB 2.6 and
   choose the best one for your use case.
 menu:
   influxdb_2_6:
     parent: Upgrade InfluxDB
-    name: InfluxDB 1.x to 2.5
+    name: InfluxDB 1.x to 2.6
 weight: 11
 ---
 

--- a/content/influxdb/v2.6/upgrade/v1-to-v2/automatic-upgrade.md
+++ b/content/influxdb/v2.6/upgrade/v1-to-v2/automatic-upgrade.md
@@ -5,7 +5,7 @@ description: >
   Use the `influx upgrade` tool to automatically upgrade from InfluxDB 1.x to InfluxDB 2.1.
 menu:
   influxdb_2_6:
-    parent: InfluxDB 1.x to 2.5
+    parent: InfluxDB 1.x to 2.6
     name: Automatically upgrade
 weight: 10
 aliases:

--- a/content/influxdb/v2.6/upgrade/v1-to-v2/automatic-upgrade.md
+++ b/content/influxdb/v2.6/upgrade/v1-to-v2/automatic-upgrade.md
@@ -2,7 +2,7 @@
 title: Automatically upgrade from InfluxDB 1.x to 2.1
 list_title: Automatically upgrade from 1.x to 2.1
 description: >
-  Use the `influx upgrade` tool to automatically upgrade from InfluxDB 1.x to InfluxDB 2.1.
+  Use the `influx upgrade` tool to automatically upgrade from InfluxDB 1.x to InfluxDB 2.6.
 menu:
   influxdb_2_6:
     parent: InfluxDB 1.x to 2.6

--- a/content/influxdb/v2.6/upgrade/v1-to-v2/automatic-upgrade.md
+++ b/content/influxdb/v2.6/upgrade/v1-to-v2/automatic-upgrade.md
@@ -1,6 +1,6 @@
 ---
-title: Automatically upgrade from InfluxDB 1.x to 2.1
-list_title: Automatically upgrade from 1.x to 2.1
+title: Automatically upgrade from InfluxDB 1.x to 2.6
+list_title: Automatically upgrade from 1.x to 2.6
 description: >
   Use the `influx upgrade` tool to automatically upgrade from InfluxDB 1.x to InfluxDB 2.6.
 menu:

--- a/content/influxdb/v2.6/upgrade/v1-to-v2/docker.md
+++ b/content/influxdb/v2.6/upgrade/v1-to-v2/docker.md
@@ -1,12 +1,12 @@
 ---
-title: Upgrade from InfluxDB 1.x to 2.5 with Docker
-list_title: Upgrade from 1.x to 2.5 with Docker
+title: Upgrade from InfluxDB 1.x to 2.6 with Docker
+list_title: Upgrade from 1.x to 2.6 with Docker
 description: >
   Use the automated upgrade process built into the InfluxDB 2.x Docker image to
   update InfluxDB 1.x Docker deployments to InfluxDB 2.x.
 menu:
   influxdb_2_6:
-    parent: InfluxDB 1.x to 2.5
+    parent: InfluxDB 1.x to 2.6
     name: Upgrade with Docker
 weight: 101
 ---

--- a/content/influxdb/v2.6/upgrade/v1-to-v2/manual-upgrade.md
+++ b/content/influxdb/v2.6/upgrade/v1-to-v2/manual-upgrade.md
@@ -1,13 +1,13 @@
 ---
-title: Manually upgrade from InfluxDB 1.x to 2.5
-list_title: Manually upgrade from 1.x to 2.5
+title: Manually upgrade from InfluxDB 1.x to 2.6
+list_title: Manually upgrade from 1.x to 2.6
 description: >
-  To manually upgrade from InfluxDB 1.x to InfluxDB 2.5, migrate data, create
+  To manually upgrade from InfluxDB 1.x to InfluxDB 2.6, migrate data, create
   1.x-compatible authorizations, and create database and retention policy
   (DBRP) mappings.
 menu:
   influxdb_2_6:
-    parent: InfluxDB 1.x to 2.5
+    parent: InfluxDB 1.x to 2.6
     name: Manually upgrade
 weight: 11
 related:

--- a/content/influxdb/v2.6/upgrade/v1-to-v2/migrate-cqs.md
+++ b/content/influxdb/v2.6/upgrade/v1-to-v2/migrate-cqs.md
@@ -6,7 +6,7 @@ description: >
   InfluxDB 2.x tasks.
 menu:
   influxdb_2_6:
-    parent: InfluxDB 1.x to 2.5
+    parent: InfluxDB 1.x to 2.6
     name: Migrate CQs
 weight: 102
 related:

--- a/content/influxdb/v2.6/upgrade/v2-to-v2.md
+++ b/content/influxdb/v2.6/upgrade/v2-to-v2.md
@@ -6,7 +6,7 @@ description: >
 menu:
   influxdb_2_6:
     parent: Upgrade InfluxDB
-    name: InfluxDB 2.x to 2.5
+    name: InfluxDB 2.x to 2.6
 weight: 10
 related:
   - /influxdb/v2.6/reference/cli/influxd/downgrade/

--- a/content/influxdb/v2.6/upgrade/v2-to-v2.md
+++ b/content/influxdb/v2.6/upgrade/v2-to-v2.md
@@ -1,7 +1,7 @@
 ---
-title: Upgrade from InfluxDB 2.x to InfluxDB 2.5
+title: Upgrade from InfluxDB 2.x to InfluxDB 2.6
 description: >
-  To upgrade from InfluxDB 2.0 beta 16 or earlier to InfluxDB 2.5 (stable),
+  To upgrade from InfluxDB 2.0 beta 16 or earlier to InfluxDB 2.6 (stable),
   manually upgrade all resources and data to the latest version by completing these steps.
 menu:
   influxdb_2_6:


### PR DESCRIPTION
Closes https://github.com/influxdata/docs-v2/issues/4673

There were references to OSS 2.1 and 2.5 that should be OSS 2.6