### PR TITLE
chore: indicate that tag values cannot be empty in line protocol

### DIFF
--- a/content/influxdb/v2.7/reference/syntax/line-protocol.md
+++ b/content/influxdb/v2.7/reference/syntax/line-protocol.md
@@ -61,7 +61,8 @@ All tag key-value pairs for the point.
 Key-value relationships are denoted with the `=` operand.
 Multiple tag key-value pairs are comma-delimited.
 _Tag keys and tag values are case-sensitive.
-Tag keys are subject to [naming restrictions](#naming-restrictions)._
+Tag keys are subject to [naming restrictions](#naming-restrictions).
+Tag values cannot be empty; instead, omit the tag from the tag set._
 
 _**Key data type:** [String](#string)_  
 _**Value data type:** [String](#string)_


### PR DESCRIPTION
_Describe your proposed changes here._

Line protocol does not allow empty tag values.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
