### PR TITLE
feat(clustered): add s3 permissions policy

### DIFF
--- a/content/influxdb/clustered/install/prerequisites.md
+++ b/content/influxdb/clustered/install/prerequisites.md
@@ -93,12 +93,17 @@ the following:
 - [jq](https://jqlang.github.io/jq/)
 - [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md)
 
-### Appendix
+## Configure object storage permissions
 
-#### S3 Permissions
+Ensure the identity you're using to connect to your S3-compatible object storehas the correct
+permissions to allow InfluxDB to perform all the actions it needs to.
+
+{{< expand-wrapper >}}
+{{% expand "View example AWS S3 access policy" %}}
 
 The IAM role that you use to access AWS S3 should have the following policy:
 
+{{% code-placeholders "S3_BUCKET_NAME" %}}
 ```json
 {
     "Version": "2012-10-17",
@@ -115,7 +120,7 @@ The IAM role that you use to access AWS S3 should have the following policy:
                 "s3:DeleteObject",
                 "s3:AbortMultipartUpload"
             ],
-            "Resource": "arn:aws:s3:::$CLUSTERED_BUCKET/*",
+            "Resource": "arn:aws:s3:::S3_BUCKET_NAME/*",
         },
         {
             "Sid": "",
@@ -124,7 +129,7 @@ The IAM role that you use to access AWS S3 should have the following policy:
                 "s3:ListBucket",
                 "s3:GetBucketLocation"
             ],
-            "Resource": "arn:aws:s3:::$CLUSTERED_BUCKET",
+            "Resource": "arn:aws:s3:::S3_BUCKET_NAME",
         },
         {
             "Sid": "",
@@ -135,5 +140,13 @@ The IAM role that you use to access AWS S3 should have the following policy:
     ]
 }
 ```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`S3_BUCKET_NAME`{{% /code-placeholder-key %}}: Name of your AWS S3 bucket
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
 
 {{< page-nav next="/influxdb/clustered/install/auth/" nextText="Set up authentication" >}}

--- a/content/influxdb/clustered/install/prerequisites.md
+++ b/content/influxdb/clustered/install/prerequisites.md
@@ -93,4 +93,47 @@ the following:
 - [jq](https://jqlang.github.io/jq/)
 - [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md)
 
+### Appendix
+
+#### S3 Permissions
+
+The IAM role that you use to access AWS S3 should have the following policy:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObjectAcl",
+                "s3:PutObject",
+                "s3:ListMultipartUploadParts",
+                "s3:GetObjectAcl",
+                "s3:GetObject",
+                "s3:DeleteObject",
+                "s3:AbortMultipartUpload"
+            ],
+            "Resource": "arn:aws:s3:::$CLUSTERED_BUCKET/*",
+        },
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetBucketLocation"
+            ],
+            "Resource": "arn:aws:s3:::$CLUSTERED_BUCKET",
+        },
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": "s3:ListAllMyBuckets",
+            "Resource": "*",
+        }
+    ]
+}
+```
+
 {{< page-nav next="/influxdb/clustered/install/auth/" nextText="Set up authentication" >}}

--- a/content/influxdb/clustered/install/prerequisites.md
+++ b/content/influxdb/clustered/install/prerequisites.md
@@ -95,7 +95,7 @@ the following:
 
 ## Configure object storage permissions
 
-Ensure the identity you're using to connect to your S3-compatible object storehas the correct
+Ensure the identity you're using to connect to your S3-compatible object store has the correct
 permissions to allow InfluxDB to perform all the actions it needs to.
 
 {{< expand-wrapper >}}


### PR DESCRIPTION
A customer asked about S3 permissions, which is something we've missed in the initial docs.

I've taken this policy from what we run in Cloud 2, so it should line up more or less perfectly. Perhaps there's some tweaks to be made, but we for sure know it works because we use it ourselves.

I'm not sure whether the additional "appendix" section is the right thing to do here, feel free to make/suggest changes as required :smile: 


- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
