### PR TITLE
Fix: Broken link in troubleshoot.md

### DIFF
--- a/content/influxdb/cloud-dedicated/query-data/execute-queries/troubleshoot.md
+++ b/content/influxdb/cloud-dedicated/query-data/execute-queries/troubleshoot.md
@@ -269,6 +269,6 @@ pyarrow._flight.FlightUnavailableError: Flight returned unavailable error,
 **Potential reason**:
 
 - Non-POSIX-compliant systems (such as Windows) need to specify the root certificates in SslCredentialsOptions for the gRPC client, since the defaults are only configured for POSIX filesystems.
-  [Specify the root certificate path](https://github.com/InfluxCommunity/influxdb3-python#windows-users) For Windows User to config the Flight gRPC client.
+  [Specify the root certificate path](/influxdb/cloud-dedicated/reference/client-libraries/v3/python/#specify-the-root-certificate-path) For Windows User to config the Flight gRPC client.
 
   For more information about gRPC SSL/TLS client-server authentication, see [Using client-side SSL/TLS](https://grpc.io/docs/guides/auth/#using-client-side-ssltls) in the [gRPC.io Authentication guide](https://grpc.io/docs/guides/auth/).

--- a/content/influxdb/cloud-dedicated/query-data/execute-queries/troubleshoot.md
+++ b/content/influxdb/cloud-dedicated/query-data/execute-queries/troubleshoot.md
@@ -269,6 +269,6 @@ pyarrow._flight.FlightUnavailableError: Flight returned unavailable error,
 **Potential reason**:
 
 - Non-POSIX-compliant systems (such as Windows) need to specify the root certificates in SslCredentialsOptions for the gRPC client, since the defaults are only configured for POSIX filesystems.
-  [Specify the root certificate path](#specify-the-root-certificate-path) for the Flight gRPC client.
+  [Specify the root certificate path](https://github.com/InfluxCommunity/influxdb3-python#windows-users) For Windows User to config the Flight gRPC client.
 
   For more information about gRPC SSL/TLS client-server authentication, see [Using client-side SSL/TLS](https://grpc.io/docs/guides/auth/#using-client-side-ssltls) in the [gRPC.io Authentication guide](https://grpc.io/docs/guides/auth/).


### PR DESCRIPTION
Closes #5173 

Fixed broken link on the flightunavailable error's potential reason by changing broken link to the Github Repo's solution on the readme page

Refer to the Issue in #5173 for more information

