### PR TITLE
fix(influx-cli): broken serverless/tools/influx-cli links

### DIFF
--- a/content/influxdb/cloud-serverless/get-started/_index.md
+++ b/content/influxdb/cloud-serverless/get-started/_index.md
@@ -101,7 +101,7 @@ To access the InfluxDB Cloud Serverless UI, [log into your InfluxDB Cloud accoun
 
 The `influx` CLI lets you interact with and manage InfluxDB Cloud Serverless from a command line.
 For detailed CLI installation instructions, see
-[Use the influx CLI](/{{< latest "influxdb" >}}/tools/influx-cli/).
+the [`influx` CLI reference](/influxdb/cloud-serverless/reference/cli/influx/).
 
 ### InfluxDB HTTP API
 

--- a/content/influxdb/cloud-serverless/get-started/setup.md
+++ b/content/influxdb/cloud-serverless/get-started/setup.md
@@ -38,7 +38,7 @@ you need is in place.
 
     The `influx` CLI provides a simple way to interact with InfluxDB from a 
     command line. For detailed installation and setup instructions,
-    see [Use the influx CLI](/influxdb/cloud-serverless/tools/influx-cli/).
+    see the [`influx` CLI reference](/influxdb/cloud-serverless/reference/cli/influx/).
 
 2.  **Create an All Access API token**.
     <span id="create-an-all-access-api-token"></span>
@@ -120,8 +120,8 @@ influx config create \
 ```
 {{% /code-placeholders%}}
 
-_For more information about CLI connection configurations, see
-[Install and use the `influx` CLI](/influxdb/cloud-serverless/tools/influx-cli/#set-up-the-influx-cli)._
+_For more information about CLI connection configurations, see the
+[`influx config` command](/influxdb/cloud-serverless/reference/cli/influx/config/)._
 
 {{% /expand %}}
 
@@ -374,7 +374,7 @@ All API, cURL, and client library examples in this getting started tutorial assu
 {{% tab-content %}}
 <!----------------------------- BEGIN CLI CONTENT ----------------------------->
 
-1.  If you haven't already, [download, install, and configure the `influx` CLI](/influxdb/cloud-serverless/tools/influx-cli/).
+1.  If you haven't already, [download, install, and configure the `influx` CLI](/influxdb/cloud-serverless/reference/cli/influx/).
 2.  Use the [`influx bucket create` command](/influxdb/cloud-serverless/reference/cli/influx/bucket/create/)
     to create a new bucket.
     

--- a/content/influxdb/cloud-serverless/get-started/write.md
+++ b/content/influxdb/cloud-serverless/get-started/write.md
@@ -188,7 +188,7 @@ The UI will confirm that the data has been written successfully.
 {{% tab-content %}}
 <!---------------------------- BEGIN CLI CONTENT ----------------------------->
 
-1.  If you haven't already, [download, install, and configure the `influx` CLI](/influxdb/cloud-serverless/tools/influx-cli/).
+1.  If you haven't already, [download, install, and configure the `influx` CLI](/influxdb/cloud-serverless/get-started/setup/?t=influx+CLI#download-install-and-configure-the-influx-cli).
 2.  Use the [`influx write` command](/influxdb/cloud-serverless/reference/cli/influx/write/)
     to write the [line protocol above](#home-sensor-data-line-protocol) to InfluxDB.
     

--- a/content/influxdb/cloud-serverless/reference/cli/influx/_index.md
+++ b/content/influxdb/cloud-serverless/reference/cli/influx/_index.md
@@ -10,6 +10,8 @@ menu:
     parent: CLIs
 weight: 101
 influxdb/cloud-serverless/tags: [cli]
+aliases:
+  - /influxdb/cloud-serverless/tools/influx-cli/
 related:
   - /influxdb/cloud/tools/clis/
 ---

--- a/content/influxdb/cloud-serverless/write-data/migrate-data/migrate-1x-to-iox.md
+++ b/content/influxdb/cloud-serverless/write-data/migrate-data/migrate-1x-to-iox.md
@@ -30,9 +30,9 @@ The migration process uses the following tools:
   is packaged with InfluxDB 1.x OSS and Enterprise.
 
 - **InfluxDB 2.x `influx` CLI**:  
-  The [2.x `influx` CLI]((/influxdb/cloud/tools/influx-cli/)) is packaged
+  The [2.x `influx` CLI](/influxdb/cloud-serverless/reference/cli/influx/) is packaged
   separately from InfluxDB OSS 2.x and InfluxDB Cloud Serverless.
-  [Download and install the 2.x CLI](/influxdb/cloud/tools/influx-cli/).
+  [Download and install the 2.x CLI](/influxdb/cloud-serverless/reference/cli/influx/).
 
 - **InfluxDB Cloud user interface (UI)**:  
   Visit [cloud2.influxdata.com](https://cloud2.influxdata.com) to access the

--- a/content/influxdb/v2.7/reference/cli/influx/_index.md
+++ b/content/influxdb/v2.7/reference/cli/influx/_index.md
@@ -28,10 +28,196 @@ InfluxDB and `influx` CLI versions may differ, but compatibility is noted for ea
 
 {{% /oss-only %}}
 
-## Download and install the influx CLI
-<a class="btn" href="/influxdb/v2.7/tools/influx-cli/">Download and install the influx CLI</a>
+<!-- TOC -->
 
-### Provide required authentication credentials
+- [Download and install the influx CLI](#download-and-install-the-influx-cli)
+  - [Use Homebrew](#use-homebrew)
+  - [Manually download and install](#manually-download-and-install)
+    - [Download from your browser](#download-from-your-browser)
+    - [Download from the command line](#download-from-the-command-line)
+- [Provide required authentication credentials](#provide-required-authentication-credentials)
+- [Usage](#usage)
+- [Commands](#commands)
+- [Flags](#flags)
+  - [Flag patterns and conventions](#flag-patterns-and-conventions)
+    - [Mapped environment variables](#mapped-environment-variables)
+    - [Shorthand and longhand flags](#shorthand-and-longhand-flags)
+    - [Flag input types](#flag-input-types)
+      - [string](#string)
+      - [stringArray](#stringarray)
+      - [integer](#integer)
+      - [duration](#duration)
+
+<!-- /TOC -->
+
+## Download and install the influx CLI
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[macOS](#)
+[Linux](#)
+[Windows](#)
+{{% /tabs %}}
+
+<!-------------------------------- BEGIN macOS -------------------------------->
+{{% tab-content %}}
+
+Do one of the following:
+
+- [Use Homebrew](#use-homebrew)
+- [Manually download and install](#manually-download-and-install)
+
+### Use Homebrew
+```sh
+brew install influxdb-cli
+```
+
+{{% oss-only %}}
+
+{{% note %}}
+If you used Homebrew to install **InfluxDB v{{< current-version >}}**, the `influxdb-cli`
+formula was downloaded as a dependency and should already be installed.
+If installed, `influxdb-cli` will appear in the output of the following command:
+
+```sh
+brew list | grep influxdb-cli
+```
+{{% /note %}}
+
+{{% /oss-only %}}
+
+### Manually download and install
+
+1. **Download the `influx` CLI package.**
+
+    <a class="btn download" href="https://dl.influxdata.com/influxdb/releases/influxdb2-client-{{< latest-patch cli=true >}}-darwin-amd64.tar.gz" download>influx CLI v{{< latest-patch cli=true >}} (macOS)</a>
+
+2. **Unpackage the downloaded package.**
+
+    Do one of the following:
+    
+    - Double-click the downloaded package file in **Finder**.
+    - Run the following command in a macOS command prompt application such
+    **Terminal** or **[iTerm2](https://www.iterm2.com/)**:
+
+        ```sh
+        # Unpackage contents to the current working directory
+        tar zxvf ~/Downloads/influxdb2-client-{{< latest-patch cli=true >}}-darwin-amd64.tar.gz
+        ```
+
+3. **(Optional) Place the binary in your `$PATH`.**
+
+    ```sh
+    # (Optional) Copy the influx binary to your $PATH
+    sudo cp ~/Downloads/influxdb2-client-{{< latest-patch cli=true >}}-darwin-amd64/influx /usr/local/bin/
+    ```
+
+    If you do not move the `influx` binary into your `$PATH`, prefix the executable
+    `./` to run it in place.
+
+4. **(macOS Catalina and newer) Authorize the `influx` binary.**
+
+    macOS requires downloaded binaries to be signed by registered Apple developers.
+    When you first attempt to run `influx`, macOS will prevent it from running.
+    To authorize the `influx` binary:
+
+    1. Attempt to run an `influx` command.
+    2. Open **System Preferences** and click **Security & Privacy**.
+    3. Under the **General** tab, there is a message about `influx` being blocked.
+      Click **Open Anyway**.
+
+{{% /tab-content %}}
+<!--------------------------------- END macOS --------------------------------->
+
+<!-------------------------------- BEGIN Linux -------------------------------->
+{{% tab-content %}}
+
+1. **Download the influx CLI package.**
+
+    Download the `influx` CLI package [from your browser](#download-from-your-browser)
+    or [from the command line](#download-from-the-command-line).
+
+    #### Download from your browser
+
+    <a class="btn download" href="https://dl.influxdata.com/influxdb/releases/influxdb2-client-{{< latest-patch cli=true >}}-linux-amd64.tar.gz" download >influx CLI v{{< latest-patch cli=true >}} (amd64)</a>
+    <a class="btn download" href="https://dl.influxdata.com/influxdb/releases/influxdb2-client-{{< latest-patch cli=true >}}-linux-arm64.tar.gz" download >influx CLI v{{< latest-patch cli=true >}} (arm)</a>
+
+    #### Download from the command line
+
+    ```sh
+    # amd64
+    wget https://dl.influxdata.com/influxdb/releases/influxdb2-client-{{< latest-patch cli=true >}}-linux-amd64.tar.gz
+
+    # arm
+    wget https://dl.influxdata.com/influxdb/releases/influxdb2-client-{{< latest-patch cli=true >}}-linux-arm64.tar.gz
+    ```
+
+4. **Unpackage the downloaded package.**
+
+    _**Note:** The following commands are examples. Adjust the filenames, paths, and utilities if necessary._
+
+    ```sh
+    # amd64
+    tar xvzf path/to/influxdb2-client-{{< latest-patch cli=true >}}-linux-amd64.tar.gz
+
+    # arm
+    tar xvzf path/to/influxdb2-client-{{< latest-patch cli=true >}}-linux-arm64.tar.gz
+    ```
+
+3. **(Optional) Place the unpackaged `influx` executable in your system `$PATH`.**
+
+    ```sh
+    # amd64
+    sudo cp influxdb2-client-{{< latest-patch cli=true >}}-linux-amd64/influx /usr/local/bin/
+
+    # arm
+    sudo cp influxdb2-client-{{< latest-patch cli=true >}}-linux-arm64/influx /usr/local/bin/
+    ```
+
+    If you do not move the `influx` binary into your `$PATH`, prefix the executable
+    `./` to run it in place.
+
+{{% /tab-content %}}
+<!--------------------------------- END Linux --------------------------------->
+
+<!-------------------------------- BEGIN Windows -------------------------------->
+{{% tab-content %}}
+
+{{% note %}}
+We recommend running `influx` CLI commands in Powershell.
+Command Prompt is not fully compatible.
+{{% /note %}}
+
+1. **Download the `influx` CLI package.**
+
+    <a class="btn download" href="https://dl.influxdata.com/influxdb/releases/influxdb2-client-{{< latest-patch cli=true >}}-windows-amd64.zip" download>influx CLI v{{< latest-patch cli=true >}} (Windows)</a>
+
+2. **Expand the downloaded archive.**
+  
+    Expand the downloaded archive into `C:\Program Files\InfluxData\` and rename it if desired.
+
+    ```powershell
+    > Expand-Archive .\influxdb2-client-{{< latest-patch cli=true >}}-windows-amd64.zip -DestinationPath 'C:\Program Files\InfluxData\'
+    > mv 'C:\Program Files\InfluxData\influxdb2-client-{{< latest-patch cli=true >}}-windows-amd64' 'C:\Program Files\InfluxData\influx'
+    ```
+
+3. **Grant network access to the `influx` CLI.**
+
+    When using the `influx` CLI for the first time, **Windows Defender** displays
+    the following message:
+
+    > Windows Defender Firewall has blocked some features of this app.
+
+    To grant the `influx` CLI the required access, do the following:
+
+    1. Select **Private networks, such as my home or work network**.
+    2. Click **Allow access**.
+
+{{% /tab-content %}}
+<!--------------------------------- END Windows --------------------------------->
+{{< /tabs-wrapper >}}
+
+## Provide required authentication credentials
 To avoid having to pass your InfluxDB **host**, **API token**, and **organization**
 with each command, store them in an `influx` CLI configuration (config).
 `influx` commands that require these credentials automatically retrieve these


### PR DESCRIPTION
- Fixes Page not found - Configure influx cli - use the influx cli button #5045
- Prevents users having to leave cloud-serverless context.
- Copies influx-cli download and installation instructions to influx reference, which is shared across oss, cloud, and cloud-serverless.
- Replaces links pointing to the nonexistent path /influxdb/cloud-serverless/tools/influx-cli and adds an alias for the path.

Closes #5045 

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
