### PR TITLE
Add info about bucket naming restrictions, update api-endpoint shortcode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,14 +356,16 @@ Maintain CLI version numbers in the `data/products.yml` file instead of updating
 
 ### API endpoint
 Use the `{{< api-endpoint >}}` shortcode to generate a code block that contains
-a colored request method and a specified API endpoint.
+a colored request method, a specified API endpoint, and an optional link to
+the API reference documentation.
 Provide the following arguments:
 
 - **method**: HTTP request method (get, post, patch, put, or delete)
 - **endpoint**: API endpoint
+- **api-ref**: Link the endpoint to a specific place in the API documentation
 
 ```md
-{{< api-endpoint method="get" endpoint="/api/v2/tasks">}}
+{{< api-endpoint method="get" endpoint="/api/v2/tasks" api-ref="/influxdb/cloud/api/#operation/GetTasks">}}
 ```
 
 ### Tabbed Content

--- a/content/influxdb/cloud-iox/admin/buckets/create-bucket.md
+++ b/content/influxdb/cloud-iox/admin/buckets/create-bucket.md
@@ -80,7 +80,7 @@ and specify values for the following flags:
 - `-n`, `--name`: Bucket name
 - `-r`, `--retention`: Retention period duration
 
-The following example creates a bucket with a retention period of seventy-two hours:
+The following example creates a bucket with a retention period of 72 hours:
 
 ```sh
 influx bucket create \

--- a/content/influxdb/cloud-iox/admin/buckets/create-bucket.md
+++ b/content/influxdb/cloud-iox/admin/buckets/create-bucket.md
@@ -20,20 +20,32 @@ By default, buckets have an `implicit` **schema-type** and a schema that conform
 To require measurements to have specific columns and data types and prevent non-conforming write requests,
 [create a bucket with the `explicit` schema-type](#create-a-bucket-that-enforces-explicit-schemas).
 
-- [Create a bucket in the InfluxDB UI](#create-a-bucket-in-the-influxdb-ui)
-- [Create a bucket using the influx CLI](#create-a-bucket-using-the-influx-cli)
-- [Create a bucket using the InfluxDB HTTP API](#create-a-bucket-using-the-influxdb-api)
+- [Create a bucket](#create-a-bucket)
 - [Create a bucket that enforces explicit schemas](#create-a-bucket-that-enforces-explicit-schemas)
 
-## Create a bucket in the InfluxDB UI
+<!-- Invisible anchor for "Create a bucket" -->
+<span id="create-a-bucket"></span>
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[InfluxDB UI](#)
+[influx CLI](#)
+[InfluxDB API](#)
+{{% /tabs %}}
+
+<!------------------------------ BEGIN UI CONTENT ----------------------------->
+{{% tab-content %}}
 
 There are two places you can create a bucket in the UI.
+
+- [Create a bucket from the Load Data menu](#create-a-bucket-from-the-load-data-menu)
+- [Create a bucket in the Data Explorer](#create-a-bucket-in-the-data-explorer)
 
 ### Create a bucket from the Load Data menu
 
 1. In the navigation menu on the left, select **Load Data** > **Buckets**.
 
-    {{< nav-icon "data" >}}
+{{< nav-icon "data" >}}
 
 2. Click **{{< icon "plus" >}} Create Bucket** in the upper right.
 3. Enter a **Name** for the bucket.
@@ -46,7 +58,7 @@ There are two places you can create a bucket in the UI.
 
 1. In the navigation menu on the left, select **Explore* (**Data Explorer**).
 
-    {{< nav-icon "data-explorer" >}}
+{{< nav-icon "data-explorer" >}}
 
 2. In the **From** panel in the Flux Builder, select `+ Create Bucket`.
 3. Enter a **Name** for the bucket.
@@ -55,38 +67,55 @@ There are two places you can create a bucket in the UI.
     - **Older than** to choose a specific retention period.
 5. Click **Create** to create the bucket.
 
-## Create a bucket using the influx CLI
+{{% /tab-content %}}
+<!------------------------------- END UI CONTENT ------------------------------>
+
+<!----------------------------- BEGIN CLI CONTENT ----------------------------->
+{{% tab-content %}}
 
 To create a bucket with the `influx` CLI, use the [`influx bucket create` command](/influxdb/cloud-iox/reference/cli/influx/bucket/create)
 and specify values for the following flags:
 
-| Requirement                    | Include by |
-|:-------------------------------|:-----------|
-| Organization                   | `-o`       |
-| Bucket                         | `-n`       |
-| Retention Period Duration      | `-r`       |
+- `-o`, `--org`: Organization name
+- `-n`, `--name`: Bucket name
+- `-r`, `--retention`: Retention period duration
 
 The following example creates a bucket with a retention period of seventy-two hours:
 
 ```sh
