### PR TITLE
docs(clustered): bump kubit to `0.0.13`

### DIFF
--- a/content/influxdb/clustered/install/configure-cluster.md
+++ b/content/influxdb/clustered/install/configure-cluster.md
@@ -115,7 +115,7 @@ update an InfluxDB cluster.
 Use `kubectl` to install the [kubecfg kubit](https://github.com/kubecfg/kubit) operator.
 
 ```sh
-kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.12'
+kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.13'
 ```
 
 ### Configure access to the InfluxDB container registry


### PR DESCRIPTION
Bumping install instructions to `0.0.13`, this includes a fix to the `base64` decoding error for docker credentials that some customers have ran into.


- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
