### PR TITLE
Add Tableau documentation to Cloud Dedicated

### DIFF
--- a/assets/js/influxdb-url.js
+++ b/assets/js/influxdb-url.js
@@ -206,7 +206,7 @@ function updateUrls(prevUrls, newUrls) {
 
   replacements.forEach(function (o) {
     if (o.replace.origin != o.with.origin) {
-      var fuzzyOrigin = new RegExp(o.replace.origin + "(:[0-9]+)?", "g");
+      var fuzzyOrigin = new RegExp(o.replace.origin + "(:(^443)|[0-9]+)?", "g");
       $(elementSelector).each(function() {
         $(this).html(
           $(this).html().replace(fuzzyOrigin, function(m){

--- a/content/influxdb/cloud-dedicated/query-data/sql/execute-queries/tableau.md
+++ b/content/influxdb/cloud-dedicated/query-data/sql/execute-queries/tableau.md
@@ -1,0 +1,105 @@
+---
+title: Use Tableau to query data with SQL
+seotitle: Use Tableau to query data stored in InfluxDB Cloud Dedicated
+description: >
+  Install and use [Tableau](https://www.tableau.com/) to query data stored in InfluxDB.
+weight: 401
+menu:
+  influxdb_cloud_dedicated:
+    parent: sql-execute-queries
+    name: Use Tableau
+    identifier: query-with-tableau
+influxdb/cloud-dedicated/tags: [query, flightsql, tableau, sql]
+aliases:
+  - /influxdb/cloud-dedicated/query-data/execute-queries/flight-sql/superset/
+  - /influxdb/cloud-dedicated/visualize-data/superset/
+---
+
+Use [Tableau](https://www.tableau.com/) to query and visualize time series data
+stored in {{< cloud-name >}}. Tableau supports multiple SQL dialects.
+
+> Tableau is a visual analytics platform transforming the way we use data to
+> solve problems—empowering people and organizations to make the most of their data.
+>
+> {{% cite %}}[tableau.com](https://www.tableau.com/why-tableau/what-is-tableau){{% /cite %}}
+
+{{% note %}}
+#### Tableau Desktop
+
+These instructions are for **Tableau Desktop**.
+Tableau Cloud and other Tableau products have not been tested, but may support
+connecting to {{< cloud-name >}} through the **Flight SQL JDBC driver**.
+{{% /note %}}
+
+## Install Tableau Desktop
+
+If you have not already, [download and install Tableau Desktop](https://www.tableau.com/products/desktop/download).
+
+## Download and install the Flight SQL JDBC driver
+
+To query {{< cloud-name >}} from Tableau, use the **Flight SQL protocol** and the
+**Flight SQL JDBC driver**.
+
+1.  **Download the Flight SQL JDBC driver.**
+    1.  Visit the [Flight SQL JDBC driver](https://central.sonatype.com/artifact/org.apache.arrow/flight-sql-jdbc-driver/) page.
+    2.  Select the **Versions** tab.
+    3.  Click **Browse {{< icon "export" >}}** next to the version you want to
+        download.
+    4.  Click the `flight-sql-jdbc-driver-XX.XX.XX.jar` file
+        (with only the `.jar` file extension) from the list of files
+        to download the driver jar file.
+        The version number in the file name is specific to the version you selected.
+
+2.  **Copy the downloaded jar file into the following directory based on your operating system.**
+  
+    - **Windows**: `C:\Program Files\Tableau\Drivers`
+    - **Mac**: `~/Library/Tableau/Drivers`
+    - **Linux**: `/opt/tableau/tableau_driver/jdbc`
+
+3.  **Start or restart Tableau.**
+
+## Configure a JDBC server connection
+
+1.  Open Tableau
+2.  In the **Connect** column, under **To a Server**, select **Other Databases (JDBC)**.
+    If that option isn't in the initial list, select **More...** to find it in
+    all the connection options.
+3.  Provide the required credentials:
+
+    - **URL**: Your **InfluxDB Cloud Dedicated cluster URL** with the following:
+
+      - **Protocol**: `jdbc:arrow-flight-sql`
+      - **Port**: `443`
+      - **Query parameters**:
+        - **disableCertificateVerification**: `true`
+        - **database**: InfluxDB database name to query
+    
+      _See an [example connection URL](#example-connection-url)._
+    
+    - **Dialect**: PostreSQL
+    - **Username**: _Leave empty_
+    - **Password**: [Database token](/influxdb/cloud-dedicated/admin/tokens/)
+      with read access to the specified database
+    - **Properties File**: _Leave empty_
+
+4.  Click **Sign In**.
+
+#### Example connection URL
+
+{{< code-placeholders "DATABASE_NAME" >}}
+```
+jdbc:arrow-flight-sql://cluster-id.influxdb.io:443?disableCertificateVerification=true&database=DATABASE_NAME
+```
+{{< /code-placeholders >}}
+
+## Query InfluxDB Cloud Dedicated
+
+With the connection successfully established, query your time series data stored
+in {{< cloud-name >}}. In the left pane:
+
+1.  Under **Database**, select **public** from the drop-down menu.
+2.  Under **Schema**, select **iox** from the drop-down menu.
+3.  Under **Table**, click and drag the measurement you want to query into the query pane.
+4.  Use Tableau to build and execute SQL queries.
+    For more information, see the
+    [Tableau Desktop documentation](https://help.tableau.com/current/pro/desktop/en-us/default.htm).


### PR DESCRIPTION
Closes #4950

Adds Tableau documentation to the InfluxDB Cloud Dedicated docs. Once this is reviewed, I'll port the content into Serverless.

- [x] Rebased/mergeable
