### PR TITLE
Fix 4965 update py library name

### DIFF
--- a/content/influxdb/cloud-dedicated/get-started/query.md
+++ b/content/influxdb/cloud-dedicated/get-started/query.md
@@ -197,6 +197,7 @@ WHERE
 {{% /tabs %}}
 {{% tab-content %}}
 <!--------------------------- BEGIN influx3 CONTENT --------------------------->
+{{% influxdb/custom-timestamps %}}
 
 Query InfluxDB v3 using SQL and the `influx3` CLI.
 
@@ -226,6 +227,7 @@ _If your project's virtual environment is already running, skip to step 3._
 
 4. Create the `config.json` configuration.
 
+    <!-- code-placeholders breaks when indented here -->
     ```sh
     influx3 config \
       --name="config-dedicated" \
@@ -237,15 +239,17 @@ _If your project's virtual environment is already running, skip to step 3._
 
     Replace the following:
 
-    - **`DATABASE_NAME`**: the name of the InfluxDB Cloud Dedicated database to query
     - **`DATABASE_TOKEN`**: a [database token](/influxdb/cloud-dedicated/admin/tokens/) with
           read access to the **get-started** database
-    - **`INFLUX_ORG_ID`**: InfluxDB organization ID
+    - **`ORG_ID`**: any non-empty string (InfluxDB ignores this parameter, but the client requires it)
 
 5. Enter the `influx3 sql` command and your SQL query statement.
 
   ```sh
-  influx3 sql "SELECT * FROM home WHERE time >= '2022-01-01T08:00:00Z' AND time <= '2022-01-01T20:00:00Z'"
+  influx3 sql "SELECT *
+                FROM home
+                WHERE time >= '2022-01-01T08:00:00Z'
+                AND time <= '2022-01-01T20:00:00Z'"
   ```
 
 `influx3` displays query results in your terminal.
@@ -253,13 +257,13 @@ _If your project's virtual environment is already running, skip to step 3._
 For more information about the `influx3` CLI, see the [`InfluxCommunity/
 influxdb3-python-cli
 `](https://github.com/InfluxCommunity/influxdb3-python-cli) community repository on GitHub.
-
+ {{% /influxdb/custom-timestamps %}}
 <!--------------------------- END influx3 CONTENT --------------------------->
 {{% /tab-content %}}
 {{% tab-content %}}
 <!--------------------------- BEGIN PYTHON CONTENT ---------------------------->
-
-To query data from InfluxDB Cloud Dedicated using Python, use the
+ {{% influxdb/custom-timestamps %}}
+To query data from {{% cloud-name %}} using Python, use the
 [`influxdb_client_3` module](https://github.com/InfluxCommunity/influxdb3-python).
 The following steps include setting up a Python virtual environment already
 covered in [Get started writing data](/influxdb/cloud-dedicated/get-started/write/?t=Python#write-line-protocol-to-influxdb).
@@ -296,66 +300,65 @@ _If your project's virtual environment is already running, skip to step 3._
 
     4. In your terminal or editor, create a new file for your code--for example: `query.py`.
 
-5.  In `query.py`, enter the following sample code:
+2.  In `query.py`, enter the following sample code:
 
-    {{% influxdb/custom-timestamps %}}
-    ```py
-    from influxdb_client_3 import InfluxDBClient3
-    import os
+      ```py
+      from influxdb_client_3 import InfluxDBClient3
+      import os
 
-    # INFLUX_TOKEN is an environment variable you created for your database READ token
-    TOKEN = os.getenv('INFLUX_TOKEN')
+      # INFLUX_TOKEN is an environment variable you created for your database READ token
+      TOKEN = os.getenv('INFLUX_TOKEN')
 
-    client = InfluxDBClient3(
-        host="cluster-id.influxdb.io",
-        token=TOKEN,
-        database="get-started",
-    )
+      client = InfluxDBClient3(
+          host="cluster-id.influxdb.io",
+          token=TOKEN,
+          database="get-started",
+      )
 
-    sql = '''
-    SELECT
-      *
-    FROM
-      home
-    WHERE
-      time >= '2022-01-01T08:00:00Z'
-      AND time <= '2022-01-01T20:00:00Z'
-    '''
+      sql = '''
+        SELECT
+          *
+        FROM
+          home
+        WHERE
+          time >= '2022-01-01T08:00:00Z'
+          AND time <= '2022-01-01T20:00:00Z'
+      '''
 
-    table = client.query(sql_query=sql)
-    print(reader.to_pandas().to_markdown())
-    ```
-    {{% /influxdb/custom-timestamps %}}
+      table = client.query(sql_query=sql)
+      print(reader.to_pandas().to_markdown())
+      ```
 
     The sample code does the following:
 
-    1.  Imports `InfluxDBClient3` from the `influxdb_client_3` module.
+    1.  Imports the `InfluxDBClient3` constructor from the `influxdb_client_3` module.
     
-    2.  Calls the `InfluxDBClient3()` constructor method with credentials to instantiate an InfluxDB `client`.
-        configured with the following credentials:
+    2.  Calls the `InfluxDBClient3()` constructor method with credentials to instantiate an InfluxDB `client` with the following credentials:
 
-        - **host**: InfluxDB Cloud Dedicated cluster URL (without `https://` protocol or trailing slash)
+        - **host**: {{% cloud-name %}} cluster URL (without `https://` protocol or trailing slash)
         - **token**: a [database token](/influxdb/cloud-dedicated/admin/tokens/) with
           read access to the **get-started** database.
-        - **database**: the name of the InfluxDB Cloud Dedicated database to query
+          _For security reasons, we recommend setting this as an environment
+          variable rather than including the raw token string._
+        - **database**: the name of the {{% cloud-name %}} database to query
     
     3.  Defines the SQL query to execute and assigns it to a `query` variable.
     
-    4.  Calls the `client.query()` method with the SQL query. `query()` sends a
-        Flight request to InfluxDB, queries the **get-started**
-        database, and retrieves the result data, and then returns a
+    4.  Calls the `client.query()` method with the SQL query.
+        `query()` sends a
+        Flight request to InfluxDB, queries the database, retrieves result data from the endpoint, and then returns a
         [pyarrow.Table](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table)
         assigned to the `table` variable.
 
-    6.  Calls the [`to_pandas()` method](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pandas)
+    5.  Calls the [`to_pandas()` method](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pandas)
         to convert the Arrow table to a [pandas DataFrame](https://arrow.apache.org/docs/python/pandas.html).
 
-    7.  Calls the [`pandas.DataFrame.to_markdown()` method](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_markdown.html)
+    6.  Calls the [`pandas.DataFrame.to_markdown()` method](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_markdown.html)
         to convert the DataFrame to a markdown table.
 
-    8.  Calls `print` to print the markdown table to stdout.
+    7.  Calls the `print()` method to print the markdown table to stdout.
 
-6. In your terminal, enter the following command to run the program and query your InfluxDB Cloud Dedicated cluster:
+6. In your terminal, enter the following command to run the program and query your {{% cloud-name %}} cluster:
 
     ```sh
     python query.py
@@ -363,7 +366,6 @@ _If your project's virtual environment is already running, skip to step 3._
 
 {{< expand-wrapper >}}
 {{% expand "View returned markdown table" %}}
-{{% influxdb/custom-timestamps %}}
 
 |    |   co |   hum | room        |   temp | time                |
 |---:|-----:|------:|:------------|-------:|:--------------------|
@@ -394,22 +396,109 @@ _If your project's virtual environment is already running, skip to step 3._
 | 24 |   14 |  36.3 | Living Room |   22.5 | 2022-01-01 19:00:00 |
 | 25 |   17 |  36.4 | Living Room |   22.2 | 2022-01-01 20:00:00 |
 
-{{% /influxdb/custom-timestamps %}}
 {{% /expand %}}
 {{< /expand-wrapper >}}
-
+{{% /influxdb/custom-timestamps %}}
 <!---------------------------- END PYTHON CONTENT ----------------------------->
 {{% /tab-content %}}
 {{% tab-content %}}
 <!----------------------------- BEGIN GO CONTENT ------------------------------>
-
+{{% influxdb/custom-timestamps %}}
 1.  In the `influxdb_go_client` directory you created in the
     [Write data section](/influxdb/cloud-dedicated/get-started/write/?t=Go#write-line-protocol-to-influxdb),
     create a new file named `query.go`.
 
-2.  In `query.go`:
+2.  In `query.go`, enter the following sample code:
+
+    ```go
+    package main
+
+    import (
+      "context"
+      "crypto/x509"
+      "encoding/json"
+      "fmt"
+      "os"
+
+      "github.com/apache/arrow/go/v12/arrow/flight/flightsql"
+      "google.golang.org/grpc"
+      "google.golang.org/grpc/credentials"
+      "google.golang.org/grpc/metadata"
+    )
+
+    func dbQuery(ctx context.Context) error {
+      url := "cluster-id.influxdb.io:443"
+
+      // INFLUX_TOKEN is an environment variable you created for your database READ token
+      token := os.Getenv("INFLUX_TOKEN")
+      database := "get-started"
+
+      // Create a gRPC transport
+      pool, err := x509.SystemCertPool()
+      if err != nil {
+        return fmt.Errorf("x509: %s", err)
+      }
+      transport := grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(pool, ""))
+      opts := []grpc.DialOption{
+        transport,
+      }
+
+      // Create query client
+      client, err := flightsql.NewClient(url, nil, nil, opts...)
+      if err != nil {
+        return fmt.Errorf("flightsql: %s", err)
+      }
+
+      ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+      ctx = metadata.AppendToOutgoingContext(ctx, "database", database)
+
+      // Execute query
+      query := `SELECT
+        *
+      FROM
+        home
+      WHERE
+        time >= '2022-01-01T08:00:00Z'
+        AND time <= '2022-01-01T20:00:00Z'`
+
+      info, err := client.Execute(ctx, query)
+      if err != nil {
+        return fmt.Errorf("flightsql flight info: %s", err)
+      }
+      reader, err := client.DoGet(ctx, info.Endpoint[0].Ticket)
+      if err != nil {
+        return fmt.Errorf("flightsql do get: %s", err)
+      }
+
+      // Print results as JSON
+      for reader.Next() {
+        record := reader.Record()
+        b, err := json.MarshalIndent(record, "", "  ")
+        if err != nil {
+          return err
+        }
+        fmt.Println("RECORD BATCH")
+        fmt.Println(string(b))
+
+        if err := reader.Err(); err != nil {
+          return fmt.Errorf("flightsql reader: %s", err)
+        }
+      }
+
+      return nil
+    }
+
+    func main() {
+      if err := dbQuery(context.Background()); err != nil {
+        fmt.Fprintf(os.Stderr, "error: %v\n", err)
+        os.Exit(1)
+      }
+    }
+    ```
+
+    The sample code does the following:
     
-    1.  Import the following packages:
+    1.  Imports the following packages:
 
         - `context`
         - `crypto/x509`
@@ -421,123 +510,36 @@ _If your project's virtual environment is already running, skip to step 3._
         - `google.golang.org/grpc/credentials`
         - `google.golang.org/grpc/metadata`
 
-    2.  Create a `dbQuery` function. In `dbQuery, define the following
-        variables:
+    2.  Creates a `dbQuery` function that does the following:
 
-        - **url**: InfluxDB Cloud Dedicated cluster URL _(no protocol, include port `443`)_
-        - **token**: [Database token](/influxdb/cloud-dedicated/admin/tokens/) with
-          read access to the **get-started** database.
+        1.  Defines variables for InfluxDB credentials.
+          
+            - **url**: {{% cloud-name %}} region hostname and port (`:443`) _(no protocol)_
+            - **token**: a [database token](/influxdb/cloud-dedicated/admin/tokens) with _read_  access to the specified database.
           _For security reasons, we recommend setting this as an environment
           variable rather than including the raw token string._
-        - **database**: Database name to query
+            - **database**: the name of the {{% cloud-name %}} database to query
 
-    3.  In the `dbQuery` function, create a gRPC transport to use to communicate
-        with your InfluxDB Cloud Dedicated cluster over the gRPC protocol.
+        2.  Defines an `opts` options list that includes a gRPC transport for communicating
+        with {{% cloud-name %}} over the _gRPC+TLS_ protocol.
 
-    4.  Use `flightsql.NewClient` to create a new Flight SQL client.
+        3.  Calls the `flightsql.NewClient()` method with `url` and `opts` to create a new Flight SQL client.
 
-    5.  Append the following key-value pairs to the outgoing context:
+        4.  Appends the following InfluxDB credentials as key-value pairs to the outgoing context:
 
-        - **authorization**: Bearer <INFLUX_TOKEN>
-        - **database-name**: Database name
-    
-    6.  Define the query to execute.
+            - **authorization**: Bearer <INFLUX_TOKEN>
+            - **database-name**: Database name
 
-    7.  Create a reader to read the Arrow table returned by the query and print
-        the results as JSON.
+        5.  Define the SQL query to execute.
 
