### PR TITLE
Fix small typo in regex docs

### DIFF
--- a/content/enterprise_influxdb/v1.10/flux/guides/regular-expressions.md
+++ b/content/enterprise_influxdb/v1.10/flux/guides/regular-expressions.md
@@ -66,7 +66,7 @@ from(bucket: "db/rp")
 ```
 
 ### Drop columns matching a regex
-The following example drops columns whose names do not being with `_`.
+The following example drops columns whose names do not begin with `_`.
 
 ```js
 from(bucket: "db/rp")

--- a/content/enterprise_influxdb/v1.9/flux/guides/regular-expressions.md
+++ b/content/enterprise_influxdb/v1.9/flux/guides/regular-expressions.md
@@ -66,7 +66,7 @@ from(bucket: "db/rp")
 ```
 
 ### Drop columns matching a regex
-The following example drops columns whose names do not being with `_`.
+The following example drops columns whose names do not begin with `_`.
 
 ```js
 from(bucket: "db/rp")

--- a/content/influxdb/v1.7/flux/guides/regular-expressions.md
+++ b/content/influxdb/v1.7/flux/guides/regular-expressions.md
@@ -73,7 +73,7 @@ from(bucket: "db/rp")
 ```
 
 ### Drop columns matching a regex
-The following example drops columns whose names do not being with `_`.
+The following example drops columns whose names do not begin with `_`.
 
 ```js
 from(bucket: "db/rp")

--- a/content/influxdb/v1.8/flux/guides/regular-expressions.md
+++ b/content/influxdb/v1.8/flux/guides/regular-expressions.md
@@ -73,7 +73,7 @@ from(bucket: "db/rp")
 ```
 
 ### Drop columns matching a regex
-The following example drops columns whose names do not being with `_`.
+The following example drops columns whose names do not begin with `_`.
 
 ```js
 from(bucket: "db/rp")

--- a/content/influxdb/v2.0/query-data/flux/regular-expressions.md
+++ b/content/influxdb/v2.0/query-data/flux/regular-expressions.md
@@ -77,7 +77,7 @@ from(bucket: "example-bucket")
 ```
 
 ### Drop columns matching a regex
-The following example drops columns whose names do not being with `_`.
+The following example drops columns whose names do not begin with `_`.
 
 ```js
 from(bucket: "example-bucket")

--- a/content/influxdb/v2.1/query-data/flux/regular-expressions.md
+++ b/content/influxdb/v2.1/query-data/flux/regular-expressions.md
@@ -70,7 +70,7 @@ from(bucket: "example-bucket")
 ```
 
 ### Drop columns matching a regex
-The following example drops columns whose names do not being with `_`.
+The following example drops columns whose names do not begin with `_`.
 
 ```js
 from(bucket: "example-bucket")

--- a/content/influxdb/v2.2/query-data/flux/regular-expressions.md
+++ b/content/influxdb/v2.2/query-data/flux/regular-expressions.md
@@ -70,7 +70,7 @@ from(bucket: "example-bucket")
 ```
 
 ### Drop columns matching a regex
-The following example drops columns whose names do not being with `_`.
+The following example drops columns whose names do not begin with `_`.
 
 ```js
 from(bucket: "example-bucket")

--- a/content/influxdb/v2.3/query-data/flux/regular-expressions.md
+++ b/content/influxdb/v2.3/query-data/flux/regular-expressions.md
@@ -70,7 +70,7 @@ from(bucket: "example-bucket")
 ```
 
 ### Drop columns matching a regex
-The following example drops columns whose names do not being with `_`.
+The following example drops columns whose names do not begin with `_`.
 
 ```js
 from(bucket: "example-bucket")

--- a/content/influxdb/v2.4/query-data/flux/regular-expressions.md
+++ b/content/influxdb/v2.4/query-data/flux/regular-expressions.md
@@ -70,7 +70,7 @@ from(bucket: "example-bucket")
 ```
 
 ### Drop columns matching a regex
-The following example drops columns whose names do not being with `_`.
+The following example drops columns whose names do not begin with `_`.
 
 ```js
 from(bucket: "example-bucket")

--- a/content/influxdb/v2.5/query-data/flux/regular-expressions.md
+++ b/content/influxdb/v2.5/query-data/flux/regular-expressions.md
@@ -70,7 +70,7 @@ from(bucket: "example-bucket")
 ```
 
 ### Drop columns matching a regex
-The following example drops columns whose names do not being with `_`.
+The following example drops columns whose names do not begin with `_`.
 
 ```js
 from(bucket: "example-bucket")

--- a/content/influxdb/v2.6/query-data/flux/regular-expressions.md
+++ b/content/influxdb/v2.6/query-data/flux/regular-expressions.md
@@ -70,7 +70,7 @@ from(bucket: "example-bucket")
 ```
 
 ### Drop columns matching a regex
-The following example drops columns whose names do not being with `_`.
+The following example drops columns whose names do not begin with `_`.
 
 ```js
 from(bucket: "example-bucket")

--- a/content/influxdb/v2.7/query-data/flux/regular-expressions.md
+++ b/content/influxdb/v2.7/query-data/flux/regular-expressions.md
@@ -70,7 +70,7 @@ from(bucket: "example-bucket")
 ```
 
 ### Drop columns matching a regex
-The following example drops columns whose names do not being with `_`.
+The following example drops columns whose names do not begin with `_`.
 
 ```js
 from(bucket: "example-bucket")


### PR DESCRIPTION
Closes (none)

_Describe your proposed changes here._
Small typo on https://docs.influxdata.com/influxdb/cloud/query-data/flux/regular-expressions/#
`being` -> `begin`

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
