### PR TITLE
hotfix(v3): missing shared example files

### DIFF
--- a/content/influxdb/clustered/guides/api-compatibility/v1/_index.md
+++ b/content/influxdb/clustered/guides/api-compatibility/v1/_index.md
@@ -171,7 +171,7 @@ Use `Bearer` to authenticate a write request:
 {{% influxdb/custom-timestamps %}}
 {{% code-placeholders "DATABASE_NAME|DATABASE_TOKEN" %}}
 ```sh
-curl -i "https://{{< influxdb/host >}}/write?db=DATABASE_NAME&precision=ms" \
+curl -i "https://{{< influxdb/host >}}/write?db=DATABASE_NAME&precision=s" \
     --header "Authorization: Bearer DATABASE_TOKEN" \
     --header "Content-type: text/plain; charset=utf-8" \
     --data-binary 'home,room=kitchen temp=72 1641024000'

--- a/content/influxdb/clustered/guides/api-compatibility/v1/_index.md
+++ b/content/influxdb/clustered/guides/api-compatibility/v1/_index.md
@@ -102,7 +102,10 @@ The following example shows how to use cURL with the `Basic` authentication sche
 
 {{% code-placeholders "DATABASE_NAME|DATABASE_TOKEN" %}}
 ```sh
-{{% get-shared-text "api/clustered/basic-auth.sh" %}}
+curl --get "https://{{< influxdb/host >}}/query" \
+  --user "":"DATABASE_TOKEN" \
+  --data-urlencode "db=DATABASE_NAME" \
+  --data-urlencode "q=SELECT * FROM MEASUREMENT"
 ```
 {{% /code-placeholders %}}
 
@@ -129,7 +132,10 @@ The following example shows how to use cURL with query string authentication and
 
 {{% code-placeholders "DATABASE_NAME|DATABASE_TOKEN" %}}
 ```sh
-{{% get-shared-text "api/clustered/querystring-auth.sh" %}}
+curl --get "https://{{< influxdb/host >}}/query" \
+  --data-urlencode "p=DATABASE_TOKEN" \
+  --data-urlencode "db=DATABASE_NAME" \
+  --data-urlencode "q=SELECT * FROM MEASUREMENT"
 ```
 {{% /code-placeholders %}}
 
@@ -162,19 +168,29 @@ Authorization: Token DATABASE_TOKEN
 
 Use `Bearer` to authenticate a write request:
 
+{{% influxdb/custom-timestamps %}}
 {{% code-placeholders "DATABASE_NAME|DATABASE_TOKEN" %}}
 ```sh
-{{% get-shared-text "api/clustered/bearer-auth-v1-write.sh" %}}
+curl -i "https://{{< influxdb/host >}}/write?db=DATABASE_NAME&precision=ms" \
+    --header "Authorization: Bearer DATABASE_TOKEN" \
+    --header "Content-type: text/plain; charset=utf-8" \
+    --data-binary 'home,room=kitchen temp=72 1641024000'
 ```
 {{% /code-placeholders %}}
+{{% /influxdb/custom-timestamps %}}
 
 Use `Token` to authenticate a write request:
 
+{{% influxdb/custom-timestamps %}}
 {{% code-placeholders "DATABASE_NAME|DATABASE_TOKEN" %}}
 ```sh
-{{% get-shared-text "api/clustered/token-auth-v1-write.sh" %}}
+curl -i "https://{{< influxdb/host >}}/write?db=DATABASE_NAME&precision=ms" \
+    --header "Authorization: Token DATABASE_TOKEN" \
+    --header "Content-type: text/plain; charset=utf-8" \
+    --data-binary 'home,room=kitchen temp=72 1641024000'
 ```
 {{% /code-placeholders %}}
+{{% /influxdb/custom-timestamps %}}
 
 Replace the following:
 

--- a/content/influxdb/clustered/guides/api-compatibility/v1/_index.md
+++ b/content/influxdb/clustered/guides/api-compatibility/v1/_index.md
@@ -184,7 +184,7 @@ Use `Token` to authenticate a write request:
 {{% influxdb/custom-timestamps %}}
 {{% code-placeholders "DATABASE_NAME|DATABASE_TOKEN" %}}
 ```sh
-curl -i "https://{{< influxdb/host >}}/write?db=DATABASE_NAME&precision=ms" \
+curl -i "https://{{< influxdb/host >}}/write?db=DATABASE_NAME&precision=s" \
     --header "Authorization: Token DATABASE_TOKEN" \
     --header "Content-type: text/plain; charset=utf-8" \
     --data-binary 'home,room=kitchen temp=72 1641024000'

--- a/content/influxdb/clustered/guides/api-compatibility/v2/_index.md
+++ b/content/influxdb/clustered/guides/api-compatibility/v2/_index.md
@@ -75,9 +75,12 @@ Authorization: Token DATABASE_TOKEN
 
 Use `Bearer` to authenticate a write request:
 
