### PR TITLE
influxql group by behavior, measurement, and time columns

### DIFF
--- a/content/influxdb/cloud-dedicated/get-started/query.md
+++ b/content/influxdb/cloud-dedicated/get-started/query.md
@@ -67,7 +67,7 @@ InfluxDB SQL queries most commonly include the following clauses:
 {{< req type="key" >}}
 
 - {{< req "\*">}} `SELECT`: Identify specific fields and tags to query from a
-  measurement or use the wild card alias (`*`) to select all fields and tags
+  measurement or use the wildcard alias (`*`) to select all fields and tags
   from a measurement.
 - {{< req "\*">}} `FROM`: Identify the measurement to query.
   If coming from an SQL background, an InfluxDB measurement is the equivalent 

--- a/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
@@ -116,7 +116,7 @@ Use `now()` to return the timestamp for the current time (UTC).
 ##### Query all data from the last month
 
 ```sql
-SELECT * FROM home WHERE time >= now() - INTERVAL '1 month'
+SELECT * FROM home WHERE time >= now() - 30d
 ```
 
 ##### Query one day of data data from a week ago

--- a/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
@@ -206,7 +206,7 @@ To alias or rename fields and tags that you query, use the `AS` clause.
 After the tag, field, or expression you want to alias, pass `AS` followed by the alias name as an identifier (wrap in double quotes (`"`) if the alias includes spaces or special characters)--for example:
 
 ```sql
-SELECT temp AS "temperature", hum AS "humidity" FROM home
+SELECT temp AS temperature, hum AS "humidity (%)" FROM home
 ```
 
 {{% note %}}

--- a/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
@@ -1,35 +1,39 @@
 ---
-title: Perform a basic SQL query
-seotitle: Perform a basic SQL query in InfluxDB Cloud
+title: Perform a basic InfluxQL query
+seotitle: Perform a basic InfluxQL query in InfluxDB Cloud
 description: >
-  A basic SQL query that queries data from InfluxDB most commonly includes
+  A basic InfluxQL query that queries data from InfluxDB most commonly includes
   `SELECT`, `FROM`, and `WHERE` clauses.
 menu:
   influxdb_cloud_dedicated:
     name: Basic query
-    parent: Query with SQL
-    identifier: query-sql-basic
+    parent: Query with InfluxQL
+    identifier: query-influxql-basic
 weight: 202
-influxdb/cloud-dedicated/tags: [query, sql]
+influxdb/cloud-dedicated/tags: [query, influxql]
 list_code_example: |
   ```sql
-  SELECT temp, room FROM home WHERE time >= now() - INTERVAL '1 day'
+  SELECT temp, room FROM home WHERE time >= now() - 1d
   ```
 ---
 
