### PR TITLE
InfluxDB 2.7.4

### DIFF
--- a/content/chronograf/v1/administration/restoring-chronograf-db.md
+++ b/content/chronograf/v1/administration/restoring-chronograf-db.md
@@ -66,7 +66,7 @@ cp backup/chronograf-v1.db.1.4.4.2 chronograf-v1.db
 ### 4. Install the desired Chronograf version
 Install the desired Chronograf version.
 Chronograf releases can be viewed and downloaded either from the
-[InfluxData downloads](https://portal.influxdata.com/downloads)
+[InfluxData downloads](https://www.influxdata.com/downloads/)
 page or from the [Chronograf releases](https://github.com/influxdata/chronograf/releases)
 page on Github.
 

--- a/content/chronograf/v1/administration/upgrading.md
+++ b/content/chronograf/v1/administration/upgrading.md
@@ -10,7 +10,7 @@ menu:
 
 If you're upgrading from Chronograf 1.3.x, first install {{< latest-patch version="1.7" >}}, and then install {{< latest-patch >}}.
 
-If you're upgrading from Chronograf 1.4 or later, [download and install](https://portal.influxdata.com/downloads) the most recent version of Chronograf, and then restart Chronograf.
+If you're upgrading from Chronograf 1.4 or later, [download and install](https://www.influxdata.com/downloads/) the most recent version of Chronograf, and then restart Chronograf.
 
 {{% note %}}
 Installing a new version of Chronograf automatically clears the localStorage settings.

--- a/content/chronograf/v1/guides/monitoring-influxenterprise-clusters.md
+++ b/content/chronograf/v1/guides/monitoring-influxenterprise-clusters.md
@@ -26,7 +26,7 @@ InfluxData recommends using a separate server to store your monitoring data.
 It is possible to store the monitoring data in your cluster and [connect the cluster to Chronograf](/chronograf/v1/troubleshooting/frequently-asked-questions/#how-do-i-connect-chronograf-to-an-influxenterprise-cluster), but, in general, your monitoring data should live on a separate server.
 
 You're working on an Ubuntu installation.
-Chronograf and the other components of the TICK stack are supported on several operating systems and hardware architectures. Check out the [downloads page](https://portal.influxdata.com/downloads) for links to the binaries of your choice.
+Chronograf and the other components of the TICK stack are supported on several operating systems and hardware architectures. Check out the [downloads page](https://www.influxdata.com/downloads/) for links to the binaries of your choice.
 
 ## Architecture overview
 
@@ -50,7 +50,7 @@ Chronograf uses the hostnames in the Telegraf data to populate the Host List pag
 
 #### Step 1: Download and install InfluxDB
 
-InfluxDB can be downloaded from the [InfluxData downloads page](https://portal.influxdata.com/downloads).
+InfluxDB can be downloaded from the [InfluxData downloads page](https://www.influxdata.com/downloads/).
 
 #### Step 2: Enable authentication
 
@@ -102,7 +102,7 @@ You'll return to your InfluxDB instance at the end of this section.
 
 #### Step 1: Download and install Telegraf
 
-Telegraf can be downloaded from the [InfluxData downloads page](https://portal.influxdata.com/downloads).
+Telegraf can be downloaded from the [InfluxData downloads page](https://www.influxdata.com/downloads/).
 
 #### Step 2: Configure Telegraf
 
@@ -248,7 +248,7 @@ Those values match the hostnames of the three data nodes in the cluster; this me
 Download and install Chronograf on the same server as the InfluxDB instance.
 This is not a requirement; you may host Chronograf on a separate server.
 
-Chronograf can be downloaded from the [InfluxData downloads page](https://portal.influxdata.com/downloads).
+Chronograf can be downloaded from the [InfluxData downloads page](https://www.influxdata.com/downloads/).
 
 #### Step 2: Start Chronograf
 

--- a/content/chronograf/v1/introduction/downloading.md
+++ b/content/chronograf/v1/introduction/downloading.md
@@ -7,7 +7,7 @@ menu:
     parent: Introduction
 ---
 
-Download the latest Chronograf release at the [InfluxData download page](https://portal.influxdata.com/downloads).
+Download the latest Chronograf release at the [InfluxData download page](https://www.influxdata.com/downloads/).
 Click **Are you interested in InfluxDB 1.x Open Source?** to expand the 1.x options. Scroll to the **Chronograf** section and select your desired Chronograf version and operating system. Execute the provided download commands.
 
 

--- a/content/chronograf/v1/introduction/installation.md
+++ b/content/chronograf/v1/introduction/installation.md
@@ -23,7 +23,7 @@ Chronograf is the user interface for InfluxData's [TICK stack](https://www.influ
 
 ## Download and install
 
-The latest Chronograf builds are available on InfluxData's [Downloads page](https://portal.influxdata.com/downloads).
+The latest Chronograf builds are available on InfluxData's [Downloads page](https://www.influxdata.com/downloads/).
 
 1. On the Downloads page, scroll to the bottom and click **Are you interested in InfluxDB 1.x Open Source?** to expand the 1.x options. Scroll to the **Chronograf** section and select your desired Chronograf version and operating system. Execute the provided download commands.
 

--- a/content/influxdb/cloud-dedicated/reference/release-notes/influxctl.md
+++ b/content/influxdb/cloud-dedicated/reference/release-notes/influxctl.md
@@ -174,7 +174,7 @@ following guidelines:
 ### Features
 
 - Add support for both InfluxDB Cloud Dedicated and InfluxDB Clustered.
-- Provide public distributions through <https://portal.influxdata.com/downloads/>
+- Provide public distributions through <https://www.influxdata.com/downloads//>
   and the <https://repos.influxdata.com/> repository.
 - The `influxctl` configuration file is now a single file that you can
   optionally pass in via the CLI.

--- a/content/influxdb/cloud-dedicated/reference/release-notes/influxctl.md
+++ b/content/influxdb/cloud-dedicated/reference/release-notes/influxctl.md
@@ -174,7 +174,7 @@ following guidelines:
 ### Features
 
 - Add support for both InfluxDB Cloud Dedicated and InfluxDB Clustered.
-- Provide public distributions through <https://www.influxdata.com/downloads//>
+- Provide public distributions through <https://www.influxdata.com/downloads/>
   and the <https://repos.influxdata.com/> repository.
 - The `influxctl` configuration file is now a single file that you can
   optionally pass in via the CLI.

--- a/content/influxdb/cloud/upgrade/v1-to-cloud/_index.md
+++ b/content/influxdb/cloud/upgrade/v1-to-cloud/_index.md
@@ -43,7 +43,7 @@ for the upgrade process.
 _For more information about managing tokens and token types, see [Manage tokens](/influxdb/cloud/admin/tokens/)._
 
 ## Download and install the influx CLI
-1.  Visit the [InfluxDB downloads page](https://www.influxdata.com/downloads//)
+1.  Visit the [InfluxDB downloads page](https://www.influxdata.com/downloads/)
     and download the **InfluxDB Cloud CLI** (`influx`).
 2.  Place the `influx` binary in your system `PATH` or execute the CLI commands from
     the directory where the `influx` CLI exists.

--- a/content/influxdb/cloud/upgrade/v1-to-cloud/_index.md
+++ b/content/influxdb/cloud/upgrade/v1-to-cloud/_index.md
@@ -43,7 +43,7 @@ for the upgrade process.
 _For more information about managing tokens and token types, see [Manage tokens](/influxdb/cloud/admin/tokens/)._
 
 ## Download and install the influx CLI
-1.  Visit the [InfluxDB downloads page](https://portal.influxdata.com/downloads/)
+1.  Visit the [InfluxDB downloads page](https://www.influxdata.com/downloads//)
     and download the **InfluxDB Cloud CLI** (`influx`).
 2.  Place the `influx` binary in your system `PATH` or execute the CLI commands from
     the directory where the `influx` CLI exists.

--- a/content/influxdb/clustered/reference/release-notes/influxctl.md
+++ b/content/influxdb/clustered/reference/release-notes/influxctl.md
@@ -175,7 +175,7 @@ following guidelines:
 ### Features
 
 - Add support for both InfluxDB Cloud Dedicated and InfluxDB Clustered.
-- Provide public distributions through <https://www.influxdata.com/downloads//>
+- Provide public distributions through <https://www.influxdata.com/downloads/>
   and the <https://repos.influxdata.com/> repository.
 - The `influxctl` configuration file is now a single file that you can
   optionally pass in via the CLI.

--- a/content/influxdb/clustered/reference/release-notes/influxctl.md
+++ b/content/influxdb/clustered/reference/release-notes/influxctl.md
@@ -175,7 +175,7 @@ following guidelines:
 ### Features
 
 - Add support for both InfluxDB Cloud Dedicated and InfluxDB Clustered.
-- Provide public distributions through <https://portal.influxdata.com/downloads/>
+- Provide public distributions through <https://www.influxdata.com/downloads//>
   and the <https://repos.influxdata.com/> repository.
 - The `influxctl` configuration file is now a single file that you can
   optionally pass in via the CLI.

--- a/content/influxdb/v1/administration/upgrading.md
+++ b/content/influxdb/v1/administration/upgrading.md
@@ -25,7 +25,7 @@ and see [Migrate to InfluxDB Enterprise](/enterprise_influxdb/v1/guides/migratio
 
 ## Upgrade to InfluxDB 1.8.x
 
-1. [Download](https://www.influxdata.com/downloads/) InfluxDB version 1.8.x and [install the upgrade](/influxdb/v1/introduction/installation).
+1. [Download](https://www.influxdata.com/downloads/) InfluxDB version 1.8.x and [install the upgrade](/influxdb/v1/introduction/installation/).
 
 2. Migrate configuration file customizations from your existing configuration file to the InfluxDB 1.8.x [configuration file](/influxdb/v1/administration/config/). Add or modify your environment variables as needed.
 

--- a/content/influxdb/v1/administration/upgrading.md
+++ b/content/influxdb/v1/administration/upgrading.md
@@ -25,7 +25,7 @@ and see [Migrate to InfluxDB Enterprise](/enterprise_influxdb/v1/guides/migratio
 
 ## Upgrade to InfluxDB 1.8.x
 
-1. [Download](https://portal.influxdata.com/downloads) InfluxDB version 1.8.x and [install the upgrade](/influxdb/v1/introduction/installation).
+1. [Download](https://www.influxdata.com/downloads/) InfluxDB version 1.8.x and [install the upgrade](/influxdb/v1/introduction/installation).
 
 2. Migrate configuration file customizations from your existing configuration file to the InfluxDB 1.8.x [configuration file](/influxdb/v1/administration/config/). Add or modify your environment variables as needed.
 

--- a/content/influxdb/v1/introduction/download.md
+++ b/content/influxdb/v1/introduction/download.md
@@ -9,9 +9,9 @@ aliases:
   - /influxdb/v1/introduction/downloading/
 ---
 
-Download the latest InfluxDB open source (OSS) release at the [InfluxData download page](https://portal.influxdata.com/downloads). 
+Download the latest InfluxDB open source (OSS) release at the [InfluxData download page](https://www.influxdata.com/downloads/). 
 
-1. Scroll to the bottom of the [`downloads page`](https://portal.influxdata.com/downloads) and click **Are you interested in InfluxDB 1.x Open Source?** to expand the 1.x options. 
+1. Scroll to the bottom of the [`downloads page`](https://www.influxdata.com/downloads/) and click **Are you interested in InfluxDB 1.x Open Source?** to expand the 1.x options. 
 2. Under **Are you interested in InfluxDB 1.x Open Source?**, select the version of InfluxDB you want to download.
 3. Under the **Platform** dropdown menu, select your operating system.
 4. Execute the provided download commands.

--- a/content/influxdb/v2/install/_index.md
+++ b/content/influxdb/v2/install/_index.md
@@ -288,7 +288,7 @@ For information about installing the `influx` CLI, see
 ### Install InfluxDB as a service with systemd
 
 1.  Download and install the appropriate `.deb` or `.rpm` file using a URL from the
-    [InfluxData downloads page](https://portal.influxdata.com/downloads/)
+    [InfluxData downloads page](https://www.influxdata.com/downloads//)
     with the following commands:
 
     ```sh

--- a/content/influxdb/v2/install/_index.md
+++ b/content/influxdb/v2/install/_index.md
@@ -288,7 +288,7 @@ For information about installing the `influx` CLI, see
 ### Install InfluxDB as a service with systemd
 
 1.  Download and install the appropriate `.deb` or `.rpm` file using a URL from the
-    [InfluxData downloads page](https://www.influxdata.com/downloads//)
+    [InfluxData downloads page](https://www.influxdata.com/downloads/)
     with the following commands:
 
     ```sh

--- a/content/influxdb/v2/install/upgrade/v1-to-v2/automatic-upgrade.md
+++ b/content/influxdb/v2/install/upgrade/v1-to-v2/automatic-upgrade.md
@@ -196,7 +196,7 @@ To build an interactive shell to execute **Flux** queries,
 If you've considered the [guidance above](#important-considerations-before-you-begin)
 and are ready to proceed, follow these steps to upgrade your InfluxDB 1.x to InfluxDB {{< current-version >}}.
 
-1. [Download InfluxDB OSS {{< current-version >}}](https://www.influxdata.com/downloads//).
+1. [Download InfluxDB OSS {{< current-version >}}](https://www.influxdata.com/downloads/).
    Unpackage the InfluxDB binaries and place them in your `$PATH`.
 2. Stop your running InfluxDB 1.x instance.
    Make a backup copy of all 1.x data before upgrading:

--- a/content/influxdb/v2/install/upgrade/v1-to-v2/automatic-upgrade.md
+++ b/content/influxdb/v2/install/upgrade/v1-to-v2/automatic-upgrade.md
@@ -196,7 +196,7 @@ To build an interactive shell to execute **Flux** queries,
 If you've considered the [guidance above](#important-considerations-before-you-begin)
 and are ready to proceed, follow these steps to upgrade your InfluxDB 1.x to InfluxDB {{< current-version >}}.
 
-1. [Download InfluxDB OSS {{< current-version >}}](https://portal.influxdata.com/downloads/).
+1. [Download InfluxDB OSS {{< current-version >}}](https://www.influxdata.com/downloads//).
    Unpackage the InfluxDB binaries and place them in your `$PATH`.
 2. Stop your running InfluxDB 1.x instance.
    Make a backup copy of all 1.x data before upgrading:

--- a/content/influxdb/v2/reference/release-notes/influxdb.md
+++ b/content/influxdb/v2/reference/release-notes/influxdb.md
@@ -608,7 +608,7 @@ This release includes the following bug fixes and updates:
 
 Beginning in InfluxDB 2.1, the `influx` CLI will no longer be packaged with the release. Future versions of `influx` CLI will be released from the [influx-cli](https://github.com/influxdata/influx-cli) repository.
 
-To adopt the new, separate `influx` CLI early, download the latest release from [GitHub](https://github.com/influxdata/influx-cli/releases/tag/v2.3.0) or from the [InfluxData Downloads portal](https://www.influxdata.com/downloads//).
+To adopt the new, separate `influx` CLI early, download the latest release from [GitHub](https://github.com/influxdata/influx-cli/releases/tag/v2.3.0) or from the [InfluxData Downloads portal](https://www.influxdata.com/downloads/).
 {{% /warn %}}
 
 ### Go version

--- a/content/influxdb/v2/reference/release-notes/influxdb.md
+++ b/content/influxdb/v2/reference/release-notes/influxdb.md
@@ -8,6 +8,10 @@ menu:
 weight: 101
 ---
 
+## v2.7.4 {date="2023-11-14"}
+
+_Internal changes only._
+
 ## v2.7.3 {date="2023-10-17"}
 
 ### Maintenance
@@ -604,7 +608,7 @@ This release includes the following bug fixes and updates:
 
 Beginning in InfluxDB 2.1, the `influx` CLI will no longer be packaged with the release. Future versions of `influx` CLI will be released from the [influx-cli](https://github.com/influxdata/influx-cli) repository.
 
-To adopt the new, separate `influx` CLI early, download the latest release from [GitHub](https://github.com/influxdata/influx-cli/releases/tag/v2.3.0) or from the [InfluxData Downloads portal](https://portal.influxdata.com/downloads/).
+To adopt the new, separate `influx` CLI early, download the latest release from [GitHub](https://github.com/influxdata/influx-cli/releases/tag/v2.3.0) or from the [InfluxData Downloads portal](https://www.influxdata.com/downloads//).
 {{% /warn %}}
 
 ### Go version

--- a/content/kapacitor/v1/administration/upgrading.md
+++ b/content/kapacitor/v1/administration/upgrading.md
@@ -36,7 +36,7 @@ For information about what is new in the latest Kapacitor release, view the [Cha
 
 In general the steps for upgrading Kapacitor are as follows:
 
-   1. Download a copy of the latest Kapacitor install package or binary distribution from the [Influxdata download site](https://portal.influxdata.com/downloads).
+   1. Download a copy of the latest Kapacitor install package or binary distribution from the [Influxdata download site](https://www.influxdata.com/downloads/).
 
       **Important note** - When upgrading Kapacitor, simply download the package using `wget`. Do not proceed directly with the installation/upgrade until the following instructions and recommendations have been understood and put to use.
 

--- a/content/kapacitor/v1/introduction/_index.md
+++ b/content/kapacitor/v1/introduction/_index.md
@@ -11,6 +11,6 @@ menu:
 To get up and running with Kapacitor, complete the following tasks:
 
 ## Download Kapacitor
-For information about downloading Kapacitor, visit the [InfluxData downloads page](https://portal.influxdata.com/downloads).
+For information about downloading Kapacitor, visit the [InfluxData downloads page](https://www.influxdata.com/downloads/).
 
 {{< children hlevel="h2">}}

--- a/content/kapacitor/v1/introduction/installation.md
+++ b/content/kapacitor/v1/introduction/installation.md
@@ -37,7 +37,7 @@ Kapacitor has two binaries:
 * kapacitord: the Kapacitor server daemon.
 
 You can download the binaries directly from the
-[downloads](https://portal.influxdata.com/downloads) page.
+[downloads](https://www.influxdata.com/downloads/) page.
 
 > **Note:** Windows support is experimental.
 

--- a/content/platform/install-and-deploy/install/oss-install.md
+++ b/content/platform/install-and-deploy/install/oss-install.md
@@ -12,7 +12,7 @@ menu:
 
 ## Download the TICK stack components
 
-To download each of the TICK stack components, see [InfluxData downloads page](https://portal.influxdata.com/downloads).
+To download each of the TICK stack components, see [InfluxData downloads page](https://www.influxdata.com/downloads/).
 Telegraf, InfluxDB, Chronograf, and Kapacitor are each separate binaries that need
 to be installed, configured, and started separately.
 

--- a/content/telegraf/v1/install.md
+++ b/content/telegraf/v1/install.md
@@ -20,7 +20,7 @@ To install Telegraf, do the following:
 
 ## Download
 
-Download the latest Telegraf release at the [InfluxData download page](https://portal.influxdata.com/downloads).
+Download the latest Telegraf release at the [InfluxData download page](https://www.influxdata.com/downloads/).
 
 ## Requirements
 
@@ -102,7 +102,7 @@ To manually install the Debian package from a `.deb` file:
 {{% /tab-content %}}
 <!---------- BEGIN RedHat & CentOS ---------->
 {{% tab-content %}}
-To learn how to manually install the RPM package from a file, see the [downloads page](https://portal.influxdata.com/downloads/).
+To learn how to manually install the RPM package from a file, see the [downloads page](https://www.influxdata.com/downloads//).
 
 To use the `yum` package manager to install the latest stable version of Telegraf, follow these steps:
 
@@ -167,7 +167,7 @@ Examples are installed at `/usr/local/etc/telegraf.conf.sample`.
 {{% tab-content %}}
 Choose from the following options to install Telegraf for macOS:
 
-- To manually install Telegraf from a file, see the [downloads page](https://portal.influxdata.com/downloads/).
+- To manually install Telegraf from a file, see the [downloads page](https://www.influxdata.com/downloads//).
 - [Install using Homebrew](#install-using-homebrew)
 
 ### Install using Homebrew
@@ -176,11 +176,11 @@ Users of macOS 10.8 and higher can install Telegraf using the [Homebrew](http://
 
 {{% note %}}
 
-The `telegraf` binary installed by Homebrew differs from the macOS `.dmg` builds available from the [downloads page](https://portal.influxdata.com/downloads/).
+The `telegraf` binary installed by Homebrew differs from the macOS `.dmg` builds available from the [downloads page](https://www.influxdata.com/downloads//).
 
 - `telegraf` (Homebrew) isn't a static binary.
 - `telegraf` (Homebrew) works with the Telegraf CPU plugin (due to Homebrew support for [Cgo](https://pkg.go.dev/cmd/cgo)).
-    The `.dmg` builds available on [downloads](https://portal.influxdata.com/downloads/) don't support the CPU plugin.
+    The `.dmg` builds available on [downloads](https://www.influxdata.com/downloads//) don't support the CPU plugin.
 
 {{% /note %}}
 

--- a/content/telegraf/v1/install.md
+++ b/content/telegraf/v1/install.md
@@ -102,7 +102,7 @@ To manually install the Debian package from a `.deb` file:
 {{% /tab-content %}}
 <!---------- BEGIN RedHat & CentOS ---------->
 {{% tab-content %}}
-To learn how to manually install the RPM package from a file, see the [downloads page](https://www.influxdata.com/downloads//).
+To learn how to manually install the RPM package from a file, see the [downloads page](https://www.influxdata.com/downloads/).
 
 To use the `yum` package manager to install the latest stable version of Telegraf, follow these steps:
 
@@ -167,7 +167,7 @@ Examples are installed at `/usr/local/etc/telegraf.conf.sample`.
 {{% tab-content %}}
 Choose from the following options to install Telegraf for macOS:
 
-- To manually install Telegraf from a file, see the [downloads page](https://www.influxdata.com/downloads//).
+- To manually install Telegraf from a file, see the [downloads page](https://www.influxdata.com/downloads/).
 - [Install using Homebrew](#install-using-homebrew)
 
 ### Install using Homebrew
@@ -176,11 +176,11 @@ Users of macOS 10.8 and higher can install Telegraf using the [Homebrew](http://
 
 {{% note %}}
 
-The `telegraf` binary installed by Homebrew differs from the macOS `.dmg` builds available from the [downloads page](https://www.influxdata.com/downloads//).
+The `telegraf` binary installed by Homebrew differs from the macOS `.dmg` builds available from the [downloads page](https://www.influxdata.com/downloads/).
 
 - `telegraf` (Homebrew) isn't a static binary.
 - `telegraf` (Homebrew) works with the Telegraf CPU plugin (due to Homebrew support for [Cgo](https://pkg.go.dev/cmd/cgo)).
-    The `.dmg` builds available on [downloads](https://www.influxdata.com/downloads//) don't support the CPU plugin.
+    The `.dmg` builds available on [downloads](https://www.influxdata.com/downloads/) don't support the CPU plugin.
 
 {{% /note %}}
 

--- a/data/products.yml
+++ b/data/products.yml
@@ -21,7 +21,7 @@ influxdb:
     - v1.7
   latest: v2.7
   latest_patches:
-    v2: 2.7.3
+    v2: 2.7.4
     v1: 1.8.10
   latest_cli:
     v2: 2.7.3

--- a/layouts/shortcodes/latest-patch.html
+++ b/layouts/shortcodes/latest-patch.html
@@ -7,7 +7,7 @@
 {{- $versionArg := .Get "version" | default "" -}}
 {{- $minorVersionOffset := .Get "minorVersionOffset" | default 0 -}}
 {{- $product := cond (gt (len $productArg) 0) $productArg $parsedProduct -}}
-{{- $latestVersion := index (index .Site.Data.products $product) "latest" -}}
+{{- $latestVersion := replaceRE `\..*$` "" (index (index .Site.Data.products $product) "latest") -}}
 {{- $versionNoOffset := cond (gt (len $versionArg) 0) $versionArg (cond (ne $product $parsedProduct) $latestVersion $parsedVersion) -}}
 {{- $version := replaceRE `\d+$` (add (int (index (findRE `\d+$` $versionNoOffset) 0)) $minorVersionOffset) $versionNoOffset  -}}
 {{- $patchVersions := index (index .Site.Data.products $product) "latest_patches" -}}


### PR DESCRIPTION
- Updates InfluxDB patch version to 2.7.4.
- Fixes `latest-patch` shortcode to correctly get the latest `influx` CLI version
- Update all downloads page links

---

- [x] Rebased/mergeable
