### PR TITLE
Fix csv examples

### DIFF
--- a/content/influxdb/cloud-serverless/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/cloud-serverless/reference/syntax/annotated-csv/_index.md
@@ -163,9 +163,9 @@ Time column values should be **Unix nanosecond timestamps**, **RFC3339**, or **R
 ##### Example line protocol elements in datatype annotation
 
 ```
-#group,false,false,false,false,false,false,false
-#datatype,measurement,tag,tag,field,field,ignored,time
-#default,,,,,,,
+#group false,false,false,false,false,false,false
+#datatype measurement,tag,tag,field,field,ignored,time
+#default ,,,,,,
 m,cpu,host,time_steal,usage_user,nothing,time
 cpu,cpu1,host1,0,2.7,a,1482669077000000000
 cpu,cpu1,host2,0,2.2,b,1482669087000000000

--- a/content/influxdb/cloud-serverless/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/cloud-serverless/reference/syntax/annotated-csv/_index.md
@@ -184,9 +184,9 @@ cpu,cpu=cpu1,host=host2 time_steal=0,usage_user=2.2 1482669087000000000
 #group,false,false,false,false,false,false,false,false,false
 #datatype,measurement,tag,string,double,boolean,long,unsignedLong,duration,dateTime
 #default,test,annotatedDatatypes,,,,,,
-m,name,s,d,b,l,ul,dur,time
-,,str1,1.0,true,1,1,1ms,1
-,,str2,2.0,false,2,2,2us,2020-01-11T10:10:10Z
+,m,name,s,d,b,l,ul,dur,time
+,,,str1,1.0,true,1,1,1ms,1
+,,,str2,2.0,false,2,2,2us,2020-01-11T10:10:10Z
 ```
 
 Resulting line protocol:

--- a/content/influxdb/cloud-serverless/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/cloud-serverless/reference/syntax/annotated-csv/_index.md
@@ -49,10 +49,11 @@ A table may have the following rows and columns.
 
 In addition to the data columns, a table may include the following columns:
 
