### PR TITLE
Fix(v3): Update Go Arrow package version

### DIFF
--- a/content/influxdb/cloud-dedicated/get-started/query.md
+++ b/content/influxdb/cloud-dedicated/get-started/query.md
@@ -533,7 +533,7 @@ _If your project's virtual environment is already running, skip to step 3._
       "time"
       "text/tabwriter"
 
-      "github.com/apache/arrow/go/v12/arrow"
+      "github.com/apache/arrow/go/v13/arrow"
       "github.com/InfluxCommunity/influxdb3-go/influxdb3"
     )
 
@@ -601,7 +601,7 @@ _If your project's virtual environment is already running, skip to step 3._
         - `io`
         - `os`
         - `text/tabwriter`
-        - `github.com/apache/arrow/go/v12/arrow`
+        - `github.com/apache/arrow/go/v13/arrow`
         - `github.com/InfluxCommunity/influxdb3-go/influxdb3`
 
     2.  Defines a `Query()` function that does the following:

--- a/content/influxdb/cloud-dedicated/query-data/execute-queries/client-libraries/go.md
+++ b/content/influxdb/cloud-dedicated/query-data/execute-queries/client-libraries/go.md
@@ -138,7 +138,7 @@ import (
     "time"
 
     "github.com/InfluxCommunity/influxdb3-go/influxdb3"
-    "github.com/apache/arrow/go/v12/arrow"
+    "github.com/apache/arrow/go/v13/arrow"
 )
 
 func Query() error {
@@ -235,7 +235,7 @@ import (
     "time"
 
     "github.com/InfluxCommunity/influxdb3-go/influxdb3"
-    "github.com/apache/arrow/go/v12/arrow"
+    "github.com/apache/arrow/go/v13/arrow"
 )
 
 func InfluxQL() error {

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/flight/go-flight.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/flight/go-flight.md
@@ -44,7 +44,7 @@ The following example shows how to use the Arrow Flight SQL client for Go to que
       "fmt"
       "os"
 
-      "github.com/apache/arrow/go/v12/arrow/flight/flightsql"
+      "github.com/apache/arrow/go/v14/arrow/flight/flightsql"
       "google.golang.org/grpc"
       "google.golang.org/grpc/credentials"
       "google.golang.org/grpc/metadata"
@@ -129,7 +129,7 @@ The following example shows how to use the Arrow Flight SQL client for Go to que
         - `encoding/json`
         - `fmt`
         - `os`
-        - `github.com/apache/arrow/go/v12/arrow/flight/flightsql`
+        - `github.com/apache/arrow/go/v14/arrow/flight/flightsql`
         - `google.golang.org/grpc`
         - `google.golang.org/grpc/credentials`
         - `google.golang.org/grpc/metadata`
@@ -216,4 +216,4 @@ RECORD BATCH
 {{% /expand %}}
 {{< /expand-wrapper >}}
 
-For more information, see the [Go Arrow Flight Client documentation](https://pkg.go.dev/github.com/apache/arrow/go/v12/arrow/flight#Client).
+For more information, see the [Go Arrow Flight Client documentation](https://pkg.go.dev/github.com/apache/arrow/go/v14/arrow/flight#Client).

--- a/content/influxdb/cloud-serverless/get-started/query.md
+++ b/content/influxdb/cloud-serverless/get-started/query.md
@@ -531,7 +531,7 @@ _If your project's virtual environment is already running, skip to step 3._
       "time"
       "text/tabwriter"
 
-      "github.com/apache/arrow/go/v12/arrow"
+      "github.com/apache/arrow/go/v13/arrow"
       "github.com/InfluxCommunity/influxdb3-go/influxdb3"
     )
 
@@ -599,7 +599,7 @@ _If your project's virtual environment is already running, skip to step 3._
         - `io`
         - `os`
         - `text/tabwriter`
-        - `github.com/apache/arrow/go/v12/arrow`
+        - `github.com/apache/arrow/go/v13/arrow`
         - `github.com/InfluxCommunity/influxdb3-go/influxdb3`
 
     2.  Defines a `Query()` function that does the following:

--- a/content/influxdb/cloud-serverless/query-data/execute-queries/client-libraries/go.md
+++ b/content/influxdb/cloud-serverless/query-data/execute-queries/client-libraries/go.md
@@ -139,7 +139,7 @@ import (
     "time"
 
     "github.com/InfluxCommunity/influxdb3-go/influxdb3"
-    "github.com/apache/arrow/go/v12/arrow"
+    "github.com/apache/arrow/go/v13/arrow"
 )
 
 func Query() error {
@@ -236,7 +236,7 @@ import (
     "time"
 
     "github.com/InfluxCommunity/influxdb3-go/influxdb3"
-    "github.com/apache/arrow/go/v12/arrow"
+    "github.com/apache/arrow/go/v13/arrow"
 )
 
 func InfluxQL() error {

--- a/content/influxdb/cloud-serverless/reference/client-libraries/flight/go-flight.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/flight/go-flight.md
@@ -44,7 +44,7 @@ The following example shows how to use the Arrow Flight SQL client for Go to que
       "fmt"
       "os"
 
-      "github.com/apache/arrow/go/v12/arrow/flight/flightsql"
+      "github.com/apache/arrow/go/v14/arrow/flight/flightsql"
       "google.golang.org/grpc"
       "google.golang.org/grpc/credentials"
       "google.golang.org/grpc/metadata"
@@ -129,7 +129,7 @@ The following example shows how to use the Arrow Flight SQL client for Go to que
         - `encoding/json`
         - `fmt`
         - `os`
-        - `github.com/apache/arrow/go/v12/arrow/flight/flightsql`
+        - `github.com/apache/arrow/go/v14/arrow/flight/flightsql`
         - `google.golang.org/grpc`
         - `google.golang.org/grpc/credentials`
         - `google.golang.org/grpc/metadata`
@@ -215,4 +215,4 @@ RECORD BATCH
 {{% /expand %}}
 {{< /expand-wrapper >}}
 
-For more information, see the [Go Arrow Flight Client documentation](https://pkg.go.dev/github.com/apache/arrow/go/v12/arrow/flight#Client).
+For more information, see the [Go Arrow Flight Client documentation](https://pkg.go.dev/github.com/apache/arrow/go/v14/arrow/flight#Client).

--- a/content/influxdb/clustered/get-started/query.md
+++ b/content/influxdb/clustered/get-started/query.md
@@ -533,7 +533,7 @@ _If your project's virtual environment is already running, skip to step 3._
       "time"
       "text/tabwriter"
 
-      "github.com/apache/arrow/go/v12/arrow"
+      "github.com/apache/arrow/go/v13/arrow"
       "github.com/InfluxCommunity/influxdb3-go/influxdb3"
     )
 
@@ -601,7 +601,7 @@ _If your project's virtual environment is already running, skip to step 3._
         - `io`
         - `os`
         - `text/tabwriter`
-        - `github.com/apache/arrow/go/v12/arrow`
+        - `github.com/apache/arrow/go/v13/arrow`
         - `github.com/InfluxCommunity/influxdb3-go/influxdb3`
 
     2.  Defines a `Query()` function that does the following:

--- a/content/influxdb/clustered/query-data/execute-queries/client-libraries/go.md
+++ b/content/influxdb/clustered/query-data/execute-queries/client-libraries/go.md
@@ -138,7 +138,7 @@ import (
     "time"
 
     "github.com/InfluxCommunity/influxdb3-go/influxdb3"
-    "github.com/apache/arrow/go/v12/arrow"
+    "github.com/apache/arrow/go/v13/arrow"
 )
 
 func Query() error {
@@ -235,7 +235,7 @@ import (
     "time"
 
     "github.com/InfluxCommunity/influxdb3-go/influxdb3"
-    "github.com/apache/arrow/go/v12/arrow"
+    "github.com/apache/arrow/go/v13/arrow"
 )
 
 func InfluxQL() error {

--- a/content/influxdb/clustered/reference/client-libraries/flight/go-flight.md
+++ b/content/influxdb/clustered/reference/client-libraries/flight/go-flight.md
@@ -44,7 +44,7 @@ The following example shows how to use the Arrow Flight SQL client for Go to que
       "fmt"
       "os"
 
-      "github.com/apache/arrow/go/v12/arrow/flight/flightsql"
+      "github.com/apache/arrow/go/v14/arrow/flight/flightsql"
       "google.golang.org/grpc"
       "google.golang.org/grpc/credentials"
       "google.golang.org/grpc/metadata"
@@ -129,7 +129,7 @@ The following example shows how to use the Arrow Flight SQL client for Go to que
         - `encoding/json`
         - `fmt`
         - `os`
-        - `github.com/apache/arrow/go/v12/arrow/flight/flightsql`
+        - `github.com/apache/arrow/go/v14/arrow/flight/flightsql`
         - `google.golang.org/grpc`
         - `google.golang.org/grpc/credentials`
         - `google.golang.org/grpc/metadata`
@@ -216,4 +216,4 @@ RECORD BATCH
 {{% /expand %}}
 {{< /expand-wrapper >}}
 
-For more information, see the [Go Arrow Flight Client documentation](https://pkg.go.dev/github.com/apache/arrow/go/v12/arrow/flight#Client).
+For more information, see the [Go Arrow Flight Client documentation](https://pkg.go.dev/github.com/apache/arrow/go/v14/arrow/flight#Client).


### PR DESCRIPTION
Fixes #5271

- Updates Go samples that use the client library to use the same Arrow package version (v13) used in the client library
- Updates Go FlightSQL examples to use the latest Arrow package (v14).
