### PR TITLE
fix: Clarify valuecounter aggregator

### DIFF
--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -2791,8 +2791,8 @@ aggregator:
       and emits the count at regular intervals of 'period' seconds.
       This plugin exclusively operates on fields and doesn't affect tags.
 
-      The fields which will be counted must be configured with the fields configuration directive.
-      When no fields are provided, the plugin will not count any fields.
+      To count specific fields, configure them using the fields configuration directive.
+      If no fields are specified, the plugin won't count any fields.
       The results are emitted in fields, formatted as `originalfieldname_fieldvalue = count`.
 
       ValueCounter only works on fields of the type `int`, `bool`, or `string`.

--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -2788,11 +2788,8 @@ aggregator:
     id: valuecounter
     description: |
       The ValueCounter aggregator plugin counts the occurrence of values in fields
-      and emits the counter once every 'period' seconds.
-
-      A use case for the ValueCounter aggregator plugin is when you are processing
-      an HTTP access log with the [Logparser input plugin](#logparser) and want to
-      count the HTTP status codes.
+      and emits the counter once every 'period' seconds. This plugin does not
+      apply to tags, only fields.
 
       The fields which will be counted must be configured with the fields configuration directive.
       When no fields are provided, the plugin will not count any fields.

--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -2788,8 +2788,8 @@ aggregator:
     id: valuecounter
     description: |
       The ValueCounter aggregator plugin counts the occurrence of values in fields
-      and emits the counter once every 'period' seconds. This plugin does not
-      apply to tags, only fields.
+      and emits the count at regular intervals of 'period' seconds.
+      This plugin exclusively operates on fields and doesn't affect tags.
 
       The fields which will be counted must be configured with the fields configuration directive.
       When no fields are provided, the plugin will not count any fields.


### PR DESCRIPTION
The aggregator only applies to fields and not tags. The current example use-case explains how to use the aggregator, but the example itself is suggesting to use the aggregator on tags that are generated. 

We got an issue complaining about this and I'd like to just remove it and instead clarify fields only.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
