### PR TITLE
docs(json v2): add 'optional' key

### DIFF
--- a/content/telegraf/v1/data_formats/input/json_v2.md
+++ b/content/telegraf/v1/data_formats/input/json_v2.md
@@ -48,10 +48,13 @@ In the sections that follow these configuration keys are defined in more detail.
             path = "" # A string with valid GJSON path syntax
             rename = "new name" # A string with a new name for the tag key
             type = "int" # A string specifying the type (int,uint,float,string,bool)
+            optional = false # true: suppress errors if configured path does not exist
 
         [[inputs.file.json_v2.tag]]
             path = "" # A string with valid GJSON path syntax
             rename = "new name" # A string with a new name for the tag key
+            type = "float" # A string specifying the type (int,uint,float,string,bool)
+            optional = false # true: suppress errors if configured path does not exist
 
         [[inputs.file.json_v2.object]]
             path = "" # A string with valid GJSON path syntax
@@ -62,6 +65,7 @@ In the sections that follow these configuration keys are defined in more detail.
             included_keys = [] # List of JSON keys (for a nested key, prepend the parent keys with underscores) that should be only included in result
             excluded_keys = [] # List of JSON keys (for a nested key, prepend the parent keys with underscores) that shouldn't be included in result
             tags = [] # List of JSON keys (for a nested key, prepend the parent keys with underscores) to be a tag instead of a field
+            optional = false # true: suppress errors if configured path does not exist
             [inputs.file.json_v2.object.renames] # A map of JSON keys (for a nested key, prepend the parent keys with underscores) with a new name for the tag key
                 key = "new name"
             [inputs.file.json_v2.object.fields] # A map of JSON keys (for a nested key, prepend the parent keys with underscores) with a type (int,uint,float,string,bool)


### PR DESCRIPTION
This PR adds the key `optional` to the documentation of the `json_v2` data format. 

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
