### PR TITLE
4918 telegraf write example

### DIFF
--- a/content/influxdb/cloud-dedicated/get-started/_index.md
+++ b/content/influxdb/cloud-dedicated/get-started/_index.md
@@ -102,7 +102,7 @@ be used to perform actions outlined in this tutorial.
 **InfluxDB Cloud Dedicated requires authentication** using
 [tokens](/influxdb/cloud-dedicated/security/tokens/).
 
-There a two types of tokens:
+There two types of tokens:
 
 - **Database token**: A token that grants read and write access to InfluxDB
   databases.

--- a/content/influxdb/cloud-dedicated/get-started/write.md
+++ b/content/influxdb/cloud-dedicated/get-started/write.md
@@ -137,13 +137,13 @@ home,room=Kitchen temp=22.7,hum=36.5,co=26i 1641067200
 
 Use the **InfluxDB v2 HTTP API** or **InfluxDB client libraries** to write the
 line protocol above to InfluxDB.
-The following examples show how to use the **Python** and **Go** client libraries to write line protocol.
 
 {{< tabs-wrapper >}}
 {{% tabs %}}
 [InfluxDB API](#)
 [Python](#)
 [Go](#)
+[Telegraf](#)
 {{% /tabs %}}
 
 {{% tab-content %}}
@@ -463,6 +463,30 @@ go run ./write.go
 {{% /influxdb/custom-timestamps %}}
 
 <!------------------------------- END GO CONTENT ------------------------------>
+{{% /tab-content %}}
+{{% tab-content %}}
+<!------------------------------- BEGIN TELEGRAF CONTENT ------------------------------>
+[Telegraf](/{{< latest "telegraf" >}}/) with the [`file` input plugin](/{{< latest "telegraf" >}}/plugins/#input-file) consume line protocol or CSV, and then use the `influxdb_v2` output plugin to write the data to InfluxDB.
+
+The following example shows a minimal [`outputs.influxdb_v2`](/{{< latest "telegraf" >}}/plugins/#output-influxdb_v2) configuration for writing data to your InfluxDB Cloud Dedicated cluster:
+
+```toml
+[[outputs.influxdb_v2]]
+  urls = ["https://cluster-id.influxdb.io"]
+  token = "${INFLUX_TOKEN}"
+  organization = ""
+  bucket = "DATABASE_NAME"
+```
+
+Replace the following:
+
+- **`DATABASE_NAME`**: your InfluxDB Cloud Dedicated [database](/influxdb/cloud-dedicated/admin/databases/)
+
+In the example, **`INFLUX_TOKEN`** is an environment variable assigned to an InfluxDB API token that has _write_ permission to the bucket.
+
+The Telegraf `file` input plugin and the `output-influxdb_v2` output plugin provide many options for reading and writing data.
+To learn more, see how to [use Telegraf to write CSV data](/influxdb/cloud-dedicated/write-data/csv/telegraf/).
+<!------------------------------- END TELEGRAF CONTENT ------------------------------>
 {{% /tab-content %}}
 {{< /tabs-wrapper >}}
 

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/go.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/go.md
@@ -103,7 +103,7 @@ func main() {
     org := "example-org"
     token := "example-token"
     // Store the URL of your InfluxDB instance
-    url := "http://localhost:8086"
+    url := "https://cluster-id.influxdb.io"
     // Create new client with default option for server url authenticate by token
     client := influxdb2.NewClient(url, token)
     // User blocking write client for writes to desired bucket

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/python.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/python.md
@@ -111,4 +111,4 @@ write_api.write(bucket=database, org=org, record=p)
 ## Query data from InfluxDB with Python
 
 The InfluxDB v2 Python client can't query InfluxDB Cloud Dedicated.
-To query your dedicated instance, use a [Flight SQL client with gRPC](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/).
+To query your dedicated instance, use a Python [Flight SQL client with gRPC](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/).

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/python.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/python.md
@@ -23,39 +23,43 @@ If just getting started, see [Get started with InfluxDB](/influxdb/cloud-dedicat
 
 ## Before you begin
 
+You'll need the following prerequisites:
+
 1. Install the InfluxDB Python library:
 
     ```sh
     pip install influxdb-client
     ```
 
-2. Ensure that InfluxDB is running.
-   If running InfluxDB locally, visit http://localhost:8086.
-   (If using InfluxDB Cloud, visit the URL of your InfluxDB Cloud UI.
-   For example: https://us-west-2-1.aws.cloud2.influxdata.com.)
+2. InfluxDB Cloud Dedicated cluster URL using the HTTPS protocol--for example: https://cluster-id.influxdb.io.
+3. Name of the [database](/influxdb/cloud-dedicated/admin/databases/) to write to.
+4. InfluxDB [database token](/influxdb/cloud-dedicated/admin/tokens/) with permission to write to the database.
+   _For security reasons, we recommend setting an environment variable to store your token and avoid exposing the raw token value in your script._
 
 ## Write data to InfluxDB with Python
 
-We are going to write some data in [line protocol](/influxdb/cloud-dedicated/reference/syntax/line-protocol/) using the Python library.
+Follow the steps to write [line protocol](/influxdb/cloud-dedicated/reference/syntax/line-protocol/) data to an InfluxDB Cloud Dedicated database.
 
-1. In your Python program, import the InfluxDB client library and use it to write data to InfluxDB.
+1. In your editor, create a file for your Python program--for example: `write.py`.
+2. In the file, import the InfluxDB client library.
 
    ```python
    import influxdb_client
    from influxdb_client.client.write_api import SYNCHRONOUS
+   import os
    ```
 
-2. Define a few variables with the name of your [database](/influxdb/cloud-dedicated/admin/databases/) (bucket), organization (required, but ignored), and [token](/influxdb/cloud-dedicated/admin/tokens/).
+3. Define variables for your [database name](/influxdb/cloud-dedicated/admin/databases/), organization (required, but ignored), and [token](/influxdb/cloud-dedicated/admin/tokens/).
 
    ```python
-   bucket = "DATABASE_NAME"
+   database = "DATABASE_NAME"
    org = "ignored"
-   token = "DATABASE_TOKEN"
-   # Store the URL of your InfluxDB instance
+   # INFLUX_TOKEN is an environment variable you created for your database WRITE token
+   token = os.getenv('INFLUX_TOKEN')
    url="https://cluster-id.influxdb.io"
    ```
 
-3. Instantiate the client. The `InfluxDBClient` object takes three named parameters: `url`, `org`, and `token`. Pass in the named parameters.
+4. To instantiate the client, call the `influxdb_client.InfluxDBClient()` method with the following keywor parameters: `url`, `org`, and `token`.
 
    ```python
    client = influxdb_client.InfluxDBClient(
@@ -66,17 +70,17 @@ We are going to write some data in [line protocol](/influxdb/cloud-dedicated/ref
    ```
     The `InfluxDBClient` object has a `write_api` method used for configuration.
 
-4. Instantiate a **write client** using the `client` object and the `write_api` method. Use the `write_api` method to configure the writer object.
+5. Instantiate a **write client** by calling the `client.write_api()` method with write configuration options.
 
    ```python
    write_api = client.write_api(write_options=SYNCHRONOUS)
    ```
 
-5. Create a [point](/influxdb/cloud-dedicated/reference/glossary/#point) object and write it to InfluxDB using the `write` method of the API writer object. The write method requires three parameters: `bucket`, `org`, and `record`.
+6. Create a [point](/influxdb/cloud-dedicated/reference/glossary/#point) object and write it to InfluxDB using the `write` method of the API writer object. The write method requires three parameters: `bucket`, `org`, and `record`.
 
    ```python
    p = influxdb_client.Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)
-   write_api.write(bucket=bucket, org=org, record=p)
+   write_api.write(bucket=database, org=org, record=p)
    ```
 
 ### Complete example write script
@@ -84,11 +88,12 @@ We are going to write some data in [line protocol](/influxdb/cloud-dedicated/ref
 ```python
 import influxdb_client
 from influxdb_client.client.write_api import SYNCHRONOUS
+import os
 
-bucket = "DATABASE_NAME"
+database = "DATABASE_NAME"
 org = "ignored"
-token = "DATABASE_TOKEN"
-# Store the URL of your InfluxDB instance
+# INFLUX_TOKEN is an environment variable you created for your database WRITE token
+token = os.getenv('INFLUX_TOKEN')
 url="https://cluster-id.influxdb.io"
 
 client = influxdb_client.InfluxDBClient(
@@ -101,9 +106,9 @@ client = influxdb_client.InfluxDBClient(
 write_api = client.write_api(write_options=SYNCHRONOUS)
 
 p = influxdb_client.Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)
-write_api.write(bucket=bucket, org=org, record=p)
+write_api.write(bucket=database, org=org, record=p)
 ```
 ## Query data from InfluxDB with Python
 
-The InfluxDB v2 Python client cannot query InfluxDB Cloud Dedicated.
-To query your dedicated instance, use a Flight SQL client with gRPC.
+The InfluxDB v2 Python client can't query InfluxDB Cloud Dedicated.
+To query your dedicated instance, use a [Flight SQL client with gRPC](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/).

--- a/content/influxdb/cloud-dedicated/reference/glossary.md
+++ b/content/influxdb/cloud-dedicated/reference/glossary.md
@@ -970,7 +970,7 @@ Related entries:
 A plugin-driven agent that collects, processes, aggregates, and writes metrics.
 
 Related entries:
-[Telegraf plugins](/{{< latest "telegraf" >}}/plugins//),
+[Telegraf plugins](/{{< latest "telegraf" >}}/plugins/),
 [Use Telegraf to collect data](/influxdb/cloud-dedicated/write-data/telegraf/),
 
 ### time (data type)

--- a/content/influxdb/cloud-dedicated/write-data/csv/telegraf.md
+++ b/content/influxdb/cloud-dedicated/write-data/csv/telegraf.md
@@ -75,7 +75,7 @@ metrics from different sources and writes them to specified destinations.
     - **url**: a list (`[]`) containing your InfluxDB Cloud Dedicated cluster URL using the HTTPS
       protocol:
 
-      ```
+      ```toml
       ["https://cluster-id.influxdb.io"]
       ```
     - **token**: a [database token](/influxdb/cloud-dedicated/admin/tokens/) with permission to write to the database.

--- a/content/influxdb/cloud-dedicated/write-data/use-telegraf/_index.md
+++ b/content/influxdb/cloud-dedicated/write-data/use-telegraf/_index.md
@@ -27,7 +27,7 @@ For a list of available plugins, see [Telegraf plugins](/{{< latest "telegraf" >
 
 - **Telegraf 1.9.2 or greater**.
   _For information about installing Telegraf, see the
-  [Telegraf Installation instructions](/{{< latest "telegraf" >}}//install/)._
+  [Telegraf Installation instructions](/{{< latest "telegraf" >}}/install/)._
 
 ## Basic Telegraf usage
 

--- a/content/influxdb/cloud-dedicated/write-data/use-telegraf/_index.md
+++ b/content/influxdb/cloud-dedicated/write-data/use-telegraf/_index.md
@@ -1,0 +1,68 @@
+---
+title: Use Telegraf to write data
+seotitle: Use the Telegraf agent to collect and write data
+weight: 101
+description: >
+  Use Telegraf to collect and write data to InfluxDB.
+  Create Telegraf configurations in the InfluxDB UI or manually configure Telegraf.
+aliases:
+  - /influxdb/cloud-dedicated/collect-data/advanced-telegraf
+  - /influxdb/cloud-dedicated/collect-data/use-telegraf
+  - /influxdb/cloud-dedicated/write-data/no-code/use-telegraf/
+menu:
+  influxdb_cloud_dedicated:
+    name: Use Telegraf
+    parent: Write data
+alt_engine: /influxdb/cloud/write-data/no-code/use-telegraf/
+---
+
+[Telegraf](https://www.influxdata.com/time-series-platform/telegraf/) is InfluxData's
+data collection agent for collecting and reporting metrics.
+Its vast library of input plugins and "plug-and-play" architecture lets you quickly
+and easily collect metrics from many different sources.
+
+For a list of available plugins, see [Telegraf plugins](/{{< latest "telegraf" >}}/plugins/).
+
+#### Requirements
+
+- **Telegraf 1.9.2 or greater**.
+  _For information about installing Telegraf, see the
+  [Telegraf Installation instructions](/{{< latest "telegraf" >}}//install/)._
+
+## Basic Telegraf usage
+
+Telegraf is a plugin-based agent with plugins that are enabled and configured in
+your Telegraf configuration file (`telegraf.conf`).
+Each Telegraf configuration must **have at least one input plugin and one output plugin**.
+
+Telegraf input plugins retrieve metrics from different sources.
+Telegraf output plugins write those metrics to a destination.
+
+Use the [`outputs.influxdb_v2`](/{{< latest "telegraf" >}}/plugins/#output-influxdb_v2) to write metrics collected by Telegraf to InfluxDB.
+
+```toml
+# ...
+
+[[outputs.influxdb_v2]]
+  urls = ["http://localhost:8086"]
+  token = "${INFLUX_TOKEN}"
+  organization = "ORG_ID"
+  bucket = "BUCKET_NAME"
+
+# ...
+```
+
+Replace the following:
+
+- **`ORG_ID`**: your InfluxDB Dedicated [organization](/influxdb/cloud-dedicated/admin/organizations/) ID.
+- **`BUCKET_NAME`**: the name of the [bucket](/influxdb/cloud-dedicated/admin/buckets/) to write to.
+
+In the example, **`INFLUX_TOKEN`** is an environment variable assigned to an InfluxDB API token with _write_ permission to the bucket.
+
+_For more information, see [Manually configure Telegraf](/influxdb/cloud-dedicated/write-data/use-telegraf/configure/manual-config/#enable-and-configure-the-influxdb-v2-output-plugin)._
+
+## Use Telegraf with InfluxDB
+
+{{< children >}}
+
+{{< influxdbu "telegraf-102" >}}

--- a/content/influxdb/cloud-dedicated/write-data/use-telegraf/configure/_index.md
+++ b/content/influxdb/cloud-dedicated/write-data/use-telegraf/configure/_index.md
@@ -1,0 +1,20 @@
+---
+title: Configure Telegraf for InfluxDB
+description: >
+  Telegraf is a plugin-based agent with plugins are that enabled and configured in
+  your Telegraf configuration file (`telegraf.conf`).
+  Learn how to create Telegraf configuration files that work with InfluxDB.
+menu:
+  influxdb_cloud_dedicated:
+    name: Configure Telegraf
+    parent: Use Telegraf
+weight: 101
+---
+
+Telegraf is a plugin-based agent with plugins are that enabled and configured in
+your Telegraf configuration file (`telegraf.conf`).
+
+The following are options you have for creating Telegraf configuration files
+that work with InfluxDB {{< current-version >}}.
+
+{{< children >}}

--- a/content/influxdb/cloud-dedicated/write-data/use-telegraf/configure/manual-config.md
+++ b/content/influxdb/cloud-dedicated/write-data/use-telegraf/configure/manual-config.md
@@ -6,15 +6,13 @@ description: >
   output plugin to write to InfluxDB.
   Start Telegraf using the custom configuration.
 menu:
-  influxdb_cloud_serverless:
+  influxdb_cloud_dedicated:
     name: Manually
     parent: Configure Telegraf
 weight: 202
-influxdb/cloud-serverless/tags: [telegraf]
+influxdb/cloud-dedicated/tags: [telegraf]
 related:
   - /{{< latest "telegraf" >}}/plugins/
-  - /influxdb/cloud-serverless/use-telegraf/telegraf-configs/create/
-  - /influxdb/cloud-serverless/use-telegraf/telegraf-configs/update/
 alt_engine: /influxdb/cloud/write-data/no-code/use-telegraf/manual-config/
 ---
 
@@ -27,9 +25,25 @@ then start Telegraf using the custom configuration file.
 {{< youtube qFS2zANwIrc >}}
 
 {{% note %}}
-_View the [requirements](/influxdb/cloud-serverless/write-data/use-telegraf#requirements)
+_View the [requirements](/influxdb/cloud-dedicated/write-data/use-telegraf#requirements)
 for using Telegraf with InfluxDB {{< current-version >}}._
 {{% /note %}}
+
+<!-- TOC -->
+
+- [Configure Telegraf input and output plugins](#configure-telegraf-input-and-output-plugins)
+  - [Manually add Telegraf plugins](#manually-add-telegraf-plugins)
+  - [Enable and configure the InfluxDB v2 output plugin](#enable-and-configure-the-influxdb-v2-output-plugin)
+      - [urls](#urls)
+      - [token](#token)
+        - [Avoid storing tokens in telegraf.conf](#avoid-storing-tokens-in-telegrafconf)
+      - [organization](#organization)
+      - [bucket](#bucket)
+    - [Example influxdb_v2 configuration](#example-influxdb_v2-configuration)
+      - [Write to InfluxDB v1.x and v2.6](#write-to-influxdb-v1x-and-v26)
+- [Start Telegraf](#start-telegraf)
+
+<!-- /TOC -->
 
 ## Configure Telegraf input and output plugins
 
@@ -71,14 +85,16 @@ The InfluxDB output plugin configuration contains the following options:
 ##### urls
 
 An array of URLs for your InfluxDB {{< current-version >}} instances.
-See [InfluxDB Cloud Serverless regions](/influxdb/cloud-serverless/reference/regions/) for
-information about which URLs to use.
-**{{< cloud-name "short">}} requires HTTPS**.
+To write to InfluxDB Cloud Dedicated, include your InfluxDB Cloud Dedicated cluster URL using the HTTPS protocol:
+
+      ```toml
+      ["https://cluster-id.influxdb.io"]
+      ```
 
 ##### token
 
-Your InfluxDB {{< current-version >}} authorization token.
-For information about viewing tokens, see [View tokens](/influxdb/cloud-serverless/security/tokens/view-tokens/).
+Your InfluxDB Cloud Dedicated [database token](/influxdb/cloud-dedicated/admin/tokens/) with _write_ permission to the database.
+For information about viewing tokens, see [List tokens](/influxdb/cloud-dedicated/admin/tokens/list/).
 
 {{% note %}}
 ###### Avoid storing tokens in `telegraf.conf`
@@ -128,26 +144,22 @@ _See the [example `telegraf.conf` below](#example-influxdb_v2-configuration)._
 
 ##### organization
 
-The name of the organization that owns the target bucket.
+For InfluxDB Cloud Dedicated, set this to an empty string (`""`).
 
 ##### bucket
 
-The name of the bucket to write data to.
+The name of the InfluxDB Cloud Dedicated database to write data to.
 
 #### Example influxdb_v2 configuration
 
-The example below illustrates an `influxdb_v2` configuration.
+The following example shows a minimal [`outputs.influxdb_v2`](/{{< latest "telegraf" >}}/plugins/#output-influxdb_v2) configuration for writing data to InfluxDB Cloud Dedicated:
 
 ```toml
-# ...
-
 [[outputs.influxdb_v2]]
-  urls = ["https://cloud2.influxdata.com"]
-  token = "{$INFLUX_TOKEN}"
-  organization = "example-org"
-  bucket = "example-bucket"
-
-# ...
+  urls = ["https://cluster-id.influxdb.io"]
+  token = "DATABASE_TOKEN"
+  organization = ""
+  bucket = "DATABASE_NAME"
 ```
 
 {{% note %}}
@@ -156,16 +168,6 @@ The example below illustrates an `influxdb_v2` configuration.
 If a Telegraf agent is already writing to an InfluxDB v1.x database,
 enabling the InfluxDB v2 output plugin will write data to both v1.x and v2.6 instances.
 {{% /note %}}
-
-## Add a custom Telegraf configuration to InfluxDB
-
-To add a custom or manually configured Telegraf configuration to your collection
-of Telegraf configurations in InfluxDB, use the [`influx telegrafs create`](/influxdb/cloud-serverless/reference/cli/influx/telegrafs/create/)
-or [`influx telegrafs update`](/influxdb/cloud-serverless/reference/cli/influx/telegrafs/update/) commands.
-For more information, see:
-
-- [Create a Telegraf configuration](/influxdb/cloud-serverless/telegraf-configs/create/#use-the-influx-cli)
-- [Update a Telegraf configuration](/influxdb/cloud-serverless/telegraf-configs/update/#use-the-influx-cli)
 
 ## Start Telegraf
 

--- a/content/influxdb/cloud-dedicated/write-data/use-telegraf/dual-write.md
+++ b/content/influxdb/cloud-dedicated/write-data/use-telegraf/dual-write.md
@@ -1,0 +1,63 @@
+---
+title: Dual write to InfluxDB OSS and InfluxDB Cloud
+description: >
+  Configure Telegraf to write data to both InfluxDB OSS and InfluxDB Cloud Dedicated simultaneously.
+menu:
+  influxdb_cloud_dedicated:
+    name: Dual write to OSS & Cloud
+    parent: Use Telegraf
+weight: 203
+alt_engine: /influxdb/cloud/write-data/no-code/use-telegraf/dual-write/
+---
+
+If you want to back up your data in two places, or if you're migrating from OSS to Cloud, you may want to set up dual write.
+
+Use Telegraf to write to both InfluxDB OSS and InfluxDB Cloud Dedicated simultaneously.
+
+The sample configuration below uses:
+  - The [InfluxDB v2 output plugin](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/influxdb_v2) twice: first pointing to the OSS instance and then to the InfluxDB Cloud Dedicated cluster.
+  - Two different tokens, one for OSS and one for Cloud Dedicated. You'll need to configure both tokens as environment variables (see [Configure your token as an environment variable](/influxdb/v2.6/write-data/no-code/use-telegraf/auto-config/#configure-your-token-as-an-environment-variable).
+
+Use the configuration below to write your data to both OSS and Cloud instances simultaneously.
+
+## Sample configuration
+
+```toml
+[[inputs.cpu]]
+[[inputs.mem]]
+
+## Any other inputs, processors, aggregators that you want to include in your configuration.
+
+# Send data to InfluxDB OSS v2
+[[outputs.influxdb_v2]]
+  ## The URLs of the InfluxDB instance.
+  ##
+  ## Multiple URLs can be specified for a single cluster, only ONE of the
+  ## urls will be written to each interval.
+  ## urls exp: http://127.0.0.1:9999
+  urls = ["http://localhost:8086"]
+
+  ## OSS token for authentication.
+  token = "${INFLUX_TOKEN_OSS}"
+
+  ## Organization is the name of the organization you want to write to. It must already exist.
+  organization = "influxdata"
+
+  ## Destination bucket to write to.
+  bucket = "telegraf"
+
+# Send data to InfluxDB Cloud - AWS West cloud instance
+ [[outputs.influxdb_v2]]
+  ## The URLs of the InfluxDB Cloud instance.
+
+  urls = ["https://cluster-id.influxdb.io"]
+
+  ## Cloud token for authentication.
+  token = "${INFLUX_TOKEN}"
+
+  ## Organization is the name of the organization you want to write to. It must already exist.
+  organization = ""
+
+  ## Destination bucket to write into.
+  bucket = "DATABASE_NAME"
+  ```

--- a/content/influxdb/cloud-serverless/get-started/write.md
+++ b/content/influxdb/cloud-serverless/get-started/write.md
@@ -25,7 +25,7 @@ the following:
 - Influx user interface (UI)
 - [InfluxDB HTTP API](/influxdb/cloud-serverless/reference/api/)
 - [`influx` CLI](/influxdb/cloud-serverless/tools/influx-cli/)
-- [Telegraf](/{{< latest "telegraf" >}}/)
+- [Telegraf](/influxdb/cloud-serverless/write-data/use-telegraf/)
 - [InfluxDB client libraries](/influxdb/cloud-serverless/api-guide/client-libraries/)
 
 This tutorial walks you through the fundamental of using **line protocol** to write
@@ -145,6 +145,7 @@ line protocol above to InfluxDB.
 [InfluxDB API](#)
 [Python](#)
 [Go](#)
+[Telegraf](#)
 {{% /tabs %}}
 
 {{% tab-content %}}
@@ -539,7 +540,31 @@ go run ./write.go
 
 <!------------------------------- END GO CONTENT ------------------------------>
 {{% /tab-content %}}
+{{% tab-content %}}
+<!------------------------------- BEGIN TELEGRAF CONTENT ------------------------------>
+[Telegraf](/{{< latest "telegraf" >}}/) with the [`file` input plugin](/{{< latest "telegraf" >}}/plugins/#input-file) consume line protocol or CSV, and then use the `influxdb_v2` output plugin to write the data to InfluxDB.
 
+The following example shows a minimal [`outputs.influxdb_v2`](/{{< latest "telegraf" >}}/plugins/#output-influxdb_v2) configuration for writing data to InfluxDB Cloud Serverless:
+
+```toml
+[[outputs.influxdb_v2]]
+  urls = ["http://localhost:8086"]
+  token = "${INFLUX_TOKEN}"
+  organization = "ORG_ID"
+  bucket = "BUCKET_NAME"
+```
+
+Replace the following:
+
+- **`ORG_ID`**: your InfluxDB Serverless [organization](/influxdb/cloud-serverless/admin/organizations/) ID.
+- **`BUCKET_NAME`**: the name of the [bucket](/influxdb/cloud-serverless/admin/buckets/) to write to.
+
+In the example, **`INFLUX_TOKEN`** is an environment variable assigned to an InfluxDB API token that has _write_ permission to the bucket.
+
+The Telegraf `file` input plugin and the `output-influxdb_v2` output plugin provide many options for reading and writing data.
+To learn more, see how to [use Telegraf to write data](/influxdb/cloud-serverless/write-data/use-telegraf/).
+<!------------------------------- END TELEGRAF CONTENT ------------------------------>
+{{% /tab-content %}}
 {{< /tabs-wrapper >}}
 
 {{< expand-wrapper >}}

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/python.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/python.md
@@ -109,3 +109,7 @@ write_api = client.write_api(write_options=SYNCHRONOUS)
 p = influxdb_client.Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)
 write_api.write(bucket=bucket, org=org, record=p)
 ```
+
+## Query data from InfluxDB with Python
+
+To use query your InfluxDB Cloud Serverless bucket, use a Python [Flight SQL client with gRPC](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/).

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/python.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/python.md
@@ -23,39 +23,44 @@ If just getting started, see [Get started with InfluxDB](/influxdb/cloud-serverl
 
 ## Before you begin
 
+You'll need the following prerequisites:
+
 1. Install the InfluxDB Python library:
 
     ```sh
     pip install influxdb-client
     ```
 
-2. Visit your InfluxDB URL to ensure InfluxDB is running:
-   
-   ```http
-   http://localhost:8086
-   ```
+2. InfluxDB Cloud Serverless region URL using the HTTPS protocol--for example: https://cloud2.influxdata.com.
+3. InfluxDB [organization](/influxdb/cloud-serverless/admin/organizations/) ID.
+4. Name of the [bucket](/influxdb/cloud-serverless/admin/buckets/) to write to.
+5. InfluxDB [API token](/influxdb/cloud-serverless/reference/glossary/#token) with permission to write to the bucket.
+   _For security reasons, we recommend setting an environment variable to store your token and avoid exposing the raw token value in your script._
 
 ## Write data to InfluxDB with Python
 
-We are going to write some data in [line protocol](/influxdb/cloud-serverless/reference/syntax/line-protocol/) using the Python library.
+Follow the steps to write [line protocol](/influxdb/cloud-serverless/reference/syntax/line-protocol/) data to an InfluxDB Cloud Serverless bucket.
 
-1. In your Python program, import the InfluxDB client library and use it to write data to InfluxDB.
+1. In your editor, create a file for your Python program--for example: `write.py`.
+2. In the file, import the InfluxDB client library.
 
    ```python
    import influxdb_client
    from influxdb_client.client.write_api import SYNCHRONOUS
+   import os
    ```
 
-2. Define a few variables with the name of your [bucket](/influxdb/cloud-serverless/organizations/buckets/), [organization](/influxdb/cloud-serverless/organizations/), and [token](/influxdb/cloud-serverless/security/tokens/).
+3. Define variables for your [bucket name](/influxdb/cloud-serverless/admin/buckets/), [organization](/influxdb/cloud-serverless/admin/organizations/), and [token](/influxdb/cloud-serverless/reference/glossary/#token).
 
    ```python
-   bucket = "INFLUX_BUCKET"
+   bucket = "BUCKET_NAME"
    org = "INFLUX_ORG"
-   token = "INFLUX_TOKEN"
-   url="http://localhost:8086"
+   # INFLUX_TOKEN is an environment variable you created for your API WRITE token
+   token = os.getenv('INFLUX_TOKEN')
+   url="https://cloud2.influxdata.com"
    ```
 
-3. Instantiate the client. The `InfluxDBClient` object takes three named parameters: `url`, `org`, and `token`. Pass in the named parameters.
+4. To instantiate the client, call the `influxdb_client.InfluxDBClient()` method with the following keyword arguments: `url`, `org`, and `token`.
 
    ```python
    client = influxdb_client.InfluxDBClient(
@@ -66,13 +71,13 @@ We are going to write some data in [line protocol](/influxdb/cloud-serverless/re
    ```
     The `InfluxDBClient` object has a `write_api` method used for configuration.
 
-4. Instantiate a **write client** using the `client` object and the `write_api` method. Use the `write_api` method to configure the writer object.
+5. Instantiate a **write client** by calling the `client.write_api()` method with write configuration options.
 
    ```python
    write_api = client.write_api(write_options=SYNCHRONOUS)
    ```
 
-5. Create a [point](/influxdb/cloud-serverless/reference/glossary/#point) object and write it to InfluxDB using the `write` method of the API writer object. The write method requires three parameters: `bucket`, `org`, and `record`.
+6. Create a [point](/influxdb/cloud-serverless/reference/glossary/#point) object and write it to InfluxDB using the `write` method of the API writer object. The write method requires three parameters: `bucket`, `org`, and `record`.
 
    ```python
    p = influxdb_client.Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)
@@ -84,12 +89,13 @@ We are going to write some data in [line protocol](/influxdb/cloud-serverless/re
 ```python
 import influxdb_client
 from influxdb_client.client.write_api import SYNCHRONOUS
+import os
 
-bucket = "<my-bucket>"
-org = "<my-org>"
-token = "<my-token>"
-# Store the URL of your InfluxDB instance
-url="http://localhost:8086"
+bucket = "BUCKET_NAME"
+org = "INFLUX_ORG"
+# INFLUX_TOKEN is an environment variable you created for your API WRITE token
+token = os.getenv('INFLUX_TOKEN')
+url="https://cloud2.influxdata.com"
 
 client = influxdb_client.InfluxDBClient(
     url=url,

--- a/content/influxdb/cloud-serverless/write-data/use-telegraf/_index.md
+++ b/content/influxdb/cloud-serverless/write-data/use-telegraf/_index.md
@@ -28,7 +28,7 @@ For a list of available plugins, see [Telegraf plugins](/{{< latest "telegraf" >
 
 - **Telegraf 1.9.2 or greater**.
   _For information about installing Telegraf, see the
-  [Telegraf Installation instructions](/{{< latest "telegraf" >}}//install/)._
+  [Telegraf Installation instructions](/{{< latest "telegraf" >}}/install/)._
 
 ## Basic Telegraf usage
 

--- a/content/influxdb/cloud-serverless/write-data/use-telegraf/_index.md
+++ b/content/influxdb/cloud-serverless/write-data/use-telegraf/_index.md
@@ -32,7 +32,7 @@ For a list of available plugins, see [Telegraf plugins](/{{< latest "telegraf" >
 
 ## Basic Telegraf usage
 
-Telegraf is a plugin-based agent with plugins are that enabled and configured in
+Telegraf is a plugin-based agent with plugins that are enabled and configured in
 your Telegraf configuration file (`telegraf.conf`).
 Each Telegraf configuration must **have at least one input plugin and one output plugin**.
 
@@ -40,17 +40,14 @@ Telegraf input plugins retrieve metrics from different sources.
 Telegraf output plugins write those metrics to a destination.
 
 Use the [`outputs.influxdb_v2`](/{{< latest "telegraf" >}}/plugins/#output-influxdb_v2) to write metrics collected by Telegraf to InfluxDB.
+The following example shows how to configure the `outputs.influxdb_v2` plugin to write to InfluxDB Cloud Serverless:
 
 ```toml
-# ...
-
 [[outputs.influxdb_v2]]
-  urls = ["http://localhost:8086"]
+  urls = ["https://cloud2.influxdata.com"]
   token = "${INFLUX_TOKEN}"
   organization = "ORG_ID"
   bucket = "BUCKET_NAME"
-
-# ...
 ```
 
 Replace the following:

--- a/content/influxdb/cloud/write-data/no-code/use-telegraf/manual-config.md
+++ b/content/influxdb/cloud/write-data/no-code/use-telegraf/manual-config.md
@@ -14,7 +14,7 @@ menu:
 weight: 202
 influxdb/cloud/tags: [manually, plugin, mqtt]
 related:
-  - /{{< latest "telegraf" >}}/plugins//
+  - /{{< latest "telegraf" >}}/plugins/
   - /influxdb/cloud/telegraf-configs/create/
   - /influxdb/cloud/telegraf-configs/update/
 alt_engine: /influxdb/cloud-serverless/write-data/use-telegraf/configure/manual-config/
@@ -36,13 +36,13 @@ Configure Telegraf input and output plugins in the Telegraf configuration file (
 Input plugins collect metrics.
 Output plugins define destinations where metrics are sent.
 
-_See [Telegraf plugins](/{{< latest "telegraf" >}}/plugins//) for a complete list of available plugins._
+_See [Telegraf plugins](/{{< latest "telegraf" >}}/plugins/) for a complete list of available plugins._
 
 ### Manually add Telegraf plugins
 
-To manually add any of the available [Telegraf plugins](/{{< latest "telegraf" >}}/plugins//), follow the steps below.
+To manually add any of the available [Telegraf plugins](/{{< latest "telegraf" >}}/plugins/), follow the steps below.
 
-1. Find the plugin you want to enable from the complete list of available [Telegraf plugins](/{{< latest "telegraf" >}}/plugins//).
+1. Find the plugin you want to enable from the complete list of available [Telegraf plugins](/{{< latest "telegraf" >}}/plugins/).
 2. Click **View** to the right of the plugin name to open the plugin page on GitHub. For example, view the MQTT plugin GitHub page [here](https://github.com/influxdata/telegraf/blob/release-1.14/plugins/inputs/mqtt_consumer/README.md).
 3. Copy and paste the example configuration into your Telegraf configuration file (typically named `telegraf.conf`).
 


### PR DESCRIPTION
Closes #4918 

Copied brief Telegraf config examples to get-started.
Linked to Use Telegraf page for config detail.
Ported Use Telegraf
Cleanup
Tailor v2 python client libraries for Dedicated and Serverless

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