-influx bucket create -n my-bucket -o {INFLUX_ORG} -r 72h
+influx bucket create \
+  --name my-bucket \
+  --org {INFLUX_ORG} \
+  --retention 72h
 ```
 
-## Create a bucket using the InfluxDB API
+{{% /tab-content %}}
+<!------------------------------ END CLI CONTENT ------------------------------>
+
+<!----------------------------- BEGIN API CONTENT ----------------------------->
+{{% tab-content %}}
 
 To create a bucket with the InfluxDB HTTP API, send a request to the following endpoint:
 
-[{{< api-endpoint method="post" endpoint="https://cloud2.influxdata.com/api/v2/buckets" >}}](/influxdb/cloud-iox/api/#operation/PostBuckets)
+{{< api-endpoint method="post" endpoint="https://cloud2.influxdata.com/api/v2/buckets" api-ref="/influxdb/cloud-iox/api/#operation/PostBuckets" >}}
 
-In your request body, specify values for the following properties:
+Include the following in your request:
 
-| Requirement          | Include by       |
-|:---------------------|:-----------------|
-| Organization         | `orgID`          |
-| Bucket               | `name`           |
-| Retention Rules      | `retentionRules` |
+- **Headers:**
+  - **Authorization:** `Token` scheme with your InfluxDB [API token](/influxdb/cloud/security/tokens/)
+  - **Content-type:** `application/json`
+- **Request body:** JSON object with the following fields:  
+  {{< req type="key" >}}
+  - {{< req "\*" >}} **name:** Bucket name
+  - **orgID:** InfluxDB organization ID
+  - **description:** Bucket description
+  - {{< req "\*" >}} **retentionRules:** JSON array containing a single object
+    with the following fields:
+    - **type:** expire
+    - **everySecond**: Number of seconds to retain data _(0 means forever)_
+    - **shardGroupDuration**: Number of seconds to retain shard groups _(0 means forever)_
 
-The following example creates a bucket with a retention period of `86,400` seconds, or twenty-four hours:
+The following example creates a bucket with a retention period of `86,400` seconds, or 24 hours:
 
 ```sh
 {{% get-shared-text "api/v2.0/buckets/oss/create.sh" %}}
