### PR TITLE
docs: update `kubit` mentions

### DIFF
--- a/content/influxdb/clustered/install/configure-cluster.md
+++ b/content/influxdb/clustered/install/configure-cluster.md
@@ -115,7 +115,7 @@ update an InfluxDB cluster.
 Use `kubectl` to install the [kubecfg kubit](https://github.com/kubecfg/kubit) operator.
 
 ```sh
-kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.11'
+kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.12'
 ```
 
 ### Configure access to the InfluxDB container registry

--- a/content/influxdb/clustered/install/deploy.md
+++ b/content/influxdb/clustered/install/deploy.md
@@ -77,8 +77,8 @@ kubectl apply \
     ```
 
 **NOTE:** By default, `kubit` will use tools that are installed on your local system.
-You specify the `--docker` flag to opt-in to using containers instead, which  will pull images
-for tool dependencies, meaning the required versions are tracked by `kubit` instead.
+You can specify the `--docker` flag to opt-in to using containers instead. This will pull images
+for tool dependencies, meaning the required versions are tracked by `kubit`.
 
 <!--------------------------------- END kubit --------------------------------->
 {{% /tab-content %}}

--- a/content/influxdb/clustered/install/deploy.md
+++ b/content/influxdb/clustered/install/deploy.md
@@ -28,7 +28,7 @@ If you do not have the necessary permissions, you can
 [use the `kubit` CLI to manually install the package in your cluster](?t=kubit#kubectl-or-kubit).
 
 {{% note %}}
-**If you meet any of the following criteria, 
+**If you meet any of the following criteria,
 [install and use the `kubit` CLI](?t=kubit#kubectl-or-kubit)
 on your local machine. This allows you to act as the operator would and deploy
 your cluster, but from your terminal.**
@@ -75,6 +75,10 @@ kubectl apply \
     ```sh
     kubit local apply myinfuxdb.yml
     ```
+
+**NOTE:** By default, `kubit` will use tools that are installed on your local system.
+You specify the `--docker` flag to opt-in to using containers instead, which  will pull images
+for tool dependencies, meaning the required versions are tracked by `kubit` instead.
 
 <!--------------------------------- END kubit --------------------------------->
 {{% /tab-content %}}

--- a/content/influxdb/clustered/install/deploy.md
+++ b/content/influxdb/clustered/install/deploy.md
@@ -25,11 +25,11 @@ fail if you do not have those permissions in your cluster.
 
 `kubectl` uses your local credentials to install the `AppInstance` CRD.
 If you do not have the necessary permissions, you can
-[use the `kubit` CLI to manually install the package in your cluster](?t=kubit#kubctl-or-kubit).
+[use the `kubit` CLI to manually install the package in your cluster](?t=kubit#kubectl-or-kubit).
 
 {{% note %}}
 **If you meet any of the following criteria, 
-[install and use the `kubit` CLI](?t=kubit#kubctl-or-kubit)
+[install and use the `kubit` CLI](?t=kubit#kubectl-or-kubit)
 on your local machine. This allows you to act as the operator would and deploy
 your cluster, but from your terminal.**
 
@@ -42,7 +42,7 @@ your cluster, but from your terminal.**
 {{% /note %}}
 
 <!-- Hidden anchor for links to the kubectl/kubit tabs -->
-<span id="kubctl-or-kubit"></span>
+<span id="kubectl-or-kubit"></span>
 
 {{< tabs-wrapper >}}
 {{% tabs %}}


### PR DESCRIPTION
There is a [new release of `kubit`](https://github.com/kubecfg/kubit/releases/tag/v0.0.12), this updates the documentation for Clustered in relation to that, alongside an extra feature which can be useful to avoid user's needing to install the correct version of `kubectl` and `kubecfg` for the tool to work in the desired manner when being ran locally.

Please feel free to alter my wording if there is a better way to convey this information too :smile: 


- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
