### PR TITLE
docs: Fix copy paste error

### DIFF
--- a/content/influxdb/v2/reference/cli/influxd/recovery/auth/list.md
+++ b/content/influxdb/v2/reference/cli/influxd/recovery/auth/list.md
@@ -9,7 +9,7 @@ menu:
 weight: 401
 ---
 
-The `influxd recovery org list` command lists authorizations stored on disk and 
+The `influxd recovery auth list` command lists authorizations stored on disk and 
 outputs data associated with each authorization.
 
 {{% note %}}


### PR DESCRIPTION
This PR fixes a copy paste error I spotted while reading the documentation.