### PR TITLE
fix: bump version in docs

### DIFF
--- a/content/influxdb/cloud-iox/visualize-data/grafana.md
+++ b/content/influxdb/cloud-iox/visualize-data/grafana.md
@@ -35,8 +35,8 @@ The Grafana FlightSQL plugin is experimental and is subject to change.
 {{% /warn %}}
 
 ```sh
-curl -L https://github.com/influxdata/grafana-flightsql-datasource/releases/download/v0.1.0/influxdata-flightsql-datasource-0.1.0.zip \
-  -o influxdata-flightsql-datasource-0.1.0.zip
+curl -L https://github.com/influxdata/grafana-flightsql-datasource/releases/download/v0.1.1/influxdata-flightsql-datasource-0.1.1.zip \
+  -o influxdata-flightsql-datasource-0.1.1.zip
 ```
 
 ## Install the Grafana FlightSQL plugin

--- a/content/influxdb/cloud-iox/visualize-data/grafana.md
+++ b/content/influxdb/cloud-iox/visualize-data/grafana.md
@@ -35,8 +35,8 @@ The Grafana FlightSQL plugin is experimental and is subject to change.
 {{% /warn %}}
 
 ```sh
-curl -L https://github.com/influxdata/grafana-flightsql-datasource/releases/download/v0.1.1/influxdata-flightsql-datasource-0.1.1.zip \
-  -o influxdata-flightsql-datasource-0.1.1.zip
+curl -L https://github.com/influxdata/grafana-flightsql-datasource/releases/download/v0.1.2/influxdata-flightsql-datasource-0.1.2.zip \
+  -o influxdata-flightsql-datasource-0.1.2.zip
 ```
 
 ## Install the Grafana FlightSQL plugin
@@ -75,7 +75,7 @@ cannot be installed on or used with Grafana Cloud.
     the Grafana process can access it.
 
     ```sh
-    unzip influxdata-flightsql-datasource-0.1.1.zip -d /path/to/grafana-plugins/
+    unzip influxdata-flightsql-datasource-0.1.2.zip -d /path/to/grafana-plugins/
     ```
 
 2.  **Edit your Grafana configuration**.

--- a/content/influxdb/cloud-iox/visualize-data/grafana.md
+++ b/content/influxdb/cloud-iox/visualize-data/grafana.md
@@ -75,7 +75,7 @@ cannot be installed on or used with Grafana Cloud.
     the Grafana process can access it.
 
     ```sh
-    unzip influxdata-flightsql-datasource-0.1.0.zip -d /path/to/grafana-plugins/
+    unzip influxdata-flightsql-datasource-0.1.1.zip -d /path/to/grafana-plugins/
     ```
 
 2.  **Edit your Grafana configuration**.


### PR DESCRIPTION
we cut a bug fix release for the grafana-flightsql plugin, so need to bump the recommended version in the docs.

_Describe your proposed changes here._

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