@@ -94,6 +123,9 @@ The following example creates a bucket with a retention period of `86,400` secon
 
 _For information about **InfluxDB API options and response codes**, see
 [InfluxDB API Buckets reference documentation](/influxdb/cloud-iox/api/#operation/PostBuckets)._
+
+{{% /tab-content %}}
+<!------------------------------ END API CONTENT ------------------------------>
 
 ## Create a bucket that enforces explicit schemas
 
@@ -112,9 +144,9 @@ Use the **`influx` CLI** or **InfluxDB HTTP API** to create a bucket with the `e
 
 Use the `influx bucket create` command and specify the `--schema-type=explicit` flag:
 
-  ```sh
-  {{< get-shared-text "bucket-schema/bucket-schema-type.sh" >}}
-  ```
+```sh
+{{< get-shared-text "bucket-schema/bucket-schema-type.sh" >}}
+```
 
 {{% /tab-content %}}
 {{% tab-content %}}
@@ -124,7 +156,7 @@ Use the `influx bucket create` command and specify the `--schema-type=explicit` 
 Use the HTTP API [`/api/v2/buckets`](/influxdb/cloud-iox/api/#operation/PostBuckets)
 endpoint and set the `schemaType` property value to `explicit` in the request body--for example:
 
-{{< api-endpoint method="post" endpoint="https://cloud2.influxdata.com/api/v2/buckets" >}}
+{{< api-endpoint method="post" endpoint="https://cloud2.influxdata.com/api/v2/buckets" api-ref="/influxdb/cloud-iox/api/#operation/PostBuckets" >}}
 
   ```js
   {

--- a/content/influxdb/cloud/organizations/buckets/create-bucket.md
+++ b/content/influxdb/cloud/organizations/buckets/create-bucket.md
@@ -1,7 +1,9 @@
 ---
 title: Create a bucket
 seotitle: Create a bucket in InfluxDB Cloud
-description: Create buckets to store time series data in InfluxDB Cloud using the InfluxDB UI, influx CLI, or InfluxDB HTTP API.
+description: >
+  Create buckets to store time series data in InfluxDB Cloud using the InfluxDB
+  UI, influx CLI, or InfluxDB HTTP API.
 menu:
   influxdb_cloud:
     name: Create a bucket
@@ -9,47 +11,67 @@ menu:
 weight: 201
 ---
 
-Use the InfluxDB user interface (UI), the `influx` command line interface (CLI), or the InfluxDB HTTP API
-to create a bucket.
+Use the InfluxDB user interface (UI), the `influx` command line interface (CLI),
+or the InfluxDB HTTP API to create a bucket.
 
 By default, buckets have an `implicit` **schema-type** and a schema that conforms to your data.
 To require measurements to have specific columns and data types and prevent non-conforming write requests,
 [create a bucket with the `explicit` schema-type](#create-a-bucket-that-enforces-explicit-schemas).
 
-- [Create a bucket in the InfluxDB UI](#create-a-bucket-in-the-influxdb-ui)
-- [Create a bucket using the influx CLI](#create-a-bucket-using-the-influx-cli)
-- [Create a bucket using the InfluxDB HTTP API](#create-a-bucket-using-the-influxdb-api)
+- [Create a bucket](#create-a-bucket)
 - [Create a bucket that enforces explicit schemas](#create-a-bucket-that-enforces-explicit-schemas)
+- [Bucket naming restrictions](#bucket-naming-restrictions)
 
-## Create a bucket in the InfluxDB UI
+<!-- Invisible anchor for "Create a bucket" -->
+<span id="create-a-bucket"></span>
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[InfluxDB UI](#)
+[influx CLI](#)
+[InfluxDB API](#)
+{{% /tabs %}}
+
+<!------------------------------ BEGIN UI CONTENT ----------------------------->
+{{% tab-content %}}
 
 There are two places you can create a bucket in the UI.
 
+- [Create a bucket from the Load Data menu](#create-a-bucket-from-the-load-data-menu)
+- [Create a bucket in the Data Explorer](#create-a-bucket-in-the-data-explorer)
+
 ### Create a bucket from the Load Data menu
 
-1. In the navigation menu on the left, select **Load Data** > **Buckets**.
+1.  In the navigation menu on the left, select **Load Data** > **Buckets**.
 
-    {{< nav-icon "data" >}}
+{{< nav-icon "data" >}}
 
-2. Click **{{< icon "plus" >}} Create Bucket** in the upper right.
-3. Enter a **Name** for the bucket.
-4. Select when to **Delete Data**:
+2.  Click **{{< icon "plus" >}} Create Bucket** in the upper right.
+3.  Enter a **Name** for the bucket
+    _(see [Bucket naming restrictions](#bucket-naming-restrictions))_.
+4.  Select when to **Delete Data**:
     - **Never** to retain data forever.  
     - **Older than** to choose a specific retention period.
-5. Click **Create** to create the bucket.
+5.  Click **Create** to create the bucket.
 
 ### Create a bucket in the Data Explorer
 
-1. In the navigation menu on the left, select **Explore* (**Data Explorer**).
+1.  In the navigation menu on the left, select **Explore* (**Data Explorer**).
 
-    {{< nav-icon "data-explorer" >}}
+{{< nav-icon "data-explorer" >}}
 
-2. In the **From** panel in the Flux Builder, select `+ Create Bucket`.
-3. Enter a **Name** for the bucket.
-4. Select when to **Delete Data**:
+2.  In the **From** panel in the Flux Builder, select `+ Create Bucket`.
+3.  Enter a **Name** for the bucket _(see [Bucket naming restrictions](#bucket-naming-restrictions))_.
+4.  Select when to **Delete Data**:
     - **Never** to retain data forever.  
     - **Older than** to choose a specific retention period.
-5. Click **Create** to create the bucket.
+5.  Click **Create** to create the bucket.
+
+{{% /tab-content %}}
+<!------------------------------- END UI CONTENT ------------------------------>
+
+<!----------------------------- BEGIN CLI CONTENT ----------------------------->
+{{% tab-content %}}
 
 ## Create a bucket using the influx CLI
 
@@ -58,27 +80,43 @@ and specify values for the following flags:
 
 - `-o`, `--org`: Organization name
 - `-n`, `--name`: Bucket name
+  _(see [Bucket naming restrictions](#bucket-naming-restrictions))_
 - `-r`, `--retention`: Retention period duration
 
 The following example creates a bucket with a retention period of `72` hours:
 
 ```sh
-influx bucket create -n my-bucket -o {INFLUX_ORG} -r 72h
+influx bucket create \
+  --name my-bucket \
+  --org {INFLUX_ORG} \
+  --retention 72h
 ```
 
-## Create a bucket using the InfluxDB API
+{{% /tab-content %}}
+<!------------------------------ END CLI CONTENT ------------------------------>
+
+<!----------------------------- BEGIN API CONTENT ----------------------------->
+{{% tab-content %}}
 
 To create a bucket with the InfluxDB HTTP API, send a request to the following endpoint:
 
-[{{< api-endpoint method="post" endpoint="https://cloud2.influxdata.com/api/v2/buckets" >}}](/influxdb/cloud/api/#operation/PostBuckets)
+{{< api-endpoint method="post" endpoint="https://cloud2.influxdata.com/api/v2/buckets" api-ref="/influxdb/cloud/api/#operation/PostBuckets" >}}
 
-In your request body, specify values for the following properties:
+Include the following in your request:
 
-| Requirement          | Include by       |
-|:---------------------|:-----------------|
-| Organization         | `orgID`          |
-| Bucket               | `name`           |
-| Retention Rules      | `retentionRules` |
+- **Headers:**
+  - **Authorization:** `Token` scheme with your InfluxDB [API token](/influxdb/cloud/security/tokens/)
+  - **Content-type:** `application/json`
+- **Request body:** JSON object with the following fields:  
+  {{< req type="key" >}}
+  - {{< req "\*" >}} **name:** Bucket name
+  - **orgID:** InfluxDB organization ID
+  - **description:** Bucket description
+  - {{< req "\*" >}} **retentionRules:** JSON array containing a single object
+    with the following fields:
+    - **type:** expire
+    - **everySecond**: Number of seconds to retain data _(0 means forever)_
+    - **shardGroupDuration**: Number of seconds to retain shard groups _(0 means forever)_
 
 The following example creates a bucket with a retention period of `86,400` seconds, or 24 hours:
 
@@ -87,7 +125,12 @@ The following example creates a bucket with a retention period of `86,400` secon
 ```
 
 _For information about **InfluxDB API options and response codes**, see
-[InfluxDB API Buckets reference documentation](/influxdb/cloud/api/#operation/PostBuckets)._
+[InfluxDB API Buckets reference documentation](/influxdb/cloud-iox/api/#operation/PostBuckets)._
+
+{{% /tab-content %}}
+<!------------------------------ END API CONTENT ------------------------------>
+
+{{< /tabs-wrapper >}}
 
 ## Create a bucket that enforces explicit schemas
 
@@ -106,9 +149,9 @@ Use the **`influx` CLI** or **InfluxDB HTTP API** to create a bucket with the `e
 
 Use the `influx bucket create` command and specify the `--schema-type=explicit` flag:
 
-  ```sh
-  {{< get-shared-text "bucket-schema/bucket-schema-type.sh" >}}
-  ```
+```sh
+{{< get-shared-text "bucket-schema/bucket-schema-type.sh" >}}
+```
 
 {{% /tab-content %}}
 {{% tab-content %}}
@@ -118,25 +161,33 @@ Use the `influx bucket create` command and specify the `--schema-type=explicit` 
 Use the HTTP API [`/api/v2/buckets`](/influxdb/cloud/api/#operation/PostBuckets)
 endpoint and set the `schemaType` property value to `explicit` in the request body--for example:
 
-{{< api-endpoint method="post" endpoint="https://cloud2.influxdata.com/api/v2/buckets" >}}
+{{< api-endpoint method="post" endpoint="https://cloud2.influxdata.com/api/v2/buckets" api-ref="/influxdb/cloud/api/#operation/PostBuckets" >}}
 
-  ```js
-  {
-    "orgID": "{INFLUX_ORG_ID}",
-    "name": "my-explicit-bucket",
-    "description": "My Explicit Bucket",
-    "rp": "string",
-    "retentionRules": [
-      {
-        "type": "expire",
-        "everySeconds": 86400,
-        "shardGroupDurationSeconds": 0
-      }
-    ],
-    "schemaType": "explicit"
-  }
-  ```
+```js
+{
+  "orgID": "{INFLUX_ORG_ID}",
+  "name": "my-explicit-bucket",
+  "description": "My Explicit Bucket",
+  "rp": "string",
+  "retentionRules": [
+    {
+      "type": "expire",
+      "everySeconds": 86400,
+      "shardGroupDurationSeconds": 0
+    }
+  ],
+  "schemaType": "explicit"
+}
+```
 {{% /tab-content %}}
 {{< /tabs-wrapper >}}
 
 Next, see how to [create an explicit bucket schema](/influxdb/cloud/organizations/buckets/bucket-schema/) for a measurement.
+
+## Bucket naming restrictions
+
+Bucket names must adhere to the following naming restrictions:
+
+- Must contain two or more characters
+- Cannot start with an underscore (`_`)
+- Cannot contain a double quote (`"`)

--- a/content/influxdb/cloud/organizations/buckets/update-bucket.md
+++ b/content/influxdb/cloud/organizations/buckets/update-bucket.md
@@ -32,6 +32,11 @@ If you change a bucket name, be sure to update the bucket name in the above plac
 3. Review the information in the window that appears and click **{{< caps >}}I understand, let's rename my bucket{{< /caps >}}**.
 4. Update the bucket's name and click **Change Bucket Name**.
 
+{{% note %}}
+For information about permitted bucket names, see
+[bucket naming restrictions](/influxdb/cloud/organizations/buckets/create-bucket/#bucket-naming-restrictions).
+{{% /note %}}
+
 ## Update a bucket's retention period in the InfluxDB UI
 
 1. In the navigation menu on the left, select **Load Data** > **Buckets**.
@@ -105,7 +110,8 @@ Updating a bucket requires the following:
 - The bucket ID _(provided in the output of the `GET /api/v2/buckets/` endpoint)_
 
 You can update the following bucket properties:
-- name
+
+- name _(see [bucket naming restrictions](/influxdb/cloud/organizations/buckets/create-bucket/#bucket-naming-restrictions))_
 - description
 - retention rules
 

--- a/content/influxdb/v2.6/organizations/buckets/create-bucket.md
+++ b/content/influxdb/v2.6/organizations/buckets/create-bucket.md
@@ -9,8 +9,8 @@ menu:
 weight: 201
 ---
 
-Use the InfluxDB user interface (UI) or the `influx` command line interface (CLI)
-to create a bucket.
+Use the InfluxDB user interface (UI) the `influx` command line interface (CLI),
+or the InfluxDB API to create a bucket.
 
 {{% note %}}
 #### Bucket limits
@@ -19,44 +19,65 @@ written to or queried across all organizations depending on the use case.
 Any more than that can adversely affect performance.
 {{% /note %}}
 
-## Create a bucket in the InfluxDB UI
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[InfluxDB UI](#)
+[influx CLI](#)
+[InfluxDB API](#)
+{{% /tabs %}}
+
+<!------------------------------ BEGIN UI CONTENT ----------------------------->
+{{% tab-content %}}
 
 There are two places you can create a bucket in the UI.
 
+- [Create a bucket from the Load Data menu](#create-a-bucket-from-the-load-data-menu)
+- [Create a bucket in the Data Explorer](#create-a-bucket-in-the-data-explorer)
+
 ### Create a bucket from the Load Data menu
 
-1. In the navigation menu on the left, select **Data (Load Data)** > **Buckets**.
+1.  In the navigation menu on the left, select **Data (Load Data)** > **Buckets**.
 
-    {{< nav-icon "data" >}}
+{{< nav-icon "data" >}}
 
-2. Click **{{< icon "plus" >}} Create Bucket** in the upper right.
-3. Enter a **Name** for the bucket.
-4. Select when to **Delete Data**:
+2.  Click **{{< icon "plus" >}} Create Bucket** in the upper right.
+3.  Enter a **Name** for the bucket 
+    _(see [Bucket naming restrictions](#bucket-naming-restrictions))_.
+4.  Select when to **Delete Data**:
     - **Never** to retain data forever.  
     - **Older than** to choose a specific retention period.
-5. Click **Create** to create the bucket.
+5.  Click **Create** to create the bucket.
 
 ### Create a bucket in the Data Explorer
 
-1. In the navigation menu on the left, select **Explore* (**Data Explorer**).
+1.  In the navigation menu on the left, select **Explore* (**Data Explorer**).
 
-    {{< nav-icon "data-explorer" >}}
+{{< nav-icon "data-explorer" >}}
 
-2. In the **From** panel in the Flux Builder, select `+ Create Bucket`.
-3. Enter a **Name** for the bucket.
-4. Select when to **Delete Data**:
+2.  In the **From** panel in the Flux Builder, select `+ Create Bucket`.
+3.  Enter a **Name** for the bucket 
+    _(see [Bucket naming restrictions](#bucket-naming-restrictions))_.
+4.  Select when to **Delete Data**:
     - **Never** to retain data forever.  
     - **Older than** to choose a specific retention period.
-5. Click **Create** to create the bucket.
+5.  Click **Create** to create the bucket.
 
-## Create a bucket using the influx CLI
+{{% /tab-content %}}
+<!------------------------------- END UI CONTENT ------------------------------>
+
+
+<!----------------------------- BEGIN CLI CONTENT ----------------------------->
+{{% tab-content %}}
 
 Use the [`influx bucket create` command](/influxdb/v2.6/reference/cli/influx/bucket/create)
-to create a new bucket. A bucket requires the following:
+to create a new bucket.
 
-- bucket name
-- organization name or ID
-- retention period (duration to keep data) in one of the following units:
+Include the following flags with the command:
+
+- `-n`, `--name`: Bucket name
+    _(see [Bucket naming restrictions](#bucket-naming-restrictions))_
+- `-o`, `--org` or `--org-id`: Organization name or ID
+- `-r`, `--retention`: Bucket retention period (duration to keep data) in one of the following units:
   - nanoseconds (`ns`)
   - microseconds (`us` or `µs`)
   - milliseconds (`ms`)
@@ -72,32 +93,44 @@ to create a new bucket. A bucket requires the following:
 
 ```sh
 # Syntax
-influx bucket create -n <bucket-name> -o <org-name> -r <retention-period-duration>
+influx bucket create \
+  --name <bucket-name> \
+  --org <org-name> \
+  --retention <retention-period-duration>
 
 # Example
-influx bucket create -n my-bucket -o my-org -r 72h
+influx bucket create \
+  --name my-bucket \
+  --org my-org \
+  --retention 72h
 ```
 
-## Create a bucket using the InfluxDB API
+{{% /tab-content %}}
+<!------------------------------ END CLI CONTENT ------------------------------>
 
-Use the InfluxDB API to create a bucket.
+<!----------------------------- BEGIN API CONTENT ----------------------------->
+{{% tab-content %}}
 
-{{% note %}}
-#### Bucket limits
-A single InfluxDB {{< current-version >}} OSS instance supports approximately 20 buckets actively being
-written to or queried across all organizations depending on the use case.
-Any more than that can adversely affect performance.
-{{% /note %}}
+To create a bucket with the InfluxDB HTTP API, send a request to the following endpoint:
 
-Create a bucket in InfluxDB using an HTTP request to the InfluxDB API `/buckets` endpoint.
-Use the `POST` request method and include the following in your request:
+{{< api-endpoint method="post" endpoint="https://localhost:8086/api/v2/buckets" api-ref="/influxdb/v2.6/api/#operation/PostBuckets" >}}
 
-| Requirement          | Include by                                               |
-|:-----------          |:----------                                               |
-| Organization         | Use `orgID` in the JSON payload.                |
-| Bucket               | Use `name` in the JSON payload.                 |
-| Retention Rules      | Use `retentionRules` in the JSON payload.    |
-| API token | Use the `Authorization: Token` header.                   |
+Include the following in your request:
+
+- **Headers:**
+  - **Authorization:** `Token` scheme with your InfluxDB [API token](/influxdb/v2.6/security/tokens/)
+  - **Content-type:** `application/json`
+- **Request body:** JSON object with the following fields:  
+  {{< req type="key" >}}
+  - {{< req "\*" >}} **name:** Bucket name
+    _(see [Bucket naming restrictions](#bucket-naming-restrictions))_
+  - {{< req "\*" >}} **orgID:** InfluxDB organization ID
+  - **description:** Bucket description
+  - **retentionRules:** JSON array containing a single object
+    with the following fields:
+    - **type:** expire
+    - **everySecond**: Number of seconds to retain data _(0 means forever)_
+    - **shardGroupDuration**: Number of seconds to retain shard groups _(0 means forever)_
 
 #### Example
 
@@ -110,3 +143,15 @@ instance _(see [InfluxDB URLs](/influxdb/v2.6/reference/urls/))_.
 
 _For information about **InfluxDB API options and response codes**, see
 [InfluxDB API Buckets documentation](/influxdb/v2.6/api/#operation/PostBuckets)._
+
+{{% /tab-content %}}
+<!------------------------------ END API CONTENT ------------------------------>
+{{< /tabs-wrapper >}}
+
+## Bucket naming restrictions
+
+Bucket names must adhere to the following naming restrictions:
+
+- Must contain two or more characters
+- Cannot start with an underscore (`_`)
+- Cannot contain a double quote (`"`)

--- a/content/influxdb/v2.6/organizations/buckets/update-bucket.md
+++ b/content/influxdb/v2.6/organizations/buckets/update-bucket.md
@@ -32,6 +32,11 @@ If you change a bucket name, be sure to update the bucket in the above places as
 3. Review the information in the window that appears and click **I understand, let's rename my bucket**.
 4. Update the bucket's name and click **Change Bucket Name**.
 
+{{% note %}}
+For information about permitted bucket names, see
+[bucket naming restrictions](/influxdb/cloud/organizations/buckets/create-bucket/#bucket-naming-restrictions).
+{{% /note %}}
+
 ## Update a bucket's retention period in the InfluxDB UI
 
 1. In the navigation menu on the left, select **Data (Load Data)** > **Buckets**.
@@ -53,6 +58,11 @@ to update a bucket. Updating a bucket requires the following:
 {{< cli/influx-creds-note >}}
 
 ##### Update the name of a bucket
+
+{{% note %}}
+For information about permitted bucket names, see
+[bucket naming restrictions](/influxdb/cloud/organizations/buckets/create-bucket/#bucket-naming-restrictions).
+{{% /note %}}
 
 ```sh
 # Syntax

--- a/layouts/shortcodes/api-endpoint.html
+++ b/layouts/shortcodes/api-endpoint.html
@@ -1,6 +1,11 @@
-{{ $method := .Get "method" | upper }}
-{{ $methodStyle := .Get "method" | lower }}
-{{ $endpoint := .Get "endpoint" }}
+{{- $method := .Get "method" | upper -}}
+{{- $methodStyle := .Get "method" | lower -}}
+{{- $endpoint := .Get "endpoint" -}}
+{{- $apiRef := .Get "api-ref" | default "" -}}
 <pre>
-<span class="api {{ $methodStyle }}">{{ $method }}</span> {{ $endpoint }}
+  {{- if ne $apiRef "" -}}
+  <a href="{{ $apiRef }}" target="_blank"><span class="api {{ $methodStyle }}">{{ $method }}</span> {{ $endpoint }}</a>
+  {{- else -}}
+  <span class="api {{ $methodStyle }}">{{ $method }}</span> {{ $endpoint }}
+  {{- end -}}
 </pre>

--- a/shared/text/api/v2.0/buckets/oss/create.sh
+++ b/shared/text/api/v2.0/buckets/oss/create.sh
@@ -2,8 +2,8 @@ INFLUX_TOKEN=YOUR_API_TOKEN
 INFLUX_ORG_ID=YOUR_ORG_ID
 
 curl --request POST \
-	"http://localhost:8086/api/v2/buckets" \
-	--header "Authorization: Token ${INFLUX_TOKEN}" \
+  "http://localhost:8086/api/v2/buckets" \
+  --header "Authorization: Token ${INFLUX_TOKEN}" \
   --header "Content-type: application/json" \
   --data '{
     "orgID": "'"${INFLUX_ORG_ID}"'",


### PR DESCRIPTION
- Adds information about bucket naming restrictions in OSS and Cloud (TSM)
- Updates the structure of "Create a bucket" docs in v2.6, cloud, and cloud-iox.
- Updates the `api-endpoint` shortcode with a `api-ref` parameter that turns the rendered codeblock into a link. This link doesn't interfere with the code block actions menu or suffer from other rendering quirks in Hugo.

---

- [x] Rebased/mergeable
