### PR TITLE
docs(clustered): fix incorrect padding and typos

### DIFF
--- a/content/influxdb/clustered/get-started/setup.md
+++ b/content/influxdb/clustered/get-started/setup.md
@@ -80,12 +80,11 @@ If stored at a non-default location, include the `--config` flag with each
 {{% /code-placeholders %}}
 
 Replace the following with your {{< product-name >}} credentials:
-
-    - {{% code-placeholder-key %}}`PORT`{{% /code-placeholder-key %}}: the port to use to access your InfluxDB cluster
-    - {{% code-placeholder-key %}}`OAUTH_CLIENT_ID`{{% /code-placeholder-key %}}: the client URL of your OAuth2 provider
-      (for example: `https://indentityprovider/oauth2/v2/token`)
-    - {{% code-placeholder-key %}}`OAUTH_DEVICE_ID`{{% /code-placeholder-key %}}: the device URL of your OAuth2 provider
-      (for example: `https://indentityprovider/oauth2/v2/auth/device`)
+  - {{% code-placeholder-key %}}`PORT`{{% /code-placeholder-key %}}: the port to use to access your InfluxDB cluster
+  - {{% code-placeholder-key %}}`OAUTH_CLIENT_ID`{{% /code-placeholder-key %}}: the client URL of your OAuth2 provider
+    (for example: `https://identityprovider/oauth2/v2/token`)
+  - {{% code-placeholder-key %}}`OAUTH_DEVICE_ID`{{% /code-placeholder-key %}}: the device URL of your OAuth2 provider
+    (for example: `https://identityprovider/oauth2/v2/auth/device`)
 
 _For detailed information about `influxctl` profiles, see
 [Configure connection profiles](/influxdb/clustered/reference/cli/influxctl/#configure-connection-profiles)_.

--- a/content/influxdb/clustered/get-started/setup.md
+++ b/content/influxdb/clustered/get-started/setup.md
@@ -63,12 +63,12 @@ If stored at a non-default location, include the `--config` flag with each
 
     **Copy and paste the sample configuration profile code** into your `config.toml`:
 
-{{% code-placeholders "PORT|HOST|OAUTH_TOKEN_URL|OAUTH_DEVICE_URL|OAUTH_CLIENT_ID" %}}
+{{% code-placeholders "PORT|OAUTH_TOKEN_URL|OAUTH_DEVICE_URL|OAUTH_CLIENT_ID" %}}
 ```toml
 [[profile]]
   name = "default"
   product = "clustered"
-  host = "HOST"
+  host = "{{< influxdb/host >}}"
   port = "PORT"
 
 [profile.auth.oauth2]

--- a/content/influxdb/clustered/get-started/setup.md
+++ b/content/influxdb/clustered/get-started/setup.md
@@ -63,12 +63,12 @@ If stored at a non-default location, include the `--config` flag with each
 
     **Copy and paste the sample configuration profile code** into your `config.toml`:
 
-{{% code-placeholders "PORT|OAUTH_TOKEN_URL|OAUTH_DEVICE_URL" %}}
+{{% code-placeholders "PORT|HOST|OAUTH_TOKEN_URL|OAUTH_DEVICE_URL|OAUTH_CLIENT_ID" %}}
 ```toml
 [[profile]]
   name = "default"
   product = "clustered"
-  host = "{{< influxdb/host >}}"
+  host = "HOST"
   port = "PORT"
 
 [profile.auth.oauth2]


### PR DESCRIPTION
The padding for the list was off which caused the `span` tags were showing in the documentation.

A good eye by @mkmik spotted this :rocket: 

Beforehand it looked like this:

![image](https://github.com/influxdata/docs-v2/assets/56563911/9330566c-fb87-488c-ac55-ac2f948a7216)

Now it looks like:

![image](https://github.com/influxdata/docs-v2/assets/56563911/af7ca893-b585-45d3-b4be-ca485494f21e)


I've also added a few extras to help with the `config.toml` file and corrected a typo in the identity (typo as indentity) field which I spotted along the way.


- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