-    8.  Create a `main` function that executes the `dbQuery` function.
+        6.  Calls the `client.execute()` method to send the query request.
+        7.  Calls the `client.doGet()` method with the _ticket_ from the query response to retrieve result data from the endpoint.
+        8.  Creates a reader to read the Arrow table returned by the endpoint and print
+            the results as JSON.
 
-{{% influxdb/custom-timestamps %}}
+    3.  Creates a `main` module function that executes the `dbQuery` function.
 
-```go
-package main
-
-import (
-	"context"
-	"crypto/x509"
-	"encoding/json"
-	"fmt"
-	"os"
-
-	"github.com/apache/arrow/go/v12/arrow/flight/flightsql"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/metadata"
-)
-
-func dbQuery(ctx context.Context) error {
-	url := "cluster-id.influxdb.io:443"
-
-  // INFLUX_TOKEN is an environment variable you created for your database READ token
-	token := os.Getenv("INFLUX_TOKEN")
-	database := "get-started"
-
-	// Create a gRPC transport
-	pool, err := x509.SystemCertPool()
-	if err != nil {
-		return fmt.Errorf("x509: %s", err)
-	}
-	transport := grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(pool, ""))
-	opts := []grpc.DialOption{
-		transport,
-	}
-
-	// Create query client
-	client, err := flightsql.NewClient(url, nil, nil, opts...)
-	if err != nil {
-		return fmt.Errorf("flightsql: %s", err)
-	}
-
-	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
-	ctx = metadata.AppendToOutgoingContext(ctx, "database", database)
-
-	// Execute query
-	query := `SELECT
-		*
-	FROM
-		home
-	WHERE
-		time >= '2022-01-01T08:00:00Z'
-		AND time <= '2022-01-01T20:00:00Z'`
-
-	info, err := client.Execute(ctx, query)
-	if err != nil {
-		return fmt.Errorf("flightsql flight info: %s", err)
-	}
-	reader, err := client.DoGet(ctx, info.Endpoint[0].Ticket)
-	if err != nil {
-		return fmt.Errorf("flightsql do get: %s", err)
-	}
-
-	// Print results as JSON
-	for reader.Next() {
-		record := reader.Record()
-		b, err := json.MarshalIndent(record, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println("RECORD BATCH")
-		fmt.Println(string(b))
-
-		if err := reader.Err(); err != nil {
-			return fmt.Errorf("flightsql reader: %s", err)
-		}
-	}
-
-	return nil
-}
-
-func main() {
-	if err := dbQuery(context.Background()); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
-}
-```
-{{% /influxdb/custom-timestamps %}}
-
-Install all the necessary packages and run the program to query your InfluxDB Cloud Dedicated cluster.
+3. In your terminal, enter the following command to install all the necessary packages and run the program to query {{% cloud-name %}}.
 
 ```sh
 go get ./...
@@ -546,8 +548,6 @@ go run ./query.go
 
 {{< expand-wrapper >}}
 {{% expand "View program output" %}}
-{{% influxdb/custom-timestamps %}}
-
 ```json
 RECORD BATCH
 [
@@ -735,18 +735,15 @@ RECORD BATCH
   }
 ]
 ```
-
-{{% /influxdb/custom-timestamps %}}
 {{% /expand %}}
 {{< /expand-wrapper >}}
-
+ {{% /influxdb/custom-timestamps %}}
 <!------------------------------ END GO CONTENT ------------------------------->
 {{% /tab-content %}}
 {{< /tabs-wrapper >}}
 
-**Congratulations!** You've learned the basics of querying data in InfluxDB
-Cloud Dedicated with SQL.
-For a deep dive into all the ways you can query InfluxDB, see the
+**Congratulations!** You've learned the basics of querying data in InfluxDB with SQL.
+For a deep dive into all the ways you can query {{% cloud-name %}}, see the
 [Query data in InfluxDB](/influxdb/cloud-dedicated/query-data/) section of documentation.
 
 {{< page-nav prev="/influxdb/cloud-dedicated/get-started/write/" keepTab=true >}}

--- a/content/influxdb/cloud-dedicated/get-started/write.md
+++ b/content/influxdb/cloud-dedicated/get-started/write.md
@@ -136,9 +136,9 @@ home,room=Kitchen temp=22.7,hum=36.5,co=26i 1641067200
 
 The following examples show how to write the 
 [sample data](#home-sensor-data-line-protocol), already in line protocol format,
-to an InfluxDB Cloud Dedicated database.
+to an {{% cloud-name %}} database.
 
-To learn more about available tools and options, see [Write data](influxdb/cloud-serverless/write-data/).
+To learn more about available tools and options, see [Write data](influxdb/cloud-dedicated/write-data/).
 
 {{% note %}}
 All API, cURL, and client library examples in this getting started tutorial assume your InfluxDB
@@ -235,7 +235,7 @@ To learn more, see how to [use Telegraf to write data](/influxdb/cloud-dedicated
 {{% tab-content %}}
 <!----------------------------- BEGIN cURL CONTENT ----------------------------->
 
-To write data to InfluxDB Cloud Dedicated using the InfluxDB v2 HTTP API, send a
+To write data to InfluxDB using the InfluxDB v2 HTTP API, send a
 request to the InfluxDB API `/api/v2/write` endpoint using the `POST` request method.
 
 {{< api-endpoint endpoint="https://cluster-id.influxdb.io/api/v2/write" method="post" api-ref="/influxdb/cloud-iox/api/#operation/PostWrite" >}}
@@ -252,7 +252,7 @@ Include the following with your request:
 - **Request body**: Line protocol as plain text
 
 {{% note %}}
-With the InfluxDB Cloud Dedicated v2 API `/api/v2/write` endpoint, `Authorization: Bearer` and `Authorization: Token` are equivalent and you can use either scheme to pass a database token in your request. For more information about HTTP API token schemes, see how to [authenticate API requests](/influxdb/cloud-dedicated/primers/api/v2/#authenticate-api-requests).
+With the {{% cloud-name %}} v2 API `/api/v2/write` endpoint, `Authorization: Bearer` and `Authorization: Token` are equivalent and you can use either scheme to pass a database token in your request. For more information about HTTP API token schemes, see how to [authenticate API requests](/influxdb/cloud-dedicated/primers/api/v2/#authenticate-api-requests).
 {{% /note %}}
 
 The following example uses cURL and the InfluxDB v2 API to write line protocol
@@ -302,7 +302,7 @@ home,room=Kitchen temp=22.7,hum=36.5,co=26i 1641067200
 {{% influxdb/custom-timestamps %}}
 
 
-To write data to InfluxDB Cloud Dedicated using Python, use the
+To write data to {{% cloud-name %}} using Python, use the
 [`influxdb_client_3` module](https://github.com/InfluxCommunity/influxdb3-python).
 The following steps include setting up a Python virtual environment to scope
 dependencies to your current project.
@@ -335,7 +335,11 @@ dependencies to your current project.
     pip install pyarrow influxdb_client_3
     ```
 
-5.  Create a new file for your python code--for example: `write.py`.
+5.  In your terminal or editor, create a new file for your code--for example: `write.py`.
+
+    ```sh
+    touch write.py
+    ```
 
 6.  Inside of `write.py`, enter the following sample code:
 
@@ -392,10 +396,10 @@ dependencies to your current project.
     2.  Calls the `InfluxDBClient3()` constructor to instantiate an InfluxDB client
         configured with the following credentials:
 
-        - **host**: InfluxDB Cloud Dedicated cluster hostname (URL without protocol or trailing slash)
+        - **host**: {{% cloud-name %}} cluster hostname (URL without protocol or trailing slash)
         - **org**: an empty or arbitrary string (InfluxDB ignores this parameter)
-        - **token**: InfluxDB API token with write access to the target database
-        - **database**: InfluxDB Cloud Dedicated database name
+        - **token**: an InfluxDB API token with write access to the target database
+        - **database**: the name of the {{% cloud-name %}} database to write to
     
     3.  Defines a list of line protocol strings where each string represents a data record.
     4.  Calls the `client.write()` method with the line protocol record list and write options.
@@ -404,7 +408,7 @@ dependencies to your current project.
         precision, the example passes the `write_precision='s'` option
         to set the timestamp precision to seconds.**
 
-6.  To execute the module and write line protocol to your InfluxDB Cloud Dedicated
+6.  To execute the module and write line protocol to your {{% cloud-name %}}
     database, enter the following command in your terminal:
     
       ```sh
@@ -419,7 +423,7 @@ dependencies to your current project.
 <!----------------------------- BEGIN GO CONTENT ------------------------------>
 {{% influxdb/custom-timestamps %}}
 
-To write data to InfluxDB Cloud Dedicated using Go, use the
+To write data to {{% cloud-name %}} using Go, use the
 [influxdb-client-go module](https://github.com/influxdata/influxdb-client-go).
 
 1.  Inside of your project directory, create a new module directory and navigate into it.
@@ -434,7 +438,7 @@ To write data to InfluxDB Cloud Dedicated using Go, use the
     go mod init influxdb_go_client
     ```
 
-3. Create a file for your code--for example, `write.go`.
+3.  In your terminal or editor, create a new file for your code--for example: `write.go`.
 
     ```sh
     touch write.go
@@ -566,7 +570,7 @@ To write data to InfluxDB Cloud Dedicated using Go, use the
     ```
 
 6.  To execute the module and write the line protocol
-    to your InfluxDB Cloud Dedicated database, enter the following command:
+    to your {{% cloud-name %}} database, enter the following command:
 
     ```sh
     go run ./write.go
@@ -578,7 +582,7 @@ To write data to InfluxDB Cloud Dedicated using Go, use the
 <!------------------------------- BEGIN NODE.JS CONTENT ----------------------->
 {{% influxdb/custom-timestamps %}}
 
-To write data to InfluxDB Cloud Dedicated using Node.js, use the
+To write data to {{% cloud-name %}} using Node.js, use the
 [influxdb-client-js package](https://github.com/influxdata/influxdb-client-js).
 
 1. Inside of your project directory, create an NPM or Yarn package and install 
@@ -588,7 +592,7 @@ To write data to InfluxDB Cloud Dedicated using Node.js, use the
     npm init -y && npm install --save @influxdata/influxdb-client
     ```
 
-2. Create a file for your code--for example: `write.js`.
+2.  In your terminal or editor, create a new file for your code--for example: `write.js`.
 
     ```sh
     touch write.js
@@ -651,7 +655,7 @@ To write data to InfluxDB Cloud Dedicated using Node.js, use the
 
     /**
     * Create a write client from the getWriteApi method.
-    * Provide your org and Database.
+    * Provide your org and database.
     **/
     const writeApi = influxDB.getWriteApi(org, 'get-started', 's');
 
@@ -695,7 +699,7 @@ To write data to InfluxDB Cloud Dedicated using Node.js, use the
           The `close()` method sends any records remaining in the buffer,
           executes callbacks, and releases resources.
 
-4. To execute the file and write the line protocol to your InfluxDB Cloud Dedicated database,
+4. To execute the file and write the line protocol to your {{% cloud-name %}} database,
     enter the following command in your terminal:
    
     ```sh

--- a/content/influxdb/cloud-dedicated/get-started/write.md
+++ b/content/influxdb/cloud-dedicated/get-started/write.md
@@ -307,36 +307,37 @@ To write data to InfluxDB Cloud Dedicated using Python, use the
 The following steps include setting up a Python virtual environment to scope
 dependencies to your current project.
 
-1.  Setup your Python virtual environment.
-    Inside of your project directory:
+1. Create a new module directory and navigate into it--for example:
+
+    ```sh
+    mkdir influxdb_py_client && cd $_
+    ```
+
+2.  Setup your Python virtual environment.
+    Inside of your module directory:
 
     ```sh
     python -m venv envs/virtual-env
     ```
 
-2. Activate the virtual environment.
+3. Activate the virtual environment.
 
     ```sh
     source ./envs/virtual-env/bin/activate
     ```
 
-3.  Install the following dependencies:
+4.  Install the following dependencies:
 
     - `pyarrow`
-    - `flightsql-dbapi`
-    - `influxdb3-client`
+    - `influxdb_client_3`
 
     ```python
-    pip install pyarrow flightsql-dbapi influxdb3-client
+    pip install pyarrow influxdb_client_3
     ```
 
-4.  Create a file for your code--for example, `write.py`.
+5.  Create a new file for your python code--for example: `write.py`.
 
