### PR TITLE
Fix Authorization header name in text

### DIFF
--- a/content/influxdb/v2.6/api-guide/api_intro.md
+++ b/content/influxdb/v2.6/api-guide/api_intro.md
@@ -36,7 +36,7 @@ InfluxDB uses [API tokens](/influxdb/v2.6/security/tokens/) to authorize API req
 1. Before exploring the API, use the InfluxDB UI to
 [create an initial API token](/influxdb/v2.6/security/tokens/create-token/) for your application.
 
-2. Include your API token in an `Authentication: Token YOUR_API_TOKEN` HTTP header with each request.
+2. Include your API token in an `Authorization: Token YOUR_API_TOKEN` HTTP header with each request.
 
 {{< code-tabs-wrapper >}}
 {{% code-tabs %}}


### PR DESCRIPTION
Text has `Authentication` as the header name but the correct name is `Authorization` (all examples are correct).