### PR TITLE
influxctl reference documentation

### DIFF
--- a/content/influxdb/cloud-dedicated/reference/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/_index.md
@@ -1,0 +1,12 @@
+---
+title: InfluxDB Cloud Dedicated reference documentation
+description: >
+  Reference documentation for InfluxDB Cloud Dedicated including updates,
+  API documentation, tools, syntaxes, and more.
+menu: 
+  influxdb_cloud_dedicated:
+    name: Reference
+weight: 20
+---
+
+{{< children >}}

--- a/content/influxdb/cloud-dedicated/reference/cli/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/_index.md
@@ -1,0 +1,19 @@
+---
+title: Command line tools
+seotitle: Command line tools for managing InfluxDB Cloud Dedicated
+description: >
+  InfluxDB provides command line tools designed to manage and work with your
+  InfluxDB Cloud Dedicated cluster from the command line.
+influxdb/cloud-dedicated/tags: [cli]
+menu:
+  influxdb_cloud_dedicated:
+    parent: Reference
+    name: CLIs
+weight: 104
+---
+
+InfluxDB provides command line tools designed to manage and work with your
+InfluxDB Cloud Dedicated cluster from the command line.
+The following command line interfaces (CLIs) are available:
+
+{{< children >}}

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/_index.md
@@ -118,6 +118,8 @@ name. The default profile must be named `default`. For example:
 The `influxctl` CLI uses [Auth0](https://auth0.com/) to authenticate access to
 your InfluxDB Cloud Dedicated cluster.
 When you issue an `influxctl` command, the CLI checks for an active
-Auth0 token. If none exists, you are be directed to login to **Auth0** via a
+Auth0 token. If none exists, you are directed to login to **Auth0** via a
 browser using credentials you should have created when setting up your
+InfluxDB Cloud Dedicated cluster.
+Auth0 issues a short-lived (1 hour) token that authenticates access to your
 InfluxDB Cloud Dedicated cluster.

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/_index.md
@@ -83,7 +83,6 @@ following credentials:
 
 - InfluxDB Cloud Dedicated account ID
 - InfluxDB Cloud Dedicated cluster ID
-- InfluxDB Cloud Dedicated cluster URL
 
 Store these credentials in a `config.toml` at a specific location based on your
 operating system:
@@ -99,27 +98,27 @@ operating system:
 #### Profile settings
 
 In your `config.toml`, you can store _multiple_ profiles, each with a unique
-name. The default profile must be named `default`. For example:
+name. The default profile must be named `default`.
+
+##### Example config.toml
 
 ```toml
 [default]
   account_id = "YOUR_ACCOUNT_ID"
   cluster_id = "YOUR_CLUSTER_ID"
-  cluster_url = "YOUR_CLUSTER_URL"
 
 [custom-profile]
   account_id = "YOUR_OTHER_ACCOUNT_ID"
   cluster_id = "YOUR_OTHER_CLUSTER_ID"
-  cluster_url = "YOUR_OTHER_CLUSTER_URL"
 ```
 
 ## Authentication
 
 The `influxctl` CLI uses [Auth0](https://auth0.com/) to authenticate access to
 your InfluxDB Cloud Dedicated cluster.
-When you issue an `influxctl` command, the CLI checks for an active
-Auth0 token. If none exists, you are directed to login to **Auth0** via a
-browser using credentials you should have created when setting up your
-InfluxDB Cloud Dedicated cluster.
+When you issue an `influxctl` command, the CLI checks for an active Auth0 token.
+If none exists, you are directed to login to **Auth0** via a browser using
+credentials you should have created when setting up your InfluxDB Cloud
+Dedicated cluster.
 Auth0 issues a short-lived (1 hour) token that authenticates access to your
 InfluxDB Cloud Dedicated cluster.

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/_index.md
@@ -37,10 +37,11 @@ influxctl [flags] [command]
 | [version](/influxdb/cloud-dedicated/reference/cli/influxctl/version/)   | Output the current `influxctl` version |
 | [help](/influxdb/cloud-dedicated/reference/cli/influxctl/help/)         | Output `influxctl` help information    |
 
-## Flags {#command-flags}
+## Global flags
 
 | Flag        | Description                                                |
 | :---------- | :--------------------------------------------------------- |
+| `--debug`   | Enable debug logging                                       |
 | `--profile` | Specify a connection profile to use (default is `default`) |
 
 ---

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/_index.md
@@ -1,0 +1,123 @@
+---
+title: influxctl
+list_title: influxctl
+description: >
+  The `influxctl` command line interface (CLI) performs administrative tasks in
+  an InfluxDB Cloud Dedicated cluster.
+menu:
+  influxdb_cloud_dedicated:
+    name: influxctl
+    parent: CLIs
+weight: 101
+influxdb/cloud-dedicated/tags: [cli]
+---
+
+The `influxctl` command line interface (CLI) performs administrative tasks in
+an InfluxDB Cloud Dedicated cluster.
+
+- [Usage](#usage)
+- [Commands](#commands)
+- [Flags](#command-flags)
+- [Download and install influxctl](#download-and-install-influxctl)
+- [Configure connection profiles](#configure-connection-profiles)
+- [Authentication](#authentication)
+
+## Usage
+
+```sh
+influxctl [flags] [command]
+```
+
+## Commands
+
+| Command                                                                 | Description                            |
+| :---------------------------------------------------------------------- | :------------------------------------- |
+| [database](/influxdb/cloud-dedicated/reference/cli/influxctl/database/) | Manage InfluxDB databases              |
+| [token](/influxdb/cloud-dedicated/reference/cli/influxctl/token/)       | Manage InfluxDB database tokens        |
+| [version](/influxdb/cloud-dedicated/reference/cli/influxctl/version/)   | Output the current `influxctl` version |
+| [help](/influxdb/cloud-dedicated/reference/cli/influxctl/help/)         | Output `influxctl` help information    |
+
+## Flags {#command-flags}
+
+| Flag        | Description                                                |
+| :---------- | :--------------------------------------------------------- |
+| `--profile` | Specify a connection profile to use (default is `default`) |
+
+---
+
+## Download and install influxctl
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[Linux](#)
+[macOS](#)
+[Windows](#)
+{{% /tabs %}}
+{{% tab-content %}}
+<!-------------------------------- BEGIN Linux -------------------------------->
+
+<!-- TODO: Linux installation instructions -->
+
+<!--------------------------------- END Linux --------------------------------->
+{{% /tab-content %}}
+{{% tab-content %}}
+<!-------------------------------- BEGIN macOS -------------------------------->
+
+<!-- TODO: macOS installation instructions -->
+
+<!--------------------------------- END macOS --------------------------------->
+{{% /tab-content %}}
+{{% tab-content %}}
+<!-------------------------------- BEGIN Windows ------------------------------->
+
+<!-- TODO: Windows installation instructions -->
+
+<!--------------------------------- END Windows -------------------------------->
+{{% /tab-content %}}
+{{< /tabs-wrapper >}}
+
+## Configure connection profiles
+
+To connect with your InfluxDB Cloud Dedicated cluster, `influxctl` needs the
+following credentials:
+
+- InfluxDB Cloud Dedicated account ID
+- InfluxDB Cloud Dedicated cluster ID
+- InfluxDB Cloud Dedicated cluster URL
+
+Store these credentials in a `config.toml` at a specific location based on your
+operating system:
+
+#### Profile configuration file locations
+
+| Operating system | Profile configuration filepath                       |
+| :--------------- | :---------------------------------------------------- |
+| Linux            | `~/.config/influxctl/config.toml`                     |
+| macOS            | `~/Library/Application Support/influxctl/config.toml` |
+| Windows          | `%APPDATA%\influxctl\config.toml`                     |
+
+#### Profile settings
+
+In your `config.toml`, you can store _multiple_ profiles, each with a unique
+name. The default profile must be named `default`. For example:
+
+```toml
+[default]
+  account_id = "YOUR_ACCOUNT_ID"
+  cluster_id = "YOUR_CLUSTER_ID"
+  cluster_url = "YOUR_CLUSTER_URL"
+
+[custom-profile]
+  account_id = "YOUR_OTHER_ACCOUNT_ID"
+  cluster_id = "YOUR_OTHER_CLUSTER_ID"
+  cluster_url = "YOUR_OTHER_CLUSTER_URL"
+```
+
+## Authentication
+
+The `influxctl` CLI uses [Auth0](https://auth0.com/) to authenticate access to
+your InfluxDB Cloud Dedicated cluster.
+When you issue an `influxctl` command, the CLI checks for an active
+Auth0 token. If none exists, you are be directed to login to **Auth0** via a
+browser using credentials you should have created when setting up your
+InfluxDB Cloud Dedicated cluster.

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/_index.md
@@ -1,0 +1,33 @@
+---
+title: influxctl database
+description: >
+  The `influx database` command and its subcommands manage databases in an
+  InfluxDB Cloud Dedicated cluster.
+menu:
+  influxdb_cloud_dedicated:
+    parent: influxctl
+weight: 201
+---
+
+The `influx database` command and its subcommands manage databases in an
+InfluxDB Cloud Dedicated cluster.
+
+## Usage
+
+```sh
+influxctl database [subcommand] [flags]
+```
+
+## Subcommands
+
+| Subcommand                                                                   | Description       |
+| :--------------------------------------------------------------------------- | :---------------- |
+| [create](/influxdb/cloud-dedicated/reference/cli/influxctl/database/create/) | Create a database |
+| [list](/influxdb/cloud-dedicated/reference/cli/influxctl/database/list/)     | List databases    |
+| [delete](/influxdb/cloud-dedicated/reference/cli/influxctl/database/delete/) | Delete a database |
+
+## Flags
+
+| Flag |          | Description                           |
+| :--- | :------- | :------------------------------------ |
+| `-h` | `--help` | Help for `influxctl database` command |

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/_index.md
@@ -28,6 +28,6 @@ influxctl database [subcommand] [flags]
 
 ## Flags
 
-| Flag |          | Description                           |
-| :--- | :------- | :------------------------------------ |
-| `-h` | `--help` | Help for `influxctl database` command |
+| Flag |          | Description         |
+| :--- | :------- | :------------------ |
+| `-h` | `--help` | Output command help |

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/create.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/create.md
@@ -50,21 +50,21 @@ The retention period value cannot be negative or contain whitespace.
 ## Usage
 
 ```sh
-influxctl database create [--retention-period 0s] {name}
+influxctl database create [--retention-period 0s] <DATABASE_NAME>
 ```
 
 ## Arguments
 
-| Argument | Description            |
-| :------- | :--------------------- |
-| **name** | InfluxDB database name |
+| Argument          | Description            |
+| :---------------- | :--------------------- |
+| **DATABASE_NAME** | InfluxDB database name |
 
 ## Flags
 
-| Flag |                      | Description                                         |
-| :--- | :------------------- | :-------------------------------------------------- |
-| `-h` | `--help`             | Output command help                                 |
-|      | `--retention-period` | Bucket retention period (default is 0s or infinite) |
+| Flag |                      | Description                                           |
+| :--- | :------------------- | :---------------------------------------------------- |
+| `-h` | `--help`             | Output command help                                   |
+|      | `--retention-period` | Database retention period (default is 0s or infinite) |
 
 ## Examples
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/create.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/create.md
@@ -9,8 +9,43 @@ menu:
 weight: 301
 ---
 
-The `influxctl database create` command creates a new database in an InfluxDB
-Cloud Dedicated cluster.
+The `influxctl database create` command creates a new database with a specified
+retention period in an InfluxDB Cloud Dedicated cluster.
+
+The retention period defines the maximum age of data retained in the database,
+based on the timestamp of the data.
+The retention period value is a time duration value made up of a numeric value
+plus a duration unit. For example, `30d` means 30 days.
+A zero duration retention period is infinite and data will not expire.
+The retention period value cannot be negative or contain whitespace.
+
+{{< flex >}}
+{{% flex-content %}}
+
+##### Valid durations units include
+
+- **m**: minute
+- **h**: hour
+- **d**: day
+- **w**: week
+- **mo**: month
+- **y**: year
+
+{{% /flex-content %}}
+{{% flex-content %}}
+
+##### Example retention period values
+
+- `0d`: infinite/none
+- `3d`: 3 days
+- `6w`: 6 weeks
+- `1mo`: 1 month (30 days)
+- `1y`: 1 year
+- `30d30d`: 60 days
+- `2.5d`: 60 hours
+
+{{% /flex-content %}}
+{{< /flex >}}
 
 ## Usage
 
@@ -24,11 +59,12 @@ influxctl database create [--retention-period 0s] {name}
 | :------- | :--------------------- |
 | **name** | InfluxDB database name |
 
-## Flags {#command-flags}
+## Flags
 
-| Flag                 | Description                                         |
-| :------------------- | :-------------------------------------------------- |
-| `--retention-period` | Bucket retention period (default is 0s or infinite) |
+| Flag |                      | Description                                         |
+| :--- | :------------------- | :-------------------------------------------------- |
+| `-h` | `--help`             | Output command help                                 |
+|      | `--retention-period` | Bucket retention period (default is 0s or infinite) |
 
 ## Examples
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/create.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/create.md
@@ -1,0 +1,50 @@
+---
+title: influxctl database create
+description: >
+  The `influxctl database create` command creates a new database in an InfluxDB
+  Cloud Dedicated cluster.
+menu:
+  influxdb_cloud_dedicated:
+    parent: influxctl database
+weight: 301
+---
+
+The `influxctl database create` command creates a new database in an InfluxDB
+Cloud Dedicated cluster.
+
+## Usage
+
+```sh
+influxctl database create [--retention-period 0s] {name}
+```
+
+## Arguments
+
+| Argument | Description            |
+| :------- | :--------------------- |
+| **name** | InfluxDB database name |
+
+## Flags {#command-flags}
+
+| Flag                 | Description                                         |
+| :------------------- | :-------------------------------------------------- |
+| `--retention-period` | Bucket retention period (default is 0s or infinite) |
+
+## Examples
+
+- [Create a database with an infinite retention period](#create-a-database-with-an-infinite-retention-period)
+- [Create a database with a 30 day retention period](#create-a-database-with-a-30-day-retention-period)
+
+##### Create a database with an infinite retention period
+
+```sh
+influxctl database create mydb
+```
+
+##### Create a database with a 30 day retention period
+
+```sh
+influxctl database create \
+  --retention-period 30d \
+  mydb
+```

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/delete.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/delete.md
@@ -1,0 +1,44 @@
+---
+title: influxctl database delete
+description: >
+  The `influxctl database delete` command deletes a database from an InfluxDB
+  Cloud Dedicated cluster.
+menu:
+  influxdb_cloud_dedicated:
+    parent: influxctl database
+weight: 302
+---
+
+The `influxctl database delete` command deletes a database from an InfluxDB
+Cloud Dedicated cluster.
+
+## Usage
+
+```sh
+influxctl database delete {name}
+```
+
+{{% warn %}}
+#### Cannot be undone
+
+Deleting a database is a destructive action that cannot be undone.
+
+#### Cannot reuse deleted database names
+
+After deleting a database, you cannot reuse the name of the deleted database
+when creating a new database.
+{{% /warn %}}
+
+## Arguments
+
+| Argument | Description                    |
+| :------- | :----------------------------- |
+| **name** | Name of the database to delete |
+
+## Examples
+
+##### Delete a database named "mydb"
+
+```sh
+influxctl database delete mydb
+```

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/delete.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/delete.md
@@ -15,7 +15,7 @@ Cloud Dedicated cluster.
 ## Usage
 
 ```sh
-influxctl database delete {name}
+influxctl database delete <DATABASE_NAME>
 ```
 
 {{% warn %}}
@@ -31,9 +31,9 @@ when creating a new database.
 
 ## Arguments
 
-| Argument | Description                    |
-| :------- | :----------------------------- |
-| **name** | Name of the database to delete |
+| Argument          | Description                    |
+| :---------------- | :----------------------------- |
+| **DATABASE_NAME** | Name of the database to delete |
 
 ## Flags
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/delete.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/delete.md
@@ -35,6 +35,12 @@ when creating a new database.
 | :------- | :----------------------------- |
 | **name** | Name of the database to delete |
 
+## Flags
+
+| Flag |          | Description         |
+| :--- | :------- | :------------------ |
+| `-h` | `--help` | Output command help |
+
 ## Examples
 
 ##### Delete a database named "mydb"

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/list.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/list.md
@@ -15,11 +15,12 @@ Dedicated cluster.
 ## Usage
 
 ```sh
-influxctl database list [--format=json]
+influxctl database list [--format=table|json]
 ```
 
-## Flags {#command-flags}
+## Flags
 
-| Flag       | Description                       |
-| :--------- | :-------------------------------- |
-| `--format` | Output format (default is `json`) |
+| Flag |            | Description                                           |
+| :--- | :--------- | :---------------------------------------------------- |
+|      | `--format` | Output format (`table` or `json`, default is `table`) |
+| `-h` | `--help`   | Output command help                                   |

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/list.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/list.md
@@ -1,0 +1,25 @@
+---
+title: influxctl database list
+description: >
+  The `influxctl database list` command lists all database in an InfluxDB Cloud
+  Dedicated cluster.
+menu:
+  influxdb_cloud_dedicated:
+    parent: influxctl database
+weight: 301
+---
+
+The `influxctl database list` command lists all database in an InfluxDB Cloud
+Dedicated cluster.
+
+## Usage
+
+```sh
+influxctl database list [--format=json]
+```
+
+## Flags {#command-flags}
+
+| Flag       | Description                       |
+| :--------- | :-------------------------------- |
+| `--format` | Output format (default is `json`) |

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/help.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/help.md
@@ -1,0 +1,19 @@
+---
+title: influxctl help
+description: >
+  The `influxctl help` command outputs help information for the `influxctl`
+  command line interface.
+menu:
+  influxdb_cloud_dedicated:
+    parent: influxctl
+weight: 203
+---
+
+The `influxctl help` command outputs help information for the `influxctl`
+command line interface.
+
+## Usage
+
+```sh
+influxctl help
+```

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/_index.md
@@ -28,6 +28,6 @@ influxctl token [subcommand] [flags]
 
 ## Flags
 
-| Flag |          | Description                           |
-| :--- | :------- | :------------------------------------ |
-| `-h` | `--help` | Help for `influxctl token` command |
+| Flag |          | Description         |
+| :--- | :------- | :------------------ |
+| `-h` | `--help` | Output command help |

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/_index.md
@@ -1,0 +1,33 @@
+---
+title: influxctl token
+description: >
+  The `influx token` command and its subcommands manage database tokens in an
+  InfluxDB Cloud Dedicated cluster.
+menu:
+  influxdb_cloud_dedicated:
+    parent: influxctl
+weight: 201
+---
+
+The `influx token` command and its subcommands manage database tokens in an
+InfluxDB Cloud Dedicated cluster.
+
+## Usage
+
+```sh
+influxctl token [subcommand] [flags]
+```
+
+## Subcommands
+
+| Subcommand                                                                | Description             |
+| :------------------------------------------------------------------------ | :---------------------- |
+| [create](/influxdb/cloud-dedicated/reference/cli/influxctl/token/create/) | Create a database token |
+| [list](/influxdb/cloud-dedicated/reference/cli/influxctl/token/list/)     | List database tokens    |
+| [delete](/influxdb/cloud-dedicated/reference/cli/influxctl/token/delete/) | Delete a database token |
+
+## Flags
+
+| Flag |          | Description                           |
+| :--- | :------- | :------------------------------------ |
+| `-h` | `--help` | Help for `influxctl token` command |

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/create.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/create.md
@@ -35,12 +35,13 @@ influxctl token create \
 | :-------------------- | :------------------------- |
 | **token-description** | Database token description |
 
-## Flags {#command-flags}
+## Flags
 
-| Flag               | Description                           |
-| :----------------- | :------------------------------------ |
-| `--read-database`  | Grant read permissions to a database  |
-| `--write-database` | Grant write permissions to a database |
+| Flag |                    | Description                           |
+| :--- | :----------------- | :------------------------------------ |
+| `-h` | `--help`           | Output command help                   |
+|      | `--read-database`  | Grant read permissions to a database  |
+|      | `--write-database` | Grant write permissions to a database |
 
 ## Examples
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/create.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/create.md
@@ -1,0 +1,86 @@
+---
+title: influxctl token create
+description: >
+  The `influxctl token create` command creates a database token with specified
+  permissions to resources in an InfluxDB Cloud Dedicated cluster.
+menu:
+  influxdb_cloud_dedicated:
+    parent: influxctl token
+weight: 301
+---
+
+The `influxctl token create` command creates a database token with specified
+permissions to resources in an InfluxDB Cloud Dedicated cluster and outputs
+the token string.
+
+{{% note %}}
+#### Store secure tokens in a secret store
+
+Token strings are returned _only_ on token creation.
+We recommend storing database tokens in a secure secret store.
+{{% /note %}}
+
+## Usage
+
+```sh
+influxctl token create \
+  --read-database={database}... \
+  --write-database={database}... \
+  {token-description}
+```
+
+## Arguments
+
+| Argument              | Description                |
+| :-------------------- | :------------------------- |
+| **token-description** | Database token description |
+
+## Flags {#command-flags}
+
+| Flag               | Description                           |
+| :----------------- | :------------------------------------ |
+| `--read-database`  | Grant read permissions to a database  |
+| `--write-database` | Grant write permissions to a database |
+
+## Examples
+
+- [Create a token with read and write access to a database](#create-a-token-with-read-and-write-access-to-a-database)
+- [Create a token with read-only access to a database](#create-a-token-with-read-only-access-to-a-database)
+- [Create a token with read-only access to multiple database](#create-a-token-with-read-only-access-to-multiple-database)
+- [Create a token with mixed permissions on multiple database](#create-a-token-with-mixed-permissions-on-multiple-database)
+
+##### Create a token with read and write access to a database
+
+```sh
+influxctl token create \
+  --read-database=mydb \
+  --write-database=mydb \
+  "Read/write token for mydb"
+```
+
+##### Create a token with read-only access to a database
+
+```sh
+influxctl token create \
+  --read-database=mydb \
+  "Read-only token for mydb"
+```
+
+##### Create a token with read-only access to multiple database
+
+```sh
+influxctl token create \
+  --read-database=mydb1 \
+  --read-database=mydb2 \
+  "Read-only token for mydb1 and mydb2"
+```
+
+##### Create a token with mixed permissions on multiple database
+
+```sh
+influxctl token create \
+  --read-database=mydb1 \
+  --read-database=mydb2 \
+  --write-database=mydb2 \
+  "Read-only on mydb1, Read/write on mydb2"
+```

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/create.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/create.md
@@ -24,16 +24,16 @@ We recommend storing database tokens in a secure secret store.
 
 ```sh
 influxctl token create \
-  --read-database={database}... \
-  --write-database={database}... \
-  {token-description}
+  [--read-database=<DATABASE_NAME>] \
+  [--write-database=<DATABASE_NAME>] \
+  <TOKEN_DESCRIPTION>
 ```
 
 ## Arguments
 
 | Argument              | Description                |
 | :-------------------- | :------------------------- |
-| **token-description** | Database token description |
+| **TOKEN_DESCRIPTION** | Database token description |
 
 ## Flags
 
@@ -54,8 +54,8 @@ influxctl token create \
 
 ```sh
 influxctl token create \
-  --read-database=mydb \
-  --write-database=mydb \
+  --read-database mydb \
+  --write-database mydb \
   "Read/write token for mydb"
 ```
 
@@ -63,7 +63,7 @@ influxctl token create \
 
 ```sh
 influxctl token create \
-  --read-database=mydb \
+  --read-database mydb \
   "Read-only token for mydb"
 ```
 
@@ -71,8 +71,8 @@ influxctl token create \
 
 ```sh
 influxctl token create \
-  --read-database=mydb1 \
-  --read-database=mydb2 \
+  --read-database mydb1 \
+  --read-database mydb2 \
   "Read-only token for mydb1 and mydb2"
 ```
 
@@ -80,8 +80,8 @@ influxctl token create \
 
 ```sh
 influxctl token create \
-  --read-database=mydb1 \
-  --read-database=mydb2 \
-  --write-database=mydb2 \
+  --read-database mydb1 \
+  --read-database mydb2 \
+  --write-database mydb2 \
   "Read-only on mydb1, Read/write on mydb2"
 ```

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/delete.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/delete.md
@@ -1,0 +1,43 @@
+---
+title: influxctl token delete
+description: >
+  The `influxctl token delete` command deletes a database token from an InfluxDB
+  Cloud Dedicated cluster and revokes all permissions associated with the token.
+menu:
+  influxdb_cloud_dedicated:
+    parent: influxctl token
+weight: 302
+---
+
+The `influxctl token delete` command deletes a database token from an InfluxDB
+Cloud Dedicated cluster and revokes all permissions associated with the token.
+
+## Usage
+
+```sh
+influxctl token delete {token-id}
+```
+
+{{% warn %}}
+#### Cannot be undone
+
+Deleting a database token is a destructive action that cannot be undone.
+
+#### Rotate delete tokens
+
+After deleting a database token, any clients using the deleted token need to be
+updated with a new database token to continue to interact with your InfluxDB
+Cloud Dedicated cluster.
+{{% /warn %}}
+
+## Arguments
+
+| Argument     | Description                 |
+| :----------- | :-------------------------- |
+| **token-id** | Database token ID to delete |
+
+## Examples
+
+```sh
+influxctl token delete 000xX0Xx00xX
+```

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/delete.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/delete.md
@@ -36,6 +36,10 @@ Cloud Dedicated cluster.
 | :----------- | :-------------------------- |
 | **token-id** | Database token ID to delete |
 
+| Flag |          | Description         |
+| :--- | :------- | :------------------ |
+| `-h` | `--help` | Output command help |
+
 ## Examples
 
 ```sh

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/delete.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/delete.md
@@ -15,7 +15,7 @@ Cloud Dedicated cluster and revokes all permissions associated with the token.
 ## Usage
 
 ```sh
-influxctl token delete {token-id}
+influxctl token delete <TOKEN_ID>
 ```
 
 {{% warn %}}
@@ -34,7 +34,9 @@ Cloud Dedicated cluster.
 
 | Argument     | Description                 |
 | :----------- | :-------------------------- |
-| **token-id** | Database token ID to delete |
+| **TOKEN_ID** | Database token ID to delete |
+
+## Flags
 
 | Flag |          | Description         |
 | :--- | :------- | :------------------ |

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/list.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/list.md
@@ -1,0 +1,25 @@
+---
+title: influxctl token list
+description: >
+  The `influxctl token list` command lists all database tokens in an InfluxDB
+  Cloud Dedicated cluster.
+menu:
+  influxdb_cloud_dedicated:
+    parent: influxctl token
+weight: 301
+---
+
+The `influxctl token list` command lists all database tokens in an InfluxDB Cloud
+Dedicated cluster.
+
+## Usage
+
+```sh
+influxctl token list [--format=json]
+```
+
+## Flags {#command-flags}
+
+| Flag       | Description                       |
+| :--------- | :-------------------------------- |
+| `--format` | Output format (default is `json`) |

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/list.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/list.md
@@ -15,11 +15,12 @@ Dedicated cluster.
 ## Usage
 
 ```sh
-influxctl token list [--format=json]
+influxctl token list [--format=table|json]
 ```
 
-## Flags {#command-flags}
+## Flags
 
-| Flag       | Description                       |
-| :--------- | :-------------------------------- |
-| `--format` | Output format (default is `json`) |
+| Flag |            | Description                                           |
+| :--- | :--------- | :---------------------------------------------------- |
+|      | `--format` | Output format (`table` or `json`, default is `table`) |
+| `-h` | `--help`   | Output command help                                   |

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/version.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/version.md
@@ -1,0 +1,19 @@
+---
+title: influxctl version
+description: >
+  The `influxctl version` command outputs the current version and architecture of
+  the `influxctl` command line interface.
+menu:
+  influxdb_cloud_dedicated:
+    parent: influxctl
+weight: 202
+---
+
+The `influxctl version` command outputs the current version and architecture of
+the `influxctl` command line interface.
+
+## Usage
+
+```sh
+influxctl version
+```


### PR DESCRIPTION
Adds reference documentation for the `influxctl` CLI. There are some outstanding TODOs regarding installation, but the bulk of the content should be there.

- [x] Rebased/mergeable
