### PR TITLE
feat: improve delete predicate keyword escaping requirements

### DIFF
--- a/content/influxdb/v2.7/reference/syntax/delete-predicate.md
+++ b/content/influxdb/v2.7/reference/syntax/delete-predicate.md
@@ -37,12 +37,15 @@ key1="value1" AND key2="value"
 If your predicate contains keywords or strings with special characters, wrap each in escaped
 quotes to ensure the predicate string is parsed correctly.
 
+Because delete predicates follow [InfluxQL](/influxdb/v2.7/reference/syntax/influxql) syntax, [any InfluxQL keyword](/influxdb/v2.7/reference/syntax/influxql/spec/#keywords)
+that matches your tag name needs to be escaped. Keywords are case-insensitive.
+
 ```js
 // Escaped due to the "-"
 "_measurement=\"example-dash\""
 
-// Escaped because "name" is a keyword
-"_measurement=example and \"name\"=predicate"
+// Escaped because "Name" is a keyword
+"_measurement=example and \"Name\"=predicate"
 ```
 {{% /note %}}
 
@@ -116,4 +119,4 @@ The delete predicate syntax has the following limitations.
 - Delete predicates only support equality (`=`), not inequality (`!=`).
 - Delete predicates can use any column or tag **except** `_time`
   {{% oss-only %}}, `_field`, {{% /oss-only %}}or `_value`.
-  
+


### PR DESCRIPTION
Delete predicates are parsed by the influxql parser. Therefore, any influxql keywords that match a tag name need to be escaped with double quotes. The keyword matching is case-insensitive but tag name matching for the delete predicate is case-sensitive.

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
