### PR TITLE
chore(tableau): replace to use `useSystemTrustStore=false` and add explanation

### DIFF
--- a/content/influxdb/cloud-dedicated/process-data/visualize/tableau.md
+++ b/content/influxdb/cloud-dedicated/process-data/visualize/tableau.md
@@ -77,7 +77,12 @@ To query {{< cloud-name >}} from Tableau, use the **Flight SQL protocol** and th
       - **Protocol**: `jdbc:arrow-flight-sql`
       - **Port**: `443`
       - **Query parameters**:
-        - **disableCertificateVerification**: `true`
+        - **useSystemTrustStore**: `false`
+        {{% note %}}
+        #### Setting `useSystemTrustStore=false` is:
+          1. Only necessary on a mac
+          2. Doesn't actually affect the security
+        {{% /note %}}
         - **database**: InfluxDB database name to query
     
       _See an [example connection URL](#example-connection-url)._
@@ -94,7 +99,7 @@ To query {{< cloud-name >}} from Tableau, use the **Flight SQL protocol** and th
 
 {{< code-placeholders "DATABASE_NAME" >}}
 ```
-jdbc:arrow-flight-sql://cluster-id.influxdb.io:443?disableCertificateVerification=true&database=DATABASE_NAME
+jdbc:arrow-flight-sql://cluster-id.influxdb.io:443?useSystemTrustStore=false&database=DATABASE_NAME
 ```
 {{< /code-placeholders >}}
 

--- a/content/influxdb/cloud-serverless/process-data/visualize/tableau.md
+++ b/content/influxdb/cloud-serverless/process-data/visualize/tableau.md
@@ -71,7 +71,12 @@ To query {{< cloud-name >}} from Tableau, use the **Flight SQL protocol** and th
       - **Protocol**: `jdbc:arrow-flight-sql`
       - **Port**: `443`
       - **Query parameters**:
-        - **disableCertificateVerification**: `true`
+        - **useSystemTrustStore**: `false`
+        {{% note %}}
+        #### Setting `useSystemTrustStore=false` is:
+          1. Only necessary on a mac
+          2. Doesn't actually affect the security
+        {{% /note %}}
         - **database**: InfluxDB bucket name to query
     
       _See an [example connection URL](#example-connection-url)._
@@ -88,7 +93,7 @@ To query {{< cloud-name >}} from Tableau, use the **Flight SQL protocol** and th
 
 {{< code-placeholders "BUCKET_NAME" >}}
 ```
-jdbc:arrow-flight-sql://us-east-1-1.aws.cloud2.influxdata.com:443?disableCertificateVerification=true&database=BUCKET_NAME
+jdbc:arrow-flight-sql://us-east-1-1.aws.cloud2.influxdata.com:443?useSystemTrustStore=false&database=BUCKET_NAME
 ```
 {{< /code-placeholders >}}
 


### PR DESCRIPTION
Closes #5041

## What

1. Replace `disableCertificateVerification=true` with `useSystemTrustStore=false` in the Tableau support pages
2. Add an explanation to users

## Why

See the original issue #5041 for the reason

_Describe your proposed changes here._

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
