### PR TITLE
Fix small typo on port number

### DIFF
--- a/content/influxdb/cloud-iox/visualize-data/grafana.md
+++ b/content/influxdb/cloud-iox/visualize-data/grafana.md
@@ -166,7 +166,7 @@ to explicitly load unsigned plugins.
       and port 443. For example:
 
       ```
-      us-east-1-1.aws.cloud2.influxdata.com:433
+      us-east-1-1.aws.cloud2.influxdata.com:443
       ```
 
     - **AuthType**: Select **token**.


### PR DESCRIPTION
Changed a typo in the port number on the FlightSQL docs. Port `433` should be `443`.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
