### PR TITLE
chore: fix link to database update influxctl

### DIFF
--- a/content/influxdb/clustered/reference/cli/influxctl/database/_index.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/database/_index.md
@@ -25,7 +25,7 @@ influxctl database [subcommand] [flags]
 | [create](/influxdb/clustered/reference/cli/influxctl/database/create/) | Create a database   |
 | [delete](/influxdb/clustered/reference/cli/influxctl/database/delete/) | Delete a database   |
 | [list](/influxdb/clustered/reference/cli/influxctl/database/list/)     | List databases      |
-| [update](/influxdb/clustered/reference/cli/influxctl/database/list/)   | Update a database   |
+| [update](/influxdb/clustered/reference/cli/influxctl/database/update/)   | Update a database   |
 | help, h                                                                      | Output command help |
 
 ## Flags


### PR DESCRIPTION
Fixes influxctl link that pointed to `list` instead of `update`

- [X] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [X] Rebased/mergeable
