### PR TITLE
TYPO Missing closing bracket from example command to get influxd PID

### DIFF
--- a/content/enterprise_influxdb/v1/troubleshooting/frequently-asked-questions.md
+++ b/content/enterprise_influxdb/v1/troubleshooting/frequently-asked-questions.md
@@ -1344,11 +1344,7 @@ If the number of maps exceeds the configured maximum limit, the node reports tha
 To check the current number of maps the `influxd` process is using:
 
 ```sh
-# Get the influxd process ID (PID)
-PID=$(ps aux | awk '/influxd/ ${print 2}' 
-
-# Count the number of maps associated with the influxd process
-wc -l /proc/$PID/maps
+wc -l /proc/$(pidof influxd)/maps
 ```
 
 The `max_map_count` file contains the maximum number of memory map areas a process may have.


### PR DESCRIPTION
TYPO Missing closing bracket from example command to get influxd PID

PID=$(ps aux | awk '/influxd/ ${print 2}' 

should read

PID=$(ps aux | awk '/influxd/ {print $2}')

But as per customer comment, just running 

wc -l /proc/$(pidof influxd)/maps

Is significantly more concise for the same objective

Closes #

Reported by customer in support ticket 00115201

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) N/A TYPO.
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
