### PR TITLE
Add InfluxDB Clustered upgrade instructions

### DIFF
--- a/assets/styles/layouts/_article.scss
+++ b/assets/styles/layouts/_article.scss
@@ -4,28 +4,58 @@
   padding: 2rem 4rem 3rem;
 }
 
-.article--content{
+.article--content {
   max-width: 850px;
   font-size: 1.1rem;
 
-  h1,h2,h3,h4,h5,h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     color: $article-heading;
+
     a {
       color: inherit !important;
       font-weight: inherit !important;
       text-decoration: none;
+
       code:after {
         border: none;
       }
     }
   }
-  h2,h3,h4,h5,h6 {
-    & + .highlight pre { margin-top: .5rem }
-    & + pre { margin-top: .5rem }
-    & + .code-tabs-wrapper { margin-top: 0; }
-    &.monospace { font-family: $code; }
-    &.green { color: $gr-rainforest; }
-    &.orange { color: $r-dreamsicle; }
+
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    &+.highlight pre {
+      margin-top: .5rem
+    }
+
+    &+pre {
+      margin-top: .5rem
+    }
+
+    &+.code-tabs-wrapper {
+      margin-top: 0;
+    }
+
+    &.monospace {
+      font-family: $code;
+    }
+
+    &.green {
+      color: $gr-rainforest;
+    }
+
+    &.orange {
+      color: $r-dreamsicle;
+    }
+
     &[metadata]::after {
       content: attr(metadata);
       margin-left: .65rem;
@@ -39,6 +69,7 @@
       display: inline-block;
       vertical-align: middle;
     }
+
     &[date]::after {
       content: attr(date);
       margin-left: .65rem;
@@ -48,11 +79,13 @@
       font-style: inherit;
     }
   }
+
   h1 {
     font-weight: normal;
     font-size: 2.75rem;
     margin: .4em 0 .2em;
   }
+
   h2 {
     font-size: 2.1rem;
     margin: -.25rem 0 .5rem;
@@ -60,12 +93,14 @@
     font-weight: $medium;
     color: $article-heading-alt;
   }
+
   h3 {
     font-size: 1.75rem;
     font-weight: $medium;
     margin: -1rem 0 .5rem;
     padding-top: 1.75rem;
   }
+
   h4 {
     font-size: 1.35rem;
     font-style: italic;
@@ -74,11 +109,13 @@
     padding-top: 1.75rem;
     color: $article-heading-alt;
   }
+
   h5 {
     font-size: 1.1rem;
     margin: -1.25rem 0 .25rem;
     padding-top: 1.75rem;
   }
+
   h6 {
     font-size: 1.1rem;
     font-style: italic;
@@ -86,7 +123,8 @@
     padding-top: 1.75rem;
   }
 
-  p,li {
+  p,
+  li {
     color: $article-text;
     line-height: 1.8rem;
   }
@@ -99,9 +137,11 @@
     color: $article-link;
     font-weight: $medium;
     text-decoration: none;
+
     &:hover {
       color: $article-link-hover;
     }
+
     &.help-link {
       display: inline-block;
       width: 1rem;
@@ -122,7 +162,7 @@
     box-shadow: 1px 3px 10px $article-shadow;
   }
 
-  ul + p > img {
+  ul+p>img {
     margin-top: 1.5rem;
   }
 
@@ -135,45 +175,46 @@
 
 
   @import "article/blocks",
-          "article/buttons",
-          "article/captions",
-          "article/children",
-          "article/code",
-          "article/cloud",
-          "article/diagrams",
-          "article/enterprise",
-          "article/expand",
-          "article/feedback",
-          "article/flex",
-          "article/flux",
-          "article/html-diagrams",
-          "article/influxdbu",
-          "article/influxql",
-          "article/keybinding",
-          "article/list-filters",
-          "article/lists",
-          "article/note",
-          "article/pagination-btns",
-          "article/product-tags",
-          "article/related",
-          "article/scrollbars",
-          "article/svgs",
-          "article/tabbed-content",
-          "article/tables",
-          "article/tags",
-          "article/telegraf-plugins",
-          "article/title",
-          "article/truncate",
-          "article/video",
-          "article/warn";
+  "article/buttons",
+  "article/captions",
+  "article/children",
+  "article/code",
+  "article/cloud",
+  "article/diagrams",
+  "article/enterprise",
+  "article/expand",
+  "article/feedback",
+  "article/flex",
+  "article/flux",
+  "article/html-diagrams",
+  "article/influxdbu",
+  "article/influxql",
+  "article/keybinding",
+  "article/list-filters",
+  "article/lists",
+  "article/note",
+  "article/pagination-btns",
+  "article/product-tags",
+  "article/related",
+  "article/scrollbars",
+  "article/svgs",
+  "article/tabbed-content",
+  "article/tables",
+  "article/tags",
+  "article/telegraf-plugins",
+  "article/title",
+  "article/truncate",
+  "article/video",
+  "article/warn";
 
 
 
   //////////////////////////////// Miscellaneous ///////////////////////////////
 
-  .required, .req {
-    color:#FF8564;
-    font-weight:$medium;
+  .required,
+  .req {
+    color: #FF8564;
+    font-weight: $medium;
     font-style: italic;
     margin: 0 .15rem 0 .1rem;
 
@@ -185,14 +226,26 @@
       font-size: .9rem;
       font-weight: $medium;
     }
-    
-    &.blue {color: $b-dodger;}
-    &.green {color: $gr-viridian;}
-    &.magenta {color: $p-comet;}
+
+    &.blue {
+      color: $b-dodger;
+    }
+
+    &.green {
+      color: $gr-viridian;
+    }
+
+    &.magenta {
+      color: $p-comet;
+    }
   }
 
-  h2,h3,h4,h5,h6 {
-    & + .keep-url {
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    &+.keep-url {
       margin-top: -1.5rem;
       z-index: -100;
     }
@@ -205,7 +258,10 @@
     color: $g20-white;
     opacity: .5;
     transition: opacity .2s;
-    &:hover {opacity: 1;}
+
+    &:hover {
+      opacity: 1;
+    }
   }
 
   p.read-more {
@@ -213,18 +269,44 @@
     font-style: italic;
   }
 
-  .highlight, pre, code, .flex-wrapper {
-    & + p.read-more {
+  .highlight,
+  pre,
+  code,
+  .flex-wrapper {
+    &+p.read-more {
       margin: -.75rem 0 .5rem;
     }
   }
 
-  .nowrap { white-space: nowrap }
+  .nowrap {
+    white-space: nowrap
+  }
+
   .all-caps {
     text-transform: uppercase;
     font-size: 1.05rem;
     letter-spacing: .1em;
     font-weight: $medium !important;
+  }
+
+  span,
+  strong,
+  em {
+    &.orange {
+      color: #FF8564;
+    }
+
+    &.blue {
+      color: $b-dodger;
+    }
+
+    &.green {
+      color: $gr-viridian;
+    }
+
+    &.magenta {
+      color: $p-comet;
+    }
   }
 
   /////////////////////////// Getting Started Buttons //////////////////////////
@@ -254,9 +336,17 @@
   .article {
     padding: 1.5rem 1.5rem 3rem;
 
-    h2 { font-size: 1.9rem; }
-    h3 { font-size: 1.55rem; }
-    h4 { font-size: 1.3rem; }
+    h2 {
+      font-size: 1.9rem;
+    }
+
+    h3 {
+      font-size: 1.55rem;
+    }
+
+    h4 {
+      font-size: 1.3rem;
+    }
 
   }
 }

--- a/content/influxdb/clustered/admin/_index.md
+++ b/content/influxdb/clustered/admin/_index.md
@@ -2,7 +2,7 @@
 title: Administer InfluxDB Clustered
 description: >
   Perform administrative tasks in your InfluxDB cluster such as
-  creating and managing tokens and databases.
+  creating and managing tokens and databases and upgrading your InfluxDB cluster.
 menu:
   influxdb_clustered:
     name: Administer InfluxDB Clustered

--- a/content/influxdb/clustered/admin/upgrade.md
+++ b/content/influxdb/clustered/admin/upgrade.md
@@ -1,0 +1,159 @@
+---
+title: Upgrade InfluxDB Clustered
+seotitle:
+description: >
+  Use Kubernetes to upgrade your InfluxDB Clustered version.
+menu:
+  influxdb_clustered:
+    name: Upgrade InfluxDB
+    parent: Administer InfluxDB Clustered
+weight: 101
+influxdb/clustered/tags: [upgrade]
+related:
+  - /influxdb/clustered/install/
+  - /influxdb/clustered/install/configure-cluster/
+  - /influxdb/clustered/install/deploy/
+---
+
+Use Kubernetes to upgrade your InfluxDB Clustered version.
+InfluxDB Clustered versioning is defined in the `AppInstance`
+`CustomResourceDefinition` (CRD) in your
+[`myinfluxdb.yml`](/influxdb/clustered/install/configure-cluster/).
+
+- [Version format](#version-format)
+- [Upgrade your InfluxDB Clustered version](#upgrade-your-influxdb-clustered-version)
+
+## Version format
+
+InfluxDB Clustered uses the `YYYYMMDD-BUILD_NUMBER` version format.
+For example, a version created on January 1, 2024 would have a version number
+similar to the following:
+
+```
+20240101-863513
+```
+
+## Upgrade your InfluxDB Clustered version
+
+1. [Identify your current InfluxDB Clustered package version](#identify-your-current-influxdb-clustered-package-version)
+2. [Identify the version to upgrade to](#identify-the-version-to-upgrade-to)
+3. [Update your image to use a new package version](#update-your-image-to-use-a-new-package-version)
+4. [Apply the updated image](#apply-the-updated-image)
+
+### Identify your current InfluxDB Clustered package version
+
+Use the following command to return the image Kubernetes uses to build your
+InfluxDB cluster:
+
+```sh
+kubectl get appinstances.kubecfg.dev influxdb -o jsonpath='{.spec.package.image}'
+```
+
+The package version number is at the end of the returned string (after `influxdb:`):
+
+{{% code-callout "PACKAGE_VERSION" "orange" %}}
+
+```
+us-docker.pkg.dev/influxdb2-artifacts/clustered/influxdb:PACKAGE_VERSION
+```
+
+{{% /code-callout %}}
+
+### Identify the version to upgrade to
+
+All available InfluxDB Clustered package versions are provided at
+[oci.influxdata.com](https://oci.influxdata.com).
+Find the package version you want to upgrade to and copy the version number.
+
+{{% note %}}
+
+#### oci.influxdata.com credentials
+
+[oci.influxdata.com](https://oci.influxdata.com) requires you to log in with
+credentials provided by InfluxData.
+If you don't have these credentials,
+[contact InfluxData Support](https://support.influxdata.com).
+
+{{% /note %}}
+
+#### Checkpoint releases
+
+Some InfluxDB Clustered releases are _checkpoint releases_ that introduce a
+breaking change to an InfluxDB component.
+Checkpoint releases are only made when absolutely necessary and is clearly
+identified at [oci.influxdata.com](https://oci.influxdata.com).
+
+**When upgrading, always upgrade to each checkpoint release first, before proceeding
+to newer versions.**
+
+{{% warn %}}
+
+#### Upgrade to checkpoint releases first
+
+Upgrading past a checkpoint release without first upgrading to it may result
+in corrupt or lost data.
+
+{{% /warn %}}
+
+{{< expand-wrapper >}}
+{{% expand "View checkpoint release upgrade example" %}}
+
+Given the following InfluxDB Clustered versions (ordered newest to oldest):
+
+| Available Versions |                                            |
+| :----------------- | :----------------------------------------: |
+| 20240215-433509    |                                            |
+| 20240214-863513    | <strong class="orange">checkpoint</strong> |
+| 20240111-824437    |                                            |
+| 20231213-791734    |                                            |
+| 20231117-750011    |                                            |
+| 20231115-746129    |                                            |
+| 20231024-711448    |                                            |
+| 20231004-666907    | <strong class="orange">checkpoint</strong> |
+| 20230922-650371    | <em class="blue">Your current version</em> |
+
+To upgrade to the most recent version (`20240215-433509`), you **must** do the
+following:
+
+1. Upgrade to the `20231004-666907` checkpoint release.
+2. Upgrade to the `20240214-863513` checkpoint release.
+3. Upgrade to `20240215-433509`.
+
+You can upgrade to versions between checkpoint releases, but you must always
+always upgrade to a checkpoint before upgrading beyond it.
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+### Update your image to use a new package version
+
+In your `myinfluxdb.conf`, update the package version defined in
+`spec.package.image` to the version you want to upgrade to.
+
+{{% code-placeholders "PACKAGE_VERSION" %}}
+
+```yml
+apiVersion: kubecfg.dev/v1alpha1
+kind: AppInstance
+# ...
+spec:
+  package:
+    # ...
+    image: us-docker.pkg.dev/influxdb2-artifacts/clustered/influxdb:PACKAGE_VERSION
+```
+
+{{% /code-placeholders %}}
+
+Replace {{% code-placeholder-key %}}`PACKAGE_VERSION`{{% /code-placeholder-key %}} with
+the version number to upgrade to.
+
+### Apply the updated image
+
+Use the following command to apply the updated image configuration and update
+your InfluxDB Cluster:
+
+```sh
+kubectl apply \
+  --filename myinfluxdb.yml \
+  --namespace influxdb
+```

--- a/content/influxdb/clustered/install/configure-cluster.md
+++ b/content/influxdb/clustered/install/configure-cluster.md
@@ -8,6 +8,8 @@ menu:
     name: Configure your cluster
     parent: Install InfluxDB Clustered
 weight: 103
+related:
+  - /influxdb/clustered/admin/upgrade/
 ---
 
 InfluxDB Clustered deployments are managed using Kubernetes and configured using
@@ -18,13 +20,16 @@ a YAML configuration file. InfluxData provides the following items:
   This file grants access to the collection of container images required to
   install InfluxDB Clustered.
 - **A tarball that contains the following files**:
+
   - **`app-instance-schema.json`**: Defines the schema for `example-customer.yml`
     to be used with [Visual Studio Code (VS Code)](https://code.visualstudio.com/).
   - **`example-customer.yml`**: Configuration for your InfluxDB cluster that includes
     information about [prerequisites](/influxdb/clustered/install/prerequisites/).
 
     {{% note %}}
+
 This documentation refers to a `myinfluxdb.yml` file that you copy from `example-customer.yml` and edit for your InfluxDB cluster.
+
     {{% /note %}}
 
 ## Configuration data
@@ -77,13 +82,14 @@ template) that contains key information, such as:
 ### Create a cluster configuration file
 
 Copy the provided `example-customer.yml` file to create a new configuration file
-specific to your InfluxDB cluster. For example, `myinfluxdb.yml`. 
+specific to your InfluxDB cluster. For example, `myinfluxdb.yml`.
 
 ```sh
 cp example-customer.yml myinfluxdb.yml
 ```
 
 {{% note %}}
+
 #### Use VS Code to edit your configuration file
 
 We recommend using [Visual Studio Code (VS Code)](https://code.visualstudio.com/) to edit your `myinfluxdb.yml` configuration file due
@@ -129,13 +135,14 @@ There are two main scenarios:
   can only access a private container registry.
 
 In both scenarios, you need a valid container registry secret file.
-Use [crane](https://github.com/google/go-containerregistry/tree/main/cmd/crane) to create a container registry secret file. 
+Use [crane](https://github.com/google/go-containerregistry/tree/main/cmd/crane) to create a container registry secret file.
 
 1.  [Install crane](https://github.com/google/go-containerregistry/tree/main/cmd/crane#installation)
 2.  Use the following command to create a container registry secret file and
     retrieve the necessary secrets:
 
 {{% code-placeholders "PACKAGE_VERSION" %}}
+
 ```sh
 mkdir /tmp/influxdbsecret
 cp influxdb-docker-config.json /tmp/influxdbsecret/config.json
@@ -143,6 +150,7 @@ DOCKER_CONFIG=/tmp/influxdbsecret \
   crane manifest \
   us-docker.pkg.dev/influxdb2-artifacts/clustered/influxdb:PACKAGE_VERSION
 ```
+
 {{% /code-placeholders %}}
 
 ---
@@ -158,28 +166,30 @@ image, similar to the following:
 
 {{< expand-wrapper >}}
 {{% expand "View JSON manifest" %}}
+
 ```json
 {
-    "schemaVersion": 2,
-    "config": {
-        "mediaType": "application/vnd.kubecfg.bundle.config.v1+json",
-        "digest": "sha256:6900d2f248e678176c68f3768e7e48958bb96a59232070ff31b3b018cf299aa7",
-        "size": 8598
-    },
-    "layers": [
-        {
-            "mediaType": "application/vnd.kubecfg.bundle.tar+gzip",
-            "digest": "sha256:7c1d62e76287035a9b22b2c155f328fae9beff2c6aa7a09a2dd2697539f41d98",
-            "size": 404059
-        }
-    ],
-    "annotations": {
-        "org.opencontainers.image.created": "1970-01-01T00:00:00Z",
-        "org.opencontainers.image.revision": "unknown",
-        "org.opencontainers.image.source": "kubecfg pack"
+  "schemaVersion": 2,
+  "config": {
+    "mediaType": "application/vnd.kubecfg.bundle.config.v1+json",
+    "digest": "sha256:6900d2f248e678176c68f3768e7e48958bb96a59232070ff31b3b018cf299aa7",
+    "size": 8598
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.kubecfg.bundle.tar+gzip",
+      "digest": "sha256:7c1d62e76287035a9b22b2c155f328fae9beff2c6aa7a09a2dd2697539f41d98",
+      "size": 404059
     }
+  ],
+  "annotations": {
+    "org.opencontainers.image.created": "1970-01-01T00:00:00Z",
+    "org.opencontainers.image.revision": "unknown",
+    "org.opencontainers.image.source": "kubecfg pack"
+  }
 }
 ```
+
 {{% /expand %}}
 {{< /expand-wrapper >}}
 
@@ -196,6 +206,7 @@ Error: fetching manifest us-docker.pkg.dev/influxdb2-artifacts/clustered/influxd
 {{% /tabs %}}
 
 {{% tab-content %}}
+
 <!--------------------------- BEGIN Public Registry --------------------------->
 
 #### Public registry (non-air-gapped)
@@ -212,14 +223,17 @@ If successful, the output is the following:
 
 ```text
 secret/gar-docker-secret created
+```
 
 By default, this secret is named `gar-docker-secret`.
 If you change the name of this secret, you must also change the value of the
 `imagePullSecret` field in the `AppInstance` custom resource to match.
 
 <!---------------------------- END Public Registry ---------------------------->
+
 {{% /tab-content %}}
 {{% tab-content %}}
+
 <!--------------------------- BEGIN Private Registry -------------------------->
 
 #### Private registry (air-gapped)
@@ -236,6 +250,7 @@ The list of images that you need to copy is included in the package metadata.
 You can obtain it with any standard OCI image inspection tool. For example:
 
 {{% code-placeholders "PACKAGE_VERSION" %}}
+
 ```sh
 DOCKER_CONFIG=/tmp/influxdbsecret \
 crane config \
@@ -243,6 +258,7 @@ crane config \
   | jq -r '.metadata["oci.image.list"].images[]' \
   > /tmp/images.txt
 ```
+
 {{% /code-placeholders %}}
 
 The output is a list of image names, similar to the following:
@@ -256,9 +272,11 @@ us-docker.pkg.dev/influxdb2-artifacts/iox/iox@sha256:b59d80add235f29b806badf7410
 Use `crane` to copy the images to your private registry:
 
 {{% code-placeholders "REGISTRY_HOSTNAME" %}}
+
 ```sh
 </tmp/images.txt xargs -I% crane cp % REGISTRY_HOSTNAME/%
 ```
+
 {{% /code-placeholders %}}
 
 ---
@@ -268,6 +286,7 @@ with the hostname of your private registry--for example:
 
 ```text
 myregistry.mydomain.io
+```
 
 ---
 
@@ -275,25 +294,28 @@ Set the
 `.spec.package.spec.images.registryOverride` field in `myinfluxdb.yml` to the location of your private registry--for example:
 
 {{% code-placeholders "REGISTRY_HOSTNAME" %}}
+
 ```yml
 apiVersion: kubecfg.dev/v1alpha1
 kind: AppInstance
-...
+---
 spec:
   package:
     spec:
       images:
         registryOverride: REGISTRY_HOSTNAME
 ```
+
 {{% /code-placeholders %}}
 
 <!---------------------------- END Private Registry --------------------------->
+
 {{% /tab-content %}}
 {{< /tabs-wrapper >}}
 
 ### Set up cluster ingress
 
- [Kubernetes ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) routes HTTP/S requests to services within the cluster and requires deploying an [ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/).
+[Kubernetes ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) routes HTTP/S requests to services within the cluster and requires deploying an [ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/).
 
 You can provide your own ingress or you can install [Nginx Ingress Controller](https://github.com/kubernetes/ingress-nginx) to use the InfluxDB-defined ingress.
 
@@ -301,12 +323,14 @@ If using the InfluxDB-defined ingress, add a valid TLS Certificate to the
 cluster as a secret. Provide the paths to the TLS certificate file and key file:
 
 {{% code-placeholders "TLS_(CERT|KEY)_PATH" %}}
+
 ```sh
 kubectl create secret tls ingress-tls \
   --namespace influxdb \
   --cert TLS_CERT_PATH \
   --key TLS_KEY_PATH
 ```
+
 {{% /code-placeholders %}}
 
 ---
@@ -341,7 +365,7 @@ To configure ingress, provide values for the following fields in your
 `myinfluxdb.yml` configuration file:
 
 - **`spec.package.spec.ingress.hosts`: Cluster hostnames**
-  
+
   Provide the hostnames that Kubernetes should
   use to expose the InfluxDB API endpoints.
   For example: `{{< influxdb/host >}}`.
@@ -349,9 +373,9 @@ To configure ingress, provide values for the following fields in your
   _You can provide multiple hostnames. The ingress layer accepts incoming
   requests for all listed hostnames. This can be useful if you want to have
   distinct paths for your internal and external traffic._
-  
+
   {{% note %}}
-You are responsible for configuring and managing DNS. Options include:
+  You are responsible for configuring and managing DNS. Options include:
 
 - Manually managing DNS records
 - Using [external-dns](https://github.com/kubernetes-sigs/external-dns) to
@@ -359,7 +383,7 @@ You are responsible for configuring and managing DNS. Options include:
   {{% /note %}}
 
 - **`spec.package.spec.ingress.tlsSecretName`: TLS certificate secret name**
-  
+
   Provide the name of the secret that
   [contains your TLS certificate and key](#set-up-cluster-ingress).
   The examples in this guide use the name `ingress-tls`.
@@ -367,7 +391,7 @@ You are responsible for configuring and managing DNS. Options include:
   _The `tlsSecretName` field is optional. You may want to use it if you already have a TLS certificate for your DNS name._
 
   {{< expand-wrapper >}}
-{{% expand "Use cert-manager and Let's Encrypt to manage TLS certificates" %}}
+  {{% expand "Use cert-manager and Let's Encrypt to manage TLS certificates" %}}
 
 If you instead want to automatically create an [ACME](https://datatracker.ietf.org/doc/html/rfc8555)
 certificate (for example, using [Let's Encrypt](https://letsencrypt.org/)), refer
@@ -383,21 +407,22 @@ If you choose to use cert-manager, it's your responsibility to install and confi
 {{< /expand-wrapper >}}
 
 {{% code-callout "ingress-tls|cluster-host\.com" "green" %}}
+
 ```yaml
 apiVersion: kubecfg.dev/v1alpha1
 kind: AppInstance
-...
+---
 spec:
   package:
     spec:
-...
-      ingress:
-        hosts: 
-          - {{< influxdb/host >}}
-        tlsSecretName: ingress-tls
+---
+ingress:
+  hosts:
+    - { { < influxdb/host > } }
+  tlsSecretName: ingress-tls
 ```
-{{% /code-callout %}}
 
+{{% /code-callout %}}
 
 #### Configure the object store
 
@@ -413,10 +438,11 @@ following fields in your `myinfluxdb.yml` configuration file:
   - `.region`: Object storage region
 
 {{% code-placeholders "S3_(URL|ACCESS_KEY|SECRET_KEY|BUCKET_NAME|REGION)" %}}
+
 ```yml
 apiVersion: kubecfg.dev/v1alpha1
 kind: AppInstance
-...
+---
 spec:
   package:
     spec:
@@ -425,7 +451,7 @@ spec:
         endpoint: S3_URL
 
         # Set to true to allow communication over HTTP (instead of HTTPS)
-        allowHttp: "false"
+        allowHttp: 'false'
 
         # S3 Access Key
         # This can also be provided as a valueFrom: secretKeyRef:
@@ -443,6 +469,7 @@ spec:
         # This value is required for AWS S3, it may or may not be required for other providers.
         region: S3_REGION
 ```
+
 {{% /code-placeholders %}}
 
 ---
@@ -471,13 +498,14 @@ as secrets in your Kubernetes cluster.
 
 - `spec.package.spec.catalog.dsn.valueFrom.secretKeyRef`
   - `.name`: Secret name
-  - `.key`:  Key in the secret that contains the DSN
+  - `.key`: Key in the secret that contains the DSN
 
 {{% code-placeholders "SECRET_(NAME|KEY)" %}}
+
 ```yml
 apiVersion: kubecfg.dev/v1alpha1
 kind: AppInstance
-...
+---
 spec:
   package:
     spec:
@@ -490,6 +518,7 @@ spec:
               name: SECRET_NAME
               key: SECRET_KEY
 ```
+
 {{% /code-placeholders %}}
 
 ---
@@ -504,15 +533,18 @@ Replace the following:
 ---
 
 {{% note %}}
+
 ##### PostgreSQL instances without TLS or SSL
 
 If your PostgreSQL-compatible instance runs without TLS or SSL, you must include
 the `sslmode=disable` parameter in the DSN. For example:
 
 {{% code-callout "sslmode=disable" %}}
+
 ```
 postgres://username:passw0rd@mydomain:5432/influxdb?sslmode=disable
 ```
+
 {{% /code-callout %}}
 {{% /note %}}
 
@@ -529,17 +561,19 @@ following fields in your `myinfluxdb.yml` configuration file:
   - `storage`: Storage size. We recommend a minimum of 2 gibibytes (`2Gi`).
 
 {{% code-placeholders "STORAGE_(CLASS|SIZE)" %}}
+
 ```yaml
 apiVersion: kubecfg.dev/v1alpha1
 kind: AppInstance
-...
+---
 spec:
   package:
     spec:
-      ingesterStorage: 
+      ingesterStorage:
         storageClassName: STORAGE_CLASS
         storage: STORAGE_SIZE
 ```
+
 {{% /code-placeholders %}}
 
 ---
@@ -580,10 +614,11 @@ other OAuth2 providers should work as well:
 
 {{% code-callout "keycloak" "green" %}}
 {{% code-placeholders "KEYCLOAK_(HOST|REALM|USER_ID)" %}}
+
 ```yaml
 apiVersion: kubecfg.dev/v1alpha1
 kind: AppInstance
-...
+---
 spec:
   package:
     spec:
@@ -594,6 +629,7 @@ spec:
         users:
           - KEYCLOAK_USER_ID
 ```
+
 {{% /code-placeholders %}}
 {{% /code-callout %}}
 
@@ -615,10 +651,11 @@ Replace the following:
 
 {{% code-callout "auth0" "green" %}}
 {{% code-placeholders "AUTH0_(HOST|USER_ID)" %}}
+
 ```yaml
 apiVersion: kubecfg.dev/v1alpha1
 kind: AppInstance
-...
+---
 spec:
   package:
     spec:
@@ -629,6 +666,7 @@ spec:
         users:
           - AUTH0_USER_ID
 ```
+
 {{% /code-placeholders %}}
 {{% /code-callout %}}
 
@@ -648,10 +686,11 @@ Replace the following:
 
 {{% code-callout "azure" "green" %}}
 {{% code-placeholders "AZURE_(USER|TENANT)_ID" %}}
+
 ```yaml
 apiVersion: kubecfg.dev/v1alpha1
 kind: AppInstance
-...
+---
 spec:
   package:
     spec:
@@ -662,6 +701,7 @@ spec:
         users:
           - AZURE_USER_ID
 ```
+
 {{% /code-placeholders %}}
 {{% /code-callout %}}
 
@@ -685,7 +725,6 @@ Replace the following:
 Finally, add all the users you wish to have access to use `influxctl`.
 Update the `spec.package.spec.admin.users` field with a list of these users.
 See [Adding or removing users](/influxdb/clustered/admin/users/) for more details.
-
 
 #### Configure the size of your cluster
 
@@ -733,12 +772,12 @@ in your `myinfluxdb.yml`. If omitted, your cluster will use the default scale se
 - [CPU resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu)
 - [Memory resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory)
 
-
 {{% code-placeholders "(INGESTER|COMPACTOR|QUERIER|ROUTER)_(CPU|MEMORY|REPLICAS)" %}}
+
 ```yml
 apiVersion: kubecfg.dev/v1alpha1
 kind: AppInstance
-...
+---
 spec:
   package:
     spec:
@@ -774,6 +813,7 @@ spec:
             memory: ROUTER_MEMORY
             replicas: ROUTER_REPLICAS # Default is 1
 ```
+
 {{% /code-placeholders %}}
 
 {{< page-nav prev="/influxdb/clustered/install/auth/" prevText="Set up authentication" next="/influxdb/clustered/install/deploy/" nextText="Deploy your cluster" >}}

--- a/content/influxdb/clustered/install/deploy.md
+++ b/content/influxdb/clustered/install/deploy.md
@@ -7,6 +7,8 @@ menu:
     name: Deploy your cluster
     parent: Install InfluxDB Clustered
 weight: 104
+related:
+  - /influxdb/clustered/admin/upgrade/
 ---
 
 Use Kubernetes and related tools to deploy your InfluxDB cluster.
@@ -39,9 +41,10 @@ your cluster, but from your terminal.**
   control (RBAC).
 - You want to preview the generated YAML.
 - You do not want to run the operator in your Kubernetes cluster.
-{{% /note %}}
+  {{% /note %}}
 
 <!-- Hidden anchor for links to the kubectl/kubit tabs -->
+
 <span id="kubectl-or-kubit"></span>
 
 {{< tabs-wrapper >}}
@@ -50,6 +53,7 @@ your cluster, but from your terminal.**
 [kubit](#)
 {{% /tabs %}}
 {{% tab-content %}}
+
 <!------------------------------- BEGIN kubectl ------------------------------->
 
 Use the `kubectl apply` command to apply your custom-configured `myinfluxdb.yml`
@@ -62,8 +66,10 @@ kubectl apply \
 ```
 
 <!-------------------------------- END kubectl -------------------------------->
+
 {{% /tab-content %}}
 {{% tab-content %}}
+
 <!-------------------------------- BEGIN kubit -------------------------------->
 
 1.  [Install the `kubit` CLI](https://github.com/kubecfg/kubit#cli-tool)
@@ -81,6 +87,7 @@ You can specify the `--docker` flag to opt-in to using containers instead. This 
 for tool dependencies, meaning the required versions are tracked by `kubit`.
 
 <!--------------------------------- END kubit --------------------------------->
+
 {{% /tab-content %}}
 {{< /tabs-wrapper >}}
 
@@ -112,18 +119,18 @@ The `status` field in the output contains two useful fields:
 For example, if you have incorrect container registry credentials, the output is similar to the following:
 
 ```yaml
-- lastTransitionTime: "2023-08-18T12:53:54Z"
-  message: ""
+- lastTransitionTime: '2023-08-18T12:53:54Z'
+  message: ''
   observedGeneration: null
   reason: Failed
-  status: "False"
+  status: 'False'
   type: Reconcilier
-- lastTransitionTime: "2023-08-18T12:53:54Z"
+- lastTransitionTime: '2023-08-18T12:53:54Z'
   message: |
     Cannot launch installation job: OCI error: Authentication failure: {"errors":[{"code":"UNAUTHORIZED","message":"authentication failed"}]}
   observedGeneration: null
   reason: Failed
-  status: "False"
+  status: 'False'
   type: Ready
 ```
 
@@ -163,4 +170,4 @@ influxdb      iox-shared-querier-7f5998b9b-fpt62        4/4     Running     1 (6
 influxdb      kubit-apply-influxdb-g6qpx                0/1     Completed   0              8s
 ```
 
-{{< page-nav prev="/influxdb/clustered/install/configure-install/" prevText="Configure your cluster" next="/influxdb/clustered/install/use-your-cluster/" nextText="Use your cluster" >}}
+{{< page-nav prev="/influxdb/clustered/install/configure-cluster/" prevText="Configure your cluster" next="/influxdb/clustered/install/use-your-cluster/" nextText="Use your cluster" >}}


### PR DESCRIPTION
Alternative to https://github.com/influxdata/docs-v2/pull/5329

This adds instructions for upgrading InfluxDB Clustered and explains the importance of checkpoint releases.

@jdockerty I squashed and merged the `clustered-install` branch into `master` and created this new branch to avoid all the extra commits left over from the `clustered-install` branch. I took the content you provide and formatted it as a single page. I restructured and reworded it a bit, but the core concepts should all be there.

- [x] Rebased/mergeable
