### PR TITLE
Telegraf documentation: fix broken links

### DIFF
--- a/content/telegraf/v1/configure_plugins/external_plugins/write_external_plugin.md
+++ b/content/telegraf/v1/configure_plugins/external_plugins/write_external_plugin.md
@@ -26,6 +26,6 @@ Include the following steps:
      - How to download the release package for your platform or how to clone the binary for your external plugin
      - Commands to build your binary
      - Location to edit your `telegraf.conf`
-     - Configuration to run your external plugin with [inputs.execd](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/execd),
-     [processors.execd](/plugins/processors/execd) or [outputs.execd](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/execd)
+     - Configuration to run your external plugin with [inputs.execd](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/execd),
+     [processors.execd](https://github.com/influxdata/telegraf/tree/master/plugins/processors/execd) or [outputs.execd](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/execd)
 4. Submit your plugin by opening a PR to add your external plugin to the [/EXTERNAL_PLUGINS.md](https://github.com/influxdata/telegraf/blob/master/EXTERNAL_PLUGINS.md) list. Include the plugin name, a link to the plugin repository and a short description of the plugin.

--- a/content/telegraf/v1/data_formats/input/csv.md
+++ b/content/telegraf/v1/data_formats/input/csv.md
@@ -235,4 +235,4 @@ cpu,cpu=cpu0,File\ Created=2021-11-17T07:02:45+10:00,Version=1.2 time_user=42,ti
 ```
 
 [time parse]: https://pkg.go.dev/time#Parse
-[metric filtering]: /docs/CONFIGURATION.md#metric-filtering
+[metric filtering]: /telegraf/v1/configuration/#metric-filtering

--- a/content/telegraf/v1/data_formats/input/dropwizard.md
+++ b/content/telegraf/v1/data_formats/input/dropwizard.md
@@ -17,8 +17,8 @@ parsed from metric names as if they were actual InfluxDB line protocol keys
 pattern][templates]. All field value types are supported, `string`, `number` and
 `boolean`.
 
-[templates]: /docs/TEMPLATE_PATTERN.md
-[dropwizard]: http://metrics.dropwizard.io/3.1.0/manual/json/
+[templates]: https://github.com/influxdata/telegraf/blob/master/docs/TEMPLATE_PATTERN.md
+[dropwizard]: https://metrics.dropwizard.io/3.1.0/manual/json/
 
 ## Configuration
 

--- a/content/telegraf/v1/data_formats/input/prometheus-remote-write.md
+++ b/content/telegraf/v1/data_formats/input/prometheus-remote-write.md
@@ -20,7 +20,7 @@ For the metrics to completely align with the 1.x endpoint, add a Starlark proces
 {{% /note %}}
 
 Converts prometheus remote write samples directly into Telegraf metrics. It can
-be used with [http_listener_v2](/plugins/inputs/http_listener_v2). There are no
+be used with [http_listener_v2](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/http_listener_v2). There are no
 additional configuration options for Prometheus Remote Write Samples.
 
 ## Configuration

--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -808,7 +808,7 @@ input:
     id: influxdb_listener
     description: |
       The InfluxDB Listener input plugin listens for requests sent
-      according to the [InfluxDB HTTP API](/influxdb/v1.8/guides/write_data/).
+      according to the [InfluxDB HTTP API](/influxdb/v1/guides/write_data/).
       The intent of the plugin is to allow Telegraf to serve as a proxy, or router,
       for the HTTP `/write` endpoint of the InfluxDB HTTP API.
 


### PR DESCRIPTION
This PR fixes broken links in the telegraf documentation.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