+{{% influxdb/custom-timestamps %}}
 {{% code-placeholders "DATABASE_NAME|DATABASE_TOKEN" %}}
 ```sh
-{{% get-shared-text "api/clustered/bearer-auth-v2-write.sh" %}}
+curl --post 'https://{{< influxdb/host >}}/api/v2/write?bucket=DATABASE_NAME&precision=s' \
+  --header 'Authorization: Bearer DATABASE_TOKEN' \
+  --data-binary 'home,room=kitchen temp=72 1641024000'
 ```
 {{% /code-placeholders %}}
 
@@ -85,9 +88,12 @@ Use `Token` to authenticate a write request:
 
 {{% code-placeholders "DATABASE_NAME|DATABASE_TOKEN" %}}
 ```sh
-{{% get-shared-text "api/clustered/token-auth-v2-write.sh" %}}
+curl --post "https://{{< influxdb/host >}}/api/v2/write?bucket=DATABASE_NAME&precision=s" \
+  --header "Authorization: Token DATABASE_TOKEN" \
+  --data-binary 'home,room=kitchen temp=72 1641024000'
 ```
 {{% /code-placeholders %}}
+{{% /influxdb/custom-timestamps %}}
 
 Replace the following:
 

--- a/content/influxdb/clustered/write-data/best-practices/optimize-writes.md
+++ b/content/influxdb/clustered/write-data/best-practices/optimize-writes.md
@@ -102,11 +102,24 @@ For specific instructions, see the
 When using the InfluxDB API `/api/v2/write` endpoint to write data,
 compress the data with `gzip` and set the `Content-Encoding` header to `gzip`.
 
+{{% influxdb/custom-timestamps %}}
 {{% code-callout "Content-Encoding: gzip" "orange" %}}
 ```sh
-{{% get-shared-text "/api/clustered/write-compressed.sh" %}}
+curl --request POST "https://{{< influxdb/host >}}/api/v2/write" \
+  --header "Authorization: Token DATABASE_TOKEN" \
+  --header "Content-Encoding: gzip" \
+  --data-urlencode "org=ignored" \
+  --data-urlencode "bucket=DATABASE_NAME" \
+  --data-urlencode "precision=s" \
+  --data-raw "
+mem,host=host1 used_percent=23.43234543 1641024000
+mem,host=host2 used_percent=26.81522361 1641027600
+mem,host=host1 used_percent=22.52984738 1641031200
+mem,host=host2 used_percent=27.18294630 1641034800
+"
 ```
 {{% /code-callout %}}
+{{% /influxdb/custom-timestamps %}}
 {{% /tab-content %}}
 {{< /tabs-wrapper >}}
 

--- a/shared/text/api/cloud-dedicated/write-compressed.sh
+++ b/shared/text/api/cloud-dedicated/write-compressed.sh
@@ -5,8 +5,8 @@ curl --request POST "https://cluster-id.influxdb.io/api/v2/write" \
   --data-urlencode "bucket=DATABASE_NAME" \
   --data-urlencode "precision=s" \
   --data-raw "
-mem,host=host1 used_percent=23.43234543 1556896326
-mem,host=host2 used_percent=26.81522361 1556896326
-mem,host=host1 used_percent=22.52984738 1556896336
-mem,host=host2 used_percent=27.18294630 1556896336
+mem,host=host1 used_percent=23.43234543 1641024000
+mem,host=host2 used_percent=26.81522361 1641027600
+mem,host=host1 used_percent=22.52984738 1641031200
+mem,host=host2 used_percent=27.18294630 1641034800
 "

--- a/shared/text/api/cloud-serverless/write-compressed.sh
+++ b/shared/text/api/cloud-serverless/write-compressed.sh
@@ -2,8 +2,8 @@ curl --request POST "http://cloud2.influxdata.com/api/v2/write?org=ORG_NAME&buck
   --header "Authorization: Token API_TOKEN" \
   --header "Content-Encoding: gzip" \
   --data-raw "
-mem,host=host1 used_percent=23.43234543 1556896326
-mem,host=host2 used_percent=26.81522361 1556896326
-mem,host=host1 used_percent=22.52984738 1556896336
-mem,host=host2 used_percent=27.18294630 1556896336
+mem,host=host1 used_percent=23.43234543 1641024000
+mem,host=host2 used_percent=26.81522361 1641027600
+mem,host=host1 used_percent=22.52984738 1641031200
+mem,host=host2 used_percent=27.18294630 1641034800
 "


### PR DESCRIPTION
- replace paths to missing shared-text files with examples.
- update timestamps for custom-timestamps in older examples.
- the shared-text solution isn't really working for us, as it can't render the host shortcode and the placeholder names differ between platforms. I'll probably start doing away with it and tinker on a better way to achieve what I was trying to do.

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
