### PR TITLE
docs: explain a few important fields on replication ls

### DIFF
--- a/content/influxdb/v2.7/reference/cli/influx/replication/list.md
+++ b/content/influxdb/v2.7/reference/cli/influx/replication/list.md
@@ -13,15 +13,22 @@ influxdb/v2.7/tags: [write, replication]
 Replication remotes and replication streams can only be configured for InfluxDB OSS.
 {{% /cloud %}}
 
-
 The `influx replication list` command lists all InfluxDB replication streams and their corresponding metrics.
 
+When listing replications, there are several fields that provide information about how the replication queue is performing:
+
+- `Latest Status Code` indicates the status code of the last `write` request to the remote. This should be a 204 during healthy operation.
+- `Remaining Bytes to be Synced` is the number of bytes that have not been synced to the remote. This number should stay relatively low/close to 0, and should not be constantly increasing.
+- `Current Queue Bytes on Disk` is the total size of the replication queue. The replication queue is cleaned up every `--max-age` seconds. If your queue is filling up your disk, lower this value at the cost of potentially lower reliability.
+
 ## Usage
+
 ```
 influx replication list [command options] [arguments...]
 ```
 
 ## Flags
+
 | Flag |                     | Description                                                           | Input type | {{< cli/mapped >}}    |
 | :--- | :------------------ | :-------------------------------------------------------------------- | :--------: | :-------------------- |
 | `-n` | `--name`            | Filter replication streams by name                                    |   string   |                       |
@@ -39,6 +46,7 @@ influx replication list [command options] [arguments...]
 | `-t` | `--token`           | InfluxDB API token                                                    |   string   | `INFLUX_TOKEN`        |
 
 ## Examples
+
 {{< cli/influx-creds-note >}}
 
 ### List all replication streams


### PR DESCRIPTION
Hoping to clear up some confusion around the `replication ls` results by adding this new field and the documentation to go with it.