-    ```sh
-    touch write.py
-    ```
-
-5.  Inside of `write.py`, enter the following sample code:
+6.  Inside of `write.py`, enter the following sample code:
 
       ```py
       from influxdb_client_3 import InfluxDBClient3

--- a/content/influxdb/cloud-dedicated/primers/api/v2/_index.md
+++ b/content/influxdb/cloud-dedicated/primers/api/v2/_index.md
@@ -346,10 +346,10 @@ Use Flight SQL clients with gRPC and SQL to query data stored in an InfluxDB Clo
 
 Choose from the following tools to query InfluxDB Cloud Dedicated:
 
-- [Flight SQL plugin]() for [Grafana]()
-- [Superset]()
-- [`pyinflux3` module](https://github.com/InfluxCommunity/pyinflux3)
-- [`flightsql-dbapi`](https://github.com/influxdata/flightsql-dbapi)
+- [Flight SQL plugin](/influxdb/cloud-dedicated/query-data/tools/grafana/) for Grafana
+- [Superset](/influxdb/cloud-dedicated/query-data/execute-queries/flight-sql/superset/)
+- [InfluxDB v3 language-specific client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/)
+- [Flight SQL language-specific clients](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/)
 
 See how to [get started querying with SQL](/influxdb/cloud-dedicated/get-started/query/#sql-query-basics)
 

--- a/content/influxdb/cloud-dedicated/query-data/tools/grafana.md
+++ b/content/influxdb/cloud-dedicated/query-data/tools/grafana.md
@@ -3,8 +3,7 @@ title: Use Grafana to query and visualize data
 seotitle: Use Grafana to query and visualize data stored in InfluxDB Cloud Dedicated
 list_title: Use Grafana
 description: >
-  Install and run [Grafana](https://grafana.com/) to query and visualize data stored in an
-  InfluxDB database.
+  Install and run [Grafana](https://grafana.com/) to query and visualize data stored in InfluxDB.
 weight: 101
 menu:
   influxdb_cloud_dedicated:
@@ -16,9 +15,9 @@ aliases:
 alt_engine: /influxdb/cloud/tools/grafana/
 ---
 
-Use [Grafana](https://grafana.com/) to query and visualize data stored in an
-InfluxDB Cloud dedicated database.
-InfluxDB Cloud Dedicated supports both **SQL** and **InfluxQL** query languages.
+Use [Grafana](https://grafana.com/) to query and visualize data stored in
+{{% cloud-name %}}.
+{{% cloud-name %}} supports both **SQL** and **InfluxQL** query languages.
 Install the [Grafana FlightSQL plugin](https://grafana.com/grafana/plugins/influxdata-flightsql-datasource/)
 to query InfluxDB with **SQL** using the Flight SQL protocol.
 Use the **InfluxDB** core Grafana plugin to query data with **InfluxQL**.
@@ -51,7 +50,7 @@ If using **Grafana Cloud**, login to your Grafana Cloud instance.
 
 ## Install the FlightSQL plugin
 
-If you want to query InfluxDB Cloud Dedicated with **SQL**, install the
+If you want to query {{% cloud-name %}} with **SQL**, install the
 [Grafana FlightSQL plugin](https://grafana.com/grafana/plugins/influxdata-flightsql-datasource/).
 
 {{< tabs-wrapper >}}
@@ -105,7 +104,7 @@ Grafana Cloud instance.
 ## Create a datasource
 
 Which datasource you create depends on which query language you want to use to
-query InfluxDB Cloud Dedicated:
+query {{% cloud-name %}}:
 
 - To query with **SQL**, create a **FlightSQL** datasource.
 - To query with **InfluxQL**, create an **InfluxDB** datasource.
@@ -125,21 +124,21 @@ query InfluxDB Cloud Dedicated:
 5.  Add your connection credentials:
 
     - **Host**: Provide the host and port of your Flight SQL client.
-      For InfluxDB Cloud Dedicated, this is your cluster URL and port 443:
+      For {{% cloud-name %}}, this is your cluster URL and port 443:
 
       ```
       cluster-id.influxdb.io:443
       ```
 
     - **AuthType**: Select **token**.
-    - **Token**: Provide your InfluxDB API token with read access to the
+    - **Token**: Provide your InfluxDB [database token](/influxdb/cloud-dedicated/admin/tokens/) with read access to the
       databases you want to query.
     - **Require TLS/SSL**: Enable this toggle.
 
 6.  Add connection **MetaData**.
     Provide key-value pairs to send to your Flight SQL client.
 
-    InfluxDB Cloud Serverless requires your **database name**:
+    {{% cloud-name %}} requires your **database name**:
     
     - **Key**: `database`
     - **Value**: Database name
@@ -160,10 +159,10 @@ query InfluxDB Cloud Dedicated:
 3.  Search for and select the **InfluxDB** core plugin.
 4.  Provide a name for your datasource.
 5.  Under **Query Language**, select **InfluxQL**.
-    _InfluxDB Cloud Dedicated does not support Flux._
+    _{{% cloud-name %}} does not support Flux._
 6.  Under **HTTP**:
 
-    - **URL**: Provide your Influx Cloud Dedicated cluster URL using the HTTPS
+    - **URL**: Provide your {{% cloud-name %}} cluster URL using the HTTPS
       protocol:
 
       ```
@@ -174,7 +173,7 @@ query InfluxDB Cloud Dedicated:
 
     - **Database**: Provide a default database name to query.
     - **User**: Provide an arbitrary string.
-      _This credential is ingored when querying InfluxDB Cloud Dedicated, but it cannot be empty._
+      _This credential is ingored when querying {{% cloud-name %}}, but it cannot be empty._
     - **Password**: Provide an InfluxDB [database token](/influxdb/cloud-dedicated/admin/tokens/)
       with read access to the databases you want to query.
 
