### PR TITLE
fix: remove static token permissions verbiage

### DIFF
--- a/content/influxdb/cloud-dedicated/admin/tokens/_index.md
+++ b/content/influxdb/cloud-dedicated/admin/tokens/_index.md
@@ -30,12 +30,6 @@ to perform administrative actions.
 Token strings are returned _only_ on token creation.
 We recommend storing database tokens in a **secure secret store**.
 For example, see how to [authenticate Telegraf using tokens in your OS secret store](https://github.com/influxdata/telegraf/tree/master/plugins/secretstores/os).
-
-#### Tokens cannot be updated
-
-Once created, token permissions cannot be updated.
-If you need a token with different permissions, create a token with the
-appropriate permissions.
 {{% /note %}}
 
 ---

--- a/content/influxdb/clustered/admin/tokens/_index.md
+++ b/content/influxdb/clustered/admin/tokens/_index.md
@@ -28,12 +28,6 @@ to perform administrative actions.
 Token strings are returned _only_ on token creation.
 We recommend storing database tokens in a **secure secret store**.
 For example, see how to [authenticate Telegraf using tokens in your OS secret store](https://github.com/influxdata/telegraf/tree/master/plugins/secretstores/os).
-
-#### Tokens cannot be updated
-
-Once created, token permissions cannot be updated.
-If you need a token with different permissions, create a token with the
-appropriate permissions.
 {{% /note %}}
 
 ---


### PR DESCRIPTION
This removes a section from the Dedicated and Clustered docs that says that token permissions cannot be updated since influxctl now supports token updates.

Closes #

_Describe your proposed changes here._

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
