### PR TITLE
Update database naming restrictions for Dedicated and Clustered

### DIFF
--- a/content/influxdb/cloud-dedicated/admin/databases/create.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/create.md
@@ -89,9 +89,11 @@ The retention period value cannot be negative or contain whitespace.
 
 Database names must adhere to the following naming restrictions:
 
-- Must contain two or more characters
-- Cannot start with an underscore (`_`)
-- Cannot contain whitespace characters, double quotes (`"`), or percent signs (`%`)
+- Cannot contain whitespace, punctuation, or special characters.
+  Only alphanumeric, underscore (`_`), dash (`-`), and forward-slash
+  (`/`) characters are permitted.
+- Should not start with an underscore (`_`)
+- Maximum length of 64 characters.
 
 ## InfluxQL DBRP naming convention
 

--- a/content/influxdb/cloud-dedicated/admin/databases/create.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/create.md
@@ -92,7 +92,7 @@ Database names must adhere to the following naming restrictions:
 - Cannot contain whitespace, punctuation, or special characters.
   Only alphanumeric, underscore (`_`), dash (`-`), and forward-slash
   (`/`) characters are permitted.
-- Should not start with an underscore (`_`)
+- Should not start with an underscore (`_`).
 - Maximum length of 64 characters.
 
 ## InfluxQL DBRP naming convention

--- a/content/influxdb/cloud-dedicated/admin/databases/update.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/update.md
@@ -96,7 +96,7 @@ Database names must adhere to the following naming restrictions:
 - Cannot contain whitespace, punctuation, or special characters.
   Only alphanumeric, underscore (`_`), dash (`-`), and forward-slash
   (`/`) characters are permitted.
-- Should not start with an underscore (`_`)
+- Should not start with an underscore (`_`).
 - Maximum length of 64 characters.
 
 ## InfluxQL DBRP naming convention

--- a/content/influxdb/cloud-dedicated/admin/databases/update.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/update.md
@@ -93,9 +93,11 @@ The retention period value cannot be negative or contain whitespace.
 
 Database names must adhere to the following naming restrictions:
 
-- Must contain two or more characters
-- Cannot start with an underscore (`_`)
-- Cannot contain whitespace characters, double quotes (`"`), or percent signs (`%`)
+- Cannot contain whitespace, punctuation, or special characters.
+  Only alphanumeric, underscore (`_`), dash (`-`), and forward-slash
+  (`/`) characters are permitted.
+- Should not start with an underscore (`_`)
+- Maximum length of 64 characters.
 
 ## InfluxQL DBRP naming convention
 

--- a/content/influxdb/clustered/admin/databases/create.md
+++ b/content/influxdb/clustered/admin/databases/create.md
@@ -89,9 +89,11 @@ The retention period value cannot be negative or contain whitespace.
 
 Database names must adhere to the following naming restrictions:
 
-- Must contain two or more characters
-- Cannot start with an underscore (`_`)
-- Cannot contain whitespace characters, double quotes (`"`), or percent signs (`%`)
+- Cannot contain whitespace, punctuation, or special characters.
+  Only alphanumeric, underscore (`_`), dash (`-`), and forward-slash
+  (`/`) characters are permitted.
+- Should not start with an underscore (`_`)
+- Maximum length of 64 characters.
 
 ## InfluxQL DBRP naming convention
 

--- a/content/influxdb/clustered/admin/databases/create.md
+++ b/content/influxdb/clustered/admin/databases/create.md
@@ -92,7 +92,7 @@ Database names must adhere to the following naming restrictions:
 - Cannot contain whitespace, punctuation, or special characters.
   Only alphanumeric, underscore (`_`), dash (`-`), and forward-slash
   (`/`) characters are permitted.
-- Should not start with an underscore (`_`)
+- Should not start with an underscore (`_`).
 - Maximum length of 64 characters.
 
 ## InfluxQL DBRP naming convention

--- a/content/influxdb/clustered/admin/databases/update.md
+++ b/content/influxdb/clustered/admin/databases/update.md
@@ -96,7 +96,7 @@ Database names must adhere to the following naming restrictions:
 - Cannot contain whitespace, punctuation, or special characters.
   Only alphanumeric, underscore (`_`), dash (`-`), and forward-slash
   (`/`) characters are permitted.
-- Should not start with an underscore (`_`)
+- Should not start with an underscore (`_`).
 - Maximum length of 64 characters.
 
 ## InfluxQL DBRP naming convention

--- a/content/influxdb/clustered/admin/databases/update.md
+++ b/content/influxdb/clustered/admin/databases/update.md
@@ -93,9 +93,11 @@ The retention period value cannot be negative or contain whitespace.
 
 Database names must adhere to the following naming restrictions:
 
-- Must contain two or more characters
-- Cannot start with an underscore (`_`)
-- Cannot contain whitespace characters, double quotes (`"`), or percent signs (`%`)
+- Cannot contain whitespace, punctuation, or special characters.
+  Only alphanumeric, underscore (`_`), dash (`-`), and forward-slash
+  (`/`) characters are permitted.
+- Should not start with an underscore (`_`)
+- Maximum length of 64 characters.
 
 ## InfluxQL DBRP naming convention
 


### PR DESCRIPTION
Closes #5167

Updates the database naming restrictions for InfluxDB Cloud Dedicated and InfluxDB Clustered to match the findings outline in #5167.

- [x] Rebased/mergeable
