### PR TITLE
fix(clustered): remove link to inaccessible google doc

### DIFF
--- a/content/influxdb/clustered/admin/users/_index.md
+++ b/content/influxdb/clustered/admin/users/_index.md
@@ -13,6 +13,6 @@ draft: true
 To add or remove users, update the users list in the `myinfluxdb.yml` file.
 The users list is found at spec.package.spec.admin.users.
 After updating the list, re-apply `myinfluxdb.yml`.
-See [Step 6: Deploy an InfluxDB cluster](/influxdb/clustered/install/deploy) for details on how to apply `myinfluxdb.yml`.
+To learn how to apply `myinfluxdb.yml`, see [Step 6: Deploy an InfluxDB cluster](/influxdb/clustered/install/deploy).
 Once the `myinfluxdb.yml` has been applied, it will take a couple minutes for the updates to roll out.
 When complete, any new users will have been added and any removed users will have been deleted.

--- a/content/influxdb/clustered/admin/users/_index.md
+++ b/content/influxdb/clustered/admin/users/_index.md
@@ -14,5 +14,5 @@ To add or remove users, update the users list in the `myinfluxdb.yml` file.
 The users list is found at spec.package.spec.admin.users.
 After updating the list, re-apply `myinfluxdb.yml`.
 To learn how to apply `myinfluxdb.yml`, see [Step 6: Deploy an InfluxDB cluster](/influxdb/clustered/install/deploy).
-Once the `myinfluxdb.yml` has been applied, it will take a couple minutes for the updates to roll out.
-When complete, any new users will have been added and any removed users will have been deleted.
+After `myinfluxdb.yml` has been applied, updates take a couple of minutes to complete.
+When the updates are finished, new users will have been added, and removed users will have been deleted.```

--- a/content/influxdb/clustered/admin/users/_index.md
+++ b/content/influxdb/clustered/admin/users/_index.md
@@ -13,6 +13,6 @@ draft: true
 To add or remove users, update the users list in the `myinfluxdb.yml` file.
 The users list is found at spec.package.spec.admin.users.
 After updating the list, re-apply `myinfluxdb.yml`.
-To learn how to apply `myinfluxdb.yml`, see [Step 6: Deploy an InfluxDB cluster](/influxdb/clustered/install/deploy).
+To learn how to apply `myinfluxdb.yml`, see [Deploy an InfluxDB cluster](/influxdb/clustered/install/deploy).
 After `myinfluxdb.yml` has been applied, updates take a couple of minutes to complete.
-When the updates are finished, new users will have been added, and removed users will have been deleted.```
+When the updates are finished, new users will have been added, and removed users will have been deleted.

--- a/content/influxdb/clustered/admin/users/_index.md
+++ b/content/influxdb/clustered/admin/users/_index.md
@@ -13,6 +13,6 @@ draft: true
 To add or remove users, update the users list in `myinfluxdb.yml` file.
 The users list is found at spec.package.spec.admin.users.
 After updating the list, re-apply `myinfluxdb.yml`.
-See [Step 6: Deploy an InfluxDB cluster](https://docs.google.com/document/d/1UCmGtZS_OQe-gYOd0ASi0E2wFM9t3MOGwfDhxR1wtgg/edit#heading=h.m40zb08bbum1) for details on how to apply `myinfluxdb.yml`.
+See [Step 6: Deploy an InfluxDB cluster](/influxdb/clustered/install/deploy) for details on how to apply `myinfluxdb.yml`.
 Once the `myinfluxdb.yml` has been applied, it will take a couple minutes for the updates to roll out.
 When complete, any new users will have been added and any removed users will have been deleted.

--- a/content/influxdb/clustered/admin/users/_index.md
+++ b/content/influxdb/clustered/admin/users/_index.md
@@ -10,7 +10,7 @@ weight: 101
 draft: true
 ---
 
-To add or remove users, update the users list in `myinfluxdb.yml` file.
+To add or remove users, update the users list in the `myinfluxdb.yml` file.
 The users list is found at spec.package.spec.admin.users.
 After updating the list, re-apply `myinfluxdb.yml`.
 See [Step 6: Deploy an InfluxDB cluster](/influxdb/clustered/install/deploy) for details on how to apply `myinfluxdb.yml`.


### PR DESCRIPTION
The Google doc link here is inaccessible to those outside of Influx, this is a leftover from before the document was ported to markdown in its early stages and subsequently moved to the docs site.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
