### PR TITLE
Migrate 1.x data to dedicated

### DIFF
--- a/content/influxdb/cloud-dedicated/get-started/setup.md
+++ b/content/influxdb/cloud-dedicated/get-started/setup.md
@@ -58,7 +58,7 @@ databases and tokens.
 
 ## Create a database
 
-Use the [`influxctl database create` command](/influxdb/cloud-dedicated/reference/cli/influxct/database/create/)
+Use the [`influxctl database create` command](/influxdb/cloud-dedicated/reference/cli/influxctl/database/create/)
 to create a database. You can use an existing database or create a new one
 specifically for this getting started tutorial.
 _Examples in this getting started tutorial assume a database named **"get-started"**._
@@ -87,7 +87,7 @@ influxctl database create \
 
 ## Create a database token
 
-Use the [`influxctl token create` command](/influxdb/cloud-dedicated/reference/cli/influxct/token/create/)
+Use the [`influxctl token create` command](/influxdb/cloud-dedicated/reference/cli/influxctl/token/create/)
 to create a database token with read and write permissions for your database.
 
 Provide the following:

--- a/content/influxdb/cloud-dedicated/write-data/migrate-data/_index.md
+++ b/content/influxdb/cloud-dedicated/write-data/migrate-data/_index.md
@@ -1,0 +1,82 @@
+---
+title: Migrate data to InfluxDB Cloud Dedicated
+description: >
+  Migrate data from InfluxDB powered by TSM (OSS, Enterprise, or Cloud) to
+  InfluxDB Cloud Dedicated.
+menu:
+  influxdb_cloud_dedicated:
+    name: Migrate data
+    parent: Write data
+weight: 104
+alt_engine: /influxdb/cloud/migrate-data/
+---
+
+Migrate data to InfluxDB Cloud Dedicated powered by InfluxDB IOx from other 
+InfluxDB instances powered by TSM including InfluxDB OSS 1.x, 2.x,
+InfluxDB Enterprise, and InfluxDB Cloud (TSM).
+
+- [Should you migrate?](#should-you-migrate)
+  - [Are you currently limited by series cardinality?](#are-you-currently-limited-by-series-cardinality)
+  - [Do you want to use SQL to query your data?](#do-you-want-to-use-sql-to-query-your-data)
+  - [Do you want better InfluxQL performance?](#do-you-want-better-influxql-performance)
+  - [Do you depend on a specific cloud provider or region?](#do-you-depend-on-a-specific-cloud-provider-or-region)
+  - [Are you reliant on Flux queries and Flux tasks?](#are-you-reliant-on-flux-queries-and-flux-tasks)
+- [Data migration guides](#data-migration-guides)
+
+## Should you migrate?
+
+There are important things to consider with migrating to InfluxDB Cloud Dedicated.
+The following questions will help guide your decision to migrate.
+
+#### Are you currently limited by series cardinality?
+
+**Yes, you should migrate**. Series cardinality is a major limiting factor with
+the InfluxDB TSM storage engine. The more unique series in your data, the less
+performant your database.
+The IOx storage engine supports near limitless series cardinality and is, without
+question, the better solution for high series cardinality workloads.
+
+#### Do you want to use SQL to query your data?
+
+**Yes, you should migrate**. InfluxDB Cloud Dedicated lets you query your time
+series data with SQL. For more information about querying your data with SQL, see:
+
+- [Query data with SQL](/influxdb/cloud-dedicated/query-data/sql/)
+- [InfluxDB SQL reference](/influxdb/cloud-dedicated/reference/sql/)
+
+#### Do you want better InfluxQL performance?
+
+**Yes, you should migrate**. One of the primary goals when designing the InfluxDB
+IOx storage engine was to enable performant implementations of both SQL and InfluxQL.
+When compared to querying InfluxDB powered by TSM (InfluxDB OSS 1.x, 2.x, and Enterprise),
+InfluxQL queries are more performant when querying InfluxDB powered by InfluxDB IOx.
+
+#### Do you depend on a specific cloud provider or region?
+
+**You should maybe migrate**. InfluxDB Cloud Dedicated instances are available
+from the following providers:
+
+{{< cloud_regions type=iox-list >}}
+
+If your deployment requires other cloud providers or regions, you may need to
+wait until the IOx storage engine is available in a region that meets your requirements.
+We are currently working to make InfluxDB IOx available on more providers and
+in more regions around the world.
+
+#### Are you reliant on Flux queries and Flux tasks?
+
+**You should maybe migrate**. Flux queries are less performant against the IOx
+storage engine. Flux is optimized to work with the TSM storage engine, but these
+optimizations do not apply to the on-disk structure of InfluxDB IOx.
+
+To maintain performant Flux queries against the IOx storage engine, you need to
+update Flux queries to use a mixture of both SQL and Flux—SQL to query the base
+dataset and Flux to perform other transformations that SQL does not support.
+For information about using SQL and Flux together for performant queries, see
+[Use Flux and SQL to query data](/influxdb/cloud-dedicated/query-data/flux-sql/).
+
+---
+
+## Data migration guides
+
+{{< children >}}

--- a/content/influxdb/cloud-dedicated/write-data/migrate-data/_index.md
+++ b/content/influxdb/cloud-dedicated/write-data/migrate-data/_index.md
@@ -65,15 +65,7 @@ in more regions around the world.
 
 #### Are you reliant on Flux queries and Flux tasks?
 
-**You should maybe migrate**. Flux queries are less performant against the IOx
-storage engine. Flux is optimized to work with the TSM storage engine, but these
-optimizations do not apply to the on-disk structure of InfluxDB IOx.
-
-To maintain performant Flux queries against the IOx storage engine, you need to
-update Flux queries to use a mixture of both SQL and Flux—SQL to query the base
-dataset and Flux to perform other transformations that SQL does not support.
-For information about using SQL and Flux together for performant queries, see
-[Use Flux and SQL to query data](/influxdb/cloud-dedicated/query-data/flux-sql/).
+**You should not migrate**. InfluxDB Cloud Dedicated does not support Flux.
 
 ---
 

--- a/content/influxdb/cloud-dedicated/write-data/migrate-data/migrate-1x-to-cloud-dedicated.md
+++ b/content/influxdb/cloud-dedicated/write-data/migrate-data/migrate-1x-to-cloud-dedicated.md
@@ -229,7 +229,7 @@ You would create the following InfluxDB {{< current-version >}} databases:
     Write each export file to the target database.
 
     {{% warn %}}
-  #### v2.x CLI not supported
+  #### v2.x influx CLI not supported
 
   Don't use the `influx` CLI with InfluxDB Cloud Dedicated.
   While it may coincidentally work, it isn't officially supported.

--- a/content/influxdb/cloud-dedicated/write-data/migrate-data/migrate-1x-to-cloud-dedicated.md
+++ b/content/influxdb/cloud-dedicated/write-data/migrate-data/migrate-1x-to-cloud-dedicated.md
@@ -1,0 +1,253 @@
+---
+title: Migrate data from InfluxDB 1.x to InfluxDB Cloud Dedicated
+description: >
+  To migrate data from a TSM-powered InfluxDB 1.x (OSS or Enterprise) to an
+  InfluxDB Cloud Dedicated cluster, export the data as line protocol and
+  write the exported data to your InfluxDB Cloud Dedicated database.
+menu:
+  influxdb_cloud_dedicated:
+    name: Migrate from 1.x to Dedicated
+    parent: Migrate data
+weight: 103
+aliases:
+  - /influxdb/cloud-dedicated/write-data/migrate-data/migrate-1x-to-iox/
+related:
+  - /influxdb/cloud-dedicated/admin/databases/
+  - /influxdb/cloud-dedicated/admin/tokens/
+  - /influxdb/cloud-dedicated/primers/api/v1/
+  - /influxdb/cloud-dedicated/primers/api/v2/
+---
+
+To migrate data from an InfluxDB 1.x OSS or Enterprise instance to InfluxDB Cloud
+Dedicated, export the data as line protocol and write
+the exported data to an InfluxDB Cloud Dedicated database.
+<!--
+Because full data migrations will likely exceed your organizations' limits and
+adjustable quotas, migrate your data in batches.
+-->
+
+<!-- cloud
+All write requests are subject to your InfluxDB Cloud Dedicated organization's
+[rate limits and adjustable quotas](/influxdb/cloud-dedicated/account-management/limits/).
+/cloud -->
+
+## Tools to use
+The migration process uses the following tools:
+
+- **`influx_inspect` utility**:
+  The [`influx_inspect` utility](/{{< latest "influxdb" "v1" >}}/tools/influx_inspect/#export)
+  is packaged with InfluxDB 1.x OSS and Enterprise.
+- **[`influxctl` admin CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/)**.
+- [v1 API `/write` endpoint](/influxdb/cloud-dedicated/primers/api/v1/) or [v2 API `/api/v2/write` endpoint](/influxdb/cloud-dedicated/primers/api/v2/) and API client libraries.
+
+{{% note %}}
+#### InfluxDB 1.x and 2.x CLIs are unique
+If both the **InfluxDB 1.x and 2.x `influx` CLIs** are installed in your `$PATH`,
+rename one of the the binaries to ensure you're executing commands with the
+correct CLI.
+{{% /note %}}
+
+## Migrate data
+
+1. **Export data from your InfluxDB 1.x instance as line protocol.**
+
+    Use the **InfluxDB 1.x `influx_inspect export` utility** to export data as
+    line protocol and store it in a file.
+    Include the following:
+
+    - ({{< req "Required" >}}) `-lponly` flag to export line protocol without InfluxQL DDL or DML.
+    - ({{< req "Required" >}}) `-out` flag with a path to an output file.
+      Default is `~/.influxdb/export`. _Any subsequent export commands without
+      the output file defined will overwrite the existing export file._
+    - `-compress` flag to use gzip to compress the output.
+    - `-datadir` flag with the path to your InfluxDB 1.x `data` directory.
+      Only required if the `data` directory is at a non-default location.
+      For information about default locations, see
+      [InfluxDB OSS 1.x file system layout](/{{< latest "influxdb" "v1" >}}/concepts/file-system-layout/#file-system-layout)
+      or [InfluxDB Enterprise 1.x file system layout](/{{< latest "enterprise_influxdb" >}}/concepts/file-system-layout/#file-system-layout).
+    - `-waldir` flag with the path to your InfluxDB 1.x `wal` directory.
+      Only required if the `wal` directory is at a non-default location.
+      For information about default locations, see
+      [InfluxDB OSS 1.x file system layout](/{{< latest "influxdb" "v1" >}}/concepts/file-system-layout/#file-system-layout)
+      or [InfluxDB Enterprise 1.x file system layout](/{{< latest "enterprise_influxdb" >}}/concepts/file-system-layout/#file-system-layout).
+    - `-database` flag with a specific database name to export.
+      By default, all databases are exported.
+    - `-retention` flag with a specific retention policy to export.
+      By default, all retention policies are exported.
+    - `-start` flag with an RFC3339 timestamp that defines the earliest time to export.
+      Default is `1677-09-20T16:27:54-07:44`.
+    - `-end` flag with an RFC3339 timestamp that defines the latest time to export.
+      Default is `2262-04-11T16:47:16-07:00`.
+
+    {{% note %}}
+We recommend exporting each database and retention policy combination separately
+to easily write the exported data into corresponding InfluxDB {{< current-version >}}
+databases.
+    {{% /note %}}
+
+    ##### Export all data in a database and retention policy to a file
+    ```sh
+    influx_inspect export \
+      -lponly \
+      -database example-db \
+      -retention example-rp \
+      -out path/to/export-file.lp
+    ```
+
+    ##### View more export command examples:
+    {{< expand-wrapper >}}
+{{% expand "Export all data to a file" %}}
+
+```sh
+influx_inspect export \
+  -lponly \
+  -out path/to/export-file.lp.gzip
+```
+
+{{% /expand %}}
+
+{{% expand "Export all data to a compressed file" %}}
+
+```sh
+influx_inspect export \
+  -lponly \
+  -compress \
+  -out path/to/export-file.lp.gzip
+```
+
+{{% /expand %}}
+
+{{% expand "Export data within time bounds to a file" %}}
+
+```sh
+influx_inspect export \
+  -lponly \
+  -start 2020-01-01T00:00:00Z \
+  -end 2023-01-01T00:00:00Z \
+  -out path/to/export-file.lp
+```
+
+{{% /expand %}}
+
+{{% expand "Export a database and all its retention policies to a file" %}}
+
+```sh
+influx_inspect export \
+  -lponly \
+  -database example-db \
+  -out path/to/export-file.lp
+```
+
+{{% /expand %}}
+
+{{% expand "Export a specific database and retention policy to a file" %}}
+
+```sh
+influx_inspect export \
+  -lponly \
+  -database example-db \
+  -retention example-rp \
+  -out path/to/export-file.lp
+```
+
+{{% /expand %}}
+
+{{% expand "Export all data from _non-default_ `data` and `wal` directories" %}}
+
+```sh
+influx_inspect export \
+  -lponly \
+  -datadir path/to/influxdb/data/ \
+  -waldir path/to/influxdb/wal/ \
+  -out path/to/export-file.lp
+```
+
+{{% /expand %}}
+    {{< /expand-wrapper >}}
+
+2. Create InfluxDB Cloud Dedicated databases for each InfluxDB 1.x database and retention policy combination.
+
+    {{% note %}}
+**If coming from InfluxDB v1**, the concepts of databases and retention policies
+have been combined into a single concept--database. Retention policies are no
+longer part of the InfluxDB data model. However, InfluxDB Cloud Dedicated does
+support InfluxQL, which requires databases and retention policies.
+See [InfluxQL DBRP naming convention](/influxdb/cloud-dedicated/admin/databases/create/#influxql-dbrp-naming-convention).
+
+**If coming from InfluxDB v2 or InfluxDB Cloud**, _database_ and _bucket_ are synonymous.
+    {{% /note %}}
+
+    {{< expand-wrapper >}}
+{{% expand "View example 1.x databases and retention policies as InfluxDB Cloud Dedicated databases" %}}
+If you have the following InfluxDB 1.x data structure:
+
+- example-db <span style="opacity:.5;">_(database)_</span>
+  - autogen <span style="opacity:.5;">_(retention policy)_</span>
+  - historical-1mo <span style="opacity:.5;">_(retention policy)_</span>
+  - historical-6mo <span style="opacity:.5;">_(retention policy)_</span>
+  - historical-1y <span style="opacity:.5;">_(retention policy)_</span>
+
+You would create the following InfluxDB {{< current-version >}} databases:
+
+- example-db/autogen
+- example-db/historical-1mo
+- example-db/historical-6mo
+- example-db/historical-1y
+
+{{% /expand %}}
+    {{< /expand-wrapper >}}
+
+    Use the [`influxctl database create` command](/influxdb/cloud-dedicated/reference/cli/influxctl/database/create/)
+    to [create a database](/influxdb/cloud-dedicated/admin/databases/create/) in your InfluxDB Cloud Dedicated cluster.
+
+    Provide the following arguments:
+
+    - _(Optional)_ Database [retention period](/influxdb/cloud-dedicated/admin/databases/#retention-periods)
+      (default is infinite)
+    - Database name _(see [Database naming restrictions](#database-naming-restrictions))_
+
+    ```sh
+    influxctl database create --retention-period 30d <DATABASE_NAME>
+    ```
+
+    To learn more about databases in InfluxDB Cloud Dedicated, see [Manage databases](/influxdb/cloud-dedicated/admin/databases/).
+
+3. **Create a database token for writing to your InfluxDB Cloud Dedicated database.**
+
+    Use the [`influxctl token create` command](/influxdb/cloud-dedicated/admin/tokens/create/)
+    to [create a database token](/influxdb/cloud-dedicated/admin/tokens/create/) with
+    _write_ permission to your database.
+
+    Provide the following:
+
+    - Permission grants
+      - `--read-database`: Grants read access to a database
+      - `--write-database` Grants write access to a database
+    - Token description
+
+    ```sh
+    influxctl token create \
+      --read-database example-db \
+      --write-database example-db \
+      "Read/write token for example-db database"
+    ```
+
+4. **Write the exported line protocol to your InfluxDB Cloud Dedicated cluster.**
+    
+    Use the v1 API or v2 API endpoints to write data to your InfluxDB Cloud Dedicated cluster.
+
+    Choose from the following options:
+
+    - The [v1 API `/write` endpoint](/influxdb/cloud-dedicated/primers/api/v1/) with v1 client libraries or HTTP clients.
+    - The [v2 API `/api/v2/write` endpoint](/influxdb/cloud-dedicated/primers/api/v2/) with v2 client libraries or HTTP clients.
+    
+    Write each export file to the target database.
+
+    {{% warn %}}
+  #### v2.x CLI not supported
+
+  Don't use the `influx` CLI with InfluxDB Cloud Dedicated.
+  While it may coincidentally work, it isn't officially supported.
+
+  For help finding the best workflow for your situation, [contact Support](mailto:support@influxdata.com).
+    {{% /warn %}}

--- a/content/influxdb/cloud-dedicated/write-data/migrate-data/migrate-1x-to-cloud-dedicated.md
+++ b/content/influxdb/cloud-dedicated/write-data/migrate-data/migrate-1x-to-cloud-dedicated.md
@@ -21,15 +21,6 @@ related:
 To migrate data from an InfluxDB 1.x OSS or Enterprise instance to InfluxDB Cloud
 Dedicated, export the data as line protocol and write
 the exported data to an InfluxDB Cloud Dedicated database.
-<!--
-Because full data migrations will likely exceed your organizations' limits and
-adjustable quotas, migrate your data in batches.
--->
-
-<!-- cloud
-All write requests are subject to your InfluxDB Cloud Dedicated organization's
-[rate limits and adjustable quotas](/influxdb/cloud-dedicated/account-management/limits/).
-/cloud -->
 
 ## Tools to use
 The migration process uses the following tools:

--- a/content/influxdb/cloud-dedicated/write-data/migrate-data/migrate-1x-to-cloud-dedicated.md
+++ b/content/influxdb/cloud-dedicated/write-data/migrate-data/migrate-1x-to-cloud-dedicated.md
@@ -234,5 +234,5 @@ You would create the following InfluxDB {{< current-version >}} databases:
   Don't use the `influx` CLI with InfluxDB Cloud Dedicated.
   While it may coincidentally work, it isn't officially supported.
 
-  For help finding the best workflow for your situation, [contact Support](mailto:support@influxdata.com).
+  For help finding the best workflow for your situation, [contact Support](https://support.influxdata.com/).
     {{% /warn %}}

--- a/content/influxdb/cloud-dedicated/write-data/migrate-data/migrate-1x-to-cloud-dedicated.md
+++ b/content/influxdb/cloud-dedicated/write-data/migrate-data/migrate-1x-to-cloud-dedicated.md
@@ -66,7 +66,7 @@ The migration process uses the following tools:
 
     {{% note %}}
 We recommend exporting each database and retention policy combination separately
-to easily write the exported data into corresponding InfluxDB {{< current-version >}}
+to easily write the exported data into corresponding InfluxDB Cloud Dedicated
 databases.
     {{% /note %}}
 

--- a/content/influxdb/cloud-dedicated/write-data/migrate-data/migrate-1x-to-cloud-dedicated.md
+++ b/content/influxdb/cloud-dedicated/write-data/migrate-data/migrate-1x-to-cloud-dedicated.md
@@ -31,12 +31,6 @@ The migration process uses the following tools:
 - **[`influxctl` admin CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/)**.
 - [v1 API `/write` endpoint](/influxdb/cloud-dedicated/primers/api/v1/) or [v2 API `/api/v2/write` endpoint](/influxdb/cloud-dedicated/primers/api/v2/) and API client libraries.
 
-{{% note %}}
-#### InfluxDB 1.x and 2.x CLIs are unique
-If both the **InfluxDB 1.x and 2.x `influx` CLIs** are installed in your `$PATH`,
-rename one of the the binaries to ensure you're executing commands with the
-correct CLI.
-{{% /note %}}
 
 ## Migrate data
 

--- a/content/influxdb/cloud-serverless/write-data/migrate-data/_index.md
+++ b/content/influxdb/cloud-serverless/write-data/migrate-data/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Migrate data to the InfluxDB Cloud Serverless
+title: Migrate data to InfluxDB Cloud Serverless
 description: >
   Migrate data from InfluxDB powered by TSM (OSS, Enterprise, or Cloud) to
   InfluxDB Cloud Serverless.


### PR DESCRIPTION
Migrate 1.x data to dedicated:
- Minimal adaptation of IOx to Dedicated for now.
- Use APIs for writing data (CLIs? pyinflux3 only writes CSV? Can't promote influxdb_iox for now)
- Add 2.x CLI warning
- Misc. fixes.

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
