### PR TITLE
Python test placeholders

### DIFF
--- a/.ci/vale/styles/Vocab/InfluxData/accept.txt
+++ b/.ci/vale/styles/Vocab/InfluxData/accept.txt
@@ -46,6 +46,7 @@ locf
 lon
 lookahead
 lookbehind
+middleware
 namespace
 noaa
 NOAA

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,6 +1,8 @@
 ## Code sample dependencies
 influxdb3-python
 pandas
+## Tabulate for printing pandas DataFrames.
+tabulate
 python-dotenv==1.0.0
 ## Test dependencies
 pytest==7.4.1

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,15 +1,33 @@
 #!/bin/bash
 
-for file in "$TEST_DIR"/*; do
+for file in `find . -type f` ; do
   if [ -f "$file" ]; then
+    echo "PROCESSING $file"
+
     # Replace placeholder values with environment variables.
-    sed -i '' 's|https:\/\/{{< influxdb/host >}}|$INFLUX_HOST|g;
-    s/API_TOKEN/$INFLUX_TOKEN/g;
+    # Non-language-specific replacements.
+    sed -i 's|https:\/\/{{< influxdb/host >}}|$INFLUX_HOST|g;
+    ' $file
+
+    # Python-specific replacements.
+    # Use f-strings to identify placeholders in Python while also keeping valid syntax if
+    # the user replaces the value.
+    # Remember to import os for your example code.
+    sed -i 's/f"DATABASE_TOKEN"/os.getenv("INFLUX_TOKEN")/g;
+    s/f"API_TOKEN"/os.getenv("INFLUX_TOKEN")/g;
+    s/f"BUCKET_NAME"/os.getenv("INFLUX_DATABASE")/g;
+    s/f"DATABASE_NAME"/os.getenv("INFLUX_DATABASE")/g;
+    s|f"{{< influxdb/host >}}"|os.getenv("INFLUX_HOSTNAME")|g;
+    ' $file
+
+    # Shell-specific replacements.
+    sed -i 's/API_TOKEN/$INFLUX_TOKEN/g;
     s/DATABASE_TOKEN/$INFLUX_TOKEN/g;
     s/BUCKET_NAME/$INFLUX_DATABASE/g;
     s/DATABASE_NAME/$INFLUX_DATABASE/g;' \
     $file
   fi
+  cat $file
 done
 
-pytest --codeblocks $TEST_DIR
+pytest --codeblocks .


### PR DESCRIPTION
[chore(test): Set language-specific replacements for code sample tests](https://github.com/influxdata/docs-v2/commit/ac849d74f5beb9b8fa6dd7f49df5bc7398d2809b) 

This is a bit of a kludge to allow for language-specific replacement patterns
while keeping the code samples valid when a user replaces placeholder strings with their own and copies the sample.
This is necessary for executing (not for validating syntax) of the code samples.

- Workaround for identifying language-specific replacements for pytest-codeblocks test runs.
- Uses Python f-strings to identify Python-specific placeholders.
- To import os for your code sample and hide it from users, wrap it in a comment and use the `pytest-codeblocks:cont` comment tag. See https://github.com/nschloe/pytest-codeblocks/blob/d0ca7e22b8e4d0c2d8807a9cf9e1f8ca7ef20442/README.md?plain=1#L117
- Example to follow...