@@ -190,7 +189,7 @@ query InfluxDB Cloud Dedicated:
 ## Query InfluxDB with Grafana
 
 After you [configure and save a FlightSQL or InfluxDB datasource](#create-a-datasource),
-use Grafana to build, run, and inspect queries against InfluxDB database.
+use Grafana to build, run, and inspect queries against your InfluxDB database.
 
 {{< tabs-wrapper >}}
 {{% tabs %}}

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/python.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/python.md
@@ -23,39 +23,47 @@ If just getting started, see [Get started with InfluxDB](/influxdb/cloud-dedicat
 
 ## Before you begin
 
+You'll need the following prerequisites:
+
 1. Install the InfluxDB Python library:
 
     ```sh
     pip install influxdb-client
     ```
 
-2. Ensure that InfluxDB is running.
-   If running InfluxDB locally, visit http://localhost:8086.
-   (If using InfluxDB Cloud, visit the URL of your InfluxDB Cloud UI.
-   For example: https://us-west-2-1.aws.cloud2.influxdata.com.)
+2. InfluxDB Cloud Dedicated cluster URL using the HTTPS protocol--for example:
+    
+    ```
+    https://cluster-id.influxdb.io
+    ```
+3. Name of the [database](/influxdb/cloud-dedicated/admin/databases/) to write to.
+4. InfluxDB [database token](/influxdb/cloud-dedicated/admin/tokens/) with permission to write to the database.
+   _For security reasons, we recommend setting an environment variable to store your token and avoid exposing the raw token value in your script._
 
 ## Write data to InfluxDB with Python
 
-We are going to write some data in [line protocol](/influxdb/cloud-dedicated/reference/syntax/line-protocol/) using the Python library.
+Follow the steps to write [line protocol](/influxdb/cloud-dedicated/reference/syntax/line-protocol/) data to an InfluxDB Cloud Dedicated database.
 
-1. In your Python program, import the InfluxDB client library and use it to write data to InfluxDB.
+1. In your editor, create a file for your Python program--for example: `write.py`.
+2. In the file, import the InfluxDB client library.
 
    ```python
    import influxdb_client
    from influxdb_client.client.write_api import SYNCHRONOUS
+   import os
    ```
 
-2. Define a few variables with the name of your [database](/influxdb/cloud-dedicated/admin/databases/) (bucket), organization (required, but ignored), and [token](/influxdb/cloud-dedicated/admin/tokens/).
+3. Define variables for your [database name](/influxdb/cloud-dedicated/admin/databases/), organization (required, but ignored), and [token](/influxdb/cloud-dedicated/admin/tokens/).
 
    ```python
-   bucket = "DATABASE_NAME"
+   database = "DATABASE_NAME"
    org = "ignored"
-   token = "DATABASE_TOKEN"
-   # Store the URL of your InfluxDB instance
+   # INFLUX_TOKEN is an environment variable you created for your database WRITE token
+   token = os.getenv('INFLUX_TOKEN')
    url="https://cluster-id.influxdb.io"
    ```
 
-3. Instantiate the client. The `InfluxDBClient` object takes three named parameters: `url`, `org`, and `token`. Pass in the named parameters.
+4. To instantiate the client, call the `influxdb_client.InfluxDBClient()` method with the following keyword arguments: `url`, `org`, and `token`.
 
    ```python
    client = influxdb_client.InfluxDBClient(
@@ -66,17 +74,17 @@ We are going to write some data in [line protocol](/influxdb/cloud-dedicated/ref
    ```
     The `InfluxDBClient` object has a `write_api` method used for configuration.
 
-4. Instantiate a **write client** using the `client` object and the `write_api` method. Use the `write_api` method to configure the writer object.
+5. Instantiate a **write client** by calling the `client.write_api()` method with write configuration options.
 
    ```python
    write_api = client.write_api(write_options=SYNCHRONOUS)
    ```
 
-5. Create a [point](/influxdb/cloud-dedicated/reference/glossary/#point) object and write it to InfluxDB using the `write` method of the API writer object. The write method requires three parameters: `bucket`, `org`, and `record`.
+6. Create a [point](/influxdb/cloud-dedicated/reference/glossary/#point) object and write it to InfluxDB using the `write` method of the API writer object. The write method requires three parameters: `bucket`, `org`, and `record`.
 
    ```python
    p = influxdb_client.Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)
-   write_api.write(bucket=bucket, org=org, record=p)
+   write_api.write(bucket=database, org=org, record=p)
    ```
 
 ### Complete example write script
@@ -84,11 +92,12 @@ We are going to write some data in [line protocol](/influxdb/cloud-dedicated/ref
 ```python
 import influxdb_client
 from influxdb_client.client.write_api import SYNCHRONOUS
+import os
 
-bucket = "DATABASE_NAME"
+database = "DATABASE_NAME"
 org = "ignored"
-token = "DATABASE_TOKEN"
-# Store the URL of your InfluxDB instance
+# INFLUX_TOKEN is an environment variable you created for your database WRITE token
+token = os.getenv('INFLUX_TOKEN')
 url="https://cluster-id.influxdb.io"
 
 client = influxdb_client.InfluxDBClient(
@@ -101,9 +110,9 @@ client = influxdb_client.InfluxDBClient(
 write_api = client.write_api(write_options=SYNCHRONOUS)
 
 p = influxdb_client.Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)
-write_api.write(bucket=bucket, org=org, record=p)
+write_api.write(bucket=database, org=org, record=p)
 ```
 ## Query data from InfluxDB with Python
 
-The InfluxDB v2 Python client cannot query InfluxDB Cloud Dedicated.
-To query your dedicated instance, use a Flight SQL client with gRPC.
+The InfluxDB v2 Python client can't query InfluxDB Cloud Dedicated.
+To query your dedicated instance, use a Python [Flight SQL client with gRPC](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/).

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v3/python.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v3/python.md
@@ -1,22 +1,24 @@
 ---
 title: Python client library for InfluxDB v3
 list_title: Python
-description: The InfluxDB v3 `pyinflux3` Python client library integrates with Python scripts and applications and provides a standalone CLI to write and query data stored in an InfluxDB Cloud Dedicated database.
-external_url: https://github.com/InfluxCommunity/pyinflux3
+description: The InfluxDB v3 `influxdb3-python` Python client library integrates with Python scripts and applications to write and query data stored in an InfluxDB Cloud Dedicated database.
+external_url: https://github.com/InfluxCommunity/influxdb3-python
 menu:
   influxdb_cloud_dedicated:
     name: Python
     parent: v3 client libraries
     params:
-      url: https://github.com/InfluxCommunity/pyinflux3
-    identifier: pyinflux3
+      url: https://github.com/InfluxCommunity/influxdb3-python
+    identifier: influxdb3-python
 influxdb/cloud-dedicated/tags: [python, gRPC, SQL, Flight SQL, client libraries]
 weight: 201
+aliases:
+  - /influxdb/cloud-dedicated/reference/client-libraries/v3/pyinflux3/
 ---
 
-The InfluxDB v3 [`pyinflux3` Python client library](https://github.com/InfluxCommunity/pyinflux3) integrates with Python scripts and applications
-and provides a standalone CLI to write and query data stored in an InfluxDB Cloud Dedicated database.
+The InfluxDB v3 [`influxdb3-python` Python client library](https://github.com/InfluxCommunity/influxdb3-python) integrates with Python scripts and applications
+to write and query data stored in an {{% cloud-name %}} database.
 
 The documentation for this client library is available on GitHub.
 
-<a href="https://github.com/InfluxCommunity/pyinflux3" target="_blank" class="btn github">pyinflux3 Python client library and CLI</a>
+<a href="https://github.com/InfluxCommunity/influxdb3-python" target="_blank" class="btn github">InfluxDB v3 Python client library</a>

--- a/content/influxdb/cloud-dedicated/write-data/csv/telegraf.md
+++ b/content/influxdb/cloud-dedicated/write-data/csv/telegraf.md
@@ -68,43 +68,31 @@ metrics from different sources and writes them to specified destinations.
 
 ## Configure Telegraf to write to InfluxDB
 
-1.  Add and enable the [`outputs.influxdb_v2`](/{{< latest "telegraf" >}}/plugins/#output-influxdb_v2)
-    plugin in your Telegraf configuration file.
-2.  Include the following options:
+To send data to {{< cloud-name >}}, enable the
+[`influxdb_v2` output plugin](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/influxdb_v2/README.md)
+in the `telegraf.conf`.
 
-    - **url**: a list (`[]`) containing your InfluxDB Cloud Dedicated cluster URL using the HTTPS
-      protocol:
-
-      ```toml
-      ["https://cluster-id.influxdb.io"]
-      ```
-    - **token**: a [database token](/influxdb/cloud-dedicated/admin/tokens/) with permission to write to the database.
-    - **organization**: an empty string (`""`) (ignored by InfluxDB Cloud Dedicated).
-    - **bucket**: the name of the [database](/influxdb/cloud-dedicated/admin/databases/) to write to.
-
-The following example shows a minimal [`outputs.influxdb_v2`](/{{< latest "telegraf" >}}/plugins/#output-influxdb_v2) configuration for writing data to InfluxDB Cloud Dedicated:
-
+{{% code-placeholders "DATABASE_NAME" %}}
 ```toml
 [[outputs.influxdb_v2]]
   urls = ["https://cluster-id.influxdb.io"]
-  token = "DATABASE_TOKEN"
+  # INFLUX_TOKEN is an environment variable you created for your API read token
+  token = "${INFLUX_TOKEN}"
   organization = ""
   bucket = "DATABASE_NAME"
 ```
+{{% /code-placeholders %}}
 
 Replace the following:
 
-- **`DATABASE_NAME`**: your InfluxDB Cloud Dedicated [database](/influxdb/cloud-dedicated/admin/databases/)
-- **`DATABASE_TOKEN`**: a [database token](/influxdb/cloud-dedicated/admin/tokens/) with sufficient permissions to the database
+- **`DATABASE_NAME`**: the name of the InfluxDB [database](/influxdb/cloud-dedicated/admin/databases/) to write data to
+
+To learn more about configuration options, see [Enable and configure the InfluxDB v2 output plugin](/influxdb/cloud-dedicated/write-data/use-telegraf/configure/#enable-and-configure-the-influxdb-v2-output-plugin).
 
 {{< expand-wrapper >}}
 {{% expand "View full example Telegraf configuration file" %}}
 
-In the following example:
-
-- **`INFLUX_TOKEN`** is an environment variable assigned to a [database token](/influxdb/cloud-dedicated/admin/tokens/) value.
-- **`DATABASE_NAME`** is the InfluxDB Cloud Dedicated database to write to.
-
+{{% code-placeholders "DATABASE_NAME" %}}
 ```toml
 [[inputs.file]]
   files = ["/path/to/example.csv"]
@@ -130,12 +118,20 @@ In the following example:
   csv_reset_mode = "none"
 
 [[outputs.influxdb_v2]]
-  urls = ["https://cluster-id.influxdb.io"]
-  token = "${INFLUX_TOKEN}"
+  urls = ["https://cloud2.influxdata.com"]
+  # INFLUX_TOKEN is an environment variable you created for your API read token
+  token = "{$INFLUX_TOKEN}"
   organization = ""
   bucket = "DATABASE_NAME"
   content_encoding = "gzip"
 ```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- **`DATABASE_NAME`**: the name of the InfluxDB [database](/influxdb/cloud-dedicated/admin/databases/) to write data to
+
+**`INFLUX_TOKEN`** is an environment variable you created in the [Setup instructions](/influxdb/cloud-dedicated/get-started/setup/?t=Telegraf) of the Get Started tutorial.
 
 {{% /expand %}}
 {{< /expand-wrapper >}}
@@ -145,7 +141,7 @@ data to InfluxDB.
 
 #### Other Telegraf configuration options
 
-The preceding examples describe Telegraf configurations necessary for writing to InfluxDB Cloud Dedicated.
+The preceding examples describe Telegraf configurations necessary for writing to {{% cloud-name %}}.
 The output plugin provides several other options for configuring the Telegraf client:
 
 - `influx_uint_support`: supported by the InfluxDB IOx storage engine.

--- a/content/influxdb/cloud-dedicated/write-data/csv/telegraf.md
+++ b/content/influxdb/cloud-dedicated/write-data/csv/telegraf.md
@@ -76,7 +76,7 @@ in the `telegraf.conf`.
 ```toml
 [[outputs.influxdb_v2]]
   urls = ["https://cluster-id.influxdb.io"]
-  # INFLUX_TOKEN is an environment variable you created for your API read token
+  # INFLUX_TOKEN is an environment variable you created for your database WRITE token
   token = "${INFLUX_TOKEN}"
   organization = ""
   bucket = "DATABASE_NAME"
@@ -119,7 +119,7 @@ To learn more about configuration options, see [Enable and configure the InfluxD
 
 [[outputs.influxdb_v2]]
   urls = ["https://cloud2.influxdata.com"]
-  # INFLUX_TOKEN is an environment variable you created for your API read token
+  # INFLUX_TOKEN is an environment variable you created for your database WRITE token
   token = "{$INFLUX_TOKEN}"
   organization = ""
   bucket = "DATABASE_NAME"

--- a/content/influxdb/cloud-dedicated/write-data/use-telegraf/configure/_index.md
+++ b/content/influxdb/cloud-dedicated/write-data/use-telegraf/configure/_index.md
@@ -22,7 +22,7 @@ aliases:
 
 Use the Telegraf `influxdb_v2` output plugin to collect and write metrics to
 {{< cloud-name >}}.
-Learn how to enable the `influxdb_v2` output plugin in new and
+Learn how to enable the plugin in new and
 existing Telegraf configurations,
 and then start Telegraf using the custom configuration file.
 
@@ -71,20 +71,28 @@ To send data to {{< cloud-name >}}, enable the
 [`influxdb_v2` output plugin](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/influxdb_v2/README.md)
 in the `telegraf.conf`.
 
+{{% code-placeholders "DATABASE_NAME" %}}
 ```toml
 [[outputs.influxdb_v2]]
   urls = ["https://cluster-id.influxdb.io"]
+  # INFLUX_TOKEN is an environment variable you created for your database WRITE token
+
   token = "${INFLUX_TOKEN}"
   organization = ""
-  bucket = "get-started"
+  bucket = "DATABASE_NAME"
 ```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- **`DATABASE_NAME`**: the name of the InfluxDB [database](/influxdb/cloud-dedicated/admin/databases/) to write data to
 
 The InfluxDB output plugin configuration contains the following options:
 
 ##### urls
 
 An array of URL strings.
-To write to InfluxDB Cloud Dedicated, include your InfluxDB Cloud Dedicated cluster URL using the HTTPS protocol:
+To write to {{% cloud-name %}}, include your {{% cloud-name %}} cluster URL using the HTTPS protocol:
 
 ```toml
 ["https://cluster-id.influxdb.io"]
@@ -92,7 +100,7 @@ To write to InfluxDB Cloud Dedicated, include your InfluxDB Cloud Dedicated clus
 
 ##### token
 
-Your InfluxDB Cloud Dedicated [database token](/influxdb/cloud-dedicated/admin/tokens/) with _write_ permission to the database.
+Your {{% cloud-name %}} [database token](/influxdb/cloud-dedicated/admin/tokens/) with _write_ permission to the database.
 
 In the examples, **`INFLUX_TOKEN`** is an environment variable assigned to a [database token](/influxdb/cloud-dedicated/admin/tokens/) that has _write_ permission to the database.
 
@@ -102,9 +110,7 @@ For {{% cloud-name %}}, set this to an empty string (`""`).
 
 ##### bucket
 
-The name of the InfluxDB Cloud Dedicated database to write data to.
-
-In the example, **`INFLUX_DATABASE`** is an environment variable assigned to the [database](/influxdb/cloud-dedicated/admin/databases/) name.
+The name of the {{% cloud-name %}} database to write data to.
 
 {{% note %}}
 ##### Write to InfluxDB v1.x and {{< cloud-name >}}

--- a/content/influxdb/cloud-serverless/admin/organizations/view-orgs.md
+++ b/content/influxdb/cloud-serverless/admin/organizations/view-orgs.md
@@ -1,0 +1,28 @@
+---
+title: View organizations
+seotitle: View organizations in InfluxDB
+description: Review a list of organizations in InfluxDB using the InfluxDB UI.
+menu:
+  influxdb_cloud_serverless:
+    name: View organizations
+    parent: Manage organizations
+weight: 102
+---
+
+Use the InfluxDB user interface (UI) to view organizations.
+
+## View your organization name
+
+After logging in to the InfluxDB UI, your organization name appears in the header.
+
+If you belong to more than one organization with the same email address, you can [switch from one organization to another](/influxdb/cloud-serverless/admin/organizations/switch-org/) while staying logged in.
+
+## View your organization ID
+
+After logging in to the InfluxDB UI, your organization ID appears in the URL--for example:
+
+{{< code-callout "03a2bbf46249a000" >}}
+```sh
+https://cloud2.influxdata.com/orgs/03a2bbf46249a000/...
+```
+{{< /code-callout >}}

--- a/content/influxdb/cloud-serverless/get-started/query.md
+++ b/content/influxdb/cloud-serverless/get-started/query.md
@@ -19,7 +19,7 @@ related:
   - /influxdb/cloud-serverless/reference/client-libraries/flight-sql/
 ---
 
-InfluxDB Cloud Serverless supports multiple query languages:
+{{% cloud-name %}} supports multiple query languages:
 
 - **SQL**: Traditional SQL powered by the [Apache Arrow DataFusion](https://arrow.apache.org/datafusion/)
   query engine. The supported SQL syntax is similar to PostgreSQL.
@@ -45,7 +45,7 @@ The examples in this section of the tutorial query the [**get-started** bucket](
 
 ## Tools to execute queries
 
-InfluxDB Cloud Serverless supports many different tools for querying data, including:
+{{% cloud-name %}} supports many different tools for querying data, including:
 
 {{< req type="key" text="Covered in this tutorial" >}}
 
@@ -76,7 +76,7 @@ InfluxDB SQL queries most commonly include the following clauses:
   measurement or use the wild card alias (`*`) to select all fields and tags
   from a measurement.
 - {{< req "\*">}} `FROM`: Identify the measurement to query.
-  If coming from a SQL background, an InfluxDB measurement is the equivalent 
+  If coming from an SQL background, an InfluxDB measurement is the equivalent 
   of a relational table.
 - `WHERE`: Only return data that meets defined conditions such as falling within
   a time range, containing specific tag values, etc.
@@ -171,7 +171,7 @@ ORDER BY room, _time
 
 ### Execute an SQL query
 
-Get started with one of the following tools for querying data stored in an InfluxDB Cloud Serverless bucket:
+Get started with one of the following tools for querying data stored in an {{% cloud-name %}} bucket:
 
 - **InfluxDB UI**: View your schema, build queries using the query editor, and generate data visualizations.
 - **Flight SQL clients**: Use language-specific (Python, Go, etc.) clients to execute queries in your terminal or custom code.
@@ -242,8 +242,10 @@ See [Query in the Data Explorer](/influxdb/cloud-serverless/query-data/execute-q
 {{% /tab-content %}}
 {{% tab-content %}}
 <!--------------------------- BEGIN influx3 CONTENT --------------------------->
+{{% influxdb/custom-timestamps %}}
 
-Query InfluxDB v3 using SQL and the `influx3` CLI, part of the [`InfluxCommunity/pyinflux3`](https://github.com/InfluxCommunity/pyinflux3) community repository.
+Query InfluxDB v3 using SQL and the `influx3` CLI.
+
 The following steps include setting up a Python virtual environment already
 covered in [Get started writing data](/influxdb/cloud-serverless/get-started/write/?t=Python#write-line-protocol-to-influxdb).
 _If your project's virtual environment is already running, skip to step 3._
@@ -266,146 +268,147 @@ _If your project's virtual environment is already running, skip to step 3._
     {{< req type="key" text="Already installed in the [Write data section](/influxdb/cloud-serverless/get-started/write/?t=Python#write-line-protocol-to-influxdb)" color="magenta" >}}
 
     - `pyarrow` {{< req text="\*" color="magenta" >}}
-    - `flightsql-dbapi` {{< req text="\*" color="magenta" >}}
-    - `pyinflux3` {{< req text="\*" color="magenta" >}}
+    - `influxdb3-python-cli` {{< req text="\*" color="magenta" >}}
 
-4. Create the `config.json` configuration.
+4.  Create the `config.json` configuration.
 
-    ```sh
-    influx3 config \
-      --name="my-config" \
+    <!-- code-placeholders breaks when indented here -->
+      ```sh
+      influx3 config \
+      --name="config-serverless" \
       --database="get-started" \
       --host="cloud2.influxdata.com" \
       --token="API_TOKEN" \
       --org="ORG_ID"
-    ```
+      ```
 
-    Replace the following:
+      Replace the following:
 
-    - **`API_TOKEN`**: InfluxDB API token with _read_ access to the **get-started** bucket
-    - **`ORG_ID`**: InfluxDB organization ID
+      - **`API_TOKEN`**: an InfluxDB [API token](/influxdb/cloud-serverless/get-started/setup/#create-an-all-access-api-token) with _read_ access to the **get-started** bucket
+      - **`ORG_ID`**: an InfluxDB [organization ID](/influxdb/cloud-serverless/admin/organizations/)
 
 5. Enter the `influx3 sql` command and your SQL query statement.
 
-  {{% influxdb/custom-timestamps %}}
   ```sh
   influx3 sql "SELECT *
                 FROM home
                 WHERE time >= '2022-01-01T08:00:00Z'
                 AND time <= '2022-01-01T20:00:00Z'"
   ```
-  {{% /influxdb/custom-timestamps %}}
 
 `influx3` displays query results in your terminal.
-  
+
+For more information about the `influx3` CLI, see the [`InfluxCommunity/
+influxdb3-python-cli
+`](https://github.com/InfluxCommunity/influxdb3-python-cli) community repository on GitHub.
+ {{% /influxdb/custom-timestamps %}}
 <!--------------------------- END influx3 CONTENT --------------------------->
 {{% /tab-content %}}
 {{% tab-content %}}
 <!--------------------------- BEGIN PYTHON CONTENT ---------------------------->
-
-To query data from InfluxDB Cloud Serverless using Python, use the
-[`pyinflux3` module](https://github.com/InfluxCommunity/pyinflux3).
+ {{% influxdb/custom-timestamps %}}
+To query data from {{% cloud-name %}} using Python, use the
+[`influxdb_client_3` module](https://github.com/InfluxCommunity/influxdb3-python).
 The following steps include setting up a Python virtual environment already
 covered in [Get started writing data](/influxdb/cloud-serverless/get-started/write/?t=Python#write-line-protocol-to-influxdb).
 _If your project's virtual environment is already running, skip to step 3._
 
-1.  Setup your Python virtual environment.
-    Inside of your project directory:
+1.  In the `influxdb_py_client` module directory you created in the
+    [Write data section](/influxdb/cloud-serverless/get-started/write/?t=Python#write-line-protocol-to-influxdb):
 
-    ```sh
-    python -m venv envs/virtual-env
+  1.  Setup your Python virtual environment.
+      Inside of your project directory:
+
+      ```sh
+      python -m venv envs/virtual-env
+      ```
+
+  2.  Activate the virtual environment.
+
+      ```sh
+      source ./envs/virtual-env/bin/activate
+      ```
+
+  3.  Install the following dependencies:
+
+      {{< req type="key" text="Already installed in the [Write data section](/influxdb/cloud-serverless/get-started/write/?t=Python#write-line-protocol-to-influxdb)" color="magenta" >}}
+
+      - `pyarrow` {{< req text="\*" color="magenta" >}}
+      - `influxdb_client_3` {{< req text="\*" color="magenta" >}}
+      - `pandas`
+      - `tabulate` _(to return formatted tables)_
+
+      ```sh
+      pip install influxdb_client_3 pandas tabulate
+      ```
+
+  4. In your terminal or editor, create a new file for your code--for example: `query.py`.
+
+2.  In `query.py`, enter the following sample code:
+
+    ```py
+    from influxdb_client_3 import InfluxDBClient3
+    import os
+
+    # INFLUX_TOKEN is an environment variable you created for your API token
+    TOKEN = os.getenv('INFLUX_TOKEN')
+
+    client = InfluxDBClient3(
+        host="cloud2.influxdata.com",
+        token=TOKEN,
+        database="get-started",
+    )
+
+    sql = '''
+    SELECT
+      *
+    FROM
+      home
+    WHERE
+      time >= '2022-01-01T08:00:00Z'
+      AND time <= '2022-01-01T20:00:00Z'
+    '''
+
+    table = client.query(sql_query=sql)
+    print(reader.to_pandas().to_markdown())
     ```
 
-2. Activate the virtual environment.
+    The sample code does the following:
 
-    ```sh
-    source ./envs/virtual-env/bin/activate
-    ```
-
-3. Install the following dependencies:
-
-    {{< req type="key" text="Already installed in the [Write data section](/influxdb/cloud-serverless/get-started/write/?t=Python#write-line-protocol-to-influxdb)" color="magenta" >}}
-
-    - `pyarrow` {{< req text="\*" color="magenta" >}}
-    - `flightsql-dbapi` {{< req text="\*" color="magenta" >}}
-    - `pyinflux3` {{< req text="\*" color="magenta" >}}
-    - `pandas`
-    - `tabulate` _(to return formatted tables)_
-
-    ```sh
-    pip install pandas tabulate
-    ```
-
-4.  Build your python script to query your InfluxDB bucket.
-    _These can be structured as a Python script or executed in a `python` shell._
-
-    1.  Import the `InfluxDBClient3` constructor from the `influxdb_client_3` module.
+    1.  Imports the `InfluxDBClient3` constructor from the `influxdb_client_3` module.
     
-    2.  Use the `InfluxDBClient3` constructor to instantiate an InfluxDB Client.
-        The example below assigns it to the `client` variable.
-        Provide the following credentials:
+    2.  Calls the `InfluxDBClient3()` constructor method with credentials to instantiate an InfluxDB `client` with the following credentials:
 
-        - **host**: InfluxDB Cloud Serverless region hostname (URL without protocol or trailing slash)
-        - **token**: InfluxDB API token with _read_ access to the specified bucket.
+        - **host**: {{% cloud-name %}} region hostname (URL without protocol or trailing slash)
+        - **token**:  an [API token](/influxdb/cloud-serverless/get-started/setup/#create-an-all-access-api-token) with _read_ access to the specified bucket.
           _For security reasons, we recommend setting this as an environment
           variable rather than including the raw token string._
-        - **database**: the name of the InfluxDB Cloud Serverless bucket to query
+        - **database**: the name of the {{% cloud-name %}} bucket to query
     
-    3.  Provide the SQL query to execute. In the example below, it's assigned
-        to the `query`variable.
-    
-    4.  Use the `client.query` method to query data in the **get-started**
-        database and return an Arrow table. Assign the return value to the
-        `table` variable. Provide the following:
-        
-        - **sql_query** SQL query string to execute
-    
-    5.  Use [`read_all`](https://docs.python.org/3/library/telnetlib.html#telnetlib.Telnet.read_all)
-        to read the data from InfluxDB and return an Arrow table.
+    3.  Defines the SQL query to execute and assigns it to a `query` variable.
 
-    6.  Use [`to_pandas`](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pandas)
-        to convert the Arrow table to a pandas DataFrame.
+    4.  Calls the `client.query()` method with the SQL query.
+        `query()` sends a
+        Flight request to InfluxDB, queries the database, retrieves result data from the endpoint, and then returns a
+        [pyarrow.Table](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table)
+        assigned to the `table` variable.
+    
+    5.  Calls the [`to_pandas()` method](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pandas)
+        to convert the Arrow table to a [pandas DataFrame](https://arrow.apache.org/docs/python/pandas.html).
 
-    7.  Use [`to_markdown`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_markdown.html)
+    6.  Calls the [`pandas.DataFrame.to_markdown()` method](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_markdown.html)
         to convert the DataFrame to a markdown table.
 
-    8.  Use `print` to print out the markdown table.
+    7.  Calls the `print()` method to print the markdown table to stdout.
 
-{{% influxdb/custom-timestamps %}}
+6. In your terminal, enter the following command to run the program and query {{% cloud-name %}}:
 
-```py
-from influxdb_client_3 import InfluxDBClient3
-import os
-
-# INFLUX_TOKEN is an environment variable you created for your API token
-TOKEN = os.getenv('INFLUX_TOKEN')
-
-client = InfluxDBClient3(
-    host="cloud2.influxdata.com",
-    token=TOKEN,
-    database="get-started",
-)
-
-sql = '''
-SELECT
-  *
-FROM
-  home
-WHERE
-  time >= '2022-01-01T08:00:00Z'
-  AND time <= '2022-01-01T20:00:00Z'
-'''
-
-table = client.query(sql_query=sql)
-reader = table.read_all()
-print(reader.to_pandas().to_markdown())
-```
-
-{{% /influxdb/custom-timestamps %}}
+    ```sh
+    python query.py
+    ```
 
 {{< expand-wrapper >}}
 {{% expand "View returned markdown table" %}}
-{{% influxdb/custom-timestamps %}}
 
 |    |   co |   hum | room        |   temp | time                |
 |---:|-----:|------:|:------------|-------:|:--------------------|
@@ -436,22 +439,109 @@ print(reader.to_pandas().to_markdown())
 | 24 |   14 |  36.3 | Living Room |   22.5 | 2022-01-01 19:00:00 |
 | 25 |   17 |  36.4 | Living Room |   22.2 | 2022-01-01 20:00:00 |
 
-{{% /influxdb/custom-timestamps %}}
 {{% /expand %}}
 {{< /expand-wrapper >}}
-
+{{% /influxdb/custom-timestamps %}}
 <!---------------------------- END PYTHON CONTENT ----------------------------->
 {{% /tab-content %}}
 {{% tab-content %}}
 <!----------------------------- BEGIN GO CONTENT ------------------------------>
-
+{{% influxdb/custom-timestamps %}}
 1.  In the `influxdb_go_client` directory you created in the
     [Write data section](/influxdb/cloud-serverless/get-started/write/?t=Go#write-line-protocol-to-influxdb),
     create a new file named `query.go`.
 
-2.  In `query.go`:
+2.  In `query.go`, enter the following sample code:
+
+    ```go
+    package main
+
+    import (
+      "context"
+      "crypto/x509"
+      "encoding/json"
+      "fmt"
+      "os"
+
+      "github.com/apache/arrow/go/v12/arrow/flight/flightsql"
+      "google.golang.org/grpc"
+      "google.golang.org/grpc/credentials"
+      "google.golang.org/grpc/metadata"
+    )
+
+    func dbQuery(ctx context.Context) error {
+      url := "cloud2.influxdata.com:443"
+
+      // INFLUX_TOKEN is an environment variable you created for your API token
+      token := os.Getenv("INFLUX_TOKEN")
+      database := "get-started"
+
+      // Create a gRPC transport
+      pool, err := x509.SystemCertPool()
+      if err != nil {
+        return fmt.Errorf("x509: %s", err)
+      }
+      transport := grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(pool, ""))
+      opts := []grpc.DialOption{
+        transport,
+      }
+
+      // Create query client
+      client, err := flightsql.NewClient(url, nil, nil, opts...)
+      if err != nil {
+        return fmt.Errorf("flightsql: %s", err)
+      }
+
+      ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+      ctx = metadata.AppendToOutgoingContext(ctx, "database", database)
+
+      // Execute query
+      query := `SELECT
+        *
+      FROM
+        home
+      WHERE
+        time >= '2022-01-01T08:00:00Z'
+        AND time <= '2022-01-01T20:00:00Z'`
+
+      info, err := client.Execute(ctx, query)
+      if err != nil {
+        return fmt.Errorf("flightsql flight info: %s", err)
+      }
+      reader, err := client.DoGet(ctx, info.Endpoint[0].Ticket)
+      if err != nil {
+        return fmt.Errorf("flightsql do get: %s", err)
+      }
+
+      // Print results as JSON
+      for reader.Next() {
+        record := reader.Record()
+        b, err := json.MarshalIndent(record, "", "  ")
+        if err != nil {
+          return err
+        }
+        fmt.Println("RECORD BATCH")
+        fmt.Println(string(b))
+
+        if err := reader.Err(); err != nil {
+          return fmt.Errorf("flightsql reader: %s", err)
+        }
+      }
+
+      return nil
+    }
+
+    func main() {
+      if err := dbQuery(context.Background()); err != nil {
+        fmt.Fprintf(os.Stderr, "error: %v\n", err)
+        os.Exit(1)
+      }
+    }
+    ```
+
+    The sample code does the following:
     
-    1.  Import the following packages:
+    1.  Imports the following packages:
 
         - `context`
         - `crypto/x509`
@@ -463,122 +553,36 @@ print(reader.to_pandas().to_markdown())
         - `google.golang.org/grpc/credentials`
         - `google.golang.org/grpc/metadata`
 
-    2.  Create a `dbQuery` function. In `dbQuery, define the following
-        variables:
+    2.  Creates a `dbQuery` function that does the following:
 
-        - **url**: InfluxDB Cloud Serverless region hostname and port (`:443`) _(no protocol)_
-        - **token**: InfluxDB API token with _read_ access to the specified bucket.
+        1.  Defines variables for InfluxDB credentials.
+          
+            - **url**: {{% cloud-name %}} region hostname and port (`:443`) _(no protocol)_
+            - **token**:  an [API token](/influxdb/cloud-serverless/get-started/setup/#create-an-all-access-api-token) with _read_  access to the specified bucket.
           _For security reasons, we recommend setting this as an environment
           variable rather than including the raw token string._
-        - **database**: the name of the InfluxDB Cloud Serverless bucket to query
+            - **database**: the name of the {{% cloud-name %}} bucket to query
 
-    3.  In the `dbQuery` function, create a gRPC transport for communicating
-        with InfluxDB Cloud Serverless over the _gRPC+TLS_ protocol.
+        2.  Defines an `opts` options list that includes a gRPC transport for communicating
+        with {{% cloud-name %}} over the _gRPC+TLS_ protocol.
 
-    4.  Use `flightsql.NewClient` to create a new Flight SQL client.
+        3.  Calls the `flightsql.NewClient()` method with `url` and `opts` to create a new Flight SQL client.
 
-    5.  Append the following key-value pairs to the outgoing context:
+        4.  Appends the following InfluxDB credentials as key-value pairs to the outgoing context:
 
-        - **authorization**: Bearer <INFLUX_TOKEN>
-        - **database-name**: Database name
-    
-    6.  Define the query to execute.
+            - **authorization**: Bearer <INFLUX_TOKEN>
+            - **database-name**: Bucket name
 
-    7.  Create a reader to read the Arrow table returned by the query and print
-        the results as JSON.
+        5.  Define the SQL query to execute.
 
-    8.  Create a `main` function that executes the `dbQuery` function.
+        6.  Calls the `client.execute()` method to send the query request.
+        7.  Calls the `client.doGet()` method with the _ticket_ from the query response to retrieve result data from the endpoint.
+        8.  Creates a reader to read the Arrow table returned by the endpoint and print
+            the results as JSON.
 
-{{% influxdb/custom-timestamps %}}
+    3.  Creates a `main` module function that executes the `dbQuery` function.
 
-```go
-package main
-
-import (
-	"context"
-	"crypto/x509"
-	"encoding/json"
-	"fmt"
-	"os"
-
-	"github.com/apache/arrow/go/v12/arrow/flight/flightsql"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/metadata"
-)
-
-func dbQuery(ctx context.Context) error {
-	url := "cloud2.influxdata.com:443"
-  // INFLUX_TOKEN is an environment variable you created for your API token
-	token := os.Getenv("INFLUX_TOKEN")
-	database := "get-started"
-
-	// Create a gRPC transport
-	pool, err := x509.SystemCertPool()
-	if err != nil {
-		return fmt.Errorf("x509: %s", err)
-	}
-	transport := grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(pool, ""))
-	opts := []grpc.DialOption{
-		transport,
-	}
-
-	// Create query client
-	client, err := flightsql.NewClient(url, nil, nil, opts...)
-	if err != nil {
-		return fmt.Errorf("flightsql: %s", err)
-	}
-
-	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
-	ctx = metadata.AppendToOutgoingContext(ctx, "database", database)
-
-	// Execute query
-	query := `SELECT
-		*
-	FROM
-		home
-	WHERE
-		time >= '2022-01-01T08:00:00Z'
-		AND time <= '2022-01-01T20:00:00Z'`
-
-	info, err := client.Execute(ctx, query)
-	if err != nil {
-		return fmt.Errorf("flightsql flight info: %s", err)
-	}
-	reader, err := client.DoGet(ctx, info.Endpoint[0].Ticket)
-	if err != nil {
-		return fmt.Errorf("flightsql do get: %s", err)
-	}
-
-	// Print results as JSON
-	for reader.Next() {
-		record := reader.Record()
-		b, err := json.MarshalIndent(record, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println("RECORD BATCH")
-		fmt.Println(string(b))
-
-		if err := reader.Err(); err != nil {
-			return fmt.Errorf("flightsql reader: %s", err)
-		}
-	}
-
-	return nil
-}
-
-func main() {
-	if err := dbQuery(context.Background()); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
-}
-```
-
-{{% /influxdb/custom-timestamps %}}
-
-Install all the necessary packages and run the program to query InfluxDB Cloud Serverless.
+3. In your terminal, enter the following command to install all the necessary packages and run the program to query {{% cloud-name %}}.
 
 ```sh
 go get ./...
@@ -587,8 +591,6 @@ go run ./query.go
 
 {{< expand-wrapper >}}
 {{% expand "View program output" %}}
-{{% influxdb/custom-timestamps %}}
-
 ```json
 RECORD BATCH
 [
@@ -776,11 +778,9 @@ RECORD BATCH
   }
 ]
 ```
-
-{{% /influxdb/custom-timestamps %}}
 {{% /expand %}}
 {{< /expand-wrapper >}}
-
+ {{% /influxdb/custom-timestamps %}}
 <!------------------------------ END GO CONTENT ------------------------------->
 {{% /tab-content %}}
 {{% tab-content %}}
@@ -883,7 +883,6 @@ Include the following with your request:
 
 The following example uses cURL and the InfluxDB API to query data with Flux:
 
-
 {{% influxdb/custom-timestamps %}}
 ```sh
 curl --request POST \
@@ -919,6 +918,7 @@ The InfluxDB `/api/v2/query` endpoint returns query results in
 {{< /tabs-wrapper >}}
 
 ### Query results
+
 {{< expand-wrapper >}}
 {{% expand "View query results" %}}
 
@@ -957,7 +957,7 @@ The InfluxDB `/api/v2/query` endpoint returns query results in
 {{< /expand-wrapper >}}
 
 **Congratulations!** You've learned the basics of querying data in InfluxDB with SQL.
-For a deep dive into all the ways you can query InfluxDB, see the
+For a deep dive into all the ways you can query {{% cloud-name %}}, see the
 [Query data in InfluxDB](/influxdb/cloud-serverless/query-data/) section of documentation.
 
 {{< page-nav prev="/influxdb/cloud-serverless/get-started/write/" keepTab=true >}}

--- a/content/influxdb/cloud-serverless/get-started/setup.md
+++ b/content/influxdb/cloud-serverless/get-started/setup.md
@@ -106,9 +106,9 @@ credentials. Use the [`influx config create` command](/influxdb/cloud-serverless
 to create a new CLI connection configuration. Include the following flags:
 
 - `-n, --config-name`: Connection configuration name. This examples uses `get-started`.
-- `-u, --host-url`: [InfluxDB Cloud Serverless region URL](/influxdb/cloud-serverless/reference/regions/).
-- `-o, --org`: InfluxDB organization name.
-- `-t, --token`: InfluxDB API token.
+- `-u, --host-url`: [{{% cloud-name %}} region URL](/influxdb/cloud-serverless/reference/regions/).
+- `-o, --org`: InfluxDB [organization name](/influxdb/cloud-serverless/admin/organizations/).
+- `-t, --token`:  your [API token](/influxdb/cloud-serverless/get-started/setup/#create-an-all-access-api-token).
 
 {{% code-placeholders "API_TOKEN|ORG_NAME|https://cloud2.influxdata.com|get-started" %}}
 ```sh
@@ -131,9 +131,9 @@ The `influx` CLI checks for specific environment variables and, if present,
 uses those environment variables to populate authentication credentials.
 Set the following environment variables in your command line session:
 
-- `INFLUX_HOST`: [InfluxDB Cloud Serverless region URL](/influxdb/cloud-serverless/reference/regions/).
-- `INFLUX_ORG`: InfluxDB organization name or [ID](/influxdb/cloud-serverless/organizations/view-orgs/#view-your-organization-id).
-- `INFLUX_TOKEN`: InfluxDB API token.
+- `INFLUX_HOST`: [{{% cloud-name %}} region URL](/influxdb/cloud-serverless/reference/regions/).
+- `INFLUX_ORG`: InfluxDB [organization name or ID](/influxdb/cloud-serverless/admin/organizations/view-orgs/).
+- `INFLUX_TOKEN`:  your [API token](/influxdb/cloud-serverless/get-started/setup/#create-an-all-access-api-token).
 
 {{< code-tabs-wrapper >}}
 {{% code-tabs %}}
@@ -186,10 +186,10 @@ set INFLUX_TOKEN=API_TOKEN
 
 Use the following `influx` CLI flags to provide required credentials to commands:
 
-- `--host`: [InfluxDB Cloud Serverless region URL](/influxdb/cloud-serverless/reference/regions/).
+- `--host`: [{{% cloud-name %}} region URL](/influxdb/cloud-serverless/reference/regions/).
 - `-o`, `--org`: InfluxDB organization name or
   [ID](/influxdb/cloud-serverless/organizations/view-orgs/#view-your-organization-id).
-- `-t`, `--token`: InfluxDB API token.
+- `-t`, `--token`:  your [API token](/influxdb/cloud-serverless/get-started/setup/#create-an-all-access-api-token).
 
 {{% /expand %}}
 {{< /expand-wrapper >}}
@@ -250,7 +250,7 @@ set INFLUX_TOKEN=API_TOKEN
 
 Replace the following:
 
-- **`API_TOKEN`**: your InfluxDB API token with sufficient permissions to your bucket
+- **`API_TOKEN`**: an InfluxDB [API token](/influxdb/cloud-serverless/get-started/setup/#create-an-all-access-api-token) with sufficient permissions to your bucket
 
 <!----------------------------- END TELEGRAF CONTENT ------------------------->
 {{% /tab-content %}}
@@ -316,14 +316,14 @@ Replace the following:
 
 - **`ORG_NAME`**: your InfluxDB organization name
 - **`ORG_ID`**: your InfluxDB organization ID
-- **`API_TOKEN`**: your InfluxDB API token with sufficient permissions to your bucket
+- **`API_TOKEN`**: an InfluxDB [API token](/influxdb/cloud-serverless/get-started/setup/#create-an-all-access-api-token) with sufficient permissions to your bucket
 
 Keep the following in mind when using API clients and client libraries:
 
 - InfluxDB ignores `org` and `org_id` parameters in API write and query requests,
   but some clients still require the parameters.
 - Some clients use `host` to refer to your _hostname_, your
-  [InfluxDB Cloud Serverless region URL](/influxdb/cloud-serverless/reference/regions/)
+  [{{% cloud-name %}} region URL](/influxdb/cloud-serverless/reference/regions/)
   without `https://`.
 
 {{% note %}}
@@ -365,7 +365,7 @@ All API, cURL, and client library examples in this getting started tutorial assu
 3.  Click **+ {{< caps >}}Create bucket{{< /caps >}}**.
 4.  Provide a bucket name (get-started) and select a
     [retention period](/influxdb/cloud-serverless/reference/glossary/#retention-period).
-    Supported retention periods depend on your InfluxDB Cloud Serverless plan.
+    Supported retention periods depend on your {{% cloud-name %}} plan.
 
 5.  Click **{{< caps >}}Create{{< /caps >}}**.
 
@@ -382,7 +382,7 @@ All API, cURL, and client library examples in this getting started tutorial assu
 
     - `-n, --name` flag with the bucket name.
     - `-r, --retention` flag with the bucket's retention period duration.
-      Supported retention periods depend on your InfluxDB Cloud Serverless plan.
+      Supported retention periods depend on your {{% cloud-name %}} plan.
     - [Connection and authentication credentials](#configure-authentication-credentials)
 
   {{% code-placeholders "get-started|7d" %}}
@@ -415,7 +415,7 @@ Include the following with your request:
     Each retention rule object has the following properties:
     - **type**: `"expire"`
     - **everySeconds**: Retention period duration in seconds.
-      Supported retention periods depend on your InfluxDB Cloud Serverless plan.
+      Supported retention periods depend on your {{% cloud-name %}} plan.
 
 {{% code-placeholders "\$INFLUX_TOKEN|\$INFLUX_ORG_ID|https://cloud2.influxdata.com|get-started"%}}
 ```sh

--- a/content/influxdb/cloud-serverless/get-started/write.md
+++ b/content/influxdb/cloud-serverless/get-started/write.md
@@ -137,7 +137,7 @@ home,room=Kitchen temp=22.7,hum=36.5,co=26i 1641067200
 
 The following examples show how to write the 
 [sample data](#home-sensor-data-line-protocol), already in line protocol format,
-to an InfluxDB Cloud Serverless bucket.
+to an {{% cloud-name %}} bucket.
 
 To learn more about available tools and options, see [Write data](influxdb/cloud-serverless/write-data/).
 
@@ -378,35 +378,40 @@ home,room=Kitchen temp=22.7,hum=36.5,co=26i 1641067200
 <!---------------------------- BEGIN PYTHON CONTENT --------------------------->
 {{% influxdb/custom-timestamps %}}
 
-To write data to InfluxDB Cloud Serverless using Python, use the
+To write data to {{% cloud-name %}} using Python, use the
 [`influxdb_client_3` module](https://github.com/InfluxCommunity/influxdb3-python).
 The following steps include setting up a Python virtual environment to scope
 dependencies to your current project.
 
-1.  Setup your Python virtual environment.
-    Inside of your project directory:
+1. Create a new module directory and navigate into it--for example:
+
+    ```sh
+    mkdir influxdb_py_client && cd $_
+    ```
+
+2.  Setup your Python virtual environment.
+    Inside of your module directory:
 
     ```sh
     python -m venv envs/virtual-env
     ```
 
-2. Activate the virtual environment.
+3. Activate the virtual environment.
 
     ```sh
     source ./envs/virtual-env/bin/activate
     ```
 
-3.  Install the following dependencies:
+4.  Install the following dependencies:
 
     - `pyarrow`
-    - `flightsql-dbapi`
-    - `influxdb3-client`
+    - `influxdb_client_3`
 
     ```python
-    pip install pyarrow flightsql-dbapi influxdb3-client
+    pip install pyarrow influxdb_client_3
     ```
 
-4.  Create a file for your code--for example, `write.py`.
+5.  In your terminal or editor, create a new file for your code--for example: `write.py`.
 
     ```sh
     touch write.py
@@ -467,10 +472,10 @@ dependencies to your current project.
     2.  Calls the `InfluxDBClient3()` constructor to instantiate an InfluxDB client
         configured with the following credentials:
 
-        - **host**: InfluxDB Cloud Serverless region hostname (URL without protocol or trailing slash)
+        - **host**: {{% cloud-name %}} region hostname (URL without protocol or trailing slash)
         - **org**: an empty or arbitrary string (InfluxDB ignores this parameter)
-        - **token**: InfluxDB API token with write access to the target bucket
-        - **database**: InfluxDB Cloud Serverless bucket name
+        - **token**: an InfluxDB [API token](/influxdb/cloud-serverless/get-started/setup/#create-an-all-access-api-token) with write access to the target bucket
+        - **database**: the name of the {{% cloud-name %}} bucket to write to
     
     3.  Defines a list of line protocol strings where each string represents a data record.
     4.  Calls the `client.write()` method with the line protocol record list and write options.
@@ -479,7 +484,7 @@ dependencies to your current project.
         precision, the example passes the `write_precision='s'` option
         to set the timestamp precision to seconds.**
 
-6.  To execute the module and write line protocol to your InfluxDB Cloud Serverless
+6.  To execute the module and write line protocol to your {{% cloud-name %}}
     bucket, enter the following command in your terminal:
     
       ```sh
@@ -494,7 +499,7 @@ dependencies to your current project.
 <!----------------------------- BEGIN GO CONTENT ------------------------------>
 {{% influxdb/custom-timestamps %}}
 
-To write data to InfluxDB Cloud Serverless using Go, use the
+To write data to {{% cloud-name %}} using Go, use the
 [influxdb-client-go module](https://github.com/influxdata/influxdb-client-go).
 
 1.  Inside of your project directory, create a new module directory and navigate into it.
@@ -509,7 +514,7 @@ To write data to InfluxDB Cloud Serverless using Go, use the
     go mod init influxdb_go_client
     ```
 
-3. Create a file for your code--for example, `write.go`.
+3.  In your terminal or editor, create a new file for your code--for example: `write.go`.
 
     ```sh
     touch write.go
@@ -641,7 +646,7 @@ To write data to InfluxDB Cloud Serverless using Go, use the
     ```
 
 6.  To execute the module and write the line protocol
-    to your InfluxDB Cloud Serverless bucket, enter the following command:
+    to your {{% cloud-name %}} bucket, enter the following command:
 
     ```sh
     go run ./write.go
@@ -653,7 +658,7 @@ To write data to InfluxDB Cloud Serverless using Go, use the
 <!------------------------------- BEGIN NODE.JS CONTENT ----------------------->
 {{% influxdb/custom-timestamps %}}
 
-To write data to InfluxDB Cloud Serverless using Node.js, use the
+To write data to {{% cloud-name %}} using Node.js, use the
 [influxdb-client-js package](https://github.com/influxdata/influxdb-client-js).
 
 1. Inside of your project directory, create an NPM or Yarn package and install 
@@ -663,7 +668,7 @@ To write data to InfluxDB Cloud Serverless using Node.js, use the
     npm init -y && npm install --save @influxdata/influxdb-client
     ```
 
-2. Create a file for your code--for example: `write.js`.
+2.  In your terminal or editor, create a new file for your code--for example: `write.js`.
 
     ```sh
     touch write.js
@@ -770,7 +775,7 @@ To write data to InfluxDB Cloud Serverless using Node.js, use the
           The `close()` method sends any records remaining in the buffer,
           executes callbacks, and releases resources.
 
-4. To execute the file and write the line protocol to your InfluxDB Cloud Serverless bucket,
+4. To execute the file and write the line protocol to your {{% cloud-name %}} bucket,
     enter the following command in your terminal:
    
     ```sh

--- a/content/influxdb/cloud-serverless/query-data/tools/grafana.md
+++ b/content/influxdb/cloud-serverless/query-data/tools/grafana.md
@@ -1,10 +1,10 @@
 ---
 title: Use Grafana to query and visualize data
-seotitle: Use Grafana to query and visualize data stored in InfluxDB Cloud Serverless
+seotitle: Use Grafana to query and visualize data stored in InfluxDB
 list_title: Use Grafana
 description: >
   Install and run [Grafana](https://grafana.com/) to query and visualize data
-  stored in InfluxDB Cloud Serverless.
+  stored in InfluxDB.
 weight: 101
 menu:
   influxdb_cloud_serverless:
@@ -17,7 +17,7 @@ alt_engine: /influxdb/cloud/tools/grafana/
 ---
 
 Use [Grafana](https://grafana.com/) to query and visualize data stored in
-InfluxDB Cloud Serverless.
+{{% cloud-name %}}.
 Install the [grafana-flight-sql-plugin](https://github.com/influxdata/grafana-flightsql-datasource)
 to query InfluxDB with the Flight SQL protocol.
 
@@ -106,8 +106,8 @@ Grafana Cloud instance.
 5.  Add your connection credentials:
 
     - **Host**: Provide the host and port of your Flight SQL client.
-      For InfluxDB Cloud Serverless, this is your
-      [InfluxDB Cloud Serverless region domain](/influxdb/cloud-serverless/reference/regions/)
+      For {{% cloud-name %}}, this is your
+      [{{% cloud-name %}} region domain](/influxdb/cloud-serverless/reference/regions/)
       and port 443. For example:
 
       ```
@@ -115,12 +115,12 @@ Grafana Cloud instance.
       ```
 
     - **AuthType**: Select **token**.
-    - **Token**: Provide your InfluxDB API token with read access to the buckets
+    - **Token**: Provide an InfluxDB [API token](/influxdb/cloud-serverless/get-started/setup/#create-an-all-access-api-token) with read access to the buckets
       you want to query.
     - **Require TLS/SSL**: Enable this toggle.
 
 6.  Add connection **MetaData**.
-    InfluxDB Cloud Serverless requires _one_ of the following key-value pairs:
+    {{% cloud-name %}} requires _one_ of the following key-value pairs:
     
     - **Key**: `database`, **Value**: Bucket name
     - **Key**: `bucket-id`, **Value**: Bucket ID
@@ -134,7 +134,7 @@ Grafana Cloud instance.
 ## Query InfluxDB with Grafana
 
 After you [configure and save a FlightSQL datasource](#create-and-configure-a-flightsql-datasource),
-use Grafana to build, run, and inspect queries against InfluxDB buckets.
+use Grafana to build, run, and inspect queries against your InfluxDB bucket.
 
 {{% note %}}
 {{% sql/sql-schema-intro %}}

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/nodejs/install.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/nodejs/install.md
@@ -57,7 +57,7 @@ Follow these steps to initialize the TypeScript project:
 
 ## Install dependencies
 
-Use the `@influxdata/influxdb-client` JavaScript client library to write and query data in InfluxDB Cloud Serverless.
+Use the `@influxdata/influxdb-client` JavaScript client library to write and query data in {{% cloud-name %}}.
 
 Open a new terminal window and install the `@influxdata/influxdb-client` package for querying and writing data:
 
@@ -84,9 +84,9 @@ Set environment variables or update `env.js` with your InfluxDB [bucket](/influx
 
    Replace the following:
    
-   - *`API_TOKEN`*: InfluxDB API token with _write_ permission to the bucket.
-   - *`ORG_ID`*: InfluxDB organization ID
-   - *`BUCKET_NAME`*: the name of the InfluxDB Cloud Serverless bucket to write to
+   - *`API_TOKEN`*: InfluxDB [API token](/influxdb/cloud-serverless/get-started/setup/#create-an-all-access-api-token) with _write_ permission to the bucket.
+   - *`ORG_ID`*: InfluxDB [organization ID](/influxdb/cloud-serverless/admin/organizations/view-orgs/)
+   - *`BUCKET_NAME`*: the name of the {{% cloud-name %}} bucket to write to
 
 ## Next steps
 

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/python.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/python.md
@@ -23,39 +23,44 @@ If just getting started, see [Get started with InfluxDB](/influxdb/cloud-serverl
 
 ## Before you begin
 
+You'll need the following prerequisites:
+
 1. Install the InfluxDB Python library:
 
     ```sh
     pip install influxdb-client
     ```
 
-2. Visit your InfluxDB URL to ensure InfluxDB is running:
-   
-   ```http
-   http://localhost:8086
-   ```
+2. InfluxDB Cloud Serverless region URL using the HTTPS protocol--for example: https://cloud2.influxdata.com.
+3. InfluxDB [organization](/influxdb/cloud-serverless/admin/organizations/) ID.
+4. Name of the [bucket](/influxdb/cloud-serverless/admin/buckets/) to write to.
+5. InfluxDB [API token](/influxdb/cloud-serverless/reference/glossary/#token) with permission to write to the bucket.
+   _For security reasons, we recommend setting an environment variable to store your token and avoid exposing the raw token value in your script._
 
 ## Write data to InfluxDB with Python
 
-We are going to write some data in [line protocol](/influxdb/cloud-serverless/reference/syntax/line-protocol/) using the Python library.
+Follow the steps to write [line protocol](/influxdb/cloud-serverless/reference/syntax/line-protocol/) data to an InfluxDB Cloud Serverless bucket.
 
-1. In your Python program, import the InfluxDB client library and use it to write data to InfluxDB.
+1. In your editor, create a file for your Python program--for example: `write.py`.
+2. In the file, import the InfluxDB client library.
 
    ```python
    import influxdb_client
    from influxdb_client.client.write_api import SYNCHRONOUS
+   import os
    ```
 
-2. Define a few variables with the name of your [bucket](/influxdb/cloud-serverless/organizations/buckets/), [organization](/influxdb/cloud-serverless/organizations/), and [token](/influxdb/cloud-serverless/security/tokens/).
+3. Define variables for your [bucket name](/influxdb/cloud-serverless/admin/buckets/), [organization](/influxdb/cloud-serverless/admin/organizations/), and [token](/influxdb/cloud-serverless/reference/glossary/#token).
 
    ```python
-   bucket = "INFLUX_BUCKET"
+   bucket = "BUCKET_NAME"
    org = "INFLUX_ORG"
-   token = "INFLUX_TOKEN"
-   url="http://localhost:8086"
+   # INFLUX_TOKEN is an environment variable you created for your API WRITE token
+   token = os.getenv('INFLUX_TOKEN')
+   url="https://cloud2.influxdata.com"
    ```
 
-3. Instantiate the client. The `InfluxDBClient` object takes three named parameters: `url`, `org`, and `token`. Pass in the named parameters.
+4. To instantiate the client, call the `influxdb_client.InfluxDBClient()` method with the following keyword arguments: `url`, `org`, and `token`.
 
    ```python
    client = influxdb_client.InfluxDBClient(
@@ -66,13 +71,13 @@ We are going to write some data in [line protocol](/influxdb/cloud-serverless/re
    ```
     The `InfluxDBClient` object has a `write_api` method used for configuration.
 
-4. Instantiate a **write client** using the `client` object and the `write_api` method. Use the `write_api` method to configure the writer object.
+5. Instantiate a **write client** by calling the `client.write_api()` method with write configuration options.
 
    ```python
    write_api = client.write_api(write_options=SYNCHRONOUS)
    ```
 
-5. Create a [point](/influxdb/cloud-serverless/reference/glossary/#point) object and write it to InfluxDB using the `write` method of the API writer object. The write method requires three parameters: `bucket`, `org`, and `record`.
+6. Create a [point](/influxdb/cloud-serverless/reference/glossary/#point) object and write it to InfluxDB using the `write` method of the API writer object. The write method requires three parameters: `bucket`, `org`, and `record`.
 
    ```python
    p = influxdb_client.Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)
@@ -84,12 +89,13 @@ We are going to write some data in [line protocol](/influxdb/cloud-serverless/re
 ```python
 import influxdb_client
 from influxdb_client.client.write_api import SYNCHRONOUS
+import os
 
-bucket = "<my-bucket>"
-org = "<my-org>"
-token = "<my-token>"
-# Store the URL of your InfluxDB instance
-url="http://localhost:8086"
+bucket = "BUCKET_NAME"
+org = "INFLUX_ORG"
+# INFLUX_TOKEN is an environment variable you created for your API WRITE token
+token = os.getenv('INFLUX_TOKEN')
+url="https://cloud2.influxdata.com"
 
 client = influxdb_client.InfluxDBClient(
     url=url,
@@ -103,3 +109,7 @@ write_api = client.write_api(write_options=SYNCHRONOUS)
 p = influxdb_client.Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)
 write_api.write(bucket=bucket, org=org, record=p)
 ```
+
+## Query data from InfluxDB with Python
+
+To use query your InfluxDB Cloud Serverless bucket, use a Python [Flight SQL client with gRPC](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/).

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v3/python.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v3/python.md
@@ -1,22 +1,24 @@
 ---
 title: Python client library for InfluxDB v3
 list_title: Python
-description: The InfluxDB v3 `pyinflux3` Python client library integrates with Python scripts and applications and provides a standalone CLI to write and query data stored in an InfluxDB Cloud Serverless bucket.
-external_ur: https://github.com/InfluxCommunity/pyinflux3
+description: The InfluxDB v3 `influxdb3-python` Python client library integrates with Python scripts and applications to write and query data stored in an InfluxDB Cloud Serverless bucket.
+external_url: https://github.com/InfluxCommunity/influxdb3-python
 menu:
   influxdb_cloud_serverless:
     name: Python
     parent: v3 client libraries
-    identifier: pyinflux3
+    identifier: influxdb3-python
     params:
-      url: https://github.com/InfluxCommunity/pyinflux3
+      url: https://github.com/InfluxCommunity/influxdb3-python
 weight: 201
 influxdb/cloud-serverless/tags: [python, gRPC, SQL, Flight SQL, client libraries]
+aliases:
+  - /influxdb/cloud-serverless/reference/client-libraries/v3/pyinflux3/
 ---
 
-The InfluxDB v3 [`pyinflux3` Python client library](https://github.com/InfluxCommunity/pyinflux3) integrates with Python scripts and applications
- and provides a standalone CLI to write and query data stored in an InfluxDB Cloud Serverless bucket.
+The InfluxDB v3 [`influxdb3-python` Python client library](https://github.com/InfluxCommunity/influxdb3-python) integrates with Python scripts and applications
+to write and query data stored in an {{% cloud-name %}} bucket.
 
 The documentation for this client library is available on GitHub.
 
-<a href="https://github.com/InfluxCommunity/pyinflux3" target="_blank" class="btn github">pyinflux3 Python client library and CLI</a>
+<a href="https://github.com/InfluxCommunity/influxdb3-python" target="_blank" class="btn github">InfluxDB v3 Python client library</a>

--- a/content/influxdb/cloud-serverless/write-data/csv/telegraf.md
+++ b/content/influxdb/cloud-serverless/write-data/csv/telegraf.md
@@ -68,24 +68,26 @@ metrics from different sources and writes them to specified destinations.
 
 ## Configure Telegraf to write to InfluxDB
 
-1.  Add and enable the [`outputs.influxdb_v2`](/{{< latest "telegraf" >}}/plugins/#output-influxdb_v2)
-    plugin in your Telegraf configuration file.
-2.  Include the following options:
+To send data to {{< cloud-name >}}, enable the
+[`influxdb_v2` output plugin](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/influxdb_v2/README.md)
+in the `telegraf.conf`.
 
-    - **urls**: a list (`[]`) of
-      [InfluxDB Cloud Serverless region URLs](/influxdb/cloud-serverless/reference/regions/)
-      to write data to
-    - **token**: an InfluxDB API token with _write_ permission to the bucket
-    - **organization**: your InfluxDB organization name
-    - **bucket**: the name of the InfluxDB bucket to write to.
-
+{{% code-placeholders "BUCKET_NAME" %}}
 ```toml
 [[outputs.influxdb_v2]]
-  urls = ["http://localhost:8086"]
-  token = "{$INFLUX_TOKEN}"
-  organization = "example-org"
-  bucket = "example-bucket"
+  urls = ["https://cloud2.influxdata.com"]
+  # INFLUX_TOKEN is an environment variable you created for your API read token
+  token = "${INFLUX_TOKEN}"
+  organization = ""
+  bucket = "BUCKET_NAME"
 ```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- **`BUCKET_NAME`**: the name of the InfluxDB [bucket](/influxdb/cloud-serverless/admin/buckets/) to write data to
+
+To learn more about configuration options, see [Enable and configure the InfluxDB v2 output plugin](/influxdb/cloud-serverless/write-data/use-telegraf/configure/#enable-and-configure-the-influxdb-v2-output-plugin).
 
 {{< expand-wrapper >}}
 {{% expand "View full example Telegraf configuration file" %}}
@@ -115,10 +117,10 @@ metrics from different sources and writes them to specified destinations.
   csv_reset_mode = "none"
 
 [[outputs.influxdb_v2]]
-  urls = ["http://localhost:8086"]
+  urls = ["https://cloud2.influxdata.com"]
   token = "{$INFLUX_TOKEN}"
-  organization = "example-org"
-  bucket = "example-bucket"
+  organization = ""
+  bucket = "BUCKET_NAME"
 ```
 
 {{% /expand %}}
@@ -129,7 +131,7 @@ data to InfluxDB.
 
 #### Other Telegraf configuration options
 
-The preceding examples describe Telegraf configurations necessary for writing to InfluxDB Cloud Serverless.
+The preceding examples describe Telegraf configurations necessary for writing to {{% cloud-name %}}.
 The output plugin provides several other options for configuring the Telegraf client:
 
 - `influx_uint_support`: supported by the InfluxDB IOx storage engine.

--- a/content/influxdb/cloud-serverless/write-data/csv/telegraf.md
+++ b/content/influxdb/cloud-serverless/write-data/csv/telegraf.md
@@ -76,7 +76,7 @@ in the `telegraf.conf`.
 ```toml
 [[outputs.influxdb_v2]]
   urls = ["https://cloud2.influxdata.com"]
-  # INFLUX_TOKEN is an environment variable you created for your API read token
+  # INFLUX_TOKEN is an environment variable you created for your API WRITE token
   token = "${INFLUX_TOKEN}"
   organization = ""
   bucket = "BUCKET_NAME"
@@ -119,7 +119,7 @@ To learn more about configuration options, see [Enable and configure the InfluxD
 
 [[outputs.influxdb_v2]]
   urls = ["https://cloud2.influxdata.com"]
-  # INFLUX_TOKEN is an environment variable you created for your API read token
+  # INFLUX_TOKEN is an environment variable you created for your API WRITE token
   token = "{$INFLUX_TOKEN}"
   organization = ""
   bucket = "BUCKET_NAME"

--- a/content/influxdb/cloud-serverless/write-data/csv/telegraf.md
+++ b/content/influxdb/cloud-serverless/write-data/csv/telegraf.md
@@ -1,5 +1,5 @@
 ---
-title: Use Telegraf to write CSV data to InfluxDB Cloud Serverless
+title: Use Telegraf to write CSV data to InfluxDB
 description: >
   Use the Telegraf `file` input plugin to read and parse CSV data into
   [line protocol](/influxdb/cloud-serverless/reference/syntax/line-protocol/)
@@ -92,6 +92,7 @@ To learn more about configuration options, see [Enable and configure the InfluxD
 {{< expand-wrapper >}}
 {{% expand "View full example Telegraf configuration file" %}}
 
+{{% code-placeholders "BUCKET_NAME" %}}
 ```toml
 [[inputs.file]]
   files = ["/path/to/example.csv"]
@@ -118,10 +119,19 @@ To learn more about configuration options, see [Enable and configure the InfluxD
 
 [[outputs.influxdb_v2]]
   urls = ["https://cloud2.influxdata.com"]
+  # INFLUX_TOKEN is an environment variable you created for your API read token
   token = "{$INFLUX_TOKEN}"
   organization = ""
   bucket = "BUCKET_NAME"
+  content_encoding = "gzip"
 ```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- **`BUCKET_NAME`**: the name of the InfluxDB [bucket](/influxdb/cloud-serverless/admin/buckets/) to write data to
+
+**`INFLUX_TOKEN`** is an environment variable you created in the [Setup instructions](/influxdb/cloud-serverless/get-started/setup/?t=Telegraf) of the Get Started tutorial.
 
 {{% /expand %}}
 {{< /expand-wrapper >}}

--- a/content/influxdb/cloud-serverless/write-data/use-telegraf/configure/_index.md
+++ b/content/influxdb/cloud-serverless/write-data/use-telegraf/configure/_index.md
@@ -74,6 +74,7 @@ in the `telegraf.conf`.
 ```toml
 [[outputs.influxdb_v2]]
   urls = ["https://cloud2.influxdata.com"]
+  # INFLUX_TOKEN is an environment variable you created for your database READ token
   token = "${INFLUX_TOKEN}"
   organization = ""
   bucket = "get-started"

--- a/content/influxdb/cloud-serverless/write-data/use-telegraf/configure/_index.md
+++ b/content/influxdb/cloud-serverless/write-data/use-telegraf/configure/_index.md
@@ -22,7 +22,7 @@ aliases:
 
 Use the Telegraf `influxdb_v2` output plugin to collect and write metrics to
 {{< cloud-name >}}.
-Learn how to enable the `influxdb_v2` output plugin in new and
+Learn how to enable the plugin in new and
 existing Telegraf configurations,
 and then start Telegraf using the custom configuration file.
 
@@ -71,21 +71,27 @@ To send data to {{< cloud-name >}}, enable the
 [`influxdb_v2` output plugin](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/influxdb_v2/README.md)
 in the `telegraf.conf`.
 
+{{% code-placeholders "BUCKET_NAME" %}}
 ```toml
 [[outputs.influxdb_v2]]
   urls = ["https://cloud2.influxdata.com"]
-  # INFLUX_TOKEN is an environment variable you created for your database READ token
+  # INFLUX_TOKEN is an environment variable you created for your API WRITE token
   token = "${INFLUX_TOKEN}"
   organization = ""
-  bucket = "get-started"
+  bucket = "BUCKET_NAME"
 ```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- **`BUCKET_NAME`**: the name of the InfluxDB [bucket](/influxdb/cloud-serverless/admin/buckets/) to write data to
 
 The InfluxDB output plugin configuration contains the following options:
 
 ##### urls
 
 An array of URL strings.
-To write to InfluxDB Cloud Serverless, include your InfluxDB Cloud Serverless region URL using the HTTPS protocol:
+To write to {{% cloud-name %}}, include your {{% cloud-name %}} region URL using the HTTPS protocol:
 
 ```toml
 ["https://cloud2.influxdata.com"]
@@ -93,7 +99,7 @@ To write to InfluxDB Cloud Serverless, include your InfluxDB Cloud Serverless re
 
 ##### token
 
-Your InfluxDB Cloud Serverless [API token](/influxdb/cloud-serverless/admin/tokens/) with _write_ permission to the database.
+Your {{% cloud-name %}} [API token](/influxdb/cloud-serverless/admin/tokens/) with _write_ permission to the database.
 
 In the examples, `INFLUX_TOKEN` is an environment variable assigned to a [API token](/influxdb/cloud-serverless/admin/tokens/) that has _write_ permission to the database.
 
@@ -103,15 +109,13 @@ For {{% cloud-name %}}, set this to an empty string (`""`).
 
 ##### bucket
 
-The name of the InfluxDB Cloud Serverless bucket to write data to.
-
-In the example, **`INFLUX_DATABASE`** is an environment variable assigned to the [database](/influxdb/cloud-serverless/admin/databases/) name.
+The name of the {{% cloud-name %}} bucket to write data to.
 
 {{% note %}}
 ##### Write to InfluxDB v1.x and {{< cloud-name >}}
 
 If a Telegraf agent is already writing to an InfluxDB v1.x database,
-enabling the InfluxDB v2 output plugin will write data to both v1.x and your {{< cloud-name >}} cluster.
+enabling the InfluxDB v2 output plugin will write data to both v1.x and your {{< cloud-name >}} bucket.
 {{% /note %}}
 
 ## Start Telegraf


### PR DESCRIPTION
Closes #4965 

- Updates package name, repo name + URL, module name, and CLI name for the v3 python client library.
- Corrections in telegraf docs and alignment of Dedicated and Serverless
- Cleanup and use `cloud-name` shortcode in other client docs.
