### PR TITLE
Update 'SHOW TAG VALUES' documentation to include a FROM clause

### DIFF
--- a/content/influxdb/cloud-dedicated/query-data/influxql/explore-schema.md
+++ b/content/influxdb/cloud-dedicated/query-data/influxql/explore-schema.md
@@ -36,6 +36,7 @@ list_code_example: |
 Use InfluxQL `SHOW` statements to return information about your data schema.
 
 {{% note %}}
+
 #### Sample data
 
 The following examples use data provided in [sample data sets](/influxdb/cloud-dedicated/reference/sample-data/).
@@ -54,7 +55,6 @@ database.
   - [List tag values for multiple tags](#list-tag-values-for-multiple-tags)
   - [List tag values for tags that match a regular expression](#list-tag-values-for-tags-that-match-a-regular-expression)
   - [List tag values associated with a specific tag key-value pair](#list-tag-values-associated-with-a-specific-tag-key-value-pair)
-
 
 ## List measurements in a database
 
@@ -224,21 +224,29 @@ name: home_actions
 Use [`SHOW TAG VALUES`](/influxdb/cloud-dedicated/reference/influxql/show/#show-field-values)
 to return all values for specific tags in a measurement.
 
-- Include a `FROM` clause to specify the measurement.
-  If no measurement is specified, the query returns all tag values from the
-  specified tag keys in the database.
+- Include a `FROM` clause to specify one or more measurements to query.
 - Use the `WITH` clause to compare `KEY` to tag keys to list the values of.
-- Use the `WHERE` clause to restrict the search to a specific time range (default time range is the current time minus 1 day).
-
-{{% note %}}
- [Tag and field values aren't indexed in {{% product-name %}}](/influxdb/cloud-dedicated/write-data/best-practices/schema-design/#tags-versus-fields) - `SHOW TAG VALUES` scans all tag values within the given time range.
-Because `SHOW TAG VALUES` can be an intensive operation, it has a default time range equal to the current time minus 1 day.
-To query more or less data, specify a time range in the `WHERE` clause.
-{{% /note %}}
+- Use the `WHERE` clause to restrict the search to a specific time range
+  (default time range is the last day).
 
 ```sql
 SHOW TAG VALUES FROM weather WITH KEY = location
 ```
+
+{{% note %}}
+
+#### Include a FROM clause
+
+We strongly recommend including a `FROM` clause with the `SHOW TAG VALUES`
+statement that specifies 1-50 tables to query.
+Without a `FROM` clause, the InfluxDB query engine must read data from all
+tables and return unique tag values from each.
+
+Depending on the number of tables in your database and the number of unique tag
+values in each table, excluding a `FROM` clause can result in poor query performance,
+query timeouts, or unnecessary resource allocation that may affect other queries.
+
+{{% /note %}}
 
 {{< expand-wrapper >}}
 {{% expand "View example output" "5" %}}
@@ -289,7 +297,7 @@ regular expression comparison operators in your `WITH` clause to compare `KEY`
 to the regular expression.
 
 ```sql
-SHOW TAG VALUES WITH KEY =~ /oo/
+SHOW TAG VALUES FROM home, home_actions WITH KEY =~ /oo/
 ```
 
 {{< expand-wrapper >}}
@@ -327,7 +335,7 @@ The following example returns tag values for the `action` and `level` tags for
 points where the `room` tag value is `Kitchen`.
 
 ```sql
-SHOW TAG VALUES WITH KEY IN ("action", "level") WHERE room = 'Kitchen'
+SHOW TAG VALUES FROM home_actions WITH KEY IN ("action", "level") WHERE room = 'Kitchen'
 ```
 
 {{< expand-wrapper >}}

--- a/content/influxdb/cloud-dedicated/reference/influxql/show.md
+++ b/content/influxdb/cloud-dedicated/reference/influxql/show.md
@@ -94,17 +94,39 @@ Use the `SHOW TAG VALUES` statement to list values of specified tags in a databa
 SHOW TAG VALUES [from_clause] WITH KEY = <tag-expression> [where_clause] [limit_clause] [offset_clause]
 ```
 
+By default, the `SHOW TAG VALUES` statement only returns unique tag values from
+**the last day**. To modify the time range, include a `WHERE` clause with a
+time-based predicate.
+
+{{% note %}}
+
+#### Include a FROM clause
+
+We strongly recommend including a `FROM` clause with the `SHOW TAG VALUES`
+statement that specifies 1-50 tables to query.
+Without a `FROM` clause, the InfluxDB query engine must read data from all
+tables and return unique tag values from each.
+
+Depending on the number of tables in your database and the number of unique tag
+values in each table, excluding a `FROM` clause can result in poor query performance,
+query timeouts, or unnecessary resource allocation that may affect other queries.
+
+{{% /note %}}
+
 #### Examples
 
 ```sql
--- Show all tag values across all measurements for the region tag
-SHOW TAG VALUES WITH KEY = "region"
-
 -- Show tag values from the cpu measurement for the region tag
 SHOW TAG VALUES FROM "cpu" WITH KEY = "region"
 
--- Show tag values across all measurements for all tag keys that do not include the letter c
-SHOW TAG VALUES WITH KEY !~ /.*c.*/
+-- Show tag values from the cpu measurement for the region tag for a custom time range
+SHOW TAG VALUES FROM "cpu" WITH KEY = "region" WHERE time > -7d
+
+-- Show tag values from the multiple measurements for the region tag
+SHOW TAG VALUES FROM "cpu", "memory", "disk" WITH KEY = "region"
+
+-- Show tag values from the cpu measurement for all tag keys that do not include the letter c
+SHOW TAG VALUES FROM "cpu" WITH KEY !~ /.*c.*/
 
 -- Show tag values from the cpu measurement for region & host tag keys where service = 'redis'
 SHOW TAG VALUES FROM "cpu" WITH KEY IN ("region", "host") WHERE "service" = 'redis'


### PR DESCRIPTION
Closes #5321

This adds a note about the best practice of including a `FROM` clause with the `SHOW TAG VALUES` statement. It updates both the InfluxQL reference and the task-based "Explore your schema" docs.

This first commit only updates the InfluxDB Cloud Dedicated documentation, but once reviewed, I'll port the changes to InfluxDB Cloud Serverless and InfluxDB Clustered.

- [x] Rebased/mergeable
