### PR TITLE
fix: reference max-cols, not just max tables in db update

### DIFF
--- a/content/influxdb/cloud-dedicated/admin/databases/update.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/update.md
@@ -35,7 +35,7 @@ to update a database in your {{< product-name omit=" Clustered" >}} cluster.
 influxctl database update DATABASE_NAME \
   --retention-period 30d \
   --max-tables 500 \
-  --max-tables 250
+  --max-columns 250
 ```
 {{% /code-placeholders %}}
 


### PR DESCRIPTION
Was working on an EAR and noticed `--max-tables` is duplicated here - second flag should be `--max-columns`

_Describe your proposed changes here._

- [X] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [X] Rebased/mergeable