-- **Annotation column**: Only used in annotation rows. Always the first column.
-  Displays the name of an annotation. Value can be empty or a supported [annotation](#annotations).
-  You'll notice a space for this column for the entire length of the table,
-  so rows appear to start with `,`.
+- **Annotation column**: Displays the name of an annotation.
+  Only used in annotation rows and is always the first column.
+  Value can be empty or a supported [annotation](#annotations).
+  The response format uses a comma (`,`) to separate an annotation name from values in the row.
+  To account for this, rows in the table start with a leading comma; you'll notice an empty column for the entire length of the table.
 
 - **Result column**: Contains the name of the result specified by the query.
 

--- a/content/influxdb/cloud-serverless/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/cloud-serverless/reference/syntax/annotated-csv/_index.md
@@ -178,7 +178,7 @@ cpu,cpu=cpu1,host=host1 time_steal=0,usage_user=2.7 1482669077000000000
 cpu,cpu=cpu1,host=host2 time_steal=0,usage_user=2.2 1482669087000000000
 ```
 
-##### Example of mixing data types line protocol elements
+##### Example of mixing data types and line protocol elements
 
 ```
 #group,false,false,false,false,false,false,false,false,false

--- a/content/influxdb/v2.0/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/write/_index.md
@@ -207,7 +207,7 @@ influx write \
   --bucket example-bucket \
   --format csv \
   "#constant measurement,sensorData
-#datatype,datetime:RFC3339,double
+#datatype dateTime:RFC3339,double
 time,temperature
 2020-12-18T18:16:11Z,72.7
 2020-12-18T18:16:21Z,73.8

--- a/content/influxdb/v2.0/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.0/reference/syntax/annotated-csv/_index.md
@@ -79,10 +79,11 @@ my-result,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,east,
 
 In addition to the data columns, a table may include the following columns:
 
-- **Annotation column**: Only used in annotation rows. Always the first column.
-  Displays the name of an annotation. Value can be empty or a supported [annotation](#annotations).
-  You'll notice a space for this column for the entire length of the table,
-  so rows appear to start with `,`.
+- **Annotation column**: Displays the name of an annotation.
+  Only used in annotation rows and is always the first column.
+  Value can be empty or a supported [annotation](#annotations).
+  The response format uses a comma (`,`) to separate an annotation name from values in the row.
+  To account for this, rows in the table start with a leading comma; you'll notice an empty column for the entire length of the table.
 
 - **Result column**: Contains the name of the result specified by the query.
 

--- a/content/influxdb/v2.0/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.0/reference/syntax/annotated-csv/_index.md
@@ -163,6 +163,8 @@ Subsequent columns contain annotation values as shown in the table below.
 | **default**     | a value of the column's data type                                              | Value to use for rows with an empty value.                                       |
 
 
+Some tools might use or require a comma (`,`) to separate the annotation name from values in an annotation row.
+
 {{% note %}}
 To encode a table with its [group key](/influxdb/v2.0/reference/glossary/#group-key),
 the `datatype`, `group`, and `default` annotations must be included.

--- a/content/influxdb/v2.0/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.0/reference/syntax/annotated-csv/_index.md
@@ -228,7 +228,7 @@ cpu,cpu=cpu1,host=host1 time_steal=0,usage_user=2.7 1482669077000000000
 cpu,cpu=cpu1,host=host2 time_steal=0,usage_user=2.2 1482669087000000000
 ```
 
-##### Example of mixing data types line protocol elements
+##### Example of mixing data types and line protocol elements
 ```
 #datatype measurement,tag,string,double,boolean,long,unsignedLong,duration,dateTime
 #default test,annotatedDatatypes,,,,,,

--- a/content/influxdb/v2.1/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.1/reference/cli/influx/write/_index.md
@@ -209,7 +209,7 @@ influx write \
   --bucket example-bucket \
   --format csv \
   "#constant measurement,sensorData
-#datatype,datetime:RFC3339,double
+#datatype dateTime:RFC3339,double
 time,temperature
 2020-12-18T18:16:11Z,72.7
 2020-12-18T18:16:21Z,73.8

--- a/content/influxdb/v2.1/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.1/reference/syntax/annotated-csv/_index.md
@@ -79,10 +79,11 @@ my-result,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,east,
 
 In addition to the data columns, a table may include the following columns:
 
-- **Annotation column**: Only used in annotation rows. Always the first column.
-  Displays the name of an annotation. Value can be empty or a supported [annotation](#annotations).
-  You'll notice a space for this column for the entire length of the table,
-  so rows appear to start with `,`.
+- **Annotation column**: Displays the name of an annotation.
+  Only used in annotation rows and is always the first column.
+  Value can be empty or a supported [annotation](#annotations).
+  The response format uses a comma (`,`) to separate an annotation name from values in the row.
+  To account for this, rows in the table start with a leading comma; you'll notice an empty column for the entire length of the table.
 
 - **Result column**: Contains the name of the result specified by the query.
 

--- a/content/influxdb/v2.1/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.1/reference/syntax/annotated-csv/_index.md
@@ -163,6 +163,8 @@ Subsequent columns contain annotation values as shown in the table below.
 | **default**     | a value of the column's data type                                              | Value to use for rows with an empty value.                                       |
 
 
+Some tools might use or require a comma (`,`) to separate the annotation name from values in an annotation row.
+
 {{% note %}}
 To encode a table with its [group key](/influxdb/v2.1/reference/glossary/#group-key),
 the `datatype`, `group`, and `default` annotations must be included.

--- a/content/influxdb/v2.1/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.1/reference/syntax/annotated-csv/_index.md
@@ -228,7 +228,7 @@ cpu,cpu=cpu1,host=host1 time_steal=0,usage_user=2.7 1482669077000000000
 cpu,cpu=cpu1,host=host2 time_steal=0,usage_user=2.2 1482669087000000000
 ```
 
-##### Example of mixing data types line protocol elements
+##### Example of mixing data types and line protocol elements
 ```
 #datatype measurement,tag,string,double,boolean,long,unsignedLong,duration,dateTime
 #default test,annotatedDatatypes,,,,,,

--- a/content/influxdb/v2.2/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.2/reference/cli/influx/write/_index.md
@@ -209,7 +209,7 @@ influx write \
   --bucket example-bucket \
   --format csv \
   "#constant measurement,sensorData
-#datatype,datetime:RFC3339,double
+#datatype dateTime:RFC3339,double
 time,temperature
 2020-12-18T18:16:11Z,72.7
 2020-12-18T18:16:21Z,73.8

--- a/content/influxdb/v2.2/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.2/reference/syntax/annotated-csv/_index.md
@@ -79,10 +79,11 @@ my-result,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,east,
 
 In addition to the data columns, a table may include the following columns:
 
-- **Annotation column**: Only used in annotation rows. Always the first column.
-  Displays the name of an annotation. Value can be empty or a supported [annotation](#annotations).
-  You'll notice a space for this column for the entire length of the table,
-  so rows appear to start with `,`.
+- **Annotation column**: Displays the name of an annotation.
+  Only used in annotation rows and is always the first column.
+  Value can be empty or a supported [annotation](#annotations).
+  The response format uses a comma (`,`) to separate an annotation name from values in the row.
+  To account for this, rows in the table start with a leading comma; you'll notice an empty column for the entire length of the table.
 
 - **Result column**: Contains the name of the result specified by the query.
 

--- a/content/influxdb/v2.2/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.2/reference/syntax/annotated-csv/_index.md
@@ -163,6 +163,8 @@ Subsequent columns contain annotation values as shown in the table below.
 | **default**     | a value of the column's data type                                              | Value to use for rows with an empty value.                                       |
 
 
+Some tools might use or require a comma (`,`) to separate the annotation name from values in an annotation row.
+
 {{% note %}}
 To encode a table with its [group key](/influxdb/v2.2/reference/glossary/#group-key),
 the `datatype`, `group`, and `default` annotations must be included.

--- a/content/influxdb/v2.2/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.2/reference/syntax/annotated-csv/_index.md
@@ -228,7 +228,7 @@ cpu,cpu=cpu1,host=host1 time_steal=0,usage_user=2.7 1482669077000000000
 cpu,cpu=cpu1,host=host2 time_steal=0,usage_user=2.2 1482669087000000000
 ```
 
-##### Example of mixing data types line protocol elements
+##### Example of mixing data types and line protocol elements
 ```
 #datatype measurement,tag,string,double,boolean,long,unsignedLong,duration,dateTime
 #default test,annotatedDatatypes,,,,,,

--- a/content/influxdb/v2.3/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.3/reference/cli/influx/write/_index.md
@@ -209,7 +209,7 @@ influx write \
   --bucket example-bucket \
   --format csv \
   "#constant measurement,sensorData
-#datatype,datetime:RFC3339,double
+#datatype dateTime:RFC3339,double
 time,temperature
 2020-12-18T18:16:11Z,72.7
 2020-12-18T18:16:21Z,73.8

--- a/content/influxdb/v2.3/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.3/reference/syntax/annotated-csv/_index.md
@@ -163,6 +163,8 @@ Subsequent columns contain annotation values as shown in the table below.
 | **default**     | a value of the column's data type                                              | Value to use for rows with an empty value.                                       |
 
 
+Some tools might use or require a comma (`,`) to separate the annotation name from values in an annotation row.
+
 {{% note %}}
 To encode a table with its [group key](/influxdb/v2.3/reference/glossary/#group-key),
 the `datatype`, `group`, and `default` annotations must be included.

--- a/content/influxdb/v2.3/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.3/reference/syntax/annotated-csv/_index.md
@@ -79,10 +79,11 @@ my-result,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,east,
 
 In addition to the data columns, a table may include the following columns:
 
-- **Annotation column**: Only used in annotation rows. Always the first column.
-  Displays the name of an annotation. Value can be empty or a supported [annotation](#annotations).
-  You'll notice a space for this column for the entire length of the table,
-  so rows appear to start with `,`.
+- **Annotation column**: Displays the name of an annotation.
+  Only used in annotation rows and is always the first column.
+  Value can be empty or a supported [annotation](#annotations).
+  The response format uses a comma (`,`) to separate an annotation name from values in the row.
+  To account for this, rows in the table start with a leading comma; you'll notice an empty column for the entire length of the table.
 
 - **Result column**: Contains the name of the result specified by the query.
 

--- a/content/influxdb/v2.3/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.3/reference/syntax/annotated-csv/_index.md
@@ -228,7 +228,7 @@ cpu,cpu=cpu1,host=host1 time_steal=0,usage_user=2.7 1482669077000000000
 cpu,cpu=cpu1,host=host2 time_steal=0,usage_user=2.2 1482669087000000000
 ```
 
-##### Example of mixing data types line protocol elements
+##### Example of mixing data types and line protocol elements
 ```
 #datatype measurement,tag,string,double,boolean,long,unsignedLong,duration,dateTime
 #default test,annotatedDatatypes,,,,,,

--- a/content/influxdb/v2.4/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.4/reference/cli/influx/write/_index.md
@@ -207,7 +207,7 @@ influx write \
   --bucket example-bucket \
   --format csv \
   "#constant measurement,sensorData
-#datatype,datetime:RFC3339,double
+#datatype dateTime:RFC3339,double
 time,temperature
 2020-12-18T18:16:11Z,72.7
 2020-12-18T18:16:21Z,73.8

--- a/content/influxdb/v2.4/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.4/reference/syntax/annotated-csv/_index.md
@@ -79,10 +79,11 @@ my-result,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,east,
 
 In addition to the data columns, a table may include the following columns:
 
-- **Annotation column**: Only used in annotation rows. Always the first column.
-  Displays the name of an annotation. Value can be empty or a supported [annotation](#annotations).
-  You'll notice a space for this column for the entire length of the table,
-  so rows appear to start with `,`.
+- **Annotation column**: Displays the name of an annotation.
+  Only used in annotation rows and is always the first column.
+  Value can be empty or a supported [annotation](#annotations).
+  The response format uses a comma (`,`) to separate an annotation name from values in the row.
+  To account for this, rows in the table start with a leading comma; you'll notice an empty column for the entire length of the table.
 
 - **Result column**: Contains the name of the result specified by the query.
 

--- a/content/influxdb/v2.4/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.4/reference/syntax/annotated-csv/_index.md
@@ -163,6 +163,8 @@ Subsequent columns contain annotation values as shown in the table below.
 | **default**     | a value of the column's data type                                              | Value to use for rows with an empty value.                                       |
 
 
+Some tools might use or require a comma (`,`) to separate the annotation name from values in an annotation row.
+
 {{% note %}}
 To encode a table with its [group key](/influxdb/v2.4/reference/glossary/#group-key),
 the `datatype`, `group`, and `default` annotations must be included.

--- a/content/influxdb/v2.4/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.4/reference/syntax/annotated-csv/_index.md
@@ -228,7 +228,7 @@ cpu,cpu=cpu1,host=host1 time_steal=0,usage_user=2.7 1482669077000000000
 cpu,cpu=cpu1,host=host2 time_steal=0,usage_user=2.2 1482669087000000000
 ```
 
-##### Example of mixing data types line protocol elements
+##### Example of mixing data types and line protocol elements
 ```
 #datatype measurement,tag,string,double,boolean,long,unsignedLong,duration,dateTime
 #default test,annotatedDatatypes,,,,,,

--- a/content/influxdb/v2.5/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.5/reference/cli/influx/write/_index.md
@@ -207,7 +207,7 @@ influx write \
   --bucket example-bucket \
   --format csv \
   "#constant measurement,sensorData
-#datatype,datetime:RFC3339,double
+#datatype dateTime:RFC3339,double
 time,temperature
 2020-12-18T18:16:11Z,72.7
 2020-12-18T18:16:21Z,73.8

--- a/content/influxdb/v2.5/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.5/reference/syntax/annotated-csv/_index.md
@@ -79,10 +79,11 @@ my-result,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,east,
 
 In addition to the data columns, a table may include the following columns:
 
-- **Annotation column**: Only used in annotation rows. Always the first column.
-  Displays the name of an annotation. Value can be empty or a supported [annotation](#annotations).
-  You'll notice a space for this column for the entire length of the table,
-  so rows appear to start with `,`.
+- **Annotation column**: Displays the name of an annotation.
+  Only used in annotation rows and is always the first column.
+  Value can be empty or a supported [annotation](#annotations).
+  The response format uses a comma (`,`) to separate an annotation name from values in the row.
+  To account for this, rows in the table start with a leading comma; you'll notice an empty column for the entire length of the table.
 
 - **Result column**: Contains the name of the result specified by the query.
 

--- a/content/influxdb/v2.5/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.5/reference/syntax/annotated-csv/_index.md
@@ -228,7 +228,7 @@ cpu,cpu=cpu1,host=host1 time_steal=0,usage_user=2.7 1482669077000000000
 cpu,cpu=cpu1,host=host2 time_steal=0,usage_user=2.2 1482669087000000000
 ```
 
-##### Example of mixing data types line protocol elements
+##### Example of mixing data types and line protocol elements
 ```
 #datatype measurement,tag,string,double,boolean,long,unsignedLong,duration,dateTime
 #default test,annotatedDatatypes,,,,,,

--- a/content/influxdb/v2.5/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.5/reference/syntax/annotated-csv/_index.md
@@ -163,6 +163,8 @@ Subsequent columns contain annotation values as shown in the table below.
 | **default**     | a value of the column's data type                                              | Value to use for rows with an empty value.                                       |
 
 
+Some tools might use or require a comma (`,`) to separate the annotation name from values in an annotation row.
+
 {{% note %}}
 To encode a table with its [group key](/influxdb/v2.5/reference/glossary/#group-key),
 the `datatype`, `group`, and `default` annotations must be included.

--- a/content/influxdb/v2.6/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.6/reference/cli/influx/write/_index.md
@@ -207,7 +207,7 @@ influx write \
   --bucket example-bucket \
   --format csv \
   "#constant measurement,sensorData
-#datatype,datetime:RFC3339,double
+#datatype dateTime:RFC3339,double
 time,temperature
 2020-12-18T18:16:11Z,72.7
 2020-12-18T18:16:21Z,73.8

--- a/content/influxdb/v2.6/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.6/reference/syntax/annotated-csv/_index.md
@@ -163,6 +163,8 @@ Subsequent columns contain annotation values as shown in the table below.
 | **default**     | a value of the column's data type                                              | Value to use for rows with an empty value.                                       |
 
 
+Some tools might use or require a comma (`,`) to separate the annotation name from values in an annotation row.
+
 {{% note %}}
 To encode a table with its [group key](/influxdb/v2.6/reference/glossary/#group-key),
 the `datatype`, `group`, and `default` annotations must be included.

--- a/content/influxdb/v2.6/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.6/reference/syntax/annotated-csv/_index.md
@@ -79,10 +79,11 @@ my-result,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,east,
 
 In addition to the data columns, a table may include the following columns:
 
-- **Annotation column**: Only used in annotation rows. Always the first column.
-  Displays the name of an annotation. Value can be empty or a supported [annotation](#annotations).
-  You'll notice a space for this column for the entire length of the table,
-  so rows appear to start with `,`.
+- **Annotation column**: Displays the name of an annotation.
+  Only used in annotation rows and is always the first column.
+  Value can be empty or a supported [annotation](#annotations).
+  The response format uses a comma (`,`) to separate an annotation name from values in the row.
+  To account for this, rows in the table start with a leading comma; you'll notice an empty column for the entire length of the table.
 
 - **Result column**: Contains the name of the result specified by the query.
 

--- a/content/influxdb/v2.6/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.6/reference/syntax/annotated-csv/_index.md
@@ -228,7 +228,7 @@ cpu,cpu=cpu1,host=host1 time_steal=0,usage_user=2.7 1482669077000000000
 cpu,cpu=cpu1,host=host2 time_steal=0,usage_user=2.2 1482669087000000000
 ```
 
-##### Example of mixing data types line protocol elements
+##### Example of mixing data types and line protocol elements
 ```
 #datatype measurement,tag,string,double,boolean,long,unsignedLong,duration,dateTime
 #default test,annotatedDatatypes,,,,,,

--- a/content/influxdb/v2.7/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.7/reference/cli/influx/write/_index.md
@@ -207,7 +207,7 @@ influx write \
   --bucket example-bucket \
   --format csv \
   "#constant measurement,sensorData
-#datatype,datetime:RFC3339,double
+#datatype dateTime:RFC3339,double
 time,temperature
 2020-12-18T18:16:11Z,72.7
 2020-12-18T18:16:21Z,73.8

--- a/content/influxdb/v2.7/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.7/reference/syntax/annotated-csv/_index.md
@@ -171,9 +171,9 @@ Time column values should be **Unix nanosecond timestamps**, **RFC3339**, or **R
 ##### Example line protocol elements in datatype annotation
 
 ```
-#group,false,false,false,false,false,false,false
-#datatype,measurement,tag,tag,field,field,ignored,time
-#default,,,,,,,
+#group false,false,false,false,false,false,false
+#datatype measurement,tag,tag,field,field,ignored,time
+#default ,,,,,,
 m,cpu,host,time_steal,usage_user,nothing,time
 cpu,cpu1,host1,0,2.7,a,1482669077000000000
 cpu,cpu1,host2,0,2.2,b,1482669087000000000

--- a/content/influxdb/v2.7/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.7/reference/syntax/annotated-csv/_index.md
@@ -186,7 +186,7 @@ cpu,cpu=cpu1,host=host1 time_steal=0,usage_user=2.7 1482669077000000000
 cpu,cpu=cpu1,host=host2 time_steal=0,usage_user=2.2 1482669087000000000
 ```
 
-##### Example of mixing data types line protocol elements
+##### Example of mixing data types and line protocol elements
 
 ```
 #group,false,false,false,false,false,false,false,false,false

--- a/content/influxdb/v2.7/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.7/reference/syntax/annotated-csv/_index.md
@@ -192,9 +192,9 @@ cpu,cpu=cpu1,host=host2 time_steal=0,usage_user=2.2 1482669087000000000
 #group,false,false,false,false,false,false,false,false,false
 #datatype,measurement,tag,string,double,boolean,long,unsignedLong,duration,dateTime
 #default,test,annotatedDatatypes,,,,,,
-m,name,s,d,b,l,ul,dur,time
-,,str1,1.0,true,1,1,1ms,1
-,,str2,2.0,false,2,2,2us,2020-01-11T10:10:10Z
+,m,name,s,d,b,l,ul,dur,time
+,,,str1,1.0,true,1,1,1ms,1
+,,,str2,2.0,false,2,2,2us,2020-01-11T10:10:10Z
 ```
 
 Resulting line protocol:

--- a/content/influxdb/v2.7/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.7/reference/syntax/annotated-csv/_index.md
@@ -116,6 +116,8 @@ Subsequent columns contain annotation values as shown in the table below.
 | **default**     | a value of the column's data type                                              | Value to use for rows with an empty value.                                       |
 
 
+Some tools might use or require a comma (`,`) to separate the annotation name from values in an annotation row.
+
 {{% note %}}
 To encode a table with its [group key](/influxdb/v2.7/reference/glossary/#group-key),
 the `datatype`, `group`, and `default` annotations must be included.

--- a/content/influxdb/v2.7/reference/syntax/annotated-csv/_index.md
+++ b/content/influxdb/v2.7/reference/syntax/annotated-csv/_index.md
@@ -52,10 +52,11 @@ A table may have the following rows and columns.
 
 In addition to the data columns, a table may include the following columns:
 
-- **Annotation column**: Only used in annotation rows. Always the first column.
-  Displays the name of an annotation. Value can be empty or a supported [annotation](#annotations).
-  You'll notice a space for this column for the entire length of the table,
-  so rows appear to start with `,`.
+- **Annotation column**: Displays the name of an annotation.
+  Only used in annotation rows and is always the first column.
+  Value can be empty or a supported [annotation](#annotations).
+  The response format uses a comma (`,`) to separate an annotation name from values in the row.
+  To account for this, rows in the table start with a leading comma; you'll notice an empty column for the entire length of the table.
 - **Result column**: Contains the name of the result specified by the query.
 - **Table column**: Contains a unique ID for each table in a result.
 


### PR DESCRIPTION
Closes #5017 

Fixes incorrect comma usage and `dateTime` name in annotated CSV examples.
Adds a little more explanation about commas following annotation names.
