### PR TITLE
Updates UI text for the IOx/Serverless wayfinding modal

### DIFF
--- a/layouts/partials/footer/iox-wayfinding.html
+++ b/layouts/partials/footer/iox-wayfinding.html
@@ -9,8 +9,10 @@
 {{ $isCloud := eq $version "cloud" }}
 {{ $isIOx := eq $version "cloud-serverless" }}
 
+{{ $scratch.Set "uiText" "" }}
 {{ $scratch.Set "link" "" }}
 {{ if $isCloud }}
+  {{ $scratch.Set "uiText" "InfluxDB Cloud powered by TSM"}}
   {{ $altIOxPage := $.GetPage ((replaceRE "influxdb/cloud" "influxdb/cloud-serverless" $.Page.RelPermalink) | replaceRE `\/$` "") }}
   {{ if ne $altDoc "" }}
     {{ $scratch.Set "link" $altDoc }}
@@ -18,6 +20,7 @@
     {{ $scratch.Set "link" $altIOxPage.RelPermalink }}
   {{ end }}
 {{ else if $isIOx }}
+{{ $scratch.Set "uiText" "InfluxDB Cloud Serverless"}}
   {{ $altCloudPage := $.GetPage ((replaceRE "influxdb/cloud-serverless" "influxdb/cloud" $.Page.RelPermalink) | replaceRE `\/$` "") }}
   {{ if ne $altDoc "" }}
     {{ $scratch.Set "link" $altDoc }}
@@ -26,6 +29,7 @@
   {{ end }}
 {{ end }}
 
+{{ $uiText := $scratch.Get "uiText" }}
 {{ $altLink := cond (eq ($scratch.Get "link") "") (print "/influxdb/" $altVersion "/") ($scratch.Get "link") }}
 
 <div id="iox-wayfinding-modal">
@@ -52,7 +56,7 @@
               and look for:
             </p>
             <div class="powered-by-example">
-              InfluxDB Cloud powered by {{ $engine }}
+              {{ $uiText }}
             </div>
           </div>
         </div>


### PR DESCRIPTION
In the IOx wayfinding modal, the example text that identifies what users should look for to know what engine they're using is:

- InfluxDB Cloud Serverless
- InfluxDB Cloud powered by TSM

---

- [x] Rebased/mergeable
