### PR TITLE
fix(oss): make package download commands easier to use (#4924)

### DIFF
--- a/content/influxdb/v2.7/install.md
+++ b/content/influxdb/v2.7/install.md
@@ -235,15 +235,28 @@ For information about installing the `influx` CLI, see
     with the following commands:
 
     ```sh
-    # Ubuntu/Debian
-    wget https://dl.influxdata.com/influxdb/releases/influxdb2-{{< latest-patch >}}-xxx.deb
-    sudo dpkg -i influxdb2-{{< latest-patch >}}-xxx.deb
-
-    # Red Hat/CentOS/Fedora
-    wget https://dl.influxdata.com/influxdb/releases/influxdb2-{{< latest-patch >}}-xxx.rpm
-    sudo yum localinstall influxdb2-{{< latest-patch >}}-xxx.rpm
+    # Ubuntu/Debian AMD64
+    wget https://dl.influxdata.com/influxdb/releases/influxdb2-{{< latest-patch >}}-amd64.deb
+    sudo dpkg -i influxdb2-{{< latest-patch >}}-amd64.deb
     ```
-    _Use the exact filename of the download of `.rpm` package (for example, `influxdb2-{{< latest-patch >}}-amd64.rpm`)._
+
+    ```sh
+    # Ubuntu/Debian ARM64
+    wget https://dl.influxdata.com/influxdb/releases/influxdb2-{{< latest-patch >}}-arm64.deb
+    sudo dpkg -i influxdb2-{{< latest-patch >}}-arm64.deb
+    ```
+
+    ```sh
+    # Red Hat/CentOS/Fedora x86-64 (x64, AMD64)
+    wget https://dl.influxdata.com/influxdb/releases/influxdb2-{{< latest-patch >}}.x86_64.rpm
+    sudo yum localinstall influxdb2-{{< latest-patch >}}.x86_64.rpm
+    ```
+
+    ```sh
+    # Red Hat/CentOS/Fedora AArch64 (ARMv8-A)
+    wget https://dl.influxdata.com/influxdb/releases/influxdb2-{{< latest-patch >}}.aarch64.rpm
+    sudo yum localinstall influxdb2-{{< latest-patch >}}.aarch64.rpm
+    ```
 
 2.  Start the InfluxDB service:
 


### PR DESCRIPTION
- use separate code blocks so users can copy the commands they want
- specific architecture file names for package downloads.

Closes #4924 

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
