### PR TITLE
Correct influx cli flag - it's --errors-file rather than --error-file.

### DIFF
--- a/content/influxdb/v2.0/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.0/reference/cli/influx/write/_index.md
@@ -72,7 +72,7 @@ In **extended annotated CSV**, measurements, fields, and values and their types 
 |      | `--compression`     | Input compression (`none` or `gzip`, default is `none` unless input file ends with `.gz`.) | string      |                       |
 |      | `--debug`           | Output errors to stderr                                                                    |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                              | string      |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                                      | string      |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                                      | string      |                       |
 | `-f` | `--file`            | File to import                                                                             | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                                 | string      |                       |
 |      | `--header`          | Prepend header line to CSV input data                                                      | string      |                       |

--- a/content/influxdb/v2.0/reference/cli/influx/write/dryrun.md
+++ b/content/influxdb/v2.0/reference/cli/influx/write/dryrun.md
@@ -39,7 +39,7 @@ influx write dryrun [flags]
 |      | `--configs-path`    | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`)           | string      | `INFLUX_CONFIGS_PATH` |
 |      | `--debug`           | Output errors to stderr                                                         |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                   | string      |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
 | `-f` | `--file`            | File to import                                                                  | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                      | string      |                       |
 |      | `--header`          | Prepend header line to CSV input data                                           | string      |                       |

--- a/content/influxdb/v2.1/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.1/reference/cli/influx/write/_index.md
@@ -74,7 +74,7 @@ In **extended annotated CSV**, measurements, fields, and values and their types 
 |      | `--compression`     | Input compression (`none` or `gzip`, default is `none` unless input file ends with `.gz`.) | string      |                       |
 |      | `--debug`           | Output errors to stderr                                                                    |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                              | string      |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                                      | string      |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                                      | string      |                       |
 | `-f` | `--file`            | File to import                                                                             | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                                 | string      |                       |
 |      | `--header`          | Prepend header line to CSV input data                                                      | string      |                       |

--- a/content/influxdb/v2.1/reference/cli/influx/write/dryrun.md
+++ b/content/influxdb/v2.1/reference/cli/influx/write/dryrun.md
@@ -39,7 +39,7 @@ influx write dryrun [flags]
 |      | `--configs-path`    | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`)           | string      | `INFLUX_CONFIGS_PATH` |
 |      | `--debug`           | Output errors to stderr                                                         |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                   | string      |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
 | `-f` | `--file`            | File to import                                                                  | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                      | string      |                       |
 |      | `--header`          | Prepend header line to CSV input data                                           | string      |                       |

--- a/content/influxdb/v2.2/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.2/reference/cli/influx/write/_index.md
@@ -74,7 +74,7 @@ In **extended annotated CSV**, measurements, fields, and values and their types 
 |      | `--compression`     | Input compression (`none` or `gzip`, default is `none` unless input file ends with `.gz`.)   |   string    |                       |
 |      | `--debug`           | Output errors to stderr                                                                      |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                                |   string    |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                                        |   string    |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                                        |   string    |                       |
 | `-f` | `--file`            | File to import                                                                               | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                                   |   string    |                       |
 |      | `--header`          | Prepend header line to CSV input data                                                        |   string    |                       |

--- a/content/influxdb/v2.2/reference/cli/influx/write/dryrun.md
+++ b/content/influxdb/v2.2/reference/cli/influx/write/dryrun.md
@@ -39,7 +39,7 @@ influx write dryrun [flags]
 |      | `--configs-path`    | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`)           | string      | `INFLUX_CONFIGS_PATH` |
 |      | `--debug`           | Output errors to stderr                                                         |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                   | string      |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
 | `-f` | `--file`            | File to import                                                                  | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                      | string      |                       |
 |      | `--header`          | Prepend header line to CSV input data                                           | string      |                       |

--- a/content/influxdb/v2.3/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.3/reference/cli/influx/write/_index.md
@@ -74,7 +74,7 @@ In **extended annotated CSV**, measurements, fields, and values and their types 
 |      | `--compression`     | Input compression (`none` or `gzip`, default is `none` unless input file ends with `.gz`.)   |   string    |                       |
 |      | `--debug`           | Output errors to stderr                                                                      |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                                |   string    |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                                        |   string    |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                                        |   string    |                       |
 | `-f` | `--file`            | File to import                                                                               | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                                   |   string    |                       |
 |      | `--header`          | Prepend header line to CSV input data                                                        |   string    |                       |

--- a/content/influxdb/v2.3/reference/cli/influx/write/dryrun.md
+++ b/content/influxdb/v2.3/reference/cli/influx/write/dryrun.md
@@ -39,7 +39,7 @@ influx write dryrun [flags]
 |      | `--configs-path`    | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`)           | string      | `INFLUX_CONFIGS_PATH` |
 |      | `--debug`           | Output errors to stderr                                                         |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                   | string      |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
 | `-f` | `--file`            | File to import                                                                  | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                      | string      |                       |
 |      | `--header`          | Prepend header line to CSV input data                                           | string      |                       |

