### PR TITLE
Remove references to InfluxDB Aware as we no longer offer it.

### DIFF
--- a/content/enterprise_influxdb/v1.10/administration/monitor/_index.md
+++ b/content/enterprise_influxdb/v1.10/administration/monitor/_index.md
@@ -19,10 +19,8 @@ do one of the following:
 - [Use InfluxQL for diagnostics](/enterprise_influxdb/v1.10/administration/monitor/diagnostics/)
 
 {{% note %}}
-### Monitor with InfluxDB Aware and Influx Insights
-InfluxDB Aware and Influx Insights is a free Enterprise service that sends your data to a free Cloud account.
-Aware assists you in monitoring your data by yourself.
-Insights assists you in monitoring your data with the help of the support team.
+### Monitor with InfluxDB Insights
+For InfluxDB Enterprise customers, Insights is a free services that can monitor your cluster. InfluxDB Insights sends monitoring metrics for your cluster to a private Cloud account. This allows the support team to monitor your cluster health as well as making resource usage statistics available to assist with support tickets that you raise.
 
 To apply for this service, please contact the [support team](https://support.influxdata.com/s/login/).
 {{% /note %}}

--- a/content/enterprise_influxdb/v1.10/administration/monitor/_index.md
+++ b/content/enterprise_influxdb/v1.10/administration/monitor/_index.md
@@ -20,7 +20,7 @@ do one of the following:
 
 {{% note %}}
 ### Monitor with InfluxDB Insights
-For InfluxDB Enterprise customers, Insights is a free services that can monitor your cluster. InfluxDB Insights sends monitoring metrics for your cluster to a private Cloud account. This allows the support team to monitor your cluster health as well as making resource usage statistics available to assist with support tickets that you raise.
+For InfluxDB Enterprise customers, Insights is a free service that monitors your cluster and sends metrics to a private Cloud account. This allows InfluxDB Support to monitor your cluster health and access usage statistics when assisting with support tickets that you raise.
 
 To apply for this service, please contact the [support team](https://support.influxdata.com/s/login/).
 {{% /note %}}

--- a/content/enterprise_influxdb/v1.10/administration/monitor/monitor-with-cloud.md
+++ b/content/enterprise_influxdb/v1.10/administration/monitor/monitor-with-cloud.md
@@ -180,6 +180,6 @@ Send a notification to PagerDuty or HTTP endpoints (other webhooks) by [upgradin
 
 ## Monitor with InfluxDB Insights
 
-For InfluxDB Enterprise customers, Insights is a free services that can monitor your cluster. InfluxDB Insights sends monitoring metrics for your cluster to a private Cloud account. This allows the support team to monitor your cluster health as well as making resource usage statistics available to assist with support tickets that you raise.
+For InfluxDB Enterprise customers, Insights is a free service that monitors your cluster and sends metrics to a private Cloud account. This allows InfluxDB Support to monitor your cluster health and access usage statistics when assisting with support tickets that you raise.
 
 To apply for this service, please contact the [InfluxData Support team](mailto:support@influxdata.com). 

--- a/content/enterprise_influxdb/v1.10/administration/monitor/monitor-with-cloud.md
+++ b/content/enterprise_influxdb/v1.10/administration/monitor/monitor-with-cloud.md
@@ -23,7 +23,7 @@ Do the following:
 5. [View the Monitoring dashboard](#view-the-monitoring-dashboard)
 6. (Optional) [Alert when metrics stop reporting](#alert-when-metrics-stop-reporting)
 7. (Optional) [Create a notification endpoint and rule](#create-a-notification-endpoint-and-rule)
-8. (Optional) [Monitor with InfluxDB Insights and Aware](#monitor-with-influxdb-insights-and-aware)
+8. (Optional) [Monitor with InfluxDB Insights](#monitor-with-influxdb-insights)
 
 ## Review requirements
 
@@ -178,8 +178,8 @@ Send a notification to PagerDuty or HTTP endpoints (other webhooks) by [upgradin
 1. Go to **Alerts > Notification Rules** and click **{{< icon "plus" "v2" >}} Create**. 
 2. Fill out the **About** and **Conditions** section then click **Create Notification Rule**. 
 
-## Monitor with InfluxDB Insights and Aware 
+## Monitor with InfluxDB Insights
 
-For InfluxDB Enterprise customers, Insights and Aware are free services that can monitor your data. InfluxDB Insights sends your data to a private Cloud account and will be monitored with the help of the support team. InfluxDB Aware is a similar service, but you monitor your data yourself. 
+For InfluxDB Enterprise customers, Insights is a free services that can monitor your cluster. InfluxDB Insights sends monitoring metrics for your cluster to a private Cloud account. This allows the support team to monitor your cluster health as well as making resource usage statistics available to assist with support tickets that you raise.
 
 To apply for this service, please contact the [InfluxData Support team](mailto:support@influxdata.com). 

--- a/content/enterprise_influxdb/v1.10/administration/monitor/monitor-with-oss.md
+++ b/content/enterprise_influxdb/v1.10/administration/monitor/monitor-with-oss.md
@@ -25,7 +25,7 @@ Do the following:
 5. [View the Monitoring dashboard](#view-the-monitoring-dashboard)
 6. (Optional) [Alert when metrics stop reporting](#alert-when-metrics-stop-reporting)
 7. (Optional) [Create a notification endpoint and rule](#create-a-notification-endpoint-and-rule)
-8. (Optional) [Monitor with InfluxDB Insights and Aware](#monitor-with-influxdb-insights-and-aware)
+8. (Optional) [Monitor with InfluxDB Insights](/enterprise_influxdb/v1.10/administration/monitor-enterprise/monitor-with-oss/#monitor-with-influxdb-insights)
 
 ## Review requirements
 

--- a/content/enterprise_influxdb/v1.9/administration/monitor/_index.md
+++ b/content/enterprise_influxdb/v1.9/administration/monitor/_index.md
@@ -20,7 +20,7 @@ do one of the following:
 
 {{% note %}}
 ### Monitor with InfluxDB Insights
-For InfluxDB Enterprise customers, Insights is a free services that can monitor your cluster. InfluxDB Insights sends monitoring metrics for your cluster to a private Cloud account. This allows the support team to monitor your cluster health as well as making resource usage statistics available to assist with support tickets that you raise.
+For InfluxDB Enterprise customers, Insights is a free service that monitors your cluster and sends metrics to a private Cloud account. This allows InfluxDB Support to monitor your cluster health and access usage statistics when assisting with support tickets that you raise.
 
 To apply for this service, please contact the [support team](https://support.influxdata.com/s/login/).
 {{% /note %}}

--- a/content/enterprise_influxdb/v1.9/administration/monitor/_index.md
+++ b/content/enterprise_influxdb/v1.9/administration/monitor/_index.md
@@ -19,10 +19,8 @@ do one of the following:
 - [Use InfluxQL for diagnostics](/enterprise_influxdb/v1.9/administration/monitor/diagnostics/)
 
 {{% note %}}
-### Monitor with InfluxDB Aware and Influx Insights
-InfluxDB Aware and Influx Insights is a free Enterprise service that sends your data to a free Cloud account.
-Aware assists you in monitoring your data by yourself.
-Insights assists you in monitoring your data with the help of the support team.
+### Monitor with InfluxDB Insights
+For InfluxDB Enterprise customers, Insights is a free services that can monitor your cluster. InfluxDB Insights sends monitoring metrics for your cluster to a private Cloud account. This allows the support team to monitor your cluster health as well as making resource usage statistics available to assist with support tickets that you raise.
 
 To apply for this service, please contact the [support team](https://support.influxdata.com/s/login/).
 {{% /note %}}

--- a/content/enterprise_influxdb/v1.9/administration/monitor/monitor-with-cloud.md
+++ b/content/enterprise_influxdb/v1.9/administration/monitor/monitor-with-cloud.md
@@ -180,6 +180,6 @@ Send a notification to PagerDuty or HTTP endpoints (other webhooks) by [upgradin
 
 ## Monitor with InfluxDB Insights
 
-For InfluxDB Enterprise customers, Insights is a free services that can monitor your cluster. InfluxDB Insights sends monitoring metrics for your cluster to a private Cloud account. This allows the support team to monitor your cluster health as well as making resource usage statistics available to assist with support tickets that you raise.
+For InfluxDB Enterprise customers, Insights is a free service that monitors your cluster and sends metrics to a private Cloud account. This allows InfluxDB Support to monitor your cluster health and access usage statistics when assisting with support tickets that you raise.
 
 To apply for this service, please contact the [InfluxData Support team](mailto:support@influxdata.com). 

--- a/content/enterprise_influxdb/v1.9/administration/monitor/monitor-with-cloud.md
+++ b/content/enterprise_influxdb/v1.9/administration/monitor/monitor-with-cloud.md
@@ -23,7 +23,7 @@ Do the following:
 5. [View the Monitoring dashboard](#view-the-monitoring-dashboard)
 6. (Optional) [Alert when metrics stop reporting](#alert-when-metrics-stop-reporting)
 7. (Optional) [Create a notification endpoint and rule](#create-a-notification-endpoint-and-rule)
-8. (Optional) [Monitor with InfluxDB Insights and Aware](#monitor-with-influxdb-insights-and-aware)
+8. (Optional) [Monitor with InfluxDB Insights](#monitor-with-influxdb-insights)
 
 ## Review requirements
 
@@ -178,8 +178,8 @@ Send a notification to PagerDuty or HTTP endpoints (other webhooks) by [upgradin
 1. Go to **Alerts > Notification Rules** and click **{{< icon "plus" "v2" >}} Create**. 
 2. Fill out the **About** and **Conditions** section then click **Create Notification Rule**. 
 
-## Monitor with InfluxDB Insights and Aware 
+## Monitor with InfluxDB Insights
 
-For InfluxDB Enterprise customers, Insights and Aware are free services that can monitor your data. InfluxDB Insights sends your data to a private Cloud account and will be monitored with the help of the support team. InfluxDB Aware is a similar service, but you monitor your data yourself. 
+For InfluxDB Enterprise customers, Insights is a free services that can monitor your cluster. InfluxDB Insights sends monitoring metrics for your cluster to a private Cloud account. This allows the support team to monitor your cluster health as well as making resource usage statistics available to assist with support tickets that you raise.
 
 To apply for this service, please contact the [InfluxData Support team](mailto:support@influxdata.com). 

--- a/content/enterprise_influxdb/v1.9/administration/monitor/monitor-with-oss.md
+++ b/content/enterprise_influxdb/v1.9/administration/monitor/monitor-with-oss.md
@@ -25,7 +25,7 @@ Do the following:
 5. [View the Monitoring dashboard](#view-the-monitoring-dashboard)
 6. (Optional) [Alert when metrics stop reporting](#alert-when-metrics-stop-reporting)
 7. (Optional) [Create a notification endpoint and rule](#create-a-notification-endpoint-and-rule)
-8. (Optional) [Monitor with InfluxDB Insights and Aware](#monitor-with-influxdb-insights-and-aware)
+8. (Optional) [Monitor with InfluxDB Insights](/enterprise_influxdb/v1.9/administration/monitor-enterprise/monitor-with-cloud/#monitor-with-influxdb-insights)
 
 ## Review requirements
 

--- a/content/influxdb/cloud/influxdb-templates/monitor-enterprise.md
+++ b/content/influxdb/cloud/influxdb-templates/monitor-enterprise.md
@@ -179,6 +179,6 @@ Send a notification to PagerDuty or HTTP endpoints (other webhooks) by [upgradin
 
 ## Monitor with InfluxDB Insights
 
-For InfluxDB Enterprise customers, Insights is a free services that can monitor your cluster. InfluxDB Insights sends monitoring metrics for your cluster to a private Cloud account. This allows the support team to monitor your cluster health as well as making resource usage statistics available to assist with support tickets that you raise.
+For InfluxDB Enterprise customers, Insights is a free service that monitors your cluster and sends metrics to a private Cloud account. This allows InfluxDB Support to monitor your cluster health and access usage statistics when assisting with support tickets that you raise.
 
 To apply for this service, contact [InfluxData Support](https://support.influxdata.com/).

--- a/content/influxdb/cloud/influxdb-templates/monitor-enterprise.md
+++ b/content/influxdb/cloud/influxdb-templates/monitor-enterprise.md
@@ -22,7 +22,7 @@ Do the following:
 5. [View the Monitoring dashboard](#view-the-monitoring-dashboard)
 6. (Optional) [Alert when metrics stop reporting](#alert-when-metrics-stop-reporting)
 7. (Optional) [Create a notification endpoint and rule](#create-a-notification-endpoint-and-rule)
-8. (Optional) [Monitor with InfluxDB Insights and Aware](#monitor-with-influxdb-insights-and-aware)
+8. (Optional) [Monitor with InfluxDB Insights](#monitor-with-influxdb-insights)
 
 ## Review requirements
 
@@ -177,8 +177,8 @@ Send a notification to PagerDuty or HTTP endpoints (other webhooks) by [upgradin
 1. Go to **Alerts > Notification Rules** and click **{{< icon "plus" >}} Create**. 
 2. Fill out the **About** and **Conditions** section then click **Create Notification Rule**. 
 
-## Monitor with InfluxDB Insights and Aware 
+## Monitor with InfluxDB Insights
 
-For InfluxDB Enterprise customers, Insights and Aware are free services that can monitor your data. InfluxDB Insights sends your data to a private Cloud account and will be monitored with the help of the support team. InfluxDB Aware is a similar service, but you monitor your data yourself. 
+For InfluxDB Enterprise customers, Insights is a free services that can monitor your cluster. InfluxDB Insights sends monitoring metrics for your cluster to a private Cloud account. This allows the support team to monitor your cluster health as well as making resource usage statistics available to assist with support tickets that you raise.
 
 To apply for this service, please contact the [InfluxData Support team](mailto:support@influxdata.com).


### PR DESCRIPTION
InfluxDB Aware was a free service that we previously offered, allowing enterprise customers to write monitoring metrics into a free Cloud2 account.

However, its operation relied on functionality (dashboards and template import) which is no longer available.


- [x ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [X ] Rebased/mergeable (see note in comments)
