### PR TITLE
fix(telegraf): remove PSI input plugin

### DIFF
--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -1647,14 +1647,6 @@ input:
     introduced: 1.16.0
     tags: [linux, macos, windows]
 
-  - name: PSI
-    id: psi
-    description: |
-      The PSI input plugins push pressure stall information (PSI) from the Linux Kernel to InfluxDB.
-    introduced: 1.22.1
-    tags: [linux]
-    external: true
-
   - name: Puppet Agent
     id: puppetagent
     description: |


### PR DESCRIPTION
This is an external plugin, not something that comes with telegraf.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