--- a/content/influxdb/v2.4/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.4/reference/cli/influx/write/_index.md
@@ -74,7 +74,7 @@ In **extended annotated CSV**, measurements, fields, and values and their types 
 |      | `--compression`     | Input compression (`none` or `gzip`, default is `none` unless input file ends with `.gz`.)   |   string    |                       |
 |      | `--debug`           | Output errors to stderr                                                                      |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                                |   string    |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                                        |   string    |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                                        |   string    |                       |
 | `-f` | `--file`            | File to import                                                                               | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                                   |   string    |                       |
 |      | `--header`          | Prepend header line to CSV input data                                                        |   string    |                       |

--- a/content/influxdb/v2.4/reference/cli/influx/write/dryrun.md
+++ b/content/influxdb/v2.4/reference/cli/influx/write/dryrun.md
@@ -39,7 +39,7 @@ influx write dryrun [flags]
 |      | `--configs-path`    | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`)           | string      | `INFLUX_CONFIGS_PATH` |
 |      | `--debug`           | Output errors to stderr                                                         |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                   | string      |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
 | `-f` | `--file`            | File to import                                                                  | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                      | string      |                       |
 |      | `--header`          | Prepend header line to CSV input data                                           | string      |                       |

--- a/content/influxdb/v2.5/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.5/reference/cli/influx/write/_index.md
@@ -74,7 +74,7 @@ In **extended annotated CSV**, measurements, fields, and values and their types 
 |      | `--compression`     | Input compression (`none` or `gzip`, default is `none` unless input file ends with `.gz`.)   |   string    |                       |
 |      | `--debug`           | Output errors to stderr                                                                      |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                                |   string    |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                                        |   string    |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                                        |   string    |                       |
 | `-f` | `--file`            | File to import                                                                               | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                                   |   string    |                       |
 |      | `--header`          | Prepend header line to CSV input data                                                        |   string    |                       |

--- a/content/influxdb/v2.5/reference/cli/influx/write/dryrun.md
+++ b/content/influxdb/v2.5/reference/cli/influx/write/dryrun.md
@@ -39,7 +39,7 @@ influx write dryrun [flags]
 |      | `--configs-path`    | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`)           | string      | `INFLUX_CONFIGS_PATH` |
 |      | `--debug`           | Output errors to stderr                                                         |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                   | string      |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
 | `-f` | `--file`            | File to import                                                                  | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                      | string      |                       |
 |      | `--header`          | Prepend header line to CSV input data                                           | string      |                       |

--- a/content/influxdb/v2.6/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.6/reference/cli/influx/write/_index.md
@@ -74,7 +74,7 @@ In **extended annotated CSV**, measurements, fields, and values and their types 
 |      | `--compression`     | Input compression (`none` or `gzip`, default is `none` unless input file ends with `.gz`.)   |   string    |                       |
 |      | `--debug`           | Output errors to stderr                                                                      |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                                |   string    |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                                        |   string    |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                                        |   string    |                       |
 | `-f` | `--file`            | File to import                                                                               | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                                   |   string    |                       |
 |      | `--header`          | Prepend header line to CSV input data                                                        |   string    |                       |

--- a/content/influxdb/v2.6/reference/cli/influx/write/dryrun.md
+++ b/content/influxdb/v2.6/reference/cli/influx/write/dryrun.md
@@ -39,7 +39,7 @@ influx write dryrun [flags]
 |      | `--configs-path`    | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`)           | string      | `INFLUX_CONFIGS_PATH` |
 |      | `--debug`           | Output errors to stderr                                                         |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                   | string      |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
 | `-f` | `--file`            | File to import                                                                  | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                      | string      |                       |
 |      | `--header`          | Prepend header line to CSV input data                                           | string      |                       |

--- a/content/influxdb/v2.7/reference/cli/influx/write/_index.md
+++ b/content/influxdb/v2.7/reference/cli/influx/write/_index.md
@@ -74,7 +74,7 @@ In **extended annotated CSV**, measurements, fields, and values and their types 
 |      | `--compression`     | Input compression (`none` or `gzip`, default is `none` unless input file ends with `.gz`.)   |   string    |                       |
 |      | `--debug`           | Output errors to stderr                                                                      |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                                |   string    |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                                        |   string    |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                                        |   string    |                       |
 | `-f` | `--file`            | File to import                                                                               | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                                   |   string    |                       |
 |      | `--header`          | Prepend header line to CSV input data                                                        |   string    |                       |

--- a/content/influxdb/v2.7/reference/cli/influx/write/dryrun.md
+++ b/content/influxdb/v2.7/reference/cli/influx/write/dryrun.md
@@ -39,7 +39,7 @@ influx write dryrun [flags]
 |      | `--configs-path`    | Path to `influx` CLI configurations (default `~/.influxdbv2/configs`)           | string      | `INFLUX_CONFIGS_PATH` |
 |      | `--debug`           | Output errors to stderr                                                         |             |                       |
 |      | `--encoding`        | Character encoding of input (default `UTF-8`)                                   | string      |                       |
-|      | `--error-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
+|      | `--errors-file`      | Path to a file used for recording rejected row errors                           | string      |                       |
 | `-f` | `--file`            | File to import                                                                  | stringArray |                       |
 |      | `--format`          | Input format (`lp` or `csv`, default `lp`)                                      | string      |                       |
 |      | `--header`          | Prepend header line to CSV input data                                           | string      |                       |


### PR DESCRIPTION
It also currently seems to need the file to already exist, but I'm going to raise a PR against the CLI shortly to fix that



- [x ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x ] Rebased/mergeable
