### PR TITLE
Revert "chore: add note about partial write failures"

### DIFF
--- a/api-docs/cloud-serverless/ref.yml
+++ b/api-docs/cloud-serverless/ref.yml
@@ -14680,8 +14680,8 @@ tags:
       | &nbsp;Code&nbsp; | Status                   | Description      |
       |:-----------:|:------------------------ |:--------------------- |
       | `200`       | Success                  |                       |
-      | `201`       | Created                  | Successfully created a resource. The response body may contain details. |
-      | `204`       | No content               | The request succeeded. For _writes_ that have [rejected points](/influxdb/cloud-serverless/write-data/troubleshoot/#troubleshoot-rejected-points), the [`/write` and `/api/v2/write` endpoints](#tag/Write) return a response body with error details. |
+      | `201`       | Created                           | Successfully created a resource. The response body may contain details. |
+      | `204`       | No content      | The request succeeded, but InfluxDB doesn't typically return a response body for the operation. |
       | `400`       | Bad request              | InfluxDB can't parse the request due to an incorrect parameter or bad syntax. For _writes_, the error may indicate one of the following problems: <ul><li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected.</li><li>The batch contains a point with the same series as other points, but one of the field values has a different data type.<li>`Authorization` header is missing or malformed or the API token doesn't have permission for the operation.</li></ul> |
       | `401`       | Unauthorized             | May indicate one of the following: <ul><li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token doesn't have permission. For more information about token types and permissions, see [Manage API tokens](/influxdb/cloud-serverless/security/tokens/)</li></ul> |
       | `404`       | Not found                | Requested resource was not found. `message` in the response body provides details about the requested resource. |


### PR DESCRIPTION
Reverts influxdata/docs-v2#5275 due to the feature being reverted in https://github.com/influxdata/k8s-idpe/pull/35667