### PR TITLE
Feat: fixed sidebar to the page for easy navigation

### DIFF
--- a/assets/styles/layouts/_sidebar.scss
+++ b/assets/styles/layouts/_sidebar.scss
@@ -1,9 +1,16 @@
 .sidebar {
   display: block;
-  position: relative;
   flex-grow: 1;
-  padding: 0 1em;
+  padding: 0 1em 0.8rem;
   width: 25%;
+
+  height: 100%;
+  max-height: 100vh;
+  position: sticky;
+  top: 0;
+  overflow-y: scroll;
+  scrollbar-width: thin;
+  scroll-behavior: smooth;
 
   &--search {
     position: relative;
@@ -114,6 +121,9 @@
     list-style: none;
     padding-left: 1.5rem;
     margin-bottom: 1rem;
+    height: 100%;
+    padding-bottom: 0.8rem;
+    word-wrap: break-word;
 
     ul {
       list-style: none;


### PR DESCRIPTION
Closes #4815

My changes will fix the sidebar to page and with this, the sidebar won't be moved when a reader scrolls through a page, the reader will be able to know where the are in the InfluxData Docs at all times and they will be able to easily navigate to another page from the sidebar without losing where they are on the current page.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
