### PR TITLE
chore(ci): Vale: ignore words, ignore spelling and ellipses in table

### DIFF
--- a/.ci/vale/styles/InfluxDataDocs/Ellipses.yml
+++ b/.ci/vale/styles/InfluxDataDocs/Ellipses.yml
@@ -1,0 +1,11 @@
+extends: existence
+message: "In general, don't use an ellipsis."
+link: 'https://developers.google.com/style/ellipses'
+nonword: true
+level: warning
+action:
+  name: remove
+scope:
+  - ~table.cell
+tokens:
+  - '\.\.\.'

--- a/.ci/vale/styles/InfluxDataDocs/Spelling.yml
+++ b/.ci/vale/styles/InfluxDataDocs/Spelling.yml
@@ -1,6 +1,9 @@
 extends: spelling
 message: "Did you really mean '%s'?"
 level: error
+scope:
+  - ~table.header
+  - ~table.cell
 ignore:
   # Located at StylesPath/ignore1.txt
   - InfluxDataDocs/Terms/query-functions.txt

--- a/.ci/vale/styles/InfluxDataDocs/Terms/query-functions.txt
+++ b/.ci/vale/styles/InfluxDataDocs/Terms/query-functions.txt
@@ -1,3 +1,5 @@
+arccosine
+arcsine
 # SQL_INFO_SQL_KEYWORDS
 # Source: https://github.com/influxdata/influxdb_iox/blob/4f9c901dcfece5fcc4d17cfecb6ec45a0dccda5a/flightsql/src/sql_info
 absolute

--- a/.ci/vale/styles/InfluxDataDocs/WordList.yml
+++ b/.ci/vale/styles/InfluxDataDocs/WordList.yml
@@ -1,0 +1,84 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: "https://developers.google.com/style/word-list"
+level: warning
+ignorecase: false
+scope:
+  - ~table.header
+  - ~table.cell
+action:
+  name: replace
+swap:
+  "(?:API Console|dev|developer) key": API key
+  "(?:cell ?phone|smart ?phone)": phone|mobile phone
+  "(?:dev|developer|APIs) console": API console
+  "(?:e-mail|Email|E-mail)": email
+  "(?:file ?path|path ?name)": path
+  "(?:kill|terminate|abort)": stop|exit|cancel|end
+  "(?:OAuth ?2|Oauth)": OAuth 2.0
+  "(?:ok|Okay)": OK|okay
+  "(?:WiFi|wifi)": Wi-Fi
+  '[\.]+apk': APK
+  '3\-D': 3D
+  'Google (?:I\-O|IO)': Google I/O
+  "tap (?:&|and) hold": touch & hold
+  "un(?:check|select)": clear
+  above: preceding
+  account name: username
+  action bar: app bar
+  admin: administrator
+  Ajax: AJAX
+  a\.k\.a|aka: or|also known as
+  Android device: Android-powered device
+  android: Android
+  API explorer: APIs Explorer
+  application: app
+  approx\.: approximately
+  authN: authentication
+  authZ: authorization
+  autoupdate: automatically update
+  cellular data: mobile data
+  cellular network: mobile network
+  chapter: documents|pages|sections
+  check box: checkbox
+  check: select
+  # CLI: command-line tool
+  click on: click|click in
+  # Cloud: Google Cloud Platform|GCP
+  Container Engine: Kubernetes Engine
+  content type: media type
+  curated roles: predefined roles
+  data are: data is
+  Developers Console: Google API Console|API Console
+  disabled?: turn off|off
+  ephemeral IP address: ephemeral external IP address
+  fewer data: less data
+  file name: filename
+  firewalls: firewall rules
+  functionality: capability|feature
+  Google account: Google Account
+  Google accounts: Google Accounts
+  Googling: search with Google
+  grayed-out: unavailable
+  HTTPs: HTTPS
+  in order to: to
+  ingest: import|load
+  k8s: Kubernetes
+  long press: touch & hold
+  network IP address: internal IP address
+  omnibox: address bar
+  open-source: open source
+  overview screen: recents screen
+  regex: regular expression
+  SHA1: SHA-1|HAS-SHA1
+  sign into: sign in to
+  sign-?on: single sign-on
+  static IP address: static external IP address
+  stylesheet: style sheet
+  synch: sync
+  tablename: table name
+  tablet: device
+  touch: tap
+  url: URL
+  vs\.: versus
+  World Wide Web: web

--- a/.ci/vale/styles/Vocab/InfluxData/accept.txt
+++ b/.ci/vale/styles/Vocab/InfluxData/accept.txt
@@ -7,6 +7,7 @@ AuthToken
 bundlers?
 [Cc]hronograf
 CLI
+Clockface
 [Cc]loud
 cloud-dedicated
 Cloud Dedicated
@@ -20,6 +21,7 @@ enum
 Flight
 FlightQuery
 Grafana
+gzip(ped)?
 hostname
 hostUrl
 hostURL
@@ -34,7 +36,9 @@ influx3
 iox
 IOx
 Kapacitor
+lat
 locf
+lon
 namespace
 noaa
 NOAA
@@ -50,6 +54,7 @@ stdout
 Superset
 svg
 [Tt]elegraf
+[Tt]ombstoned
 unescaped
 venv
 Webpack

--- a/.vale.ini
+++ b/.vale.ini
@@ -9,4 +9,6 @@ Packages = Google, Hugo
 [*.md]
 BasedOnStyles = InfluxDataDocs, Google
 
+Google.Ellipses = NO
 Google.Headings = NO
+Google.WordList = NO


### PR DESCRIPTION
Configure Vale to override some Google styles.

- Copy Google's Wordlist to our own so we don't get conflicts when syncing.
- Ignore ellipses and spelling in table cells.
- Ignore more function names
- Add some Vocab terms
