### PR TITLE
fix(v3): remove v2-prefer note, replace with specific recommendations

### DIFF
--- a/content/influxdb/cloud-dedicated/get-started/_index.md
+++ b/content/influxdb/cloud-dedicated/get-started/_index.md
@@ -91,18 +91,18 @@ The following definitions are important to understand when using InfluxDB:
 The following table compares tools that you can use to interact with {{% product-name %}}.
 This tutorial covers many of the recommended tools.
 
-| Tool                              | Administration  | Write   | Query   |
-|:--------------------------------- |:---------------:|:-------:|:-------:|
-| [Chronograf](/chronograf/v1/)     |       -         |   -     | **{{< icon "check" >}}**  |
-| <span style="color:gray">`influx` CLI</span>                                        |   -      | -  |   -     |
-| [`influx3` data CLI](#influx3-data-cli){{< req text="\* " color="magenta" >}}               |       -         | **{{< icon "check" >}}**  | **{{< icon "check" >}}**  |
-| [`influxctl` admin CLI](#influxctl-admin-cli)                          |    **{{< icon "check" >}}**         |   -     |   -     |
-| [InfluxDB HTTP API](#influxdb-http-api)                          |    -        |   **{{< icon "check" >}}**  |   **{{< icon "check" >}}**     |
-| <span style="color:gray">InfluxDB user interface</span> |     -      |   -     | -  |
-| [InfluxDB v3 client libraries](#influxdb-v3-client-libraries){{< req text="\* " color="magenta" >}}      |       -         | **{{< icon "check" >}}**  | **{{< icon "check" >}}**  |
-| [InfluxDB v1 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v1/)      |       -         | **{{< icon "check" >}}**  | **{{< icon "check" >}}**  |
-| [InfluxDB v2 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v2/)      |     **{{< icon "check" >}}**      | **{{< icon "check" >}}**  |   -     |
-| Telegraf                          |       -         | **{{< icon "check" >}}**  |   -     |
+| Tool                                                                                                |      Administration      |          Write           |          Query           |
+|:----------------------------------------------------------------------------------------------------|:------------------------:|:------------------------:|:------------------------:|
+| [Chronograf](/chronograf/v1/)                                                                       |            -             |            -             | **{{< icon "check" >}}** |
+| <span style="color:gray">`influx` CLI</span>                                                        |            -             |            -             |            -             |
+| [`influx3` data CLI](#influx3-data-cli){{< req text="\* " color="magenta" >}}                       |            -             | **{{< icon "check" >}}** | **{{< icon "check" >}}** |
+| [`influxctl` admin CLI](#influxctl-admin-cli)                                                       | **{{< icon "check" >}}** |            -             |            -             |
+| [InfluxDB HTTP API](#influxdb-http-api)                                                             |            -             | **{{< icon "check" >}}** | **{{< icon "check" >}}** |
+| <span style="color:gray">InfluxDB user interface</span>                                             |            -             |            -             |            -             |
+| [InfluxDB v3 client libraries](#influxdb-v3-client-libraries){{< req text="\* " color="magenta" >}} |            -             | **{{< icon "check" >}}** | **{{< icon "check" >}}** |
+| [InfluxDB v1 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v1/)            |            -             | **{{< icon "check" >}}** | **{{< icon "check" >}}** |
+| [InfluxDB v2 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v2/)            |            -             | **{{< icon "check" >}}** |            -             |
+| Telegraf                                                                                            |            -             | **{{< icon "check" >}}** |            -             |
 | **Third-party tools**                                                   |
 | Flight SQL clients               |       -         |   -     | **{{< icon "check" >}}**  |
 |  [Grafana](/influxdb/cloud-dedicated/query-data/sql/execute-queries/grafana/)  |       -         |   -     | **{{< icon "check" >}}**  |

--- a/content/influxdb/cloud-dedicated/guides/api-compatibility/v2/_index.md
+++ b/content/influxdb/cloud-dedicated/guides/api-compatibility/v2/_index.md
@@ -45,7 +45,7 @@ For help finding the best workflow for your situation, [contact Support](mailto:
     - [Client libraries](#client-libraries)
 - [Query data](#query-data)
     - [Tools to execute queries](#tools-to-execute-queries)
-  - [/api/v2/query not supported](#apiv2query-not-supported)
+    - [/api/v2/query not supported](#apiv2query-not-supported)
 
 <!-- /TOC -->
 
@@ -232,7 +232,10 @@ To setup and start using client libraries, see the [Get started](/influxdb/cloud
 
 {{% /note %}}
 
-### /api/v2/query not supported
+{{% warn %}}
+#### /api/v2/query not supported
 
-The `/api/v2/query` API endpoint and associated tooling aren't supported in {{% product-name %}}.
+The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
+
+{{% /warn %}}
 

--- a/content/influxdb/cloud-dedicated/guides/prototype-evaluation.md
+++ b/content/influxdb/cloud-dedicated/guides/prototype-evaluation.md
@@ -184,7 +184,7 @@ as an evaluation or prototyping platform for InfluxDB Cloud Dedicated.
 ### Use the v3 lightweight client libraries
 
 Use the InfluxDB [v3 lightweight client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/)
-to help make your code for writing and querying cross-compatible with InfluxDB Cloud Serverless and Cloud Dedicated.
+to help make your code for writing and querying cross-compatible with InfluxDB Cloud Serverless, Cloud Dedicated, and Clustered.
 You'll only need to change your InfluxDB connection credentials
 (host, database name, and token).
 

--- a/content/influxdb/cloud-dedicated/process-data/visualize/grafana.md
+++ b/content/influxdb/cloud-dedicated/process-data/visualize/grafana.md
@@ -9,7 +9,7 @@ menu:
   influxdb_cloud_dedicated:
     name: Use Grafana
     parent: Visualize data
-influxdb/cloud-dedicated/tags: [query, visualization]
+influxdb/cloud-dedicated/tags: [Flight client, query, visualization]
 aliases:
   - /influxdb/cloud-dedicated/query-data/tools/grafana/
   - /influxdb/cloud-dedicated/query-data/sql/execute-queries/grafana/

--- a/content/influxdb/cloud-dedicated/process-data/visualize/superset.md
+++ b/content/influxdb/cloud-dedicated/process-data/visualize/superset.md
@@ -10,7 +10,7 @@ menu:
     parent: Visualize data
     name: Use Superset
     identifier: query-with-superset
-influxdb/cloud-dedicated/tags: [query, flightsql, superset]
+influxdb/cloud-dedicated/tags: [Flight client, query, flightsql, superset]
 aliases:
   - /influxdb/cloud-dedicated/query-data/execute-queries/flight-sql/superset/
   - /influxdb/cloud-dedicated/query-data/tools/superset/

--- a/content/influxdb/cloud-dedicated/process-data/visualize/tableau.md
+++ b/content/influxdb/cloud-dedicated/process-data/visualize/tableau.md
@@ -10,7 +10,7 @@ menu:
     parent: Visualize data
     name: Use Tableau
     identifier: query-with-tableau
-influxdb/cloud-dedicated/tags: [query, flightsql, tableau, sql]
+influxdb/cloud-dedicated/tags: [Flight client, query, flightsql, tableau, sql]
 aliases:
   - /influxdb/cloud-dedicated/query-data/execute-queries/flight-sql/tableau/
   - /influxdb/cloud-dedicated/query-data/tools/tableau/

--- a/content/influxdb/cloud-dedicated/query-data/_index.md
+++ b/content/influxdb/cloud-dedicated/query-data/_index.md
@@ -12,4 +12,13 @@ influxdb/cloud-dedicated/tags: [query]
 
 Learn to query data stored in InfluxDB.
 
+{{% note %}}
+
+#### Choose the query method for your workload
+
+- For new query workloads, use one of the many available [Flight clients](/influxdb/cloud-dedicated/tags/flight-client/) and SQL or InfluxQL.
+- [Use the HTTP API `/query` endpoint and InfluxQL](/influxdb/cloud-dedicated/query-data/execute-queries/influxdb-v1-api/) when you bring existing v1 query workloads to {{% product-name %}}.
+
+{{% /note %}}
+
 {{< children >}}

--- a/content/influxdb/cloud-dedicated/query-data/execute-queries/_index.md
+++ b/content/influxdb/cloud-dedicated/query-data/execute-queries/_index.md
@@ -17,7 +17,7 @@ aliases:
 Use tools and libraries to query data stored in an {{% product-name %}} bucket.
 
 InfluxDB client libraries and Flight clients can use the Flight+gRPC protocol to query with SQL or InfluxQL and retrieve data in the [Arrow in-memory format](https://arrow.apache.org/docs/format/Columnar.html).
-HTTP clients can use the InfluxDB v1 `/query` REST API to query with InfluxQL and retrieve data in formatted as JSON.
+HTTP clients can use the InfluxDB v1 `/query` REST API to query with InfluxQL and retrieve data in JSON format.
 
 Learn how to connect to InfluxDB and query your data using the following tools:
 

--- a/content/influxdb/cloud-dedicated/query-data/execute-queries/client-libraries/go.md
+++ b/content/influxdb/cloud-dedicated/query-data/execute-queries/client-libraries/go.md
@@ -12,7 +12,7 @@ menu:
     name: Use Go
     identifier: query-with-go
 metadata: [InfluxQL, SQL]
-influxdb/cloud-dedicated/tags: [query, flight, go, sql, influxql]
+influxdb/cloud-dedicated/tags: [query, flight, Flight client, go, sql, influxql]
 related:
     - /influxdb/cloud-dedicated/reference/client-libraries/v3/go/
     - /influxdb/cloud-dedicated/reference/sql/

--- a/content/influxdb/cloud-dedicated/query-data/execute-queries/client-libraries/python.md
+++ b/content/influxdb/cloud-dedicated/query-data/execute-queries/client-libraries/python.md
@@ -11,7 +11,7 @@ menu:
     parent: Use client libraries
     name: Use Python
     identifier: query-with-python-sql
-influxdb/cloud-dedicated/tags: [query, flight, python, sql, influxql]
+influxdb/cloud-dedicated/tags: [query, flight, Flight client, python, sql, influxql]
 aliases:
     - /influxdb/cloud-dedicated/query-data/execute-queries/flight-sql/python/
     - /influxdb/cloud-dedicated/query-data/execute-queries/influxql/python/

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/flight/go-flight.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/flight/go-flight.md
@@ -6,7 +6,7 @@ menu:
     name: Go
     parent: Arrow Flight clients
     identifier: go-flight-client
-influxdb/cloud-dedicated/tags: [Go, gRPC, SQL, Flight SQL, client libraries]
+influxdb/cloud-dedicated/tags: [Flight client, Go, gRPC, SQL, Flight SQL, client libraries]
 related:
   - /influxdb/cloud-dedicated/reference/client-libraries/v3/go/
 aliases:

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/flight/java-flightsql.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/flight/java-flightsql.md
@@ -6,7 +6,7 @@ menu:
     name: Java Flight SQL
     parent: Arrow Flight clients
     identifier: java-flightsql-client
-influxdb/cloud-dedicated/tags: [Java, gRPC, SQL, Flight SQL]
+influxdb/cloud-dedicated/tags: [Flight client, Java, gRPC, SQL, Flight SQL]
 weight: 201
 related:
   - /influxdb/cloud-dedicated/reference/client-libraries/v3/java/

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/flight/python-flight.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/flight/python-flight.md
@@ -6,7 +6,7 @@ menu:
     name: Python
     parent: Arrow Flight clients
     identifier: python-flight-client
-influxdb/cloud-dedicated/tags: [Python, gRPC, SQL, Flight SQL, client libraries]
+influxdb/cloud-dedicated/tags: [Flight client, Python, gRPC, SQL, Flight SQL, client libraries]
 aliases:
   - /influxdb/cloud-dedicated/reference/client-libraries/flight-sql/python-flightsql/
 weight: 201

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/flight/python-flightsql-dbapi.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/flight/python-flightsql-dbapi.md
@@ -6,7 +6,7 @@ menu:
     name: Python Flight SQL
     parent: Arrow Flight clients
     identifier: python-flightsql-client
-influxdb/cloud-dedicated/tags: [Python, SQL, Flight SQL]
+influxdb/cloud-dedicated/tags: [Flight client, Python, SQL, Flight SQL]
 weight: 201
 aliases:
   - /influxdb/cloud-dedicated/reference/client-libraries/flight-sql/python-flightsql/

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/_index.md
@@ -21,13 +21,13 @@ InfluxDB client libraries are maintained by the InfluxDB community.
 For specifics about a client library, see the library's GitHub repository.
 
 {{% note %}}
-### Tools to execute queries
+#### Tools to execute queries
 
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
+This client library can't query an {{% product-name omit=" Clustered" %}} database.
 
 {{% product-name %}} supports many different tools for querying data, including:
 
+- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
 - [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/)
 - [Flight clients](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/)
 - [Superset](/influxdb/cloud-dedicated/query-data/sql/execute-queries/superset/)
@@ -37,5 +37,13 @@ This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
 
 {{% /note %}}
 
+{{% warn %}}
+
+#### /api/v2/query not supported
+
+The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
+The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
+
+{{% /warn %}}
 
 {{< children type="list" depth="999" >}}

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/_index.md
@@ -9,6 +9,17 @@ menu:
     name: v2 client libraries
     parent: Client libraries
 influxdb/cloud-dedicated/tags: [client libraries, API, developer tools]
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 ## Client libraries for InfluxDB 2.x and 1.8+
@@ -19,31 +30,5 @@ InfluxDB v2 client libraries use InfluxDB `/api/v2` endpoints and work with [Inf
 Functionality varies among client libraries.
 InfluxDB client libraries are maintained by the InfluxDB community.
 For specifics about a client library, see the library's GitHub repository.
-
-{{% note %}}
-#### Tools to execute queries
-
-This client library can't query an {{% product-name omit=" Clustered" %}} database.
-
-{{% product-name %}} supports many different tools for querying data, including:
-
-- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
-- [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/)
-- [Flight clients](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/)
-- [Superset](/influxdb/cloud-dedicated/query-data/sql/execute-queries/superset/)
-- [Grafana](/influxdb/cloud-dedicated/query-data/sql/execute-queries/grafana/)
-- [InfluxQL with InfluxDB v1 HTTP API](/influxdb/cloud-dedicated/primers/api/v1/#query-using-the-v1-api)
-- [Chronograf](/chronograf/v1/)
-
-{{% /note %}}
-
-{{% warn %}}
-
-#### /api/v2/query not supported
-
-The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
-
-{{% /warn %}}
 
 {{< children type="list" depth="999" >}}

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/arduino.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/arduino.md
@@ -9,9 +9,18 @@ menu:
   influxdb_cloud_dedicated:
     name: Arduino
     parent: v2 client libraries
-    params:
-      url: https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Arduino is an open-source hardware and software platform used for building electronics projects.

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/csharp.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/csharp.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_dedicated:
     name: C#
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-csharp
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 C# is a general-purpose object-oriented programming language.

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/dart.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/dart.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_dedicated:
     name: Dart
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-dart
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Dart is a programming language created for quick application development for both web and mobile apps.

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/go.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/go.md
@@ -16,8 +16,7 @@ Use the [InfluxDB Go client library](https://github.com/influxdata/influxdb-clie
 {{% note %}}
 ### Use the InfluxDB v3 client library
 
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name %}} database.
+This client library can't query an {{% product-name %}} database.
 
 Use the [InfluxDB v3 Go client library](/influxdb/cloud-dedicated/reference/client-libraries/v3/go/)
 to write and query data stored in {{% product-name %}}.

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/go.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/go.md
@@ -9,18 +9,20 @@ menu:
     parent: v2 client libraries
 influxdb/cloud-dedicated/tags: [client libraries, Go]
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Use the [InfluxDB Go client library](https://github.com/influxdata/influxdb-client-go) to write data to an {{% product-name %}} database.
-
-{{% note %}}
-### Use the InfluxDB v3 client library
-
-This client library can't query an {{% product-name %}} database.
-
-Use the [InfluxDB v3 Go client library](/influxdb/cloud-dedicated/reference/client-libraries/v3/go/)
-to write and query data stored in {{% product-name %}}.
-{{% /note %}}
 
 This guide presumes some familiarity with Go and InfluxDB.
 If just getting started, see [Get started with InfluxDB](/influxdb/cloud-dedicated/get-started/).

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/java.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/java.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_dedicated:
     name: Java
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-java
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Java is one of the oldest and most popular class-based, object-oriented programming languages.

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/_index.md
@@ -12,36 +12,21 @@ menu:
 influxdb/cloud-dedicated/tags: [client libraries, JavaScript, NodeJS]
 weight: 201
 aliases:
-  - /influxdb/cloud-dedicated/reference/api/client-libraries/js/  
+  - /influxdb/cloud-dedicated/reference/api/client-libraries/js/
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 The [InfluxDB v2 JavaScript client library](https://github.com/influxdata/influxdb-client-js)
 for Node.js and browsers integrates with the InfluxDB v2 API to write data to an {{% product-name omit=" Clustered" %}} cluster.
-
-{{% note %}}
-### Tools to execute queries
-
-This client library can't query an {{% product-name omit=" Clustered" %}} database.
-
-{{% product-name %}} supports many different tools for querying data, including:
-
-- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
-- [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/)
-- [Flight clients](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/)
-- [Superset](/influxdb/cloud-dedicated/query-data/sql/execute-queries/superset/)
-- [Grafana](/influxdb/cloud-dedicated/query-data/sql/execute-queries/grafana/)
-- [InfluxQL with InfluxDB v1 HTTP API](/influxdb/cloud-dedicated/primers/api/v1/#query-using-the-v1-api)
-- [Chronograf](/chronograf/v1/)
-
-{{% /note %}}
-
-{{% warn %}}
-
-#### /api/v2/query not supported
-
-The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
-
-{{% /warn %}}
 
 {{< children depth="999" >}}

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/_index.md
@@ -21,8 +21,7 @@ for Node.js and browsers integrates with the InfluxDB v2 API to write data to an
 {{% note %}}
 ### Tools to execute queries
 
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
+This client library can't query an {{% product-name omit=" Clustered" %}} database.
 
 {{% product-name %}} supports many different tools for querying data, including:
 
@@ -35,5 +34,14 @@ This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
 - [Chronograf](/chronograf/v1/)
 
 {{% /note %}}
+
+{{% warn %}}
+
+#### /api/v2/query not supported
+
+The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
+The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
+
+{{% /warn %}}
 
 {{< children depth="999" >}}

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/browser.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/browser.md
@@ -24,11 +24,11 @@ Use the [InfluxDB v2 JavaScript client library](https://github.com/influxdata/in
 
 ### Tools to execute queries
 
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name %}} database.
+This client library can't query an {{% product-name %}} database.
 
 {{% product-name %}} supports many different tools for querying data, including:
 
+- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
 - [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/)
 - [Flight clients](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/)
 - [Superset](/influxdb/cloud-dedicated/query-data/sql/execute-queries/superset/)
@@ -37,6 +37,15 @@ This endpoint can't query an {{% product-name %}} database.
 - [Chronograf](/chronograf/v1/)
 
 {{% /note %}}
+
+{{% warn %}}
+
+#### /api/v2/query not supported
+
+The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
+The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
+
+{{% /warn %}}
 
 This library supports both front-end and server-side environments and provides the following distributions:
 

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/browser.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/browser.md
@@ -16,36 +16,20 @@ aliases:
 related:
   - /influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/nodejs/write/
   - /influxdb/cloud-dedicated/api-guide/client-libraries/nodejs/query/
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Use the [InfluxDB v2 JavaScript client library](https://github.com/influxdata/influxdb-client-js) in browsers and front-end clients to write data to an {{% product-name %}} database.
-
-{{% note %}}
-
-### Tools to execute queries
-
-This client library can't query an {{% product-name %}} database.
-
-{{% product-name %}} supports many different tools for querying data, including:
-
-- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
-- [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/)
-- [Flight clients](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/)
-- [Superset](/influxdb/cloud-dedicated/query-data/sql/execute-queries/superset/)
-- [Grafana](/influxdb/cloud-dedicated/query-data/sql/execute-queries/grafana/)
-- [InfluxQL with InfluxDB v1 HTTP API](/influxdb/cloud-dedicated/primers/api/v1/#query-using-the-v1-api)
-- [Chronograf](/chronograf/v1/)
-
-{{% /note %}}
-
-{{% warn %}}
-
-#### /api/v2/query not supported
-
-The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
-
-{{% /warn %}}
 
 This library supports both front-end and server-side environments and provides the following distributions:
 

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/nodejs/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/nodejs/_index.md
@@ -22,11 +22,11 @@ integrates with the InfluxDB v2 API to write data from Node.js and browser appli
 
 ### Tools to execute queries
 
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name %}} database.
+This client library can't query an {{% product-name omit=" Clustered" %}} database.
 
 {{% product-name %}} supports many different tools for querying data, including:
 
+- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
 - [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/)
 - [Flight clients](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/)
 - [Superset](/influxdb/cloud-dedicated/query-data/sql/execute-queries/superset/)
@@ -35,6 +35,15 @@ This endpoint can't query an {{% product-name %}} database.
 - [Chronograf](/chronograf/v1/)
 
 {{% /note %}}
+
+{{% warn %}}
+
+#### /api/v2/query not supported
+
+The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
+The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
+
+{{% /warn %}}
 
 ## Use the client library in a Node.js application
 

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/nodejs/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/nodejs/_index.md
@@ -12,38 +12,22 @@ menu:
 influxdb/cloud-dedicated/tags: [client libraries, JavaScript, NodeJS]
 weight: 201
 aliases:
-  - /influxdb/cloud-dedicated/reference/api/client-libraries/nodejs/ 
+  - /influxdb/cloud-dedicated/reference/api/client-libraries/nodejs/
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 The [InfluxDB v2 JavaScript client library](https://github.com/influxdata/influxdb-client-js)
 integrates with the InfluxDB v2 API to write data from Node.js and browser applications to an {{% product-name %}} database.
-
-{{% note %}}
-
-### Tools to execute queries
-
-This client library can't query an {{% product-name omit=" Clustered" %}} database.
-
-{{% product-name %}} supports many different tools for querying data, including:
-
-- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
-- [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/)
-- [Flight clients](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/)
-- [Superset](/influxdb/cloud-dedicated/query-data/sql/execute-queries/superset/)
-- [Grafana](/influxdb/cloud-dedicated/query-data/sql/execute-queries/grafana/)
-- [InfluxQL with InfluxDB v1 HTTP API](/influxdb/cloud-dedicated/primers/api/v1/#query-using-the-v1-api)
-- [Chronograf](/chronograf/v1/)
-
-{{% /note %}}
-
-{{% warn %}}
-
-#### /api/v2/query not supported
-
-The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
-
-{{% /warn %}}
 
 ## Use the client library in a Node.js application
 

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/nodejs/install.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/nodejs/install.md
@@ -10,36 +10,18 @@ influxdb/cloud-dedicated/tags: [client libraries, JavaScript]
 weight: 100
 aliases:
   - /influxdb/cloud-dedicated/reference/api/client-libraries/nodejs/install
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
-
-{{% note %}}
-
-Install the Node.js JavaScript client library to write data to an {{% product-name %}} database.
-
-### Tools to execute queries
-
-This client library can't query an {{% product-name %}} database.
-
-{{% product-name %}} supports many different tools for querying data, including:
-
-- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
-- [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/)
-- [Flight clients](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/)
-- [Superset](/influxdb/cloud-dedicated/query-data/sql/execute-queries/superset/)
-- [Grafana](/influxdb/cloud-dedicated/query-data/sql/execute-queries/grafana/)
-- [InfluxQL with InfluxDB v1 HTTP API](/influxdb/cloud-dedicated/primers/api/v1/#query-using-the-v1-api)
-- [Chronograf](/chronograf/v1/)
-
-{{% /note %}}
-
-{{% warn %}}
-
-#### /api/v2/query not supported
-
-The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
-
-{{% /warn %}}
 
 ## Install Node.js
 

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/nodejs/install.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/nodejs/install.md
@@ -18,11 +18,11 @@ Install the Node.js JavaScript client library to write data to an {{% product-na
 
 ### Tools to execute queries
 
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name %}} database.
+This client library can't query an {{% product-name %}} database.
 
 {{% product-name %}} supports many different tools for querying data, including:
 
+- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
 - [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/)
 - [Flight clients](/influxdb/cloud-dedicated/reference/client-libraries/flight-sql/)
 - [Superset](/influxdb/cloud-dedicated/query-data/sql/execute-queries/superset/)
@@ -31,6 +31,15 @@ This endpoint can't query an {{% product-name %}} database.
 - [Chronograf](/chronograf/v1/)
 
 {{% /note %}}
+
+{{% warn %}}
+
+#### /api/v2/query not supported
+
+The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
+The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
+
+{{% /warn %}}
 
 ## Install Node.js
 

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/nodejs/write.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/javascript/nodejs/write.md
@@ -13,6 +13,17 @@ aliases:
   - /influxdb/cloud-dedicated/reference/api/client-libraries/nodejs/write
 related:
   - /influxdb/cloud-dedicated/write-data/troubleshoot/
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Use the [InfluxDB v2 JavaScript client library](https://github.com/influxdata/influxdb-client-js) to write data from a Node.js environment to InfluxDB.

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/kotlin.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/kotlin.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_dedicated:
     name: Kotlin
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-java/tree/master/client-kotlin
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Kotlin is an open-source programming language that runs on the Java Virtual Machine (JVM). 

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/php.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/php.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_dedicated:
     name: PHP
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-php
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 PHP is a popular general-purpose scripting language primarily used for web development. 

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/python.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/python.md
@@ -14,6 +14,17 @@ aliases:
   - /influxdb/cloud-dedicated/reference/api/client-libraries/python-cl-guide/
   - /influxdb/cloud-dedicated/tools/client-libraries/python/
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Use the [InfluxDB Python client library](https://github.com/influxdata/influxdb-client-python) to integrate InfluxDB into Python scripts and applications.

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/r.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/r.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_dedicated:
     name: R
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-r
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 R is a programming language and software environment for statistical analysis, reporting, and graphical representation primarily used in data science. 

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/ruby.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/ruby.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_dedicated:
     name: Ruby
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-ruby
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Ruby is a highly flexible, open-source, object-oriented programming language.

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/scala.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/scala.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_dedicated:
     name: Scala
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-java/tree/master/client-scala
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Scala is a general-purpose programming language that supports both object-oriented and functional programming.

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v2/swift.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v2/swift.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_dedicated:
     name: Swift
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-swift
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-dedicated/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-dedicated/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-dedicated/write-data/) and [**querying**](/influxdb/cloud-dedicated/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-dedicated/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Swift is a programming language created by Apple for building applications across multiple Apple platforms.

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v3/go.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v3/go.md
@@ -7,7 +7,7 @@ menu:
     name: Go
     parent: v3 client libraries
     identifier: influxdb3-go
-influxdb/cloud-dedicated/tags: [go, InfluxQL, SQL, Flight, client libraries]
+influxdb/cloud-dedicated/tags: [Flight client, go, InfluxQL, SQL, Flight, client libraries]
 weight: 201
 aliases:
   - /influxdb/cloud-dedicated/reference/api/client-libraries/go/

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v3/java.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v3/java.md
@@ -9,7 +9,7 @@ menu:
     name: Java
     parent: v3 client libraries
     identifier: influxdb3-java
-influxdb/cloud-dedicated/tags: [Java, gRPC, SQL, Flight SQL, client libraries]
+influxdb/cloud-dedicated/tags: [Flight client, Java, gRPC, SQL, Flight SQL, client libraries]
 weight: 201
 ---
 

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v3/javascript.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v3/javascript.md
@@ -9,7 +9,7 @@ menu:
     name: JavaScript
     parent: v3 client libraries
     identifier: influxdb3-js
-influxdb/cloud-dedicated/tags: [JavaScript, gRPC, SQL, Flight SQL, client libraries]
+influxdb/cloud-dedicated/tags: [Flight client, JavaScript, gRPC, SQL, Flight SQL, client libraries]
 weight: 201
 aliases:
   - /influxdb/cloud-dedicated/reference/api/client-libraries/go/

--- a/content/influxdb/cloud-dedicated/write-data/_index.md
+++ b/content/influxdb/cloud-dedicated/write-data/_index.md
@@ -18,9 +18,14 @@ influxdb/cloud-dedicated/tags: [write, line protocol]
 
 Write data to {{% product-name %}} using the following tools and methods:
 
-{{% warn %}}
-{{% api/cloud/v2-prefer %}}
-{{% /warn %}}
+{{% note %}}
+
+#### Choose the write endpoint for your workload
+
+When bringing existing v1 write workloads, use the {{% product-name %}} HTTP API [`/write` endpoint](/influxdb/cloud-dedicated/guides/api-compatibility/v1/).
+When creating new write workloads, use the HTTP API [`/api/v2/write` endpoint](/influxdb/cloud-dedicated/guides/api-compatibility/v2/).
+
+{{% /note %}}
 
 {{< children >}}
  

--- a/content/influxdb/cloud-dedicated/write-data/use-telegraf/configure/_index.md
+++ b/content/influxdb/cloud-dedicated/write-data/use-telegraf/configure/_index.md
@@ -41,11 +41,9 @@ for using Telegraf with {{< product-name >}}._
       - [token](#token)
       - [organization](#organization)
       - [bucket](#bucket)
-      - [Write to InfluxDB v1.x and {{< product-name >}}](#write-to-influxdb-v1x-and--product-name-)
+      - [Write to InfluxDB v1.x and {{< product-name >}}](#write-to-influxdb-v1x-and-influxdb-cloud-dedicated)
   - [Other Telegraf configuration options](#other-telegraf-configuration-options)
 - [Start Telegraf](#start-telegraf)
-
-<!-- /TOC -->
 
 ## Configure Telegraf input and output plugins
 

--- a/content/influxdb/cloud-serverless/guides/api-compatibility/v2/_index.md
+++ b/content/influxdb/cloud-serverless/guides/api-compatibility/v2/_index.md
@@ -45,7 +45,7 @@ To query data, use the _Flight+gRPC_ protocol  or the InfluxDB v1 `/query` HTTP 
     - [Client libraries](#client-libraries)
 - [Query data](#query-data)
     - [Tools to execute queries](#tools-to-execute-queries)
-  - [/api/v2/query not supported](#apiv2query-not-supported)
+    - [Avoid using /api/v2/query](#avoid-using-apiv2query)
 
 <!-- /TOC -->
 
@@ -210,7 +210,12 @@ InfluxDB v3 provides the following protocols for executing a query:
 
 {{% /note %}}
 
-### /api/v2/query not supported
+{{% warn %}}
 
-The `/api/v2/query` API endpoint and associated tooling aren't supported in {{% product-name %}}.
+#### Avoid using /api/v2/query
+
+Avoid using the `/api/v2/query` API endpoint in {{% product-name %}} and associated tooling, such as the `influx query` CLI command and InfluxDB v2 client libraries.
+You can't use SQL or InfluxQL with these tools.
+
+{{% /warn %}}
 

--- a/content/influxdb/cloud-serverless/guides/prototype-evaluation.md
+++ b/content/influxdb/cloud-serverless/guides/prototype-evaluation.md
@@ -183,7 +183,7 @@ as an evaluation or prototyping platform for InfluxDB Cloud Dedicated.
 ### Use the v3 lightweight client libraries
 
 Use the InfluxDB [v3 lightweight client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/)
-to help make your code for writing and querying cross-compatible with InfluxDB Cloud Serverless and Cloud Dedicated.
+to help make your code for writing and querying cross-compatible with InfluxDB Cloud Serverless, Cloud Dedicated, and Clustered.
 You'll only need to change your InfluxDB connection credentials
 (host, database name, and token).
 

--- a/content/influxdb/cloud-serverless/process-data/visualize/superset.md
+++ b/content/influxdb/cloud-serverless/process-data/visualize/superset.md
@@ -9,7 +9,7 @@ menu:
   influxdb_cloud_serverless:
     parent: Visualize data
     name: Use Superset
-influxdb/cloud-serverless/tags: [query, flightsql, superset]
+influxdb/cloud-serverless/tags: [Flight client, query, flightsql, superset]
 aliases:
   - /influxdb/cloud-serverless/query-data/tools/superset/
   - /influxdb/cloud-serverless/query-data/sql/execute-queries/superset/

--- a/content/influxdb/cloud-serverless/process-data/visualize/tableau.md
+++ b/content/influxdb/cloud-serverless/process-data/visualize/tableau.md
@@ -8,7 +8,7 @@ menu:
   influxdb_cloud_serverless:
     parent: Visualize data
     name: Use Tableau
-influxdb/cloud-serverless/tags: [query, flightsql, tableau, sql]
+influxdb/cloud-serverless/tags: [Flight client, query, flightsql, tableau, sql]
 aliases:
   - /influxdb/cloud-serverless/query-data/sql/execute-queries/tableau/
 metadata: [SQL only]

--- a/content/influxdb/cloud-serverless/query-data/_index.md
+++ b/content/influxdb/cloud-serverless/query-data/_index.md
@@ -14,4 +14,13 @@ aliases:
 
 Learn to query data stored in InfluxDB.
 
+{{% note %}}
+
+#### Choose the query method for your workload
+
+- For new query workloads, use one of the many available [Flight clients](/influxdb/cloud-serverless/tags/flight-client/) and SQL or InfluxQL.
+- [Use the HTTP API `/query` endpoint and InfluxQL](/influxdb/cloud-serverless/query-data/execute-queries/influxdb-v1-api/) when you bring existing v1 query workloads to {{% product-name %}}.
+
+{{% /note %}}
+
 {{< children >}}

--- a/content/influxdb/cloud-serverless/query-data/execute-queries/_index.md
+++ b/content/influxdb/cloud-serverless/query-data/execute-queries/_index.md
@@ -17,7 +17,7 @@ aliases:
 Use tools and libraries to query data stored in an {{% product-name %}} bucket.
 
 InfluxDB client libraries and Flight clients can use the Flight+gRPC protocol to query with SQL or InfluxQL and retrieve data in the [Arrow in-memory format](https://arrow.apache.org/docs/format/Columnar.html).
-HTTP clients can use the InfluxDB v1 `/query` REST API to query with InfluxQL and retrieve data in formatted as JSON.
+HTTP clients can use the InfluxDB v1 `/query` REST API to query with InfluxQL and retrieve data in JSON format.
 
 {{% note %}}
 #### Map databases and retention policies to buckets

--- a/content/influxdb/cloud-serverless/query-data/execute-queries/client-libraries/go.md
+++ b/content/influxdb/cloud-serverless/query-data/execute-queries/client-libraries/go.md
@@ -12,7 +12,7 @@ menu:
     name: Use Go
     identifier: query-with-go
 metadata: [InfluxQL, SQL]
-influxdb/cloud-serverless/tags: [query, flight, go, sql, influxql]
+influxdb/cloud-serverless/tags: [Flight client, query, flight, go, sql, influxql]
 related:
     - /influxdb/cloud-serverless/reference/client-libraries/v3/go/
     - /influxdb/cloud-serverless/reference/sql/

--- a/content/influxdb/cloud-serverless/query-data/execute-queries/client-libraries/python.md
+++ b/content/influxdb/cloud-serverless/query-data/execute-queries/client-libraries/python.md
@@ -11,7 +11,7 @@ menu:
     parent: Use client libraries
     name: Use Python
     identifier: query-with-python-sql
-influxdb/cloud-serverless/tags: [query, flight, python, sql, influxql]
+influxdb/cloud-serverless/tags: [Flight client, query, flight, python, sql, influxql]
 metadata: [SQL, InfluxQL]
 aliases:
     - /influxdb/cloud-serverless/query-data/execute-queries/flight-sql/python/

--- a/content/influxdb/cloud-serverless/reference/client-libraries/flight/csharp-flight.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/flight/csharp-flight.md
@@ -6,7 +6,7 @@ menu:
     name: C# .NET
     parent: Arrow Flight clients
     identifier: csharp-flight-client
-influxdb/cloud-serverless/tags: [C#, gRPC, SQL, Flight SQL, client libraries]
+influxdb/cloud-serverless/tags: [Flight client, C#, gRPC, SQL, Flight SQL, client libraries]
 aliases:
   - /influxdb/cloud-serverless/reference/client-libraries/flight-sql/csharp-flightsql/
 weight: 201

--- a/content/influxdb/cloud-serverless/reference/client-libraries/flight/go-flight.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/flight/go-flight.md
@@ -6,7 +6,7 @@ menu:
     name: Go
     parent: Arrow Flight clients
     identifier: go-flight-client
-influxdb/cloud-serverless/tags: [Golang, gRPC, SQL, Flight SQL, client libraries]
+influxdb/cloud-serverless/tags: [Flight client, Golang, gRPC, SQL, Flight SQL, client libraries]
 related:
   - /influxdb/cloud-serverless/reference/client-libraries/v3/go/
 aliases:

--- a/content/influxdb/cloud-serverless/reference/client-libraries/flight/java-flightsql.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/flight/java-flightsql.md
@@ -6,7 +6,7 @@ menu:
     name: Java Flight SQL
     parent: Arrow Flight clients
     identifier: java-flightsql-client
-influxdb/cloud-serverless/tags: [Java, gRPC, SQL, Flight SQL]
+influxdb/cloud-serverless/tags: [Flight client, Java, gRPC, SQL, Flight SQL]
 weight: 201
 related:
   - /influxdb/cloud-serverless/reference/client-libraries/v3/java/

--- a/content/influxdb/cloud-serverless/reference/client-libraries/flight/python-flight.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/flight/python-flight.md
@@ -6,7 +6,7 @@ menu:
     name: Python
     parent: Arrow Flight clients
     identifier: python-flight-client
-influxdb/cloud-serverless/tags: [Python, gRPC, SQL, Flight SQL, client libraries]
+influxdb/cloud-serverless/tags: [Flight client, Python, gRPC, SQL, Flight SQL, client libraries]
 aliases:
   - /influxdb/cloud-serverless/reference/client-libraries/flight-sql/python-flightsql/
 weight: 201

--- a/content/influxdb/cloud-serverless/reference/client-libraries/flight/python-flightsql-dbapi.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/flight/python-flightsql-dbapi.md
@@ -6,7 +6,7 @@ menu:
     name: Python Flight SQL
     parent: Arrow Flight clients
     identifier: python-flightsql-client
-influxdb/cloud-serverless/tags: [Python, SQL, Flight SQL]
+influxdb/cloud-serverless/tags: [Flight client, Python, SQL, Flight SQL]
 weight: 201
 ---
 

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/_index.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/_index.md
@@ -9,6 +9,17 @@ menu:
     name: v2 client libraries
     parent: Client libraries
 influxdb/cloud-serverless/tags: [client libraries, API, developer tools]
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 ## Client libraries for InfluxDB 2.x and 1.8+

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/arduino.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/arduino.md
@@ -9,9 +9,18 @@ menu:
   influxdb_cloud_serverless:
     name: Arduino
     parent: v2 client libraries
-    params:
-      url: https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Arduino is an open-source hardware and software platform used for building electronics projects.

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/csharp.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/csharp.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_serverless:
     name: C#
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-csharp
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 C# is a general-purpose object-oriented programming language.

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/dart.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/dart.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_serverless:
     name: Dart
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-dart
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Dart is a programming language created for quick application development for both web and mobile apps.

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/go.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/go.md
@@ -9,20 +9,21 @@ menu:
     parent: v2 client libraries
 influxdb/cloud-serverless/tags: [client libraries, Go]
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 The [InfluxDB Go client library](https://github.com/influxdata/influxdb-client-go)
 integrates with Go applications to write data to an {{% product-name %}} bucket.
-
-{{% note %}}
-### Use the InfluxDB v3 client library
-
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-
-Use the [InfluxDB v3 Go client library](/influxdb/cloud-serverless/reference/client-libraries/v3/go/)
-to write and query data stored in {{% product-name %}}.
-{{% /note %}}
 
 This guide presumes some familiarity with Go and InfluxDB.
 If just getting started, see [Get started with InfluxDB](/influxdb/cloud-serverless/get-started/).

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/java.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/java.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_serverless:
     name: Java
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-java
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Java is one of the oldest and most popular class-based, object-oriented programming languages.

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/_index.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/_index.md
@@ -21,9 +21,6 @@ for Node.js and browsers integrates with the InfluxDB v2 API to write data to an
 {{% note %}}
 ### Tools to execute queries
 
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-
 {{% product-name %}} supports many different tools for querying data, including:
 
 - [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
@@ -35,5 +32,14 @@ This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
 - [Chronograf](/chronograf/v1/)
 
 {{% /note %}}
+
+{{% warn %}}
+
+#### Avoid using /api/v2/query
+
+Avoid using the `/api/v2/query` API endpoint in {{% product-name %}} and associated tooling, such as the `influx query` CLI command and InfluxDB v2 client libraries.
+You can't use SQL or InfluxQL with these tools.
+
+{{% /warn %}}
 
 {{< children type="list">}}

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/_index.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/_index.md
@@ -12,34 +12,21 @@ menu:
 influxdb/cloud-serverless/tags: [client libraries, JavaScript, NodeJS]
 weight: 201
 aliases:
-  - /influxdb/cloud-serverless/reference/api/client-libraries/js/  
+  - /influxdb/cloud-serverless/reference/api/client-libraries/js/
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 The [InfluxDB v2 JavaScript client library](https://github.com/influxdata/influxdb-client-js)
 for Node.js and browsers integrates with the InfluxDB v2 API to write data to an {{% product-name omit=" Clustered" %}} cluster.
-
-{{% note %}}
-### Tools to execute queries
-
-{{% product-name %}} supports many different tools for querying data, including:
-
-- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
-- [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/)
-- [Flight clients](/influxdb/cloud-serverless/reference/client-libraries/flight-sql/)
-- [Superset](/influxdb/cloud-serverless/query-data/sql/execute-queries/superset/)
-- [Grafana](/influxdb/cloud-serverless/query-data/sql/execute-queries/grafana/)
-- [InfluxQL with InfluxDB v1 HTTP API](/influxdb/cloud-serverless/primers/api/v1/#query-using-the-v1-api)
-- [Chronograf](/chronograf/v1/)
-
-{{% /note %}}
-
-{{% warn %}}
-
-#### Avoid using /api/v2/query
-
-Avoid using the `/api/v2/query` API endpoint in {{% product-name %}} and associated tooling, such as the `influx query` CLI command and InfluxDB v2 client libraries.
-You can't use SQL or InfluxQL with these tools.
-
-{{% /warn %}}
 
 {{< children type="list">}}

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/browser.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/browser.md
@@ -24,9 +24,6 @@ Use the [InfluxDB v2 JavaScript client library](https://github.com/influxdata/in
 
 ### Tools to execute queries
 
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-
 {{% product-name %}} supports many different tools for querying data, including:
 
 - [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/)
@@ -37,6 +34,15 @@ This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
 - [Chronograf](/chronograf/v1/)
 
 {{% /note %}}
+
+{{% warn %}}
+
+#### Avoid using /api/v2/query
+
+Avoid using the `/api/v2/query` API endpoint in {{% product-name %}} and associated tooling, such as the `influx query` CLI command and InfluxDB v2 client libraries.
+You can't use SQL or InfluxQL with these tools.
+
+{{% /warn %}}
 
 This library supports both front-end and server-side environments and provides the following distributions:
 * ECMAScript modules (ESM) and CommonJS modules (CJS)

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/browser.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/browser.md
@@ -16,33 +16,20 @@ aliases:
 related:
   - /influxdb/cloud-serverless/reference/client-libraries/v2/javascript/nodejs/write/
   - /influxdb/cloud-serverless/api-guide/client-libraries/nodejs/query/
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Use the [InfluxDB v2 JavaScript client library](https://github.com/influxdata/influxdb-client-js) in browsers and front-end clients to write data to an {{% product-name %}} bucket.
-
-{{% note %}}
-
-### Tools to execute queries
-
-{{% product-name %}} supports many different tools for querying data, including:
-
-- [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/)
-- [Flight clients](/influxdb/cloud-serverless/reference/client-libraries/flight-sql/)
-- [Superset](/influxdb/cloud-serverless/query-data/sql/execute-queries/superset/)
-- [Grafana](/influxdb/cloud-serverless/query-data/sql/execute-queries/grafana/)
-- [InfluxQL with InfluxDB v1 HTTP API](/influxdb/cloud-serverless/primers/api/v1/#query-using-the-v1-api)
-- [Chronograf](/chronograf/v1/)
-
-{{% /note %}}
-
-{{% warn %}}
-
-#### Avoid using /api/v2/query
-
-Avoid using the `/api/v2/query` API endpoint in {{% product-name %}} and associated tooling, such as the `influx query` CLI command and InfluxDB v2 client libraries.
-You can't use SQL or InfluxQL with these tools.
-
-{{% /warn %}}
 
 This library supports both front-end and server-side environments and provides the following distributions:
 * ECMAScript modules (ESM) and CommonJS modules (CJS)

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/nodejs/_index.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/nodejs/_index.md
@@ -14,35 +14,21 @@ weight: 201
 aliases:
   - /influxdb/cloud-serverless/reference/api/client-libraries/nodejs/
   - /influxdb/cloud-serverless/reference/api/client-libraries/nodejs/query/
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
 
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 The [InfluxDB v2 JavaScript client library](https://github.com/influxdata/influxdb-client-js)
 integrates with the InfluxDB v2 API to write data from Node.js and browser applications to {{% product-name %}}.
-
-{{% note %}}
-
-### Tools to execute queries
-
-{{% product-name %}} supports many different tools for querying data, including:
-
-- [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/)
-- [Flight clients](/influxdb/cloud-serverless/reference/client-libraries/flight-sql/)
-- [Superset](/influxdb/cloud-serverless/query-data/sql/execute-queries/superset/)
-- [Grafana](/influxdb/cloud-serverless/query-data/sql/execute-queries/grafana/)
-- [InfluxQL with InfluxDB v1 HTTP API](/influxdb/cloud-serverless/primers/api/v1/#query-using-the-v1-api)
-- [Chronograf](/chronograf/v1/)
-
-{{% /note %}}
-
-{{% warn %}}
-
-#### Avoid using /api/v2/query
-
-Avoid using the `/api/v2/query` API endpoint in {{% product-name %}} and associated tooling, such as the `influx query` CLI command and InfluxDB v2 client libraries.
-You can't use SQL or InfluxQL with these tools.
-
-{{% /warn %}}
 
 ## Use the client library in a Node.js application
 

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/nodejs/_index.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/nodejs/_index.md
@@ -24,9 +24,6 @@ integrates with the InfluxDB v2 API to write data from Node.js and browser appli
 
 ### Tools to execute queries
 
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-
 {{% product-name %}} supports many different tools for querying data, including:
 
 - [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/)
@@ -37,6 +34,15 @@ This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
 - [Chronograf](/chronograf/v1/)
 
 {{% /note %}}
+
+{{% warn %}}
+
+#### Avoid using /api/v2/query
+
+Avoid using the `/api/v2/query` API endpoint in {{% product-name %}} and associated tooling, such as the `influx query` CLI command and InfluxDB v2 client libraries.
+You can't use SQL or InfluxQL with these tools.
+
+{{% /warn %}}
 
 ## Use the client library in a Node.js application
 

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/nodejs/install.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/nodejs/install.md
@@ -10,33 +10,20 @@ influxdb/cloud-serverless/tags: [client libraries, JavaScript]
 weight: 100
 aliases:
   - /influxdb/cloud-serverless/reference/api/client-libraries/nodejs/install
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
-{{% note %}}
-
 Install the Node.js JavaScript client library to write data to InfluxDB {{% product-name %}}.
-
-### Tools to execute queries
-
-{{% product-name %}} supports many different tools for querying data, including:
-
-- [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/)
-- [Flight clients](/influxdb/cloud-serverless/reference/client-libraries/flight-sql/)
-- [Superset](/influxdb/cloud-serverless/query-data/sql/execute-queries/superset/)
-- [Grafana](/influxdb/cloud-serverless/query-data/sql/execute-queries/grafana/)
-- [InfluxQL with InfluxDB v1 HTTP API](/influxdb/cloud-serverless/primers/api/v1/#query-using-the-v1-api)
-- [Chronograf](/chronograf/v1/)
-
-{{% /note %}}
-
-{{% warn %}}
-
-#### Avoid using /api/v2/query
-
-Avoid using the `/api/v2/query` API endpoint in {{% product-name %}} and associated tooling, such as the `influx query` CLI command and InfluxDB v2 client libraries.
-You can't use SQL or InfluxQL with these tools.
-
-{{% /warn %}}
 
 ## Install Node.js
 

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/nodejs/install.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/nodejs/install.md
@@ -18,9 +18,6 @@ Install the Node.js JavaScript client library to write data to InfluxDB {{% prod
 
 ### Tools to execute queries
 
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-
 {{% product-name %}} supports many different tools for querying data, including:
 
 - [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/)
@@ -31,6 +28,15 @@ This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
 - [Chronograf](/chronograf/v1/)
 
 {{% /note %}}
+
+{{% warn %}}
+
+#### Avoid using /api/v2/query
+
+Avoid using the `/api/v2/query` API endpoint in {{% product-name %}} and associated tooling, such as the `influx query` CLI command and InfluxDB v2 client libraries.
+You can't use SQL or InfluxQL with these tools.
+
+{{% /warn %}}
 
 ## Install Node.js
 

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/nodejs/write.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/javascript/nodejs/write.md
@@ -13,6 +13,17 @@ aliases:
   - /influxdb/cloud-serverless/reference/api/client-libraries/nodejs/write/
 related:
   - /influxdb/cloud-serverless/write-data/troubleshoot/
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Use the [InfluxDB v2 JavaScript client library](https://github.com/influxdata/influxdb-client-js) to write data from a Node.js environment to InfluxDB.

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/kotlin.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/kotlin.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_serverless:
     name: Kotlin
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-java/tree/master/client-kotlin
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Kotlin is an open-source programming language that runs on the Java Virtual Machine (JVM). 

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/php.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/php.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_serverless:
     name: PHP
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-php
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 PHP is a popular general-purpose scripting language primarily used for web development. 

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/python.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/python.md
@@ -14,6 +14,17 @@ aliases:
   - /influxdb/cloud-serverless/reference/api/client-libraries/python-cl-guide/
   - /influxdb/cloud-serverless/tools/client-libraries/python/
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Use the [InfluxDB Python client library](https://github.com/influxdata/influxdb-client-python) to integrate InfluxDB into Python scripts and applications.

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/r.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/r.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_serverless:
     name: R
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-r
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 R is a programming language and software environment for statistical analysis, reporting, and graphical representation primarily used in data science. 

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/ruby.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/ruby.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_serverless:
     name: Ruby
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-ruby
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Ruby is a highly flexible, open-source, object-oriented programming language.

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/scala.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/scala.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_serverless:
     name: Scala
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-java/tree/master/client-scala
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Scala is a general-purpose programming language that supports both object-oriented and functional programming.

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v2/swift.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v2/swift.md
@@ -8,9 +8,18 @@ menu:
   influxdb_cloud_serverless:
     name: Swift
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-swift
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/cloud-serverless/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/cloud-serverless/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/cloud-serverless/write-data/) and [**querying**](/influxdb/cloud-serverless/query-data/) data.
+    [**Compare tools you can use**](/influxdb/cloud-serverless/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Swift is a programming language created by Apple for building applications across multiple Apple platforms.

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v3/csharp.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v3/csharp.md
@@ -9,7 +9,7 @@ menu:
     name: C# .NET
     parent: v3 client libraries
     identifier: influxdb3-csharp
-influxdb/cloud-serverless/tags: [C#, gRPC, SQL, Flight SQL, client libraries]
+influxdb/cloud-serverless/tags: [Flight client, C#, gRPC, SQL, Flight SQL, client libraries]
 weight: 201
 ---
 

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v3/go.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v3/go.md
@@ -7,7 +7,7 @@ menu:
     name: Go
     parent: v3 client libraries
     identifier: influxdb3-go
-influxdb/cloud-serverless/tags: [go, InfluxQL, SQL, Flight, client libraries]
+influxdb/cloud-serverless/tags: [Flight client, go, InfluxQL, SQL, Flight, client libraries]
 weight: 201
 aliases:
   - /influxdb/cloud-serverless/reference/api/client-libraries/go/

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v3/java.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v3/java.md
@@ -9,7 +9,7 @@ menu:
     name: Java
     parent: v3 client libraries
     identifier: influxdb3-java
-influxdb/cloud-serverless/tags: [Java, gRPC, SQL, Flight SQL, client libraries]
+influxdb/cloud-serverless/tags: [Flight client, Java, gRPC, SQL, Flight SQL, client libraries]
 weight: 201
 aliases:
   - /cloud-serverless/query-data/sql/execute-queries/java/

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v3/javascript.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v3/javascript.md
@@ -9,7 +9,7 @@ menu:
     name: JavaScript
     parent: v3 client libraries
     identifier: influxdb3-js
-influxdb/cloud-serverless/tags: [JavaScript, gRPC, SQL, Flight SQL, client libraries]
+influxdb/cloud-serverless/tags: [Flight client, JavaScript, gRPC, SQL, Flight SQL, client libraries]
 weight: 201
 aliases:
   - /influxdb/cloud-serverless/reference/api/client-libraries/go/

--- a/content/influxdb/cloud-serverless/write-data/_index.md
+++ b/content/influxdb/cloud-serverless/write-data/_index.md
@@ -16,4 +16,15 @@ influxdb/cloud-serverless/tags: [write, line protocol]
 #   - /resources/videos/ingest-data/, How to Ingest Data in InfluxDB (Video)
 ---
 
+Write data to {{% product-name %}} using the following tools and methods:
+
+{{% note %}}
+
+#### Choose the write endpoint for your workload
+
+When bringing existing v1 write workloads, use the {{% product-name %}} HTTP API [`/write` endpoint](/influxdb/cloud-serverless/guides/api-compatibility/v1/).
+When creating new write workloads, use the HTTP API [`/api/v2/write` endpoint](/influxdb/cloud-serverless/guides/api-compatibility/v2/).
+
+{{% /note %}}
+
 {{< children >}}

--- a/content/influxdb/cloud-serverless/write-data/use-telegraf/configure/_index.md
+++ b/content/influxdb/cloud-serverless/write-data/use-telegraf/configure/_index.md
@@ -41,10 +41,8 @@ for using Telegraf with {{< product-name >}}._
       - [token](#token)
       - [organization](#organization)
       - [bucket](#bucket)
-      - [Write to InfluxDB v1.x and {{< product-name >}}](#write-to-influxdb-v1x-and--product-name-)
+      - [Write to InfluxDB v1.x and {{< product-name >}}](#write-to-influxdb-v1x-and-influxdb-cloud-serverless)
 - [Start Telegraf](#start-telegraf)
-
-<!-- /TOC -->
 
 ## Configure Telegraf input and output plugins
 

--- a/content/influxdb/clustered/get-started/_index.md
+++ b/content/influxdb/clustered/get-started/_index.md
@@ -92,18 +92,18 @@ The following definitions are important to understand when using InfluxDB:
 The following table compares tools that you can use to interact with {{% product-name %}}.
 This tutorial covers many of the recommended tools.
 
-| Tool                              | Administration  | Write   | Query   |
-|:--------------------------------- |:---------------:|:-------:|:-------:|
-| [Chronograf](/chronograf/v1/)     |       -         |   -     | **{{< icon "check" >}}**  |
-| <span style="color:gray">`influx` CLI</span>                                        |   -      | -  |   -     |
-| [`influx3` data CLI](#influx3-data-cli){{< req text="\* " color="magenta" >}}               |       -         | **{{< icon "check" >}}**  | **{{< icon "check" >}}**  |
-| [`influxctl` admin CLI](#influxctl-admin-cli)                          |    **{{< icon "check" >}}**         |   -     |   -     |
-| [InfluxDB HTTP API](#influxdb-http-api)                          |    -        |   **{{< icon "check" >}}**  |   **{{< icon "check" >}}**     |
-| <span style="color:gray">InfluxDB user interface</span> |     -      |   -     | -  |
-| [InfluxDB v3 client libraries](#influxdb-v3-client-libraries){{< req text="\* " color="magenta" >}}      |       -         | **{{< icon "check" >}}**  | **{{< icon "check" >}}**  |
-| [InfluxDB v1 client libraries](/influxdb/clustered/reference/client-libraries/v1/)      |       -         | **{{< icon "check" >}}**  | **{{< icon "check" >}}**  |
-| [InfluxDB v2 client libraries](/influxdb/clustered/reference/client-libraries/v2/)      |     **{{< icon "check" >}}**      | **{{< icon "check" >}}**  |   -     |
-| Telegraf                          |       -         | **{{< icon "check" >}}**  |   -     |
+| Tool                                                                                                |      Administration      |          Write           |          Query           |
+|:----------------------------------------------------------------------------------------------------|:------------------------:|:------------------------:|:------------------------:|
+| [Chronograf](/chronograf/v1/)                                                                       |            -             |            -             | **{{< icon "check" >}}** |
+| <span style="color:gray">`influx` CLI</span>                                                        |            -             |            -             |            -             |
+| [`influx3` data CLI](#influx3-data-cli){{< req text="\* " color="magenta" >}}                       |            -             | **{{< icon "check" >}}** | **{{< icon "check" >}}** |
+| [`influxctl` admin CLI](#influxctl-admin-cli)                                                       | **{{< icon "check" >}}** |            -             |            -             |
+| [InfluxDB HTTP API](#influxdb-http-api)                                                             |            -             | **{{< icon "check" >}}** | **{{< icon "check" >}}** |
+| <span style="color:gray">InfluxDB user interface</span>                                             |            -             |            -             |            -             |
+| [InfluxDB v3 client libraries](#influxdb-v3-client-libraries){{< req text="\* " color="magenta" >}} |            -             | **{{< icon "check" >}}** | **{{< icon "check" >}}** |
+| [InfluxDB v1 client libraries](/influxdb/clustered/reference/client-libraries/v1/)                  |            -             | **{{< icon "check" >}}** | **{{< icon "check" >}}** |
+| [InfluxDB v2 client libraries](/influxdb/clustered/reference/client-libraries/v2/)                  |            -             | **{{< icon "check" >}}** |            -             |
+| Telegraf                                                                                            |            -             | **{{< icon "check" >}}** |            -             |
 | **Third-party tools**                                                   |
 | Flight SQL clients               |       -         |   -     | **{{< icon "check" >}}**  |
 |  [Grafana](/influxdb/clustered/query-data/sql/execute-queries/grafana/)  |       -         |   -     | **{{< icon "check" >}}**  |

--- a/content/influxdb/clustered/guides/api-compatibility/v2/_index.md
+++ b/content/influxdb/clustered/guides/api-compatibility/v2/_index.md
@@ -44,7 +44,7 @@ For help finding the best workflow for your situation, [contact Support](mailto:
     - [Client libraries](#client-libraries)
 - [Query data](#query-data)
     - [Tools to execute queries](#tools-to-execute-queries)
-  - [/api/v2/query not supported](#apiv2query-not-supported)
+    - [/api/v2/query not supported](#apiv2query-not-supported)
 
 <!-- /TOC -->
 
@@ -237,7 +237,12 @@ To setup and start using client libraries, see the [Get started](/influxdb/clust
 
 {{% /note %}}
 
-### /api/v2/query not supported
+{{% warn %}}
 
-The `/api/v2/query` API endpoint and associated tooling aren't supported in {{% product-name %}}.
+#### /api/v2/query not supported
+
+The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
+The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
+
+{{% /warn %}}
 

--- a/content/influxdb/clustered/process-data/visualize/superset.md
+++ b/content/influxdb/clustered/process-data/visualize/superset.md
@@ -10,7 +10,7 @@ menu:
     parent: Visualize data
     name: Use Superset
     identifier: query-with-superset
-influxdb/clustered/tags: [query, flightsql, superset]
+influxdb/clustered/tags: [Flight client, query, flightsql, superset]
 aliases:
   - /influxdb/clustered/query-data/execute-queries/flight-sql/superset/
   - /influxdb/clustered/query-data/tools/superset/

--- a/content/influxdb/clustered/process-data/visualize/tableau.md
+++ b/content/influxdb/clustered/process-data/visualize/tableau.md
@@ -10,7 +10,7 @@ menu:
     parent: Visualize data
     name: Use Tableau
     identifier: query-with-tableau
-influxdb/clustered/tags: [query, flightsql, tableau, sql]
+influxdb/clustered/tags: [Flight client, query, flightsql, tableau, sql]
 aliases:
   - /influxdb/clustered/query-data/execute-queries/flight-sql/tableau/
   - /influxdb/clustered/query-data/tools/tableau/

--- a/content/influxdb/clustered/query-data/_index.md
+++ b/content/influxdb/clustered/query-data/_index.md
@@ -12,4 +12,13 @@ influxdb/clustered/tags: [query]
 
 Learn to query data stored in InfluxDB.
 
+{{% note %}}
+
+#### Choose the query method for your workload
+
+- For new query workloads, use one of the many available [Flight clients](/influxdb/clustered/tags/flight-client/) and SQL or InfluxQL.
+- [Use the HTTP API `/query` endpoint and InfluxQL](/influxdb/clustered/query-data/execute-queries/influxdb-v1-api/) when you bring existing v1 query workloads to {{% product-name %}}.
+
+{{% /note %}}
+
 {{< children >}}

--- a/content/influxdb/clustered/query-data/execute-queries/_index.md
+++ b/content/influxdb/clustered/query-data/execute-queries/_index.md
@@ -17,7 +17,7 @@ aliases:
 Use tools and libraries to query data stored in an {{% product-name %}} bucket.
 
 InfluxDB client libraries and Flight clients can use the Flight+gRPC protocol to query with SQL or InfluxQL and retrieve data in the [Arrow in-memory format](https://arrow.apache.org/docs/format/Columnar.html).
-HTTP clients can use the InfluxDB v1 `/query` REST API to query with InfluxQL and retrieve data in formatted as JSON.
+HTTP clients can use the InfluxDB v1 `/query` REST API to query with InfluxQL and retrieve data in JSON format.
 
 Learn how to connect to InfluxDB and query your data using the following tools:
 

--- a/content/influxdb/clustered/query-data/execute-queries/client-libraries/go.md
+++ b/content/influxdb/clustered/query-data/execute-queries/client-libraries/go.md
@@ -12,7 +12,7 @@ menu:
     name: Use Go
     identifier: query-with-go
 metadata: [InfluxQL, SQL]
-influxdb/clustered/tags: [query, flight, go, sql, influxql]
+influxdb/clustered/tags: [Flight client, query, flight, go, sql, influxql]
 related:
     - /influxdb/clustered/reference/client-libraries/v3/go/
     - /influxdb/clustered/reference/sql/

--- a/content/influxdb/clustered/query-data/execute-queries/client-libraries/python.md
+++ b/content/influxdb/clustered/query-data/execute-queries/client-libraries/python.md
@@ -11,7 +11,7 @@ menu:
     parent: Use client libraries
     name: Use Python
     identifier: query-with-python-sql
-influxdb/clustered/tags: [query, flight, python, sql, influxql]
+influxdb/clustered/tags: [Flight client, query, flight, python, sql, influxql]
 related:
     - /influxdb/clustered/reference/client-libraries/v3/python/
     - /influxdb/clustered/process-data/tools/pandas/

--- a/content/influxdb/clustered/reference/cli/influxctl/_index.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/_index.md
@@ -13,7 +13,7 @@ influxdb/clustered/tags: [cli]
 ---
 
 The `influxctl` command line interface (CLI) performs administrative tasks in
-an cluster.
+a cluster.
 
 - [Usage](#usage)
 - [Commands](#commands)

--- a/content/influxdb/clustered/reference/client-libraries/flight/csharp-flight.md
+++ b/content/influxdb/clustered/reference/client-libraries/flight/csharp-flight.md
@@ -6,7 +6,7 @@ menu:
     name: C# .NET
     parent: Arrow Flight clients
     identifier: csharp-flight-client
-influxdb/clustered/tags: [C#, gRPC, SQL, Flight SQL, client libraries]
+influxdb/clustered/tags: [Flight client, C#, gRPC, SQL, Flight SQL, client libraries]
 aliases:
   - /influxdb/clustered/reference/client-libraries/flight-sql/csharp-flightsql/
 weight: 201

--- a/content/influxdb/clustered/reference/client-libraries/flight/go-flight.md
+++ b/content/influxdb/clustered/reference/client-libraries/flight/go-flight.md
@@ -6,7 +6,7 @@ menu:
     name: Go
     parent: Arrow Flight clients
     identifier: go-flight-client
-influxdb/clustered/tags: [Go, gRPC, SQL, Flight SQL, client libraries]
+influxdb/clustered/tags: [Flight client, Go, gRPC, SQL, Flight SQL, client libraries]
 related:
   - /influxdb/clustered/reference/client-libraries/v3/go/
 aliases:

--- a/content/influxdb/clustered/reference/client-libraries/flight/java-flightsql.md
+++ b/content/influxdb/clustered/reference/client-libraries/flight/java-flightsql.md
@@ -6,7 +6,7 @@ menu:
     name: Java Flight SQL
     parent: Arrow Flight clients
     identifier: java-flightsql-client
-influxdb/clustered/tags: [Java, gRPC, SQL, Flight SQL]
+influxdb/clustered/tags: [Flight client, Java, gRPC, SQL, Flight SQL]
 weight: 201
 related:
   - /influxdb/clustered/reference/client-libraries/v3/java/

--- a/content/influxdb/clustered/reference/client-libraries/flight/python-flight.md
+++ b/content/influxdb/clustered/reference/client-libraries/flight/python-flight.md
@@ -6,7 +6,7 @@ menu:
     name: Python
     parent: Arrow Flight clients
     identifier: python-flight-client
-influxdb/clustered/tags: [Python, gRPC, SQL, Flight SQL, client libraries]
+influxdb/clustered/tags: [Flight client, Python, gRPC, SQL, Flight SQL, client libraries]
 aliases:
   - /influxdb/clustered/reference/client-libraries/flight-sql/python-flightsql/
 weight: 201

--- a/content/influxdb/clustered/reference/client-libraries/flight/python-flightsql-dbapi.md
+++ b/content/influxdb/clustered/reference/client-libraries/flight/python-flightsql-dbapi.md
@@ -8,7 +8,7 @@ menu:
     name: Python Flight SQL
     parent: Arrow Flight clients
     identifier: python-flightsql-client
-influxdb/clustered/tags: [Python, SQL, Flight SQL]
+influxdb/clustered/tags: [Flight client, Python, SQL, Flight SQL]
 weight: 201
 ---
 

--- a/content/influxdb/clustered/reference/client-libraries/v2/_index.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/_index.md
@@ -28,6 +28,7 @@ This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
 
 {{% product-name %}} supports many different tools for querying data, including:
 
+- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
 - [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/)
 - [Flight clients](/influxdb/clustered/reference/client-libraries/flight-sql/)
 - [Superset](/influxdb/clustered/query-data/sql/execute-queries/superset/)
@@ -37,5 +38,13 @@ This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
 
 {{% /note %}}
 
+{{% warn %}}
+
+#### /api/v2/query not supported
+
+The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
+The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
+
+{{% /warn %}}
 
 {{< children type="list" depth="999" >}}

--- a/content/influxdb/clustered/reference/client-libraries/v2/_index.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/_index.md
@@ -9,6 +9,17 @@ menu:
     name: v2 client libraries
     parent: Client libraries
 influxdb/clustered/tags: [client libraries, API, developer tools]
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 ## Client libraries for InfluxDB 2.x and 1.8+
@@ -19,32 +30,5 @@ InfluxDB v2 client libraries use InfluxDB `/api/v2` endpoints and work with [Inf
 Functionality varies among client libraries.
 InfluxDB client libraries are maintained by the InfluxDB community.
 For specifics about a client library, see the library's GitHub repository.
-
-{{% note %}}
-### Tools to execute queries
-
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-
-{{% product-name %}} supports many different tools for querying data, including:
-
-- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
-- [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/)
-- [Flight clients](/influxdb/clustered/reference/client-libraries/flight-sql/)
-- [Superset](/influxdb/clustered/query-data/sql/execute-queries/superset/)
-- [Grafana](/influxdb/clustered/query-data/sql/execute-queries/grafana/)
-- [InfluxQL with InfluxDB v1 HTTP API](/influxdb/clustered/primers/api/v1/#query-using-the-v1-api)
-- [Chronograf](/chronograf/v1/)
-
-{{% /note %}}
-
-{{% warn %}}
-
-#### /api/v2/query not supported
-
-The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
-
-{{% /warn %}}
 
 {{< children type="list" depth="999" >}}

--- a/content/influxdb/clustered/reference/client-libraries/v2/arduino.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/arduino.md
@@ -9,9 +9,18 @@ menu:
   influxdb_clustered:
     name: Arduino
     parent: v2 client libraries
-    params:
-      url: https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Arduino is an open-source hardware and software platform used for building electronics projects.

--- a/content/influxdb/clustered/reference/client-libraries/v2/csharp.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/csharp.md
@@ -8,9 +8,18 @@ menu:
   influxdb_clustered:
     name: C#
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-csharp
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 C# is a general-purpose object-oriented programming language.

--- a/content/influxdb/clustered/reference/client-libraries/v2/dart.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/dart.md
@@ -8,9 +8,18 @@ menu:
   influxdb_clustered:
     name: Dart
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-dart
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Dart is a programming language created for quick application development for both web and mobile apps.

--- a/content/influxdb/clustered/reference/client-libraries/v2/go.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/go.md
@@ -16,8 +16,7 @@ Use the [InfluxDB Go client library](https://github.com/influxdata/influxdb-clie
 {{% note %}}
 ### Use the InfluxDB v3 client library
 
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name %}} database.
+This client library can't query an {{% product-name %}} database.
 
 Use the [InfluxDB v3 Go client library](/influxdb/clustered/reference/client-libraries/v3/go/)
 to write and query data stored in {{% product-name %}}.

--- a/content/influxdb/clustered/reference/client-libraries/v2/go.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/go.md
@@ -9,18 +9,20 @@ menu:
     parent: v2 client libraries
 influxdb/clustered/tags: [client libraries, Go]
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Use the [InfluxDB Go client library](https://github.com/influxdata/influxdb-client-go) to write data to an {{% product-name %}} database.
-
-{{% note %}}
-### Use the InfluxDB v3 client library
-
-This client library can't query an {{% product-name %}} database.
-
-Use the [InfluxDB v3 Go client library](/influxdb/clustered/reference/client-libraries/v3/go/)
-to write and query data stored in {{% product-name %}}.
-{{% /note %}}
 
 This guide presumes some familiarity with Go and InfluxDB.
 If just getting started, see [Get started with InfluxDB](/influxdb/clustered/get-started/).

--- a/content/influxdb/clustered/reference/client-libraries/v2/java.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/java.md
@@ -8,9 +8,18 @@ menu:
   influxdb_clustered:
     name: Java
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-java
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Java is one of the oldest and most popular class-based, object-oriented programming languages.

--- a/content/influxdb/clustered/reference/client-libraries/v2/javascript/_index.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/javascript/_index.md
@@ -36,4 +36,13 @@ This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
 
 {{% /note %}}
 
+{{% warn %}}
+
+#### /api/v2/query not supported
+
+The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
+The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
+
+{{% /warn %}}
+
 {{< children depth="999" >}}

--- a/content/influxdb/clustered/reference/client-libraries/v2/javascript/_index.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/javascript/_index.md
@@ -12,37 +12,21 @@ menu:
 influxdb/clustered/tags: [client libraries, JavaScript, NodeJS]
 weight: 201
 aliases:
-  - /influxdb/clustered/reference/api/client-libraries/js/  
+  - /influxdb/clustered/reference/api/client-libraries/js/
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 The [InfluxDB v2 JavaScript client library](https://github.com/influxdata/influxdb-client-js)
 for Node.js and browsers integrates with the InfluxDB v2 API to write data to an {{% product-name omit=" Clustered" %}} cluster.
-
-{{% note %}}
-### Tools to execute queries
-
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-
-{{% product-name %}} supports many different tools for querying data, including:
-
-- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
-- [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/)
-- [Flight clients](/influxdb/clustered/reference/client-libraries/flight-sql/)
-- [Superset](/influxdb/clustered/query-data/sql/execute-queries/superset/)
-- [Grafana](/influxdb/clustered/query-data/sql/execute-queries/grafana/)
-- [InfluxQL with InfluxDB v1 HTTP API](/influxdb/clustered/primers/api/v1/#query-using-the-v1-api)
-- [Chronograf](/chronograf/v1/)
-
-{{% /note %}}
-
-{{% warn %}}
-
-#### /api/v2/query not supported
-
-The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
-
-{{% /warn %}}
 
 {{< children depth="999" >}}

--- a/content/influxdb/clustered/reference/client-libraries/v2/javascript/browser.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/javascript/browser.md
@@ -24,11 +24,11 @@ Use the [InfluxDB v2 JavaScript client library](https://github.com/influxdata/in
 
 ### Tools to execute queries
 
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name %}} database.
+This client library can't query an {{% product-name %}} database.
 
 {{% product-name %}} supports many different tools for querying data, including:
 
+- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
 - [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/)
 - [Flight clients](/influxdb/clustered/reference/client-libraries/flight-sql/)
 - [Superset](/influxdb/clustered/query-data/sql/execute-queries/superset/)
@@ -37,6 +37,15 @@ This endpoint can't query an {{% product-name %}} database.
 - [Chronograf](/chronograf/v1/)
 
 {{% /note %}}
+
+{{% warn %}}
+
+#### /api/v2/query not supported
+
+The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
+The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
+
+{{% /warn %}}
 
 This library supports both front-end and server-side environments and provides the following distributions:
 

--- a/content/influxdb/clustered/reference/client-libraries/v2/javascript/browser.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/javascript/browser.md
@@ -16,36 +16,20 @@ aliases:
 related:
   - /influxdb/clustered/reference/client-libraries/v2/javascript/nodejs/write/
   - /influxdb/clustered/api-guide/client-libraries/nodejs/query/
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Use the [InfluxDB v2 JavaScript client library](https://github.com/influxdata/influxdb-client-js) in browsers and front-end clients to write data to an {{% product-name %}} database.
-
-{{% note %}}
-
-### Tools to execute queries
-
-This client library can't query an {{% product-name %}} database.
-
-{{% product-name %}} supports many different tools for querying data, including:
-
-- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
-- [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/)
-- [Flight clients](/influxdb/clustered/reference/client-libraries/flight-sql/)
-- [Superset](/influxdb/clustered/query-data/sql/execute-queries/superset/)
-- [Grafana](/influxdb/clustered/query-data/sql/execute-queries/grafana/)
-- [InfluxQL with InfluxDB v1 HTTP API](/influxdb/clustered/primers/api/v1/#query-using-the-v1-api)
-- [Chronograf](/chronograf/v1/)
-
-{{% /note %}}
-
-{{% warn %}}
-
-#### /api/v2/query not supported
-
-The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
-
-{{% /warn %}}
 
 This library supports both front-end and server-side environments and provides the following distributions:
 

--- a/content/influxdb/clustered/reference/client-libraries/v2/javascript/nodejs/_index.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/javascript/nodejs/_index.md
@@ -22,11 +22,11 @@ integrates with the InfluxDB v2 API to write data from Node.js and browser appli
 
 ### Tools to execute queries
 
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name %}} database.
+This client library can't query an {{% product-name %}} database.
 
 {{% product-name %}} supports many different tools for querying data, including:
 
+- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
 - [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/)
 - [Flight clients](/influxdb/clustered/reference/client-libraries/flight-sql/)
 - [Superset](/influxdb/clustered/query-data/sql/execute-queries/superset/)
@@ -35,6 +35,15 @@ This endpoint can't query an {{% product-name %}} database.
 - [Chronograf](/chronograf/v1/)
 
 {{% /note %}}
+
+{{% warn %}}
+
+#### /api/v2/query not supported
+
+The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
+The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
+
+{{% /warn %}}
 
 ## Use the client library in a Node.js application
 

--- a/content/influxdb/clustered/reference/client-libraries/v2/javascript/nodejs/_index.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/javascript/nodejs/_index.md
@@ -12,38 +12,22 @@ menu:
 influxdb/clustered/tags: [client libraries, JavaScript, NodeJS]
 weight: 201
 aliases:
-  - /influxdb/clustered/reference/api/client-libraries/nodejs/ 
+  - /influxdb/clustered/reference/api/client-libraries/nodejs/
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 The [InfluxDB v2 JavaScript client library](https://github.com/influxdata/influxdb-client-js)
 integrates with the InfluxDB v2 API to write data from Node.js and browser applications to an {{% product-name %}} database.
-
-{{% note %}}
-
-### Tools to execute queries
-
-This client library can't query an {{% product-name %}} database.
-
-{{% product-name %}} supports many different tools for querying data, including:
-
-- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
-- [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/)
-- [Flight clients](/influxdb/clustered/reference/client-libraries/flight-sql/)
-- [Superset](/influxdb/clustered/query-data/sql/execute-queries/superset/)
-- [Grafana](/influxdb/clustered/query-data/sql/execute-queries/grafana/)
-- [InfluxQL with InfluxDB v1 HTTP API](/influxdb/clustered/primers/api/v1/#query-using-the-v1-api)
-- [Chronograf](/chronograf/v1/)
-
-{{% /note %}}
-
-{{% warn %}}
-
-#### /api/v2/query not supported
-
-The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
-
-{{% /warn %}}
 
 ## Use the client library in a Node.js application
 

--- a/content/influxdb/clustered/reference/client-libraries/v2/javascript/nodejs/install.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/javascript/nodejs/install.md
@@ -10,36 +10,18 @@ influxdb/clustered/tags: [client libraries, JavaScript]
 weight: 100
 aliases:
   - /influxdb/clustered/reference/api/client-libraries/nodejs/install
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
-
-{{% note %}}
-
-Install the Node.js JavaScript client library to write data to an {{% product-name %}} database.
-
-### Tools to execute queries
-
-This client library can't query an {{% product-name %}} database.
-
-{{% product-name %}} supports many different tools for querying data, including:
-
-- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
-- [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/)
-- [Flight clients](/influxdb/clustered/reference/client-libraries/flight-sql/)
-- [Superset](/influxdb/clustered/query-data/sql/execute-queries/superset/)
-- [Grafana](/influxdb/clustered/query-data/sql/execute-queries/grafana/)
-- [InfluxQL with InfluxDB v1 HTTP API](/influxdb/clustered/primers/api/v1/#query-using-the-v1-api)
-- [Chronograf](/chronograf/v1/)
-
-{{% /note %}}
-
-{{% warn %}}
-
-#### /api/v2/query not supported
-
-The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
-The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
-
-{{% /warn %}}
 
 ## Install Node.js
 

--- a/content/influxdb/clustered/reference/client-libraries/v2/javascript/nodejs/install.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/javascript/nodejs/install.md
@@ -18,11 +18,11 @@ Install the Node.js JavaScript client library to write data to an {{% product-na
 
 ### Tools to execute queries
 
-InfluxDB v2 client libraries use the InfluxDB API `/api/v2/query` endpoint.
-This endpoint can't query an {{% product-name %}} database.
+This client library can't query an {{% product-name %}} database.
 
 {{% product-name %}} supports many different tools for querying data, including:
 
+- [`influx3` data CLI](https://github.com/InfluxCommunity/influxdb3-python-cli)
 - [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/)
 - [Flight clients](/influxdb/clustered/reference/client-libraries/flight-sql/)
 - [Superset](/influxdb/clustered/query-data/sql/execute-queries/superset/)
@@ -31,6 +31,15 @@ This endpoint can't query an {{% product-name %}} database.
 - [Chronograf](/chronograf/v1/)
 
 {{% /note %}}
+
+{{% warn %}}
+
+#### /api/v2/query not supported
+
+The InfluxDB API `/api/v2/query` endpoint can't query an {{% product-name omit=" Clustered" %}} cluster.
+The `/api/v2/query` API endpoint and associated tooling, such as the `influx` CLI and InfluxDB v2 client libraries, **aren’t** supported in {{% product-name %}}.
+
+{{% /warn %}}
 
 ## Install Node.js
 

--- a/content/influxdb/clustered/reference/client-libraries/v2/javascript/nodejs/write.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/javascript/nodejs/write.md
@@ -13,6 +13,17 @@ aliases:
   - /influxdb/clustered/reference/api/client-libraries/nodejs/write
 related:
   - /influxdb/clustered/write-data/troubleshoot/
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Use the [InfluxDB v2 JavaScript client library](https://github.com/influxdata/influxdb-client-js) to write data from a Node.js environment to InfluxDB.

--- a/content/influxdb/clustered/reference/client-libraries/v2/kotlin.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/kotlin.md
@@ -8,9 +8,18 @@ menu:
   influxdb_clustered:
     name: Kotlin
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-java/tree/master/client-kotlin
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Kotlin is an open-source programming language that runs on the Java Virtual Machine (JVM). 

--- a/content/influxdb/clustered/reference/client-libraries/v2/php.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/php.md
@@ -8,9 +8,18 @@ menu:
   influxdb_clustered:
     name: PHP
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-php
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 PHP is a popular general-purpose scripting language primarily used for web development. 

--- a/content/influxdb/clustered/reference/client-libraries/v2/python.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/python.md
@@ -14,6 +14,17 @@ aliases:
   - /influxdb/clustered/reference/api/client-libraries/python-cl-guide/
   - /influxdb/clustered/tools/client-libraries/python/
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Use the [InfluxDB Python client library](https://github.com/influxdata/influxdb-client-python) to integrate InfluxDB into Python scripts and applications.

--- a/content/influxdb/clustered/reference/client-libraries/v2/r.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/r.md
@@ -8,9 +8,18 @@ menu:
   influxdb_clustered:
     name: R
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-r
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 R is a programming language and software environment for statistical analysis, reporting, and graphical representation primarily used in data science. 

--- a/content/influxdb/clustered/reference/client-libraries/v2/ruby.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/ruby.md
@@ -8,9 +8,18 @@ menu:
   influxdb_clustered:
     name: Ruby
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-ruby
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Ruby is a highly flexible, open-source, object-oriented programming language.

--- a/content/influxdb/clustered/reference/client-libraries/v2/scala.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/scala.md
@@ -8,9 +8,18 @@ menu:
   influxdb_clustered:
     name: Scala
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-java/tree/master/client-scala
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Scala is a general-purpose programming language that supports both object-oriented and functional programming.

--- a/content/influxdb/clustered/reference/client-libraries/v2/swift.md
+++ b/content/influxdb/clustered/reference/client-libraries/v2/swift.md
@@ -8,9 +8,18 @@ menu:
   influxdb_clustered:
     name: Swift
     parent: v2 client libraries
-    params:
-      url: https://github.com/influxdata/influxdb-client-swift
 weight: 201
+prepend:
+  block: warn
+  content: |
+    ### Use InfluxDB v3 clients
+
+    The `/api/v2/query` API endpoint and associated tooling, such as InfluxDB v2 client libraries and the `influx` CLI, **can't** query an {{% product-name omit=" Clustered" %}} cluster.
+
+    [InfluxDB v3 client libraries](/influxdb/clustered/reference/client-libraries/v3/) and [Flight SQL clients](/influxdb/clustered/reference/client-libraries/) are available that integrate with your code to write and query data stored in {{% product-name %}}.
+
+    InfluxDB v3 supports many different tools for [**writing**](/influxdb/clustered/write-data/) and [**querying**](/influxdb/clustered/query-data/) data.
+    [**Compare tools you can use**](/influxdb/clustered/get-started/#tools-to-use) to interact with {{% product-name %}}.
 ---
 
 Swift is a programming language created by Apple for building applications across multiple Apple platforms.

--- a/content/influxdb/clustered/reference/client-libraries/v3/csharp.md
+++ b/content/influxdb/clustered/reference/client-libraries/v3/csharp.md
@@ -9,7 +9,7 @@ menu:
     name: C# .NET
     parent: v3 client libraries
     identifier: influxdb3-csharp
-influxdb/clustered/tags: [C#, gRPC, SQL, Flight SQL, client libraries]
+influxdb/clustered/tags: [Flight client, C#, gRPC, SQL, Flight SQL, client libraries]
 weight: 201
 ---
 

--- a/content/influxdb/clustered/reference/client-libraries/v3/go.md
+++ b/content/influxdb/clustered/reference/client-libraries/v3/go.md
@@ -7,7 +7,7 @@ menu:
     name: Go
     parent: v3 client libraries
     identifier: influxdb3-go
-influxdb/clustered/tags: [go, InfluxQL, SQL, Flight, client libraries]
+influxdb/clustered/tags: [Flight client, go, InfluxQL, SQL, Flight, client libraries]
 weight: 201
 aliases:
   - /influxdb/clustered/reference/api/client-libraries/go/

--- a/content/influxdb/clustered/reference/client-libraries/v3/java.md
+++ b/content/influxdb/clustered/reference/client-libraries/v3/java.md
@@ -9,7 +9,7 @@ menu:
     name: Java
     parent: v3 client libraries
     identifier: influxdb3-java
-influxdb/clustered/tags: [Java, gRPC, SQL, Flight SQL, client libraries]
+influxdb/clustered/tags: [Flight client, Java, gRPC, SQL, Flight SQL, client libraries]
 weight: 201
 ---
 

--- a/content/influxdb/clustered/reference/client-libraries/v3/javascript.md
+++ b/content/influxdb/clustered/reference/client-libraries/v3/javascript.md
@@ -9,7 +9,7 @@ menu:
     name: JavaScript
     parent: v3 client libraries
     identifier: influxdb3-js
-influxdb/clustered/tags: [JavaScript, gRPC, SQL, Flight SQL, client libraries]
+influxdb/clustered/tags: [Flight client, JavaScript, gRPC, SQL, Flight SQL, client libraries]
 weight: 201
 aliases:
   - /influxdb/clustered/reference/api/client-libraries/go/

--- a/content/influxdb/clustered/reference/client-libraries/v3/python.md
+++ b/content/influxdb/clustered/reference/client-libraries/v3/python.md
@@ -7,7 +7,7 @@ menu:
     name: Python
     parent: v3 client libraries
     identifier: influxdb3-python
-influxdb/clustered/tags: [python, gRPC, SQL, Flight SQL, client libraries]
+influxdb/clustered/tags: [Flight client, python, gRPC, SQL, Flight SQL, client libraries]
 weight: 201
 aliases:
   - /influxdb/clustered/reference/client-libraries/v3/pyinflux3/

--- a/content/influxdb/clustered/write-data/_index.md
+++ b/content/influxdb/clustered/write-data/_index.md
@@ -18,9 +18,14 @@ influxdb/clustered/tags: [write, line protocol]
 
 Write data to {{% product-name %}} using the following tools and methods:
 
-{{% warn %}}
-{{% api/cloud/v2-prefer %}}
-{{% /warn %}}
+{{% note %}}
+
+#### Choose the write endpoint for your workload
+
+When bringing existing v1 write workloads, use the {{% product-name %}} HTTP API [`/write` endpoint](/influxdb/clustered/guides/api-compatibility/v1/).
+When creating new write workloads, use the HTTP API [`/api/v2/write` endpoint](/influxdb/clustered/guides/api-compatibility/v2/).
+
+{{% /note %}}
 
 {{< children >}}
  

--- a/content/influxdb/clustered/write-data/use-telegraf/configure/_index.md
+++ b/content/influxdb/clustered/write-data/use-telegraf/configure/_index.md
@@ -41,11 +41,9 @@ for using Telegraf with {{< product-name >}}._
       - [token](#token)
       - [organization](#organization)
       - [bucket](#bucket)
-      - [Write to InfluxDB v1.x and {{< product-name >}}](#write-to-influxdb-v1x-and--product-name-)
+      - [Write to InfluxDB v1.x and {{< product-name >}}](#write-to-influxdb-v1x-and-influxdb-clustered)
   - [Other Telegraf configuration options](#other-telegraf-configuration-options)
 - [Start Telegraf](#start-telegraf)
-
-<!-- /TOC -->
 
 ## Configure Telegraf input and output plugins
 

--- a/layouts/shortcodes/api/cloud/v2-prefer.html
+++ b/layouts/shortcodes/api/cloud/v2-prefer.html
@@ -1,4 +1,0 @@
-For new workloads, use the following:
-
-- The [InfluxDB v2 API `/api/v2/write` endpoint](/influxdb/cloud-dedicated/primers/api/v2/) for writing data.
-- A Flight SQL client and SQL for querying data.


### PR DESCRIPTION
- removes the shared v2-prefer shortcode note.
- adds "Flight client" tag to all Flight RPC and Flight SQL client pages.
- replaces the note with specific write/query notes in each platform.
- misc fixes

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
