### PR TITLE
hotfix(cloud-iox): Fix alias and resulting 404

### DIFF
--- a/content/influxdb/cloud-iox/query-data/tools/superset.md
+++ b/content/influxdb/cloud-iox/query-data/tools/superset.md
@@ -13,9 +13,9 @@ menu:
     identifier: visualize_with_superset
 influxdb/cloud-iox/tags: [query, visualization]
 aliases:
-  - /influxdb/cloud-iox/query-data/tools/superset/
+  - /influxdb/cloud-iox/visualize-data/superset/
 related:
-    - /influxdb/cloud-iox/query-data/execute-queries/flight-sql/superset/
+  - /influxdb/cloud-iox/query-data/execute-queries/flight-sql/superset/
 ---
 
 Use [Apache Superset](https://superset.apache.org/) to query and visualize data


### PR DESCRIPTION
Replaces self-referential alias with the intended alias for /influxdb/cloud-iox/visualize-data/superset/.

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
