### PR TITLE
fix(tests): test runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN chmod -R 755 .
 
 # Prevents Python from writing pyc files.
 ENV PYTHONDONTWRITEBYTECODE=1
-	@@ -22,26 +28,23 @@ ENV PYTHONDONTWRITEBYTECODE=1
+
 # the application crashes without emitting any logs due to buffering.
 ENV PYTHONUNBUFFERED=1
 

--- a/test.sh
+++ b/test.sh
@@ -32,6 +32,11 @@ if [ -z "$paths" ]; then
   echo "No path provided. Running tests for *.md files that have been added or modified in the current branch."
   paths=$(git diff --name-only --diff-filter=AM --relative origin/master | \
     grep -E '\.md$')
+
+  if [ -z "$paths" ]; then
+    echo "No files found for pattern: $paths"
+    exit 1
+  fi
 else
   paths=$(find "$paths" -type f -name '*.md')
 fi

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -93,4 +93,4 @@ mkdir -p ~/Downloads && rm -rf ~/Downloads/*
 gpg -q --batch --yes --delete-key D8FF8E1F7DF8B07E > /dev/null 2>&1
 
 # Run test commands with options provided in the CMD of the Dockerfile.
-pytest --codeblocks ./content "$@"
+pytest --codeblocks . "$@"


### PR DESCRIPTION
- Bad Dockerfile merge.
- Add condition to abort if there are no files to test.
- Revert search path to `.`. If we need to change it, we can do it in pytest.ini.
