### PR TITLE
Update go get to go install for installing executables

### DIFF
--- a/content/enterprise_influxdb/v1/tools/inch.md
+++ b/content/enterprise_influxdb/v1/tools/inch.md
@@ -18,7 +18,7 @@ Use the InfluxDB inch tool to simulate streaming data to InfluxDB and measure yo
 1. To install `inch`, run the following command in your terminal:
 
     ```bash
-    $ go get github.com/influxdata/inch/cmd/inch
+    $ go install github.com/influxdata/inch/cmd/inch
     ```
 
 2. Verify `inch` is successfully installed in your `GOPATH/bin` (default on Unix `$HOME/go/bin`).

--- a/content/influxdb/v1/tools/inch.md
+++ b/content/influxdb/v1/tools/inch.md
@@ -18,7 +18,7 @@ Use the InfluxDB inch tool to simulate streaming data to InfluxDB and measure yo
 1. To install `inch`, run the following command in your terminal:
 
     ```bash
-    $ go get github.com/influxdata/inch/cmd/inch
+    $ go install github.com/influxdata/inch/cmd/inch
     ```
 
 2. Verify `inch` is successfully installed in your `GOPATH/bin` (default on Unix `$HOME/go/bin`).


### PR DESCRIPTION
Closes influxdata/DAR#394

With Go 1.18+, you can no longer install executables with `go get`. You must use `go install`. There is only one executable we instruct users to install using Go in our docs–the `inch` tool. This PR updates the installation instructions to use `go install`.

- [x] Rebased/mergeable
