### PR TITLE
Provide links to alternate pages in IOx and TSM docs

### DIFF
--- a/assets/js/iox-wayfinding.js
+++ b/assets/js/iox-wayfinding.js
@@ -137,9 +137,9 @@ wayfindingFindOutToggle.onclick = function(event) {
  * the iox-wayfinding modal.
  * This reuses the referrerHost variable defined in assets/js/influxdb-url.js
 */
-// if (shouldOpenWayfinding()) {
+if (shouldOpenWayfinding()) {
   toggleWayfinding();
-// }
+}
 
 // Set the state of the show wayfinding input checkbox
 setWayfindingInputState();

--- a/assets/js/iox-wayfinding.js
+++ b/assets/js/iox-wayfinding.js
@@ -137,9 +137,9 @@ wayfindingFindOutToggle.onclick = function(event) {
  * the iox-wayfinding modal.
  * This reuses the referrerHost variable defined in assets/js/influxdb-url.js
 */
-if (shouldOpenWayfinding()) {
+// if (shouldOpenWayfinding()) {
   toggleWayfinding();
-}
+// }
 
 // Set the state of the show wayfinding input checkbox
 setWayfindingInputState();

--- a/content/influxdb/cloud-iox/admin/accounts/_index.md
+++ b/content/influxdb/cloud-iox/admin/accounts/_index.md
@@ -8,6 +8,7 @@ menu:
   influxdb_cloud_iox:
     parent: Administer InfluxDB Cloud
     name: Manage accounts
+alt_engine: /influxdb/cloud/account-management/
 ---
 
 {{< children >}}

--- a/content/influxdb/cloud-iox/admin/accounts/data-usage.md
+++ b/content/influxdb/cloud-iox/admin/accounts/data-usage.md
@@ -11,6 +11,7 @@ menu:
 related:
   - /flux/v0.x/stdlib/experimental/usage/from/
   - /flux/v0.x/stdlib/experimental/usage/limits/
+alt_engine: /influxdb/cloud/account-management/data-usage/
 ---
 
 View the statistics of your data usage and rate limits (reads, writes, and delete limits) on the InfluxDB Cloud UI **Usage** page. Some usage data affects monthly costs and other usage data (for example, delete limits), does not affect pricing. For more information, see [limits and adjustable quotas](/influxdb/cloud-iox/admin/accounts/limits/).

--- a/content/influxdb/cloud-iox/admin/accounts/limits.md
+++ b/content/influxdb/cloud-iox/admin/accounts/limits.md
@@ -11,6 +11,7 @@ menu:
 related:
   - /flux/v0.x/stdlib/experimental/usage/from/
   - /flux/v0.x/stdlib/experimental/usage/limits/
+alt_engine: /influxdb/cloud/account-management/limits/
 ---
 
 InfluxDB Cloud applies (non-adjustable) global system limits and adjustable service quotas on a per organization basis.

--- a/content/influxdb/cloud-iox/admin/accounts/switch-account.md
+++ b/content/influxdb/cloud-iox/admin/accounts/switch-account.md
@@ -10,6 +10,7 @@ menu:
 weight: 105
 aliases:
   - /influxdb/cloud-iox/account-management/switch-account/
+alt_engine: /influxdb/cloud/account-management/switch-account/
 ---
 
 If you belong to more than one {{< cloud-name >}} account with the same email address, you can switch from one account to another while staying logged in.

--- a/content/influxdb/cloud-iox/admin/buckets/_index.md
+++ b/content/influxdb/cloud-iox/admin/buckets/_index.md
@@ -10,6 +10,7 @@ weight: 105
 influxdb/cloud-iox/tags: [buckets]
 aliases:
   - /influxdb/cloud-iox/organizations/buckets/
+alt_engine: /influxdb/cloud/organizations/buckets/
 ---
 
 A **bucket** is a named location where time series data is stored.

--- a/content/influxdb/cloud-iox/admin/buckets/create-bucket.md
+++ b/content/influxdb/cloud-iox/admin/buckets/create-bucket.md
@@ -11,6 +11,7 @@ related:
   - /influxdb/cloud-iox/admin/buckets/manage-explicit-bucket-schemas/
 aliases:
   - /influxdb/cloud-iox/organizations/buckets/create-bucket/
+alt_engine: /influxdb/cloud/organizations/buckets/create-bucket/
 ---
 
 Use the InfluxDB user interface (UI), `influx` command line interface (CLI), or InfluxDB HTTP API

--- a/content/influxdb/cloud-iox/admin/buckets/manage-explicit-bucket-schemas.md
+++ b/content/influxdb/cloud-iox/admin/buckets/manage-explicit-bucket-schemas.md
@@ -13,6 +13,7 @@ related:
   - /influxdb/cloud-iox/reference/cli/influx/bucket-schema/
   - /influxdb/cloud-iox/admin/buckets/create-bucket/
   - /influxdb/cloud-iox/reference/cli/influx/
+alt_engine: /influxdb/cloud/organizations/buckets/bucket-schema/
 ---
 
 Use [**explicit bucket schemas**](/influxdb/cloud-iox/reference/glossary/#bucket-schema) to enforce [column names](/influxdb/cloud-iox/reference/glossary/#column), [tags](/influxdb/cloud-iox/reference/glossary/#tag), [fields](/influxdb/cloud-iox/reference/glossary/#field), and

--- a/content/influxdb/cloud-iox/admin/buckets/update-bucket.md
+++ b/content/influxdb/cloud-iox/admin/buckets/update-bucket.md
@@ -9,6 +9,7 @@ menu:
 weight: 202
 aliases:
     - /influxdb/cloud-iox/organizations/buckets/update-bucket/
+alt_engine: /influxdb/cloud/organizations/buckets/update-bucket/
 ---
 
 Use the InfluxDB user interface (UI), the `influx` command line interface (CLI), or the InfluxDB HTTP API to update a bucket.

--- a/content/influxdb/cloud-iox/admin/buckets/view-buckets.md
+++ b/content/influxdb/cloud-iox/admin/buckets/view-buckets.md
@@ -9,6 +9,7 @@ menu:
 weight: 202
 aliases:
   - /influxdb/cloud-iox/organizations/buckets/view-buckets/
+alt_engine: /influxdb/cloud/organizations/buckets/view-buckets/
 ---
 
 ## View buckets in the InfluxDB UI

--- a/content/influxdb/cloud-iox/admin/organizations/_index.md
+++ b/content/influxdb/cloud-iox/admin/organizations/_index.md
@@ -12,6 +12,7 @@ related:
   - /influxdb/cloud-iox/admin/accounts/
 aliases:
   - /influxdb/cloud-iox/organizations/
+alt_engine: /influxdb/cloud/organizations/
 ---
 
 An **organization** is a workspace for a group of users.

--- a/content/influxdb/cloud-iox/admin/organizations/switch-org.md
+++ b/content/influxdb/cloud-iox/admin/organizations/switch-org.md
@@ -12,6 +12,7 @@ aliases:
   - /influxdb/cloud-iox/account-management/switch-org/
 related:
   - /influxdb/cloud-iox/admin/accounts/switch-account/
+alt_engine: /influxdb/cloud/account-management/switch-org/
 ---
 
 If you belong to more than one {{< cloud-name >}} organization with the same email address, you can switch from one organization to another while staying logged in.

--- a/content/influxdb/cloud-iox/visualize-data/grafana.md
+++ b/content/influxdb/cloud-iox/visualize-data/grafana.md
@@ -11,6 +11,7 @@ menu:
     name: Grafana
     parent: Visualize data
 influxdb/cloud-iox/tags: [visualization]
+alt_engine: /influxdb/cloud/tools/grafana/
 ---
 
 Use [Grafana](https://grafana.com/) to query and visualize data stored in an

--- a/content/influxdb/cloud-iox/write-data/csv/_index.md
+++ b/content/influxdb/cloud-iox/write-data/csv/_index.md
@@ -12,6 +12,7 @@ related:
   - /influxdb/cloud-iox/reference/syntax/line-protocol/
   - /influxdb/cloud-iox/reference/syntax/annotated-csv/
   - /influxdb/cloud-iox/reference/cli/influx/write/
+alt_engine: /influxdb/cloud/write-data/developer-tools/csv/
 ---
 
 {{< children >}}

--- a/content/influxdb/cloud-iox/write-data/csv/influx-cli.md
+++ b/content/influxdb/cloud-iox/write-data/csv/influx-cli.md
@@ -13,6 +13,7 @@ related:
   - /influxdb/cloud-iox/reference/syntax/line-protocol/
   - /influxdb/cloud-iox/reference/syntax/annotated-csv/
   - /influxdb/cloud-iox/reference/cli/influx/write/
+alt_engine: /influxdb/cloud/write-data/developer-tools/csv/
 ---
 
 Use the [`influx write` command](/influxdb/cloud-iox/reference/cli/influx/write/) to write CSV data

--- a/content/influxdb/cloud-iox/write-data/migrate-data/_index.md
+++ b/content/influxdb/cloud-iox/write-data/migrate-data/_index.md
@@ -8,6 +8,7 @@ menu:
     name: Migrate data
     parent: Write data
 weight: 104
+alt_engine: /influxdb/cloud/migrate-data/
 ---
 
 Migrate data to InfluxDB Cloud backed by InfluxDB IOx from other 

--- a/content/influxdb/cloud-iox/write-data/migrate-data/migrate-tsm-to-iox.md
+++ b/content/influxdb/cloud-iox/write-data/migrate-data/migrate-tsm-to-iox.md
@@ -9,6 +9,7 @@ menu:
     name: Migrate from TSM to IOx
     parent: Migrate data
 weight: 102
+alt_engine: /influxdb/cloud/migrate-data/migrate-cloud-to-cloud/
 ---
 
 To migrate data from an InfluxDB Cloud organization backed by TSM to an organization

--- a/content/influxdb/cloud-iox/write-data/use-telegraf/_index.md
+++ b/content/influxdb/cloud-iox/write-data/use-telegraf/_index.md
@@ -14,6 +14,7 @@ menu:
   influxdb_cloud_iox:
     name: Use Telegraf
     parent: Write data
+alt_engine: /influxdb/cloud/write-data/no-code/use-telegraf/
 ---
 
 [Telegraf](https://www.influxdata.com/time-series-platform/telegraf/) is InfluxData's

--- a/content/influxdb/cloud-iox/write-data/use-telegraf/configure/auto-config.md
+++ b/content/influxdb/cloud-iox/write-data/use-telegraf/configure/auto-config.md
@@ -14,6 +14,7 @@ menu:
 weight: 201
 related:
   - /influxdb/cloud-iox/use-telegraf/telegraf-configs/create/
+alt_engine: /influxdb/cloud/write-data/no-code/use-telegraf/auto-config/
 ---
 
 The InfluxDB user interface (UI) can automatically create Telegraf configuration files based on user-selected Telegraf plugins.

--- a/content/influxdb/cloud-iox/write-data/use-telegraf/configure/manual-config.md
+++ b/content/influxdb/cloud-iox/write-data/use-telegraf/configure/manual-config.md
@@ -15,6 +15,7 @@ related:
   - /{{< latest "telegraf" >}}/plugins//
   - /influxdb/cloud-iox/use-telegraf/telegraf-configs/create/
   - /influxdb/cloud-iox/use-telegraf/telegraf-configs/update/
+alt_engine: /influxdb/cloud/write-data/no-code/use-telegraf/manual-config/
 ---
 
 Use the Telegraf `influxdb_v2` output plugin to collect and write metrics into

--- a/content/influxdb/cloud-iox/write-data/use-telegraf/dual-write.md
+++ b/content/influxdb/cloud-iox/write-data/use-telegraf/dual-write.md
@@ -7,6 +7,7 @@ menu:
     name: Dual write to OSS & Cloud
     parent: Use Telegraf
 weight: 203
+alt_engine: /influxdb/cloud/write-data/no-code/use-telegraf/dual-write/
 ---
 
 If you want to back up your data in two places, or if you're migrating from OSS to Cloud, you may want to set up dual write.

--- a/content/influxdb/cloud-iox/write-data/use-telegraf/telegraf-configs/_index.md
+++ b/content/influxdb/cloud-iox/write-data/use-telegraf/telegraf-configs/_index.md
@@ -12,6 +12,7 @@ influxdb/cloud-iox/tags: [telegraf]
 related:
   - /influxdb/cloud-iox/write-data/use-telegraf/manual-config/
   - /influxdb/cloud-iox/write-data/use-telegraf/auto-config/
+alt_engine: /influxdb/cloud/telegraf-configs/
 ---
 
 {{< duplicate-oss "/telegraf-configs/" >}}

--- a/content/influxdb/cloud-iox/write-data/use-telegraf/telegraf-configs/create.md
+++ b/content/influxdb/cloud-iox/write-data/use-telegraf/telegraf-configs/create.md
@@ -15,6 +15,7 @@ related:
 aliases:
   - /influxdb/cloud-iox/telegraf-configs/create/
   - /influxdb/cloud-iox/telegraf-configs/clone/
+alt_engine: /influxdb/cloud/telegraf-configs/create/
 ---
 
 {{< duplicate-oss "/telegraf-configs/create" >}}

--- a/content/influxdb/cloud-iox/write-data/use-telegraf/telegraf-configs/remove.md
+++ b/content/influxdb/cloud-iox/write-data/use-telegraf/telegraf-configs/remove.md
@@ -10,6 +10,7 @@ menu:
     parent: Manage Telegraf configs
 aliases:
   - /influxdb/cloud-iox/telegraf-configs/remove/
+alt_engine: /influxdb/cloud/telegraf-configs/remove/
 ---
 
 {{< duplicate-oss "/telegraf-configs/remove" >}}

--- a/content/influxdb/cloud-iox/write-data/use-telegraf/telegraf-configs/update.md
+++ b/content/influxdb/cloud-iox/write-data/use-telegraf/telegraf-configs/update.md
@@ -10,6 +10,7 @@ menu:
     parent: Manage Telegraf configs
 aliases:
   - /influxdb/cloud-iox/telegraf-configs/update/
+alt_engine: /influxdb/cloud/telegraf-configs/update/
 ---
 
 {{< duplicate-oss "/telegraf-configs/update" >}}

--- a/content/influxdb/cloud-iox/write-data/use-telegraf/telegraf-configs/view.md
+++ b/content/influxdb/cloud-iox/write-data/use-telegraf/telegraf-configs/view.md
@@ -10,6 +10,7 @@ menu:
     parent: Manage Telegraf configs
 aliases:
   - /influxdb/cloud-iox/telegraf-configs/view/
+alt_engine: /influxdb/cloud/telegraf-configs/view/
 ---
 
 {{< duplicate-oss "/telegraf-configs/view" >}}

--- a/content/influxdb/cloud/account-management/_index.md
+++ b/content/influxdb/cloud/account-management/_index.md
@@ -10,6 +10,7 @@ aliases:
 menu:
   influxdb_cloud:
     name: Account management
+alt_engine: /influxdb/cloud-iox/admin/accounts/
 ---
 
 {{< children >}}

--- a/content/influxdb/cloud/account-management/data-usage.md
+++ b/content/influxdb/cloud/account-management/data-usage.md
@@ -14,6 +14,7 @@ menu:
 related:
   - /flux/v0.x/stdlib/experimental/usage/from/
   - /flux/v0.x/stdlib/experimental/usage/limits/
+alt_engine: /influxdb/cloud-iox/admin/accounts/data-usage/
 ---
 
 View the statistics of your data usage and rate limits (reads, writes, and delete limits) on the Usage page. Some usage data affects monthly costs ([pricing vectors](/influxdb/cloud/account-management/pricing-plans/#pricing-vectors)) and other usage data (for example, delete limits), does not affect pricing. For more information, see the [InfluxDB Cloud limits and adjustable quotas](/influxdb/cloud/account-management/limits/).

--- a/content/influxdb/cloud/account-management/limits.md
+++ b/content/influxdb/cloud/account-management/limits.md
@@ -12,6 +12,7 @@ related:
   - /flux/v0.x/stdlib/experimental/usage/from/
   - /flux/v0.x/stdlib/experimental/usage/limits/
   - /influxdb/cloud/write-data/best-practices/resolve-high-cardinality/
+alt_engine: /influxdb/cloud-iox/admin/accounts/limits/
 ---
 
 InfluxDB Cloud applies (non-adjustable) global system limits and adjustable service quotas on a per organization basis.

--- a/content/influxdb/cloud/account-management/switch-account.md
+++ b/content/influxdb/cloud/account-management/switch-account.md
@@ -8,6 +8,7 @@ menu:
     name: Switch InfluxDB accounts
     parent: Account management
 weight: 105
+alt_engine: /influxdb/cloud-iox/admin/accounts/switch-account/
 ---
 
 If you belong to more than one {{< cloud-name >}} account with the same email address, you can switch from one account to another while staying logged in.

--- a/content/influxdb/cloud/account-management/switch-org.md
+++ b/content/influxdb/cloud/account-management/switch-org.md
@@ -10,6 +10,7 @@ menu:
 weight: 105
 related:
   - /influxdb/cloud/account-management/switch-account/
+alt_engine: /influxdb/cloud-iox/admin/organizations/switch-org/
 ---
 
 If you belong to more than one {{< cloud-name >}} organization with the same email address, you can switch from one organization to another while staying logged in.

--- a/content/influxdb/cloud/get-started/_index.md
+++ b/content/influxdb/cloud/get-started/_index.md
@@ -10,7 +10,6 @@ weight: 2
 influxdb/cloud/tags: [get-started]
 aliases:
   - /influxdb/cloud/introduction/get-started/
-alt_engine: /influxdb/cloud-iox/get-started/
 ---
 
 InfluxDB {{< current-version >}} is the platform purpose-built to collect, store,

--- a/content/influxdb/cloud/migrate-data/_index.md
+++ b/content/influxdb/cloud/migrate-data/_index.md
@@ -6,6 +6,7 @@ menu:
   influxdb_cloud:
     name: Migrate data
 weight: 9
+alt_engine: /influxdb/cloud-iox/write-data/migrate-data/
 ---
 
 Migrate data to InfluxDB from other InfluxDB instances including by InfluxDB OSS

--- a/content/influxdb/cloud/migrate-data/migrate-cloud-to-cloud.md
+++ b/content/influxdb/cloud/migrate-data/migrate-cloud-to-cloud.md
@@ -9,6 +9,7 @@ menu:
     name: Migrate from Cloud to Cloud
     parent: Migrate data
 weight: 102
+alt_engine: /influxdb/cloud-iox/write-data/migrate-data/migrate-tsm-to-iox/
 ---
 
 To migrate data from one InfluxDB Cloud organization to another, query the

--- a/content/influxdb/cloud/organizations/_index.md
+++ b/content/influxdb/cloud/organizations/_index.md
@@ -9,6 +9,7 @@ weight: 10
 influxdb/cloud/tags: [organizations]
 related:
   - /influxdb/cloud/account-management/
+alt_engine: /influxdb/cloud-iox/admin/organizations/
 ---
 
 An **organization** is a workspace for a group of users.

--- a/content/influxdb/cloud/organizations/buckets/_index.md
+++ b/content/influxdb/cloud/organizations/buckets/_index.md
@@ -8,6 +8,7 @@ menu:
     parent: Manage organizations
 weight: 105
 influxdb/cloud/tags: [buckets]
+alt_engine: /influxdb/cloud-iox/admin/buckets/
 ---
 
 A **bucket** is a named location where time series data is stored.

--- a/content/influxdb/cloud/organizations/buckets/bucket-schema/_index.md
+++ b/content/influxdb/cloud/organizations/buckets/bucket-schema/_index.md
@@ -14,6 +14,7 @@ related:
   - /influxdb/cloud/reference/key-concepts/data-elements/
   - /influxdb/cloud/organizations/buckets/create-bucket/
   - /influxdb/cloud/reference/cli/influx/
+alt_engine: /influxdb/cloud-iox/admin/buckets/manage-explicit-bucket-schemas/
 ---
 
 Use [**explicit bucket schemas**](/influxdb/cloud/reference/key-concepts/data-elements/#bucket-schema) to enforce [column names](/influxdb/cloud/reference/glossary/#column), [tags](/influxdb/cloud/reference/glossary/#tag), [fields](/influxdb/cloud/reference/glossary/#field), and

--- a/content/influxdb/cloud/organizations/buckets/create-bucket.md
+++ b/content/influxdb/cloud/organizations/buckets/create-bucket.md
@@ -9,6 +9,7 @@ menu:
     name: Create a bucket
     parent: Manage buckets
 weight: 201
+alt_engine: /influxdb/cloud-iox/admin/buckets/create-bucket/
 ---
 
 Use the InfluxDB user interface (UI), the `influx` command line interface (CLI),

--- a/content/influxdb/cloud/organizations/buckets/update-bucket.md
+++ b/content/influxdb/cloud/organizations/buckets/update-bucket.md
@@ -7,6 +7,7 @@ menu:
     name: Update a bucket
     parent: Manage buckets
 weight: 202
+alt_engine: /influxdb/cloud-iox/admin/buckets/update-bucket/
 ---
 
 Use the InfluxDB user interface (UI), the `influx` command line interface (CLI), or the InfluxDB HTTP API to update a bucket.

--- a/content/influxdb/cloud/organizations/buckets/view-buckets.md
+++ b/content/influxdb/cloud/organizations/buckets/view-buckets.md
@@ -7,6 +7,7 @@ menu:
     name: View buckets
     parent: Manage buckets
 weight: 202
+alt_engine: /influxdb/cloud-iox/admin/buckets/view-buckets/
 ---
 
 ## View buckets in the InfluxDB UI

--- a/content/influxdb/cloud/telegraf-configs/_index.md
+++ b/content/influxdb/cloud/telegraf-configs/_index.md
@@ -9,6 +9,7 @@ influxdb/cloud/tags: [telegraf]
 related:
   - /influxdb/cloud/write-data/no-code/use-telegraf/manual-config/
   - /influxdb/cloud/write-data/no-code/use-telegraf/auto-config/
+alt_engine: /influxdb/cloud-iox/write-data/use-telegraf/telegraf-configs/
 ---
 
 {{< duplicate-oss >}}

--- a/content/influxdb/cloud/telegraf-configs/clone.md
+++ b/content/influxdb/cloud/telegraf-configs/clone.md
@@ -2,9 +2,9 @@
 title: Clone a Telegraf configuration
 description: >
   Use the InfluxDB UI to clone an Telegraf configuration.
-weight: 101
+weight: 102
 menu:
-  influxdb_cloud::
+  influxdb_cloud:
     name: Clone a config
     parent: Telegraf configurations
 ---

--- a/content/influxdb/cloud/telegraf-configs/create.md
+++ b/content/influxdb/cloud/telegraf-configs/create.md
@@ -12,6 +12,7 @@ related:
   - /influxdb/cloud/write-data/no-code/use-telegraf/manual-config/
   - /influxdb/cloud/write-data/no-code/use-telegraf/auto-config/
   - /influxdb/cloud/telegraf-configs/update/
+alt_engine: /influxdb/cloud-iox/write-data/use-telegraf/telegraf-configs/create/
 ---
 
 {{< duplicate-oss >}}

--- a/content/influxdb/cloud/telegraf-configs/remove.md
+++ b/content/influxdb/cloud/telegraf-configs/remove.md
@@ -11,6 +11,7 @@ menu:
 aliases:
   - /influxdb/cloud/write-data/no-code/use-telegraf/auto-config/delete-telegraf-config/
   - /influxdb/cloud/collect-data/use-telegraf/auto-config/delete-telegraf-config
+alt_engine: /influxdb/cloud-iox/write-data/use-telegraf/telegraf-configs/remove/
 ---
 
 {{< duplicate-oss >}}

--- a/content/influxdb/cloud/telegraf-configs/update.md
+++ b/content/influxdb/cloud/telegraf-configs/update.md
@@ -8,6 +8,7 @@ menu:
   influxdb_cloud:
     name: Update a config
     parent: Telegraf configurations
+alt_engine: /influxdb/cloud-iox/write-data/use-telegraf/telegraf-configs/update/
 ---
 
 {{< duplicate-oss >}}

--- a/content/influxdb/cloud/telegraf-configs/view.md
+++ b/content/influxdb/cloud/telegraf-configs/view.md
@@ -8,6 +8,7 @@ menu:
   influxdb_cloud:
     name: View configs
     parent: Telegraf configurations
+alt_engine: /influxdb/cloud-iox/write-data/use-telegraf/telegraf-configs/view/
 ---
 
 {{< duplicate-oss >}}

--- a/content/influxdb/cloud/tools/grafana.md
+++ b/content/influxdb/cloud/tools/grafana.md
@@ -12,6 +12,7 @@ related:
   - https://grafana.com/docs/, Grafana documentation
   - /influxdb/cloud/query-data/get-started/
   - /influxdb/cloud/query-data/influxql/
+alt_engine: /influxdb/cloud-iox/visualize-data/grafana/
 ---
 
 {{< duplicate-oss >}}

--- a/content/influxdb/cloud/write-data/developer-tools/csv.md
+++ b/content/influxdb/cloud/write-data/developer-tools/csv.md
@@ -13,6 +13,7 @@ related:
   - /influxdb/cloud/reference/syntax/line-protocol/
   - /influxdb/cloud/reference/syntax/annotated-csv/
   - /influxdb/cloud/reference/cli/influx/write/
+alt_engine: /influxdb/cloud-iox/write-data/csv/
 ---
 
 {{< duplicate-oss >}}

--- a/content/influxdb/cloud/write-data/no-code/use-telegraf/_index.md
+++ b/content/influxdb/cloud/write-data/no-code/use-telegraf/_index.md
@@ -14,6 +14,7 @@ menu:
   influxdb_cloud:
     name: Telegraf (agent)
     parent: No-code solutions
+alt_engine: /influxdb/cloud-iox/write-data/use-telegraf/
 ---
 
 [Telegraf](https://www.influxdata.com/time-series-platform/telegraf/) is InfluxData's

--- a/content/influxdb/cloud/write-data/no-code/use-telegraf/auto-config.md
+++ b/content/influxdb/cloud/write-data/no-code/use-telegraf/auto-config.md
@@ -10,6 +10,7 @@ menu:
 weight: 201
 related:
   - /influxdb/cloud/telegraf-configs/create/
+alt_engine: /influxdb/cloud-iox/write-data/use-telegraf/configure/auto-config/
 ---
 
 The InfluxDB user interface (UI) can automatically create

--- a/content/influxdb/cloud/write-data/no-code/use-telegraf/dual-write.md
+++ b/content/influxdb/cloud/write-data/no-code/use-telegraf/dual-write.md
@@ -5,6 +5,7 @@ menu:
   influxdb_cloud:
     parent: Telegraf (agent)
 weight: 201
+alt_engine: /influxdb/cloud-iox/write-data/use-telegraf/dual-write/
 ---
 
 {{< duplicate-oss >}}

--- a/content/influxdb/cloud/write-data/no-code/use-telegraf/manual-config.md
+++ b/content/influxdb/cloud/write-data/no-code/use-telegraf/manual-config.md
@@ -17,6 +17,7 @@ related:
   - /{{< latest "telegraf" >}}/plugins//
   - /influxdb/cloud/telegraf-configs/create/
   - /influxdb/cloud/telegraf-configs/update/
+alt_engine: /influxdb/cloud-iox/write-data/use-telegraf/configure/manual-config/
 ---
 
 Use the Telegraf `influxdb_v2` output plugin to collect and write metrics into an InfluxDB v2.0 bucket.

--- a/layouts/partials/footer/iox-wayfinding.html
+++ b/layouts/partials/footer/iox-wayfinding.html
@@ -1,3 +1,4 @@
+{{ $scratch := newScratch }}
 {{ $productPathData := findRE "[^/]+.*?" .RelPermalink }}
 {{ $version := index $productPathData 1 }}
 {{ $altVersion := cond (ne $version "cloud-iox") "cloud-iox" "cloud" }}
@@ -5,6 +6,27 @@
 {{ $altEngine := cond (eq $version "cloud-iox") "TSM" "IOx" }}
 {{ $altDoc := .Page.Params.alt_engine | default "" }}
 {{ $altLink := cond (ne $altDoc "") $altDoc (print "/influxdb/" $altVersion "/") }}
+{{ $isCloud := eq $version "cloud" }}
+{{ $isIOx := eq $version "cloud-iox" }}
+
+{{ $scratch.Set "link" "" }}
+{{ if $isCloud }}
+  {{ $altIOxPage := $.GetPage ((replaceRE "influxdb/cloud" "influxdb/cloud-iox" $.Page.RelPermalink) | replaceRE `\/$` "") }}
+  {{ if ne $altDoc "" }}
+    {{ $scratch.Set "link" $altDoc }}
+  {{ else if gt (len $altIOxPage.Title) 0 }}
+    {{ $scratch.Set "link" $altIOxPage.RelPermalink }}
+  {{ end }}
+{{ else if $isIOx }}
+  {{ $altCloudPage := $.GetPage ((replaceRE "influxdb/cloud-iox" "influxdb/cloud" $.Page.RelPermalink) | replaceRE `\/$` "") }}
+  {{ if ne $altDoc "" }}
+    {{ $scratch.Set "link" $altDoc }}
+  {{ else if gt (len $altCloudPage.Title) 0 }}
+    {{ $scratch.Set "link" $altCloudPage.RelPermalink }}
+  {{ end }}
+{{ end }}
+
+{{ $altLink := cond (eq ($scratch.Get "link") "") (print "/influxdb/" $altVersion "/") ($scratch.Get "link") }}
 
 <div id="iox-wayfinding-modal">
   <div class="wayfinding-wrapper">

--- a/layouts/partials/topnav/product-selector.html
+++ b/layouts/partials/topnav/product-selector.html
@@ -2,14 +2,16 @@
 {{ $productPathData := findRE "[^/]+.*?" .RelPermalink }}
 {{ $product := index $productPathData 0 }}
 {{ $currentVersion := index $productPathData 1 }}
-{{ $isCloud := in (print $product "/" $currentVersion ) "influxdb/cloud" }}
-{{ $isOSSv2 := in (print $product "/" $currentVersion ) "influxdb/v2."}}
+{{ $isOSSv2 := in (print $product "/" $currentVersion ) "influxdb/v2." }}
+{{ $isCloud := eq (print $product "/" $currentVersion ) "influxdb/cloud" }}
+{{ $isIOx := eq (print $product "/" $currentVersion ) "influxdb/cloud-iox" }}
+{{ $altEngine := .Page.Params.alt_engine | default "" }}
 
 <div class="dropdown">
   {{ if or (eq $product nil) (eq $product "platform") (eq $product "resources") }}
     <p class="selected">Select product</p>
-  {{ else if $isCloud }}
-    {{ $cloudType := cond (in $currentVersion "iox") $.Site.Data.products.influxdb_cloud_iox.altname $.Site.Data.products.influxdb_cloud.altname}}
+  {{ else if or $isCloud $isIOx }}
+    {{ $cloudType := cond $isIOx $.Site.Data.products.influxdb_cloud_iox.altname $.Site.Data.products.influxdb_cloud.altname }}
     <p class="selected">{{ $cloudType }}</p>
   {{ else }}
     {{ $productData := (index .Site.Data.products $product) }}
@@ -21,6 +23,33 @@
       {{ $scratch.Set "link" (print "/" .namespace "/" .latest "/") }}
       {{ if $isCurrentProduct }}
         {{ $scratch.Set "link" "" }}
+      
+      {{/* ////////////////// BEGIN IOx WAYFINDING LOGIC ////////////////// */}}
+
+      {{ else if and $isCloud (eq .altname "InfluxDB Cloud (IOx)")}}
+        {{ $altIOxPage := $.GetPage ((replaceRE "influxdb/cloud" "influxdb/cloud-iox" $.Page.RelPermalink) | replaceRE `\/$` "") }}
+        {{ if ne $altEngine "" }}
+          {{ $scratch.Set "link" $altEngine }}
+        {{ else if gt (len $altIOxPage.Title) 0 }}
+          {{ $scratch.Set "link" $altIOxPage.RelPermalink }}
+        {{ end }}
+      {{ else if and $isIOx (eq .altname "InfluxDB Cloud")}}
+        {{ $altCloudPage := $.GetPage ((replaceRE "influxdb/cloud-iox" "influxdb/cloud" $.Page.RelPermalink) | replaceRE `\/$` "") }}
+        {{ if ne $altEngine "" }}
+          {{ $scratch.Set "link" $altEngine }}
+        {{ else if gt (len $altCloudPage.Title) 0 }}
+          {{ $scratch.Set "link" $altCloudPage.RelPermalink }}
+        {{ end }}
+      {{ else if and $isIOx (eq .altname "InfluxDB OSS") }}
+        {{ $altOSSPage := $.GetPage ((replaceRE "influxdb/cloud-iox" (print "influxdb/" $.Site.Data.products.influxdb.latest) $.Page.RelPermalink) | replaceRE `\/$` "") }}
+        {{ if ne $altEngine "" }}
+          {{ $scratch.Set "link" (replaceRE "influxdb/cloud-iox" (print "influxdb/" $.Site.Data.products.influxdb.latest) $altEngine) }}
+        {{ else if gt (len $altOSSPage.Title) 0 }}
+          {{ $scratch.Set "link" $altOSSPage.RelPermalink }}
+        {{ end }}
+      
+      {{/* /////////////////// END IOx WAYFINDING LOGIC /////////////////// */}}
+
       {{ else if and $isCloud (eq .altname "InfluxDB OSS")}}
         {{ $altOSSPage := $.GetPage ((replaceRE "influxdb/cloud" (print "influxdb/" $.Site.Data.products.influxdb.latest) $.Page.RelPermalink) | replaceRE `\/$` "") }}
         {{ if gt (len $altOSSPage.Title) 0 }}


### PR DESCRIPTION
This PR extends the functionality of the product dropdown menu and the IOx wayfinding modal to link users to an appropriate alternative page in the other engine's documentation. For the product dropdown, this will also work for linking to alternative OSS docs when in the IOx documentation.

The `alt_engine` frontmatter is used to point to the correct alternative page in the other engine documentation. If the page exists at the same path, the `alt_engine` frontmatter isn't needed.

- [x] Rebased/mergeable