-The InfluxDB SQL implementation is powered by the [Apache Arrow DataFusion](https://arrow.apache.org/datafusion/)
-query engine which provides an SQL syntax similar to other relational query languages.
+InfluxQL (Influx Query Language) is an SQL-like query language used to interact
+with InfluxDB and work with times series data.
 
-A basic SQL query that queries data from InfluxDB most commonly includes the
+A basic InfluxQL query that queries data from InfluxDB most commonly includes the
 following clauses:
 
 {{< req type="key" >}}
 
 - {{< req "\*">}} `SELECT`: Specify fields, tags, and calculations to output from a
   measurement or use the wildcard alias (`*`) to select all fields and tags
-  from a measurement.
-- {{< req "\*">}} `FROM`: Specify the measurement to query data from.
-- `WHERE`: Only return data that meets the specified conditions--for example, falls within
+  from a measurement. It requires at least one [field key](/influxdb/cloud-dedicated/reference/glossary/#field-key) or the wildcard alias (`*`). For more information, see [/influxdb/cloud-dedicated/reference/influxql/select/#notable-select-statement-behaviors].
+- {{< req "\*">}} `FROM`: Specify the [measurement](/influxdb/cloud-dedicated/reference/glossary/#measurement) to query from.
+It requires one or more comma-delimited [measurement expressions](/influxdb/cloud-dedicated/reference/influxql/select/#measurement_expression).
+- `WHERE`: Filter data based on
+[field values](/influxdb/cloud-dedicated/reference/glossary/#field),
+[tag values](/influxdb/cloud-dedicated/reference/glossary/#tag), or
+[timestamps](/influxdb/cloud-dedicated/reference/glossary/#timestamp). Only return data that meets the specified conditions--for example, falls within
   a time range, contains specific tag values, or contains a field value outside a specified range.
 
 {{% influxdb/custom-timestamps %}}
@@ -67,6 +71,7 @@ to your {{% cloud-name %}} database before running the example queries.
 ### Query data within time boundaries
 
 - Use the `SELECT` clause to specify what tags and fields to return.
+  Specify at least one field key.
   To return all tags and fields, use the wildcard alias (`*`).
 - Specify the measurement to query in the `FROM` clause.
 - Specify time boundaries in the `WHERE` clause.
@@ -134,6 +139,8 @@ WHERE
 
 To query data without time boundaries, do not include any time-based predicates
 in your `WHERE` clause.
+If a time range is not defined in the `WHERE` clause, the default time range is
+the Unix epoch (`1970-01-01T00:00:00Z`) to _now_.
 
 {{% warn %}}
 Querying data _without time bounds_ can return an unexpected amount of data.
@@ -157,11 +164,9 @@ SELECT time, room, temp, hum FROM home
 
 ### Query fields based on tag values
 
-- Include the fields you want to query and the tags you want to base conditions
-  on in the `SELECT` clause.
-- Include predicates in the `WHERE` clause that compare the tag identifier to
-  a string literal.
-  Use [logical operators](/influxdb/cloud-dedicated/reference/sql/where/#logical-operators) to chain multiple predicates together and apply
+- In the `SELECT` clause, include fields you want to query and tags you want to base conditions on.
+- In the `WHERE` clause, include predicates that compare the tag identifier to a string literal.
+  Use [logical operators](/influxdb/cloud-dedicated/reference/influxql/where/#logical-operators) to chain multiple predicates together and apply
   multiple conditions.
 
 ```sql
@@ -172,7 +177,7 @@ SELECT * FROM home WHERE room = 'Kitchen'
 
 - In the `SELECT` clause, include fields you want to query.
 - In the `WHERE` clause, include predicates that compare the field identifier to a value or expression.
-  Use [logical operators](/influxdb/cloud-dedicated/reference/sql/where/#logical-operators) (`AND`, `OR`) to chain multiple predicates together
+  Use [logical operators](/influxdb/cloud-dedicated/reference/influxql/where/#logical-operators) (`AND`, `OR`) to chain multiple predicates together
   and apply multiple conditions.
 
 ```sql
@@ -181,20 +186,23 @@ SELECT co, time FROM home WHERE co >= 10 OR co <= -10
 
 ### Alias queried fields and tags
 
-To alias or rename fields and tags that you query, pass a string literal after
-the field or tag identifier in the `SELECT` clause.
-You can use the `AS` clause to define the alias, but it isn't necessary.
-The following queries are functionally the same:
+To alias or rename fields and tags that you query, use the `AS` clause.
+After the tag, field, or expression you want to alias, pass `AS` followed by the alias name as a string literal in double quotes (`"`)--for example:
 
 ```sql
-SELECT temp 'temperature', hum 'humidity' FROM home
-
-SELECT temp AS 'temperature', hum AS 'humidity' FROM home
+SELECT temp AS "temperature", hum AS "humidity" FROM home
 ```
+
+{{% note %}}
+When aliasing columns in **InfluxQL**, use the `AS` clause and double-quoted alias names.
+When [aliasing columns in **SQL**](/influxdb/cloud-dedicated/query-data/sql/basic-query/#alias-queried-fields-and-tags), you can use the `AS` clause to define the alias, but it isn't necessary.
+{{% /note %}}
 
 ### Query result set
 
 If at least one row satisfies the query, {{% cloud-name %}} returns row data in the query result set.
-An SQL query result set includes the following columns:
+An InfluxQL query result set includes the following columns:
 
 - Data for columns listed in the query's `SELECT` statement
+- The `time` column that contains the timestamp for each record
+- An `iox::measurement` column that contains the record's measurement (table) name

--- a/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
@@ -203,7 +203,7 @@ SELECT co, time FROM home WHERE co >= 10 OR co <= -10
 ### Alias queried fields and tags
 
 To alias or rename fields and tags that you query, use the `AS` clause.
-After the tag, field, or expression you want to alias, pass `AS` followed by the alias name as a string literal in double quotes (`"`)--for example:
+After the tag, field, or expression you want to alias, pass `AS` followed by the alias name as an identifier (wrap in double quotes (`"`) if the alias includes spaces or special characters)--for example:
 
 ```sql
 SELECT temp AS "temperature", hum AS "humidity" FROM home

--- a/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
@@ -124,8 +124,8 @@ SELECT * FROM home WHERE time >= now() - 30d
 SELECT *
 FROM home
 WHERE
-  time >= now() - INTERVAL '7 days'
-  AND time <= now() - INTERVAL '6 days'
+  time >= now() - 7d
+  AND time <= now() - 6d
 ```
 {{% /expand %}}
 

--- a/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
@@ -210,7 +210,7 @@ SELECT temp AS temperature, hum AS "humidity (%)" FROM home
 ```
 
 {{% note %}}
-When aliasing columns in **InfluxQL**, use the `AS` clause and double-quoted alias names.
+When aliasing columns in **InfluxQL**, use the `AS` clause and an [identifier](/influxdb/cloud-dedicated/reference/influxql/#identifiers).
 When [aliasing columns in **SQL**](/influxdb/cloud-dedicated/query-data/sql/basic-query/#alias-queried-fields-and-tags), you can use the `AS` clause to define the alias, but it isn't necessary.
 {{% /note %}}
 

--- a/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
@@ -25,9 +25,11 @@ following clauses:
 
 {{< req type="key" >}}
 
-- {{< req "\*">}} `SELECT`: Specify fields, tags, and calculations to output from a
+- {{< req "\*">}} `SELECT`: Specify fields, tags, and calculations to return from a
   measurement or use the wildcard alias (`*`) to select all fields and tags
-  from a measurement. It requires at least one [field key](/influxdb/cloud-dedicated/reference/glossary/#field-key) or the wildcard alias (`*`). For more information, see [/influxdb/cloud-dedicated/reference/influxql/select/#notable-select-statement-behaviors].
+  from a measurement. It requires at least one
+  [field key](/influxdb/cloud-dedicated/reference/glossary/#field-key) or the wildcard alias (`*`).
+  For more information, see [Notable SELECT statement behaviors](/influxdb/cloud-dedicated/reference/influxql/select/#notable-select-statement-behaviors).
 - {{< req "\*">}} `FROM`: Specify the [measurement](/influxdb/cloud-dedicated/reference/glossary/#measurement) to query from.
 It requires one or more comma-delimited [measurement expressions](/influxdb/cloud-dedicated/reference/influxql/select/#measurement_expression).
 - `WHERE`: Filter data based on

--- a/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
@@ -49,6 +49,20 @@ WHERE
 ```
 {{% /influxdb/custom-timestamps %}}
 
+## Result set
+
+If at least one row satisfies the query, {{% cloud-name %}} returns row data in the query result set.
+If a query uses a `GROUP BY` clause, the result set includes the following:
+
+- Columns listed in the query's `SELECT` clause
+- A `time` column that contains the timestamp for the record or the group
+- An `iox::measurement` column that contains the record's measurement (table) name
+- Columns listed in the query's `GROUP BY` clause; each row in the result set contains the values used for grouping
+
+### GROUP BY result columns
+
+If a query uses `GROUP BY` and the `WHERE` clause doesn't filter by time, then groups are based on the [default time range](/influxdb/cloud-dedicated/reference/group-by/#default-time-range).
+
 ## Basic query examples
 
 - [Query data within time boundaries](#query-data-within-time-boundaries)
@@ -198,11 +212,4 @@ When aliasing columns in **InfluxQL**, use the `AS` clause and double-quoted ali
 When [aliasing columns in **SQL**](/influxdb/cloud-dedicated/query-data/sql/basic-query/#alias-queried-fields-and-tags), you can use the `AS` clause to define the alias, but it isn't necessary.
 {{% /note %}}
 
-### Query result set
 
-If at least one row satisfies the query, {{% cloud-name %}} returns row data in the query result set.
-An InfluxQL query result set includes the following columns:
-
-- Data for columns listed in the query's `SELECT` statement
-- The `time` column that contains the timestamp for each record
-- An `iox::measurement` column that contains the record's measurement (table) name

--- a/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-dedicated/query-data/influxql/basic-query.md
@@ -77,10 +77,10 @@ If a query uses `GROUP BY` and the `WHERE` clause doesn't filter by time, then g
 {{% note %}}
 #### Sample data
 
-The following examples use the sample data written in the
-[Get started writing data guide](/influxdb/cloud-dedicated/get-started/write/).
+The following examples use the 
+[Get started home sensor data](/influxdb/cloud-dedicated/reference/sample-data/#get-started-home-sensor-data).
 To run the example queries and return results,
-[write the sample data](/influxdb/cloud-dedicated/get-started/write/#write-line-protocol-to-influxdb)
+[write the sample data](/influxdb/cloud-dedicated/reference/sample-data/#write-the-home-sensor-data-to-influxdb)
 to your {{% cloud-name %}} database before running the example queries.
 {{% /note %}}
 

--- a/content/influxdb/cloud-dedicated/query-data/sql/aggregate-select.md
+++ b/content/influxdb/cloud-dedicated/query-data/sql/aggregate-select.md
@@ -44,7 +44,7 @@ An SQL query that aggregates data includes the following clauses:
 {{< req type="key" >}}
 
 - {{< req "\*">}} `SELECT`: Specify fields, tags, and calculations to output from a
-  measurement or use the wild card alias (`*`) to select all fields and tags
+  measurement or use the wildcard alias (`*`) to select all fields and tags
   from a measurement.
 - {{< req "\*">}} `FROM`: Specify the measurement to query data from.
 - `WHERE`: Only return data that meets the specified conditions--for example, falls within

--- a/content/influxdb/cloud-dedicated/query-data/sql/basic-query.md
+++ b/content/influxdb/cloud-dedicated/query-data/sql/basic-query.md
@@ -45,6 +45,11 @@ WHERE
 ```
 {{% /influxdb/custom-timestamps %}}
 
+## Result set
+
+If at least one row satisfies the query, {{% cloud-name %}} returns row data in the query result set.
+An SQL query result set includes columns listed in the query's `SELECT` statement.
+
 ## Basic query examples
 
 - [Query data within time boundaries](#query-data-within-time-boundaries)
@@ -191,10 +196,3 @@ SELECT temp 'temperature', hum 'humidity' FROM home
 
 SELECT temp AS 'temperature', hum AS 'humidity' FROM home
 ```
-
-### Query result set
-
-If at least one row satisfies the query, {{% cloud-name %}} returns row data in the query result set.
-An SQL query result set includes the following columns:
-
-- Data for columns listed in the query's `SELECT` statement

--- a/content/influxdb/cloud-dedicated/reference/glossary.md
+++ b/content/influxdb/cloud-dedicated/reference/glossary.md
@@ -276,6 +276,15 @@ Metrics gathered at irregular time intervals.
 
 A combination of one or more constants, variables, operators, and functions.
 
+In the following SQL example, `now() - INTERVAL '7 days'` is an expression that calculates the difference between the `now()` function expression and the duration represented by `INTERVAL '7 days`:
+
+```sql
+SELECT *
+FROM home
+WHERE
+  time >= now() - INTERVAL '7 days'
+```
+
 ## F
 
 ### field
@@ -421,7 +430,6 @@ An open-source time series database (TSDB) developed by InfluxData.
 Written in Go and optimized for fast, high-availability storage and retrieval of
 time series data in fields such as operations monitoring, application metrics,
 Internet of Things sensor data, and real-time analytics.
-
 
 ### InfluxQL
 

--- a/content/influxdb/cloud-dedicated/reference/influxql/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/influxql/_index.md
@@ -10,7 +10,7 @@ menu:
 weight: 102
 ---
 
-InfluxQL (Influx Query Language) is a SQL-like query language used to interact
+InfluxQL (Influx Query Language) is an SQL-like query language used to interact
 with InfluxDB and work with times series data.
 
 {{% warn %}}
@@ -35,6 +35,7 @@ see [InfluxQL feature support](/influxdb/cloud-dedicated/reference/influxql/feat
 - [Expressions](#expressions)
 - [Comments](#comments)
 - [Other](#other)
+- [Result set](#result-set)
 
 <!-- To learn more about InfluxQL, browse the following topics:
 
@@ -157,7 +158,9 @@ In those cases, you don't need to double-quote `time`  in queries.
 `time` can't be a [field key](/influxdb/cloud-dedicated/reference/glossary/#field-key) or
 [tag key](/influxdb/cloud-dedicated/reference/glossary/#tag-key);
 InfluxDB rejects writes with `time` as a field key or tag key and returns an error.
+<!--
 See [Frequently Asked Questions](/influxdb/v2.7/reference/faq/) for more information.
+-->
 
 ### Literals
 
@@ -716,6 +719,10 @@ expr             = unary_expr { binary_op unary_expr } .
 unary_expr       = "(" expr ")" | var_ref | time_lit | string_lit | int_lit |
                    float_lit | bool_lit | duration_lit | regex_lit .
 ```
+
+## Default time range
+
+The default time range is the Unix epoch (`1970-01-01T00:00:00Z`) to _now_.
 
 ## Comments
 

--- a/content/influxdb/cloud-dedicated/reference/influxql/group-by.md
+++ b/content/influxdb/cloud-dedicated/reference/influxql/group-by.md
@@ -21,19 +21,31 @@ Use the `GROUP BY` clause to group data by one or more specified
 or [selector](/influxdb/cloud-dedicated/reference/influxql/functions/selectors/)
 function in the `SELECT` statement.
 
+<!-- TOC -->
+
 - [Syntax](#syntax)
+- [GROUP BY clause behaviors](#group-by-clause-behaviors)
+- [GROUP BY tags](#group-by-tags)
   - [GROUP BY tags examples](#group-by-tags-examples)
 - [GROUP BY time](#group-by-time)
   - [GROUP by time and fill gaps](#group-by-time-and-fill-gaps)
   - [GROUP BY time examples](#group-by-time-examples)
+        - [GROUP BY time with offset](#group-by-time-with-offset)
+        - [GROUP BY time and fill gaps](#group-by-time-and-fill-gaps)
+- [Result set](#result-set)
+  - [Default time range](#default-time-range)
 - [Notable behaviors of the GROUP BY clause](#notable-behaviors-of-the-group-by-clause)
   - [Cannot group by fields](#cannot-group-by-fields)
   - [Tag order does not matter](#tag-order-does-not-matter)
   - [Grouping by tag and no time range returns unexpected timestamps](#grouping-by-tag-and-no-time-range-returns-unexpected-timestamps)
   - [Data grouped by time may return unexpected timestamps](#data-grouped-by-time-may-return-unexpected-timestamps)
+    - [Example data](#example-data)
+    - [Query results](#query-results)
   - [Fill with no data in the queried time range](#fill-with-no-data-in-the-queried-time-range)
   - [Fill with previous if no previous value exists](#fill-with-previous-if-no-previous-value-exists)
   - [Fill with linear interpolation if there are not two values to interpolate between](#fill-with-linear-interpolation-if-there-are-not-two-values-to-interpolate-between)
+
+<!-- /TOC -->
 
 ## Syntax
 
@@ -44,13 +56,13 @@ SELECT_clause FROM_clause [WHERE_clause] GROUP BY group_expression[, ..., group_
 - **group_expression**: Expression to identify tags or time intervals to group by.
   Can be a [tag key](/influxdb/cloud-dedicated/reference/glossary/#tag-key),
   constant, [regular expression](/influxdb/cloud-dedicated/reference/influxql/regular-expressions/),
-  wildcard (`*`), or [function](/influxdb/cloud-dedicated/reference/influxql/functions/).
+  wildcard (`*`), or [function expression](/influxdb/cloud-dedicated/reference/influxql/functions/).
 
-#### GROUP BY clause behaviors
+## GROUP BY clause behaviors
 
 - `GROUP BY tag_key` - Groups data by a specific tag
 - `GROUP BY tag_key1, tag_key2` - Groups data by more than one tag
-- `GROUP BY *` - Groups data by all [tags](/influxdb/v2.7/reference/glossary/#tag)
+- `GROUP BY *` - Groups data by all [tags](/influxdb/cloud-dedicated/reference/glossary/#tag)
 - `GROUP BY /regex/` - Groups data by tag keys that match the regular expression
 - `GROUP BY time()` - Groups data into time intervals (windows)
 
@@ -58,6 +70,10 @@ SELECT_clause FROM_clause [WHERE_clause] GROUP BY group_expression[, ..., group_
 If a query includes `WHERE` and `GROUP BY`, the `GROUP BY` clause must appear after
 the `WHERE` clause.
 {{% /note %}}
+
+## GROUP BY tags
+
+Groups data by one or more tag columns.
 
 ### GROUP BY tags examples
 
@@ -482,23 +498,24 @@ name: bitcoin
 
 {{< /expand-wrapper >}}
 
-## Notable behaviors of the GROUP BY clause
+## Result set
 
-### Cannot group by fields
+If at least one row satisfies the query, {{% cloud-name %}} returns row data in the query result set.
+If a query uses a `GROUP BY` clause, the result set includes the following:
 
-InfluxQL does not support grouping data by **fields**.
+- Columns listed in the query's `SELECT` clause
+- A `time` column that contains the timestamp for the record or the group
+- An `iox::measurement` column that contains the record's measurement (table) name
+- Columns listed in the query's `GROUP BY` clause; each row in the result set contains the values used for grouping
 
-### Tag order does not matter
+### Default time range
 
-The order that tags are listed in the `GROUP BY` clause does not affect how
-data is grouped.
-
-### Grouping by tag and no time range returns unexpected timestamps
-
-When grouping by tags and no time range is specified in the
-[`WHERE` clause](/influxdb/cloud-dedicated/reference/influxql/where/), results
-use the [Unix epoch](/influxdb/cloud-dedicated/reference/glossary/#unix-epoch) as the default timestamp for the aggregate timestamp.
-For example:
+If a query doesn't specify a time range in the
+[`WHERE` clause](/influxdb/cloud-dedicated/reference/influxql/where/), InfluxDB uses the
+[default time range](/influxdb/cloud-dedicated/reference/influxql/#default-time-range) for filtering and grouping by time.
+If a query includes the `GROUP BY` clause and doesn't specify a time range in the
+`WHERE` clause, the default time group is the
+[default time range](/influxdb/cloud-dedicated/reference/influxql/#default-time-range), and the `time` column in the result set contains the start of the range--for example:
 
 ```sql
 SELECT mean(temp) FROM home GROUP BY room
@@ -521,6 +538,21 @@ tags: room=Living Room
 | time                 |              mean |
 | :------------------- | ----------------: |
 | 1970-01-01T00:00:00Z | 22.16923076923077 |
+
+## Notable behaviors of the GROUP BY clause
+
+### Cannot group by fields
+
+InfluxQL does not support grouping data by **fields**.
+
+### Tag order does not matter
+
+The order that tags are listed in the `GROUP BY` clause does not affect how
+data is grouped.
+
+### Grouping by tag and no time range returns unexpected timestamps
+
+The `time` column contains the start of the [default time range](#default-time-range).
 
 ### Data grouped by time may return unexpected timestamps
 

--- a/content/influxdb/cloud-dedicated/reference/influxql/select.md
+++ b/content/influxdb/cloud-dedicated/reference/influxql/select.md
@@ -44,7 +44,7 @@ It requires one or more **field expressions** and optional **tag expressions**.
   Can be a [field key](/influxdb/cloud-dedicated/reference/glossary/#field-key),
   constant, [regular expression](/influxdb/cloud-dedicated/reference/influxql/regular-expressions/),
   [wildcard (`*`)](#wildcard-expressions-in-select-clauses), or
-  [function](/influxdb/cloud-dedicated/reference/influxql/functions/) and any
+  [function expression](/influxdb/cloud-dedicated/reference/influxql/functions/) and any
   combination of arithmetic operators.
 - **tag_expression**: Expression to identify one or more tags to return in query results.
   Can be a [tag key](/influxdb/cloud-dedicated/reference/glossary/#tag-key) or constant.
@@ -69,7 +69,9 @@ The `FROM` clause specifies the
 [measurement](/influxdb/cloud-dedicated/reference/glossary/#measurement) to query.
 It requires one or more comma-delimited **measurement expressions**.
 
-- **measurement_expression**: Expression to identify one or more measurements to query.
+- #### measurement_expression
+
+  Expression to identify one or more measurements to query.
   Can be a measurement name, fully-qualified measurement, constant, or
   [regular expression](/influxdb/cloud-dedicated/reference/influxql/regular-expressions/).
 

--- a/content/influxdb/cloud-dedicated/reference/influxql/where.md
+++ b/content/influxdb/cloud-dedicated/reference/influxql/where.md
@@ -72,18 +72,17 @@ Operators evaluate the relationship between two operands and return
 ## Time ranges
 
 Use the `WHERE` clause to specify a time range to query.
-If a time range is not defined in the `WHERE` clause, the default time range is
-the Unix epoch (`1970-01-01T00:00:00Z`) to _now_.
+If a time range isn't specified in the `WHERE` clause, the [default time range](/influxdb/cloud-dedicated/reference/influxql/#default-time-range) is used.
 
-Timestamps are stored in the `time` columns.
+Timestamps are stored in the `time` column.
 Use comparison operators to compare the value of the `time` column to a
-timestamp literal, integer (Unix nanosecond timestamp), or function.
+timestamp literal, integer (Unix nanosecond timestamp), or [expression](/influxdb/cloud-dedicated/reference/glossary/#expression).
 
 {{< code-tabs-wrapper >}}
 {{% code-tabs %}}
 [Timestamp](#)
 [Integer](#)
-[Function](#)
+[Expression](#)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```sql

--- a/content/influxdb/cloud-dedicated/reference/sql/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/sql/_index.md
@@ -11,7 +11,7 @@ related:
   - /influxdb/cloud-dedicated/reference/internals/arrow-flightsql/
 ---
 
-InfluxDB Cloud Dedicated uses the [Apache Arrow DataFusion](https://arrow.apache.org/datafusion/) implementation of SQL.  
+{{% cloud-name %}} uses the [Apache Arrow DataFusion](https://arrow.apache.org/datafusion/) implementation of SQL.  
 
 - [Identifiers](#identifiers)  
 - [Quoting and case sensitivity](#quoting-and-case-sensitivity)    
@@ -22,7 +22,7 @@ InfluxDB Cloud Dedicated uses the [Apache Arrow DataFusion](https://arrow.apache
 - [Conditional expressions](#conditional-expressions)
 - [Statements and clauses](#statements-and-clauses)  
 - [Comments](#comments)  
-- [Functions](#functions)  
+- [Functions](#functions)
 
 ## Identifiers
 
@@ -482,7 +482,7 @@ Use comments to describe and add detail or notes to your queries.
 
 ## Schema information
 
-InfluxDB {{< current-version >}} backed by InfluxDB IOx supports the following metedata schema queries:
+{{% cloud-name %}} supports the following metedata schema queries:
 
 ```sql
 SHOW tables
@@ -621,4 +621,3 @@ GROUP BY time
 | :------------- | :---------------------------------------------------------------------------- |
 | REGEXP_MATCH   | Matches a regular expression against a string and returns matched substrings. |
 | REGEXP_REPLACE | Replaces substrings that match a regular expression by a new substring.       |
-

--- a/content/influxdb/cloud-serverless/get-started/query.md
+++ b/content/influxdb/cloud-serverless/get-started/query.md
@@ -69,7 +69,7 @@ InfluxDB SQL queries most commonly include the following clauses:
 {{< req type="key" >}}
 
 - {{< req "\*">}} `SELECT`: Identify specific fields and tags to query from a
-  measurement or use the wild card alias (`*`) to select all fields and tags
+  measurement or use the wildcard alias (`*`) to select all fields and tags
   from a measurement.
 - {{< req "\*">}} `FROM`: Identify the measurement to query.
   If coming from an SQL background, an InfluxDB measurement is the equivalent 

--- a/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
@@ -116,7 +116,7 @@ Use `now()` to return the timestamp for the current time (UTC).
 ##### Query all data from the last month
 
 ```sql
-SELECT * FROM home WHERE time >= now() - INTERVAL '1 month'
+SELECT * FROM home WHERE time >= now() - 30d
 ```
 
 ##### Query one day of data data from a week ago

--- a/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
@@ -206,7 +206,7 @@ To alias or rename fields and tags that you query, use the `AS` clause.
 After the tag, field, or expression you want to alias, pass `AS` followed by the alias name as an identifier (wrap in double quotes (`"`) if the alias includes spaces or special characters)--for example:
 
 ```sql
-SELECT temp AS "temperature", hum AS "humidity" FROM home
+SELECT temp AS temperature, hum AS "humidity (%)" FROM home
 ```
 
 {{% note %}}

--- a/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
@@ -210,6 +210,6 @@ SELECT temp AS temperature, hum AS "humidity (%)" FROM home
 ```
 
 {{% note %}}
-When aliasing columns in **InfluxQL**, use the `AS` clause and double-quoted alias names.
+When aliasing columns in **InfluxQL**, use the `AS` clause and an [identifier](/influxdb/cloud-serverless/reference/influxql/#identifiers).
 When [aliasing columns in **SQL**](/influxdb/cloud-serverless/query-data/sql/basic-query/#alias-queried-fields-and-tags), you can use the `AS` clause to define the alias, but it isn't necessary.
 {{% /note %}}

--- a/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
@@ -203,7 +203,7 @@ SELECT co, time FROM home WHERE co >= 10 OR co <= -10
 ### Alias queried fields and tags
 
 To alias or rename fields and tags that you query, use the `AS` clause.
-After the tag, field, or expression you want to alias, pass `AS` followed by the alias name as a string literal in double quotes (`"`)--for example:
+After the tag, field, or expression you want to alias, pass `AS` followed by the alias name as an identifier (wrap in double quotes (`"`) if the alias includes spaces or special characters)--for example:
 
 ```sql
 SELECT temp AS "temperature", hum AS "humidity" FROM home

--- a/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
@@ -124,8 +124,8 @@ SELECT * FROM home WHERE time >= now() - 30d
 SELECT *
 FROM home
 WHERE
-  time >= now() - INTERVAL '7 days'
-  AND time <= now() - INTERVAL '6 days'
+  time >= now() - 7d
+  AND time <= now() - 6d
 ```
 {{% /expand %}}
 

--- a/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
@@ -1,35 +1,39 @@
 ---
-title: Perform a basic SQL query
-seotitle: Perform a basic SQL query in InfluxDB Cloud
+title: Perform a basic InfluxQL query
+seotitle: Perform a basic InfluxQL query in InfluxDB Cloud
 description: >
-  A basic SQL query that queries data from InfluxDB most commonly includes
+  A basic InfluxQL query that queries data from InfluxDB most commonly includes
   `SELECT`, `FROM`, and `WHERE` clauses.
 menu:
-  influxdb_cloud_dedicated:
+  influxdb_cloud_serverless:
     name: Basic query
-    parent: Query with SQL
-    identifier: query-sql-basic
+    parent: Query with InfluxQL
+    identifier: query-influxql-basic
 weight: 202
-influxdb/cloud-dedicated/tags: [query, sql]
+influxdb/cloud-serverless/tags: [query, influxql]
 list_code_example: |
   ```sql
-  SELECT temp, room FROM home WHERE time >= now() - INTERVAL '1 day'
+  SELECT temp, room FROM home WHERE time >= now() - 1d
   ```
 ---
 
-The InfluxDB SQL implementation is powered by the [Apache Arrow DataFusion](https://arrow.apache.org/datafusion/)
-query engine which provides an SQL syntax similar to other relational query languages.
+InfluxQL (Influx Query Language) is an SQL-like query language used to interact
+with InfluxDB and work with times series data.
 
-A basic SQL query that queries data from InfluxDB most commonly includes the
+A basic InfluxQL query that queries data from InfluxDB most commonly includes the
 following clauses:
 
 {{< req type="key" >}}
 
 - {{< req "\*">}} `SELECT`: Specify fields, tags, and calculations to output from a
   measurement or use the wildcard alias (`*`) to select all fields and tags
-  from a measurement.
-- {{< req "\*">}} `FROM`: Specify the measurement to query data from.
-- `WHERE`: Only return data that meets the specified conditions--for example, falls within
+  from a measurement. It requires at least one [field key](/influxdb/cloud-serverless/reference/glossary/#field-key) or the wildcard alias (`*`). For more information, see [/influxdb/cloud-serverless/reference/influxql/select/#notable-select-statement-behaviors].
+- {{< req "\*">}} `FROM`: Specify the [measurement](/influxdb/cloud-serverless/reference/glossary/#measurement) to query from.
+It requires one or more comma-delimited [measurement expressions](/influxdb/cloud-serverless/reference/influxql/select/#measurement_expression).
+- `WHERE`: Filter data based on
+[field values](/influxdb/cloud-serverless/reference/glossary/#field),
+[tag values](/influxdb/cloud-serverless/reference/glossary/#tag), or
+[timestamps](/influxdb/cloud-serverless/reference/glossary/#timestamp). Only return data that meets the specified conditions--for example, falls within
   a time range, contains specific tag values, or contains a field value outside a specified range.
 
 {{% influxdb/custom-timestamps %}}
@@ -58,15 +62,16 @@ WHERE
 #### Sample data
 
 The following examples use the sample data written in the
-[Get started writing data guide](/influxdb/cloud-dedicated/get-started/write/).
+[Get started writing data guide](/influxdb/cloud-serverless/get-started/write/).
 To run the example queries and return results,
-[write the sample data](/influxdb/cloud-dedicated/get-started/write/#write-line-protocol-to-influxdb)
+[write the sample data](/influxdb/cloud-serverless/get-started/write/#write-line-protocol-to-influxdb)
 to your {{% cloud-name %}} database before running the example queries.
 {{% /note %}}
 
 ### Query data within time boundaries
 
 - Use the `SELECT` clause to specify what tags and fields to return.
+  Specify at least one field key.
   To return all tags and fields, use the wildcard alias (`*`).
 - Specify the measurement to query in the `FROM` clause.
 - Specify time boundaries in the `WHERE` clause.
@@ -134,6 +139,8 @@ WHERE
 
 To query data without time boundaries, do not include any time-based predicates
 in your `WHERE` clause.
+If a time range is not defined in the `WHERE` clause, the default time range is
+the Unix epoch (`1970-01-01T00:00:00Z`) to _now_.
 
 {{% warn %}}
 Querying data _without time bounds_ can return an unexpected amount of data.
@@ -157,11 +164,9 @@ SELECT time, room, temp, hum FROM home
 
 ### Query fields based on tag values
 
-- Include the fields you want to query and the tags you want to base conditions
-  on in the `SELECT` clause.
-- Include predicates in the `WHERE` clause that compare the tag identifier to
-  a string literal.
-  Use [logical operators](/influxdb/cloud-dedicated/reference/sql/where/#logical-operators) to chain multiple predicates together and apply
+- In the `SELECT` clause, include fields you want to query and tags you want to base conditions on.
+- In the `WHERE` clause, include predicates that compare the tag identifier to a string literal.
+  Use [logical operators](/influxdb/cloud-serverless/reference/influxql/where/#logical-operators) to chain multiple predicates together and apply
   multiple conditions.
 
 ```sql
@@ -172,7 +177,7 @@ SELECT * FROM home WHERE room = 'Kitchen'
 
 - In the `SELECT` clause, include fields you want to query.
 - In the `WHERE` clause, include predicates that compare the field identifier to a value or expression.
-  Use [logical operators](/influxdb/cloud-dedicated/reference/sql/where/#logical-operators) (`AND`, `OR`) to chain multiple predicates together
+  Use [logical operators](/influxdb/cloud-serverless/reference/influxql/where/#logical-operators) (`AND`, `OR`) to chain multiple predicates together
   and apply multiple conditions.
 
 ```sql
@@ -181,20 +186,23 @@ SELECT co, time FROM home WHERE co >= 10 OR co <= -10
 
 ### Alias queried fields and tags
 
-To alias or rename fields and tags that you query, pass a string literal after
-the field or tag identifier in the `SELECT` clause.
-You can use the `AS` clause to define the alias, but it isn't necessary.
-The following queries are functionally the same:
+To alias or rename fields and tags that you query, use the `AS` clause.
+After the tag, field, or expression you want to alias, pass `AS` followed by the alias name as a string literal in double quotes (`"`)--for example:
 
 ```sql
-SELECT temp 'temperature', hum 'humidity' FROM home
-
-SELECT temp AS 'temperature', hum AS 'humidity' FROM home
+SELECT temp AS "temperature", hum AS "humidity" FROM home
 ```
+
+{{% note %}}
+When aliasing columns in **InfluxQL**, use the `AS` clause and double-quoted alias names.
+When [aliasing columns in **SQL**](/influxdb/cloud-serverless/query-data/sql/basic-query/#alias-queried-fields-and-tags), you can use the `AS` clause to define the alias, but it isn't necessary.
+{{% /note %}}
 
 ### Query result set
 
 If at least one row satisfies the query, {{% cloud-name %}} returns row data in the query result set.
-An SQL query result set includes the following columns:
+An InfluxQL query result set includes the following columns:
 
 - Data for columns listed in the query's `SELECT` statement
+- The `time` column that contains the timestamp for each record
+- An `iox::measurement` column that contains the record's measurement (table) name

--- a/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
@@ -25,9 +25,11 @@ following clauses:
 
 {{< req type="key" >}}
 
-- {{< req "\*">}} `SELECT`: Specify fields, tags, and calculations to output from a
+- {{< req "\*">}} `SELECT`: Specify fields, tags, and calculations to return from a
   measurement or use the wildcard alias (`*`) to select all fields and tags
-  from a measurement. It requires at least one [field key](/influxdb/cloud-serverless/reference/glossary/#field-key) or the wildcard alias (`*`). For more information, see [/influxdb/cloud-serverless/reference/influxql/select/#notable-select-statement-behaviors].
+  from a measurement. It requires at least one
+  [field key](/influxdb/cloud-serverless/reference/glossary/#field-key) or the wildcard alias (`*`).
+  For more information, see [Notable SELECT statement behaviors](/influxdb/cloud-serverless/reference/influxql/select/#notable-select-statement-behaviors).
 - {{< req "\*">}} `FROM`: Specify the [measurement](/influxdb/cloud-serverless/reference/glossary/#measurement) to query from.
 It requires one or more comma-delimited [measurement expressions](/influxdb/cloud-serverless/reference/influxql/select/#measurement_expression).
 - `WHERE`: Filter data based on

--- a/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
@@ -75,10 +75,10 @@ If a query uses `GROUP BY` and the `WHERE` clause doesn't filter by time, then g
 {{% note %}}
 #### Sample data
 
-The following examples use the sample data written in the
-[Get started writing data guide](/influxdb/cloud-serverless/get-started/write/).
+The following examples use the 
+[Get started home sensor data](/influxdb/cloud-serverless/reference/sample-data/#get-started-home-sensor-data).
 To run the example queries and return results,
-[write the sample data](/influxdb/cloud-serverless/get-started/write/#write-line-protocol-to-influxdb)
+[write the sample data](/influxdb/cloud-serverless/reference/sample-data/#write-the-home-sensor-data-to-influxdb)
 to your {{% cloud-name %}} database before running the example queries.
 {{% /note %}}
 

--- a/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
+++ b/content/influxdb/cloud-serverless/query-data/influxql/basic-query.md
@@ -49,6 +49,20 @@ WHERE
 ```
 {{% /influxdb/custom-timestamps %}}
 
+## Result set
+
+If at least one row satisfies the query, {{% cloud-name %}} returns row data in the query result set.
+If a query uses a `GROUP BY` clause, the result set includes the following:
+
+- Columns listed in the query's `SELECT` clause
+- A `time` column that contains the timestamp for the record or the group
+- An `iox::measurement` column that contains the record's measurement (table) name
+- Columns listed in the query's `GROUP BY` clause; each row in the result set contains the values used for grouping
+
+### GROUP BY result columns
+
+If a query uses `GROUP BY` and the `WHERE` clause doesn't filter by time, then groups are based on the [default time range](/influxdb/cloud-serverless/reference/group-by/#default-time-range).
+
 ## Basic query examples
 
 - [Query data within time boundaries](#query-data-within-time-boundaries)
@@ -197,12 +211,3 @@ SELECT temp AS "temperature", hum AS "humidity" FROM home
 When aliasing columns in **InfluxQL**, use the `AS` clause and double-quoted alias names.
 When [aliasing columns in **SQL**](/influxdb/cloud-serverless/query-data/sql/basic-query/#alias-queried-fields-and-tags), you can use the `AS` clause to define the alias, but it isn't necessary.
 {{% /note %}}
-
-### Query result set
-
-If at least one row satisfies the query, {{% cloud-name %}} returns row data in the query result set.
-An InfluxQL query result set includes the following columns:
-
-- Data for columns listed in the query's `SELECT` statement
-- The `time` column that contains the timestamp for each record
-- An `iox::measurement` column that contains the record's measurement (table) name

--- a/content/influxdb/cloud-serverless/query-data/sql/aggregate-select.md
+++ b/content/influxdb/cloud-serverless/query-data/sql/aggregate-select.md
@@ -44,7 +44,7 @@ A SQL query that aggregates data includes the following clauses:
 {{< req type="key" >}}
 
 - {{< req "\*">}} `SELECT`: Specify fields, tags, and calculations to output from a
-  measurement or use the wild card alias (`*`) to select all fields and tags
+  measurement or use the wildcard alias (`*`) to select all fields and tags
   from a measurement.
 - {{< req "\*">}} `FROM`: Specify the measurement to query data from.
 - `WHERE`: Only return data that meets the specified conditions--for example, falls within

--- a/content/influxdb/cloud-serverless/query-data/sql/basic-query.md
+++ b/content/influxdb/cloud-serverless/query-data/sql/basic-query.md
@@ -26,7 +26,7 @@ following clauses:
 {{< req type="key" >}}
 
 - {{< req "\*">}} `SELECT`: Specify fields, tags, and calculations to output from a
-  measurement or use the wild card alias (`*`) to select all fields and tags
+  measurement or use the wildcard alias (`*`) to select all fields and tags
   from a measurement.
 - {{< req "\*">}} `FROM`: Specify the measurement to query data from.
 - `WHERE`: Only return data that meets the specified conditions--for example, falls within

--- a/content/influxdb/cloud-serverless/query-data/sql/basic-query.md
+++ b/content/influxdb/cloud-serverless/query-data/sql/basic-query.md
@@ -45,6 +45,11 @@ WHERE
 ```
 {{% /influxdb/custom-timestamps %}}
 
+## Result set
+
+If at least one row satisfies the query, {{% cloud-name %}} returns row data in the query result set.
+An SQL query result set includes columns listed in the query's `SELECT` statement.
+
 ## Basic query examples
 
 - [Query data within time boundaries](#query-data-within-time-boundaries)

--- a/content/influxdb/cloud-serverless/reference/glossary.md
+++ b/content/influxdb/cloud-serverless/reference/glossary.md
@@ -281,6 +281,15 @@ Metrics gathered at irregular time intervals.
 
 A combination of one or more constants, variables, operators, and functions.
 
+In the following SQL example, `now() - INTERVAL '7 days'` is an expression that calculates the difference between the `now()` function expression and the duration represented by `INTERVAL '7 days`:
+
+```sql
+SELECT *
+FROM home
+WHERE
+  time >= now() - INTERVAL '7 days'
+```
+
 ## F
 
 ### field
@@ -428,7 +437,6 @@ An open-source time series database (TSDB) developed by InfluxData.
 Written in Go and optimized for fast, high-availability storage and retrieval of
 time series data in fields such as operations monitoring, application metrics,
 Internet of Things sensor data, and real-time analytics.
-
 
 ### InfluxQL
 
@@ -1109,4 +1117,3 @@ Related entries:
 
 Grouping data based on specified time intervals.
 This is also referred to as "time binning" or "date binning."
-

--- a/content/influxdb/cloud-serverless/reference/influxql/_index.md
+++ b/content/influxdb/cloud-serverless/reference/influxql/_index.md
@@ -35,6 +35,7 @@ see [InfluxQL feature support](/influxdb/cloud-serverless/reference/influxql/fea
 - [Expressions](#expressions)
 - [Comments](#comments)
 - [Other](#other)
+- [Result set](#result-set)
 
 <!-- To learn more about InfluxQL, browse the following topics:
 
@@ -157,7 +158,9 @@ In those cases, you don't need to double-quote `time`  in queries.
 `time` can't be a [field key](/influxdb/cloud-serverless/reference/glossary/#field-key) or
 [tag key](/influxdb/cloud-serverless/reference/glossary/#tag-key);
 InfluxDB rejects writes with `time` as a field key or tag key and returns an error.
+<!--
 See [Frequently Asked Questions](/influxdb/v2.7/reference/faq/) for more information.
+-->
 
 ### Literals
 
@@ -716,6 +719,10 @@ expr             = unary_expr { binary_op unary_expr } .
 unary_expr       = "(" expr ")" | var_ref | time_lit | string_lit | int_lit |
                    float_lit | bool_lit | duration_lit | regex_lit .
 ```
+
+## Default time range
+
+The default time range is the Unix epoch (`1970-01-01T00:00:00Z`) to _now_.
 
 ## Comments
 

--- a/content/influxdb/cloud-serverless/reference/influxql/select.md
+++ b/content/influxdb/cloud-serverless/reference/influxql/select.md
@@ -44,7 +44,7 @@ It requires one or more **field expressions** and optional **tag expressions**.
   Can be a [field key](/influxdb/cloud-serverless/reference/glossary/#field-key),
   constant, [regular expression](/influxdb/cloud-serverless/reference/influxql/regular-expressions/),
   [wildcard (`*`)](#wildcard-expressions-in-select-clauses), or
-  [function](/influxdb/cloud-serverless/reference/influxql/functions/) and any
+  [function expression](/influxdb/cloud-serverless/reference/influxql/functions/) and any
   combination of arithmetic operators.
 - **tag_expression**: Expression to identify one or more tags to return in query results.
   Can be a [tag key](/influxdb/cloud-serverless/reference/glossary/#tag-key) or constant.
@@ -67,9 +67,11 @@ It requires one or more **field expressions** and optional **tag expressions**.
 
 The `FROM` clause specifies the
 [measurement](/influxdb/cloud-serverless/reference/glossary/#measurement) to query.
-It requires one or more comma-delimited **measurement expressions**.
+It requires one or more comma-delimited [measurement_expressions](#measurement_expression).
 
-- **measurement_expression**: Expression to identify one or more measurements to query.
+- #### measurement_expression
+
+  Expression to identify one or more measurements to query.
   Can be a measurement name, fully-qualified measurement, constant, or
   [regular expression](/influxdb/cloud-serverless/reference/influxql/regular-expressions/).
 

--- a/content/influxdb/cloud-serverless/reference/influxql/where.md
+++ b/content/influxdb/cloud-serverless/reference/influxql/where.md
@@ -72,18 +72,17 @@ Operators evaluate the relationship between two operands and return
 ## Time ranges
 
 Use the `WHERE` clause to specify a time range to query.
-If a time range is not defined in the `WHERE` clause, the default time range is
-the Unix epoch (`1970-01-01T00:00:00Z`) to _now_.
+If a time range isn't specified in the `WHERE` clause, the [default time range](/influxdb/cloud-serverless/reference/influxql/#default-time-range) is used.
 
-Timestamps are stored in the `time` columns.
+Timestamps are stored in the `time` column.
 Use comparison operators to compare the value of the `time` column to a
-timestamp literal, integer (Unix nanosecond timestamp), or function.
+timestamp literal, integer (Unix nanosecond timestamp), or [expression](/influxdb/cloud-serverless/reference/glossary/#expression).
 
 {{< code-tabs-wrapper >}}
 {{% code-tabs %}}
 [Timestamp](#)
 [Integer](#)
-[Function](#)
+[Expression](#)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```sql

--- a/content/influxdb/cloud-serverless/reference/sql/_index.md
+++ b/content/influxdb/cloud-serverless/reference/sql/_index.md
@@ -9,7 +9,7 @@ menu:
 weight: 101
 ---
 
-InfluxDB Cloud Serverless uses the [Apache Arrow DataFusion](https://arrow.apache.org/datafusion/) implementation of SQL.  
+{{% cloud-name %}} uses the [Apache Arrow DataFusion](https://arrow.apache.org/datafusion/) implementation of SQL.  
 
 - [Identifiers](#identifiers)  
 - [Quoting and case sensitivity](#quoting-and-case-sensitivity)    
@@ -20,7 +20,7 @@ InfluxDB Cloud Serverless uses the [Apache Arrow DataFusion](https://arrow.apach
 - [Conditional expressions](#conditional-expressions)
 - [Statements and clauses](#statements-and-clauses)  
 - [Comments](#comments)  
-- [Functions](#functions)  
+- [Functions](#functions)
 
 ## Identifiers
 
@@ -480,7 +480,7 @@ Use comments to describe and add detail or notes to your queries.
 
 ## Schema information
 
-InfluxDB Cloud Serverless supports the following metedata schema queries:
+{{% cloud-name %}} supports the following metedata schema queries:
 
 ```sql
 SHOW tables
@@ -619,4 +619,3 @@ GROUP BY time
 | :------------- | :---------------------------------------------------------------------------- |
 | REGEXP_MATCH   | Matches a regular expression against a string and returns matched substrings. |
 | REGEXP_REPLACE | Replaces substrings that match a regular expression by a new substring.       |
-


### PR DESCRIPTION
Closes #5016
Closes #5018 

Drops `iox::measurement` column in downsample examples before writing back to InfluxDB
Describes the InfluxQL default time range and representation in `group by` results.
