### PR TITLE
docs(clustered): add azure/gcp storage permission requirements

### DIFF
--- a/content/influxdb/clustered/install/prerequisites.md
+++ b/content/influxdb/clustered/install/prerequisites.md
@@ -170,9 +170,10 @@ Replace the following:
 
 {{% expand "View the requirements for Azure Blob Storage" %}}
 
-When opting for Azure Blob Storage as the backing object store, the principal you are using should be granted the `Storage Blob Data Contributor` role.
-
-This is a built-in role for Azure which encompasses common permissions, you can assign it by issuing the following command:
+To use Azure Blob Storage as your object store, your [service principal](https://learn.microsoft.com/en-us/entra/architecture/service-accounts-principal)
+should be granted the `Storage Blob Data Contributor` role.
+This is a built-in role for Azure which encompasses common permissions.
+You can assign it using the following command:
 
 {{% code-placeholders "PRINCIPAL|AZURE_SUBSCRIPTION|AZURE_RESOURCE_GROUP|AZURE_STORAGE_ACCOUNT|AZURE_STORAGE_CONTAINER" %}}
 ```bash

--- a/content/influxdb/clustered/install/prerequisites.md
+++ b/content/influxdb/clustered/install/prerequisites.md
@@ -189,7 +189,7 @@ Replace the following:
 - {{% code-placeholder-key %}}`AZURE_SUBSCRIPTION`{{% /code-placeholder-key %}}: Your Azure subscription.
 - {{% code-placeholder-key %}}`AZURE_RESOURCE_GROUP`{{% /code-placeholder-key %}}: The resource group where your Azure Blob storage account resides.
 - {{% code-placeholder-key %}}`AZURE_STORAGE_ACCOUNT`{{% /code-placeholder-key %}}: The name of your Azure Blob storage account.
-- {{% code-placeholder-key %}}`AZURE_STORAGE_CONTAINER`{{% /code-placeholder-key %}}: The name of the container within Azure Blob storage.
+- {{% code-placeholder-key %}}`AZURE_STORAGE_CONTAINER`{{% /code-placeholder-key %}}: The name of the container within your Azure Blob storage account.
 
 {{% /expand %}}
 

--- a/content/influxdb/clustered/install/prerequisites.md
+++ b/content/influxdb/clustered/install/prerequisites.md
@@ -163,8 +163,8 @@ gcloud storage buckets add-iam-policy-binding \
 
 Replace the following:
 
-- {{% code-placeholder-key %}}`GCP_SERVICE_ACCOUNT`{{% /code-placeholder-key %}}: The name of the Google Service Account.
-- {{% code-placeholder-key %}}`GCP_BUCKET`{{% /code-placeholder-key %}}: The name of your GCS bucket.
+- {{% code-placeholder-key %}}`GCP_SERVICE_ACCOUNT`{{% /code-placeholder-key %}}: Google Service Account name
+- {{% code-placeholder-key %}}`GCP_BUCKET`{{% /code-placeholder-key %}}: GCS bucket name
 
 {{% /expand %}}
 

--- a/content/influxdb/clustered/install/prerequisites.md
+++ b/content/influxdb/clustered/install/prerequisites.md
@@ -187,7 +187,7 @@ Replace the following:
 
 - {{% code-placeholder-key %}}`PRINCIPAL`{{% /code-placeholder-key %}}: A user, group, or service principal that the role should be assigned to
 - {{% code-placeholder-key %}}`AZURE_SUBSCRIPTION`{{% /code-placeholder-key %}}: Your Azure subscription
-- {{% code-placeholder-key %}}`AZURE_RESOURCE_GROUP`{{% /code-placeholder-key %}}: The resource group that your Azure Blob storage account belongs to.
+- {{% code-placeholder-key %}}`AZURE_RESOURCE_GROUP`{{% /code-placeholder-key %}}: The resource group that your Azure Blob storage account belongs to
 - {{% code-placeholder-key %}}`AZURE_STORAGE_ACCOUNT`{{% /code-placeholder-key %}}: Azure Blob storage account name
 - {{% code-placeholder-key %}}`AZURE_STORAGE_CONTAINER`{{% /code-placeholder-key %}}: Container name in your Azure Blob storage account
 

--- a/content/influxdb/clustered/install/prerequisites.md
+++ b/content/influxdb/clustered/install/prerequisites.md
@@ -186,11 +186,11 @@ az role assignment create \
 
 Replace the following:
 
-- {{% code-placeholder-key %}}`PRINCIPAL`{{% /code-placeholder-key %}}: A user, group, or service principal that the role should be assigned to.
-- {{% code-placeholder-key %}}`AZURE_SUBSCRIPTION`{{% /code-placeholder-key %}}: Your Azure subscription.
-- {{% code-placeholder-key %}}`AZURE_RESOURCE_GROUP`{{% /code-placeholder-key %}}: The resource group where your Azure Blob storage account resides.
-- {{% code-placeholder-key %}}`AZURE_STORAGE_ACCOUNT`{{% /code-placeholder-key %}}: The name of your Azure Blob storage account.
-- {{% code-placeholder-key %}}`AZURE_STORAGE_CONTAINER`{{% /code-placeholder-key %}}: The name of the container within your Azure Blob storage account.
+- {{% code-placeholder-key %}}`PRINCIPAL`{{% /code-placeholder-key %}}: A user, group, or service principal that the role should be assigned to
+- {{% code-placeholder-key %}}`AZURE_SUBSCRIPTION`{{% /code-placeholder-key %}}: Your Azure subscription
+- {{% code-placeholder-key %}}`AZURE_RESOURCE_GROUP`{{% /code-placeholder-key %}}: The resource group that your Azure Blob storage account belongs to.
+- {{% code-placeholder-key %}}`AZURE_STORAGE_ACCOUNT`{{% /code-placeholder-key %}}: Azure Blob storage account name
+- {{% code-placeholder-key %}}`AZURE_STORAGE_CONTAINER`{{% /code-placeholder-key %}}: Container name in your Azure Blob storage account
 
 {{% /expand %}}
 

--- a/content/influxdb/clustered/install/prerequisites.md
+++ b/content/influxdb/clustered/install/prerequisites.md
@@ -154,7 +154,10 @@ For example, when leveraging Google Service Accounts:
 
 {{% code-placeholders "GCP_SERVICE_ACCOUNT|GCP_BUCKET" %}}
 ```bash
-gcloud storage buckets add-iam-policy-binding gs://GCP_BUCKET --member="serviceAccount:GCP_SERVICE_ACCOUNT" --role="roles/storage.objectUser"
+gcloud storage buckets add-iam-policy-binding \
+    gs://GCP_BUCKET \
+    --member="serviceAccount:GCP_SERVICE_ACCOUNT" \
+    --role="roles/storage.objectUser"
 ```
 {{% /code-placeholders %}}
 
@@ -162,6 +165,31 @@ Replace the following:
 
 - {{% code-placeholder-key %}}`GCP_SERVICE_ACCOUNT`{{% /code-placeholder-key %}}: The name of the Google Service Account.
 - {{% code-placeholder-key %}}`GCP_BUCKET`{{% /code-placeholder-key %}}: The name of your GCS bucket.
+
+{{% /expand %}}
+
+{{% expand "View the requirements for Azure Blob Storage" %}}
+
+When opting for Azure Blob Storage as the backing object store, the principal you are using should be granted the `Storage Blob Data Contributor` role.
+
+This is a built-in role for Azure which encompasses common permissions, you can assign it by issuing the following command:
+
+{{% code-placeholders "PRINCIPAL|AZURE_SUBSCRIPTION|AZURE_RESOURCE_GROUP|AZURE_STORAGE_ACCOUNT|AZURE_STORAGE_CONTAINER" %}}
+```bash
+az role assignment create \
+    --role "Storage Blob Data Contributor" \
+    --assignee PRINCIPAL \
+    --scope "/subscriptions/AZURE_SUBSCRIPTION/resourceGroups/AZURE_RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/AZURE_STORAGE_ACCOUNT/blobServices/default/containers/AZURE_STORAGE_CONTAINER"
+```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`PRINCIPAL`{{% /code-placeholder-key %}}: A user, group, or service principal that the role should be assigned to.
+- {{% code-placeholder-key %}}`AZURE_SUBSCRIPTION`{{% /code-placeholder-key %}}: Your Azure subscription.
+- {{% code-placeholder-key %}}`AZURE_RESOURCE_GROUP`{{% /code-placeholder-key %}}: The resource group where your Azure Blob storage account resides.
+- {{% code-placeholder-key %}}`AZURE_STORAGE_ACCOUNT`{{% /code-placeholder-key %}}: The name of your Azure Blob storage account.
+- {{% code-placeholder-key %}}`AZURE_STORAGE_CONTAINER`{{% /code-placeholder-key %}}: The name of the container within Azure Blob storage.
 
 {{% /expand %}}
 

--- a/content/influxdb/clustered/install/prerequisites.md
+++ b/content/influxdb/clustered/install/prerequisites.md
@@ -146,11 +146,11 @@ Replace the following:
 
 {{% /expand %}}
 
-{{% expand "View requirements for Google Cloud Storage" %}}
+{{% expand "View the requirements for Google Cloud Storage" %}}
 
-When opting for Google Cloud Storage as the backing object store, the principal you are using should be granted the `roles/storage.objectUser` role.
+When opting for Google Cloud Storage (GCS) as the backing object store, the principal you are using should be granted the `roles/storage.objectUser` role.
 
-For example, leveraging Google Service Accounts:
+For example, when leveraging Google Service Accounts:
 
 {{% code-placeholders "GCP_SERVICE_ACCOUNT|GCP_BUCKET" %}}
 ```bash
@@ -160,8 +160,8 @@ gcloud storage buckets add-iam-policy-binding gs://GCP_BUCKET --member="serviceA
 
 Replace the following:
 
-- {{% code-placeholder-key %}}`GCP_SERVICE_ACCOUNT`{{% /code-placeholder-key %}}: The name of the Service Account.
-- {{% code-placeholder-key %}}`GCP_BUCKET`{{% /code-placeholder-key %}}: The name of your Google Cloud Storage bucket.
+- {{% code-placeholder-key %}}`GCP_SERVICE_ACCOUNT`{{% /code-placeholder-key %}}: The name of the Google Service Account.
+- {{% code-placeholder-key %}}`GCP_BUCKET`{{% /code-placeholder-key %}}: The name of your GCS bucket.
 
 {{% /expand %}}
 

--- a/content/influxdb/clustered/install/prerequisites.md
+++ b/content/influxdb/clustered/install/prerequisites.md
@@ -14,7 +14,7 @@ InfluxDB Clustered requires the following prerequisites:
 - **Kubernetes cluster**: version 1.25 or higher
 - **Object storage**: AWS S3 or S3-compatible storage used to store the InfluxDB parquet files
 - **PostgreSQL-compatible database** _(AWS Aurora, hosted Postgres, etc.)_:
-  Used to store the InfluxDB catalog 
+  Used to store the InfluxDB catalog
   - Supported PostgreSQL versions: **13.8–14.6**
 - **OAuth 2.0 provider**:
   - Must support [Device Authorization Flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/device-authorization-flow)
@@ -32,7 +32,7 @@ InfluxDB Clustered requires the following prerequisites:
     valid TLS certificate (for example: [cert-manager](https://cert-manager.io/)
     or provide the certificate PEM manually out of band). InfluxDB Clustered
     currently supports [Ingress NGINX](https://github.com/kubernetes/ingress-nginx),
-    but others may work. 
+    but others may work.
 4.  Ensure your Kubernetes cluster can access to the InfluxDB container registry,
     or, if running in an air-gapped environment, a local container registry to
     which you will need to copy the InfluxDB images.
@@ -53,8 +53,8 @@ For a [medium-size workload](https://www.influxdata.com/resources/influxdb-3-0-v
 InfluxData has tested the InfluxDB Clustered using the following AWS products
 and sizing:
 
-- S3 for object store (size is determined by how much data you write) 
-- Aurora Postgresql - serverless v2 scaling configuration (2-64 ACUs) 
+- S3 for object store (size is determined by how much data you write)
+- Aurora Postgresql - serverless v2 scaling configuration (2-64 ACUs)
 - EC2 instances - primarily m6i.2xlarge (8 CPU, 32GB RAM)
   - 3 m6i.2xlarge instances for ingesters and routers (with minimum of 2Gi of local storage)
   - 3 m6i.2xlarge instances for queriers
@@ -77,18 +77,18 @@ InfluxDB Clustered requires that the OAuth2 service supports
 InfluxData has tested with [Microsoft Entra ID _(formerly Azure Active Directory)_](https://www.microsoft.com/en-us/security/business/microsoft-entra), [Keycloak](https://www.keycloak.org/), and
 [Auth0](https://auth0.com/), but the any OAuth2 provider should work.
 To access the OAuth2 server, InfluxDB requires the following OAuth2 connection credentials:
-  
+
   - Client ID
   - JWKS endpoint
   - Device authorization endpoint
-  - Token endpoint. 
+  - Token endpoint.
 
 ## Set up client Software
 
 On the system used to configure the cluster (not the cluster itself), install
 the following:
 
-- [kubectl _(v1.27)_](https://kubernetes.io/docs/reference/kubectl/kubectl/) 
+- [kubectl _(v1.27)_](https://kubernetes.io/docs/reference/kubectl/kubectl/)
 - [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md)
 
 ## Configure object storage permissions
@@ -145,6 +145,26 @@ Replace the following:
 - {{% code-placeholder-key %}}`S3_BUCKET_NAME`{{% /code-placeholder-key %}}: Name of your AWS S3 bucket
 
 {{% /expand %}}
+
+{{% expand "View requirements for Google Cloud Storage" %}}
+
+When opting for Google Cloud Storage as the backing object store, the principal you are using should be granted the `roles/storage.objectUser` role.
+
+For example, leveraging Google Service Accounts:
+
+{{% code-placeholders "GCP_SERVICE_ACCOUNT|GCP_BUCKET" %}}
+```bash
+gcloud storage buckets add-iam-policy-binding gs://GCP_BUCKET --member="serviceAccount:GCP_SERVICE_ACCOUNT" --role="roles/storage.objectUser"
+```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`GCP_SERVICE_ACCOUNT`{{% /code-placeholder-key %}}: The name of the Service Account.
+- {{% code-placeholder-key %}}`GCP_BUCKET`{{% /code-placeholder-key %}}: The name of your Google Cloud Storage bucket.
+
+{{% /expand %}}
+
 {{< /expand-wrapper >}}
 
 {{< page-nav next="/influxdb/clustered/install/auth/" nextText="Set up authentication" >}}

--- a/content/influxdb/clustered/install/prerequisites.md
+++ b/content/influxdb/clustered/install/prerequisites.md
@@ -148,9 +148,8 @@ Replace the following:
 
 {{% expand "View the requirements for Google Cloud Storage" %}}
 
-When opting for Google Cloud Storage (GCS) as the backing object store, the principal you are using should be granted the `roles/storage.objectUser` role.
-
-For example, when leveraging Google Service Accounts:
+To use Google Cloud Storage (GCS) as your object store, your [IAM principal](https://cloud.google.com/iam/docs/overview) should be granted the `roles/storage.objectUser` role.
+For example, if using [Google Service Accounts](https://cloud.google.com/iam/docs/service-account-overview):
 
 {{% code-placeholders "GCP_SERVICE_ACCOUNT|GCP_BUCKET" %}}
 ```bash


### PR DESCRIPTION
Closes https://github.com/influxdata/project-clustered/issues/217 and https://github.com/influxdata/project-clustered/issues/218

This provides the required storage permissions for InfluxDB3 Clustered to manage its access to the configured object store, GCS/Azure Blob Storage in this case.

Both providers offer managed roles in this case, so they can simply be attached to an existing principal/account.

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
