### PR TITLE
Add manage table task-based docs with partitioning info

### DIFF
--- a/content/influxdb/cloud-dedicated/admin/databases/create.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/create.md
@@ -18,10 +18,11 @@ list_code_example: |
   ```
 related:
   - /influxdb/cloud-dedicated/reference/cli/influxctl/database/create/
+  - /influxdb/cloud-dedicated/admin/custom-partitions/
 ---
 
 Use the [`influxctl database create` command](/influxdb/cloud-dedicated/reference/cli/influxctl/database/create/)
-to create a database in your InfluxDB Cloud Dedicated cluster.
+to create a database in your {{< product-name omit=" Clustered" >}} cluster.
 
 1.  If you haven't already, [download and install the `influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/#download-and-install-influxctl).
 2.  Run the `influxctl database create` command and provide the following:
@@ -30,6 +31,11 @@ to create a database in your InfluxDB Cloud Dedicated cluster.
       _(default is infinite)_
     - _Optional_: Database table (measurement) limit _(default is 500)_
     - _Optional_: Database column limit _(default is 250)_
+    - _Optional_: [InfluxDB tags](/influxdb/cloud-dedicated/reference/glossary/#tag)
+      to use in the partition template _(supports up to 7 different tags)_
+    - _Optional_: A [Rust strftime date and time string](/influxdb/cloud-dedicated/admin/custom-partitions/partition-templates/#time-part-templates)
+      that specifies the time format in the partition template and determines
+      the time interval to partition by _(default is `%Y-%m-%d`)_
     - Database name _(see [Database naming restrictions](#database-naming-restrictions))_
 
 {{% code-placeholders "DATABASE_NAME|30d|500|200" %}}
@@ -38,6 +44,9 @@ influxctl database create \
   --retention-period 30d \
   --max-tables 500 \
   --max-columns 250 \
+  --template-tag tag1 \
+  --template-tag tag2 \
+  --template-time '%Y-%m-%d' \
   DATABASE_NAME
 ```
 {{% /code-placeholders %}}
@@ -46,6 +55,7 @@ influxctl database create \
 - [Database naming restrictions](#database-naming-restrictions)
 - [InfluxQL DBRP naming convention](#influxql-dbrp-naming-convention)
 - [Table and column limits](#table-and-column-limits)
+- [Custom partitioning](#custom-partitioning)
 
 ## Retention period syntax
 
@@ -59,7 +69,7 @@ A zero duration (`0d`) retention period is infinite and data won't expire.
 The retention period value cannot be negative or contain whitespace.
 
 {{< flex >}}
-{{% flex-content %}}
+{{% flex-content "half" %}}
 
 ##### Valid durations units include
 
@@ -71,7 +81,7 @@ The retention period value cannot be negative or contain whitespace.
 - **y**: year
 
 {{% /flex-content %}}
-{{% flex-content %}}
+{{% flex-content "half" %}}
 
 ##### Example retention period values
 
@@ -190,3 +200,22 @@ threshold beyond which query performance may be affected
 
 {{% /expand %}}
 {{< /expand-wrapper >}}
+
+### Custom partitioning
+
+{{< product-name >}} lets you define a custom partitioning strategy for each database.
+A _partition_ is a logical grouping of data stored in [Apache Parquet](https://parquet.apache.org/)
+format in the InfluxDB v3 storage engine. By default, data is partitioned by day,
+but, depending on your schema and workload, customizing the partitioning
+strategy can improve query performance.
+
+Use the `--template-tag` and `--template-time` flags define partition template
+parts used to generate partition keys for the database.
+For more information, see [Manage data partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/).
+
+{{% note %}}
+#### Partition templates can only be applied on create
+
+You can only apply a partition template when creating a database.
+There is no way to update a partition template on an existing database.
+{{% /note %}}

--- a/content/influxdb/cloud-dedicated/admin/tables/_index.md
+++ b/content/influxdb/cloud-dedicated/admin/tables/_index.md
@@ -1,0 +1,23 @@
+---
+title: Manage tables
+seotitle: Manage tables in InfluxDB Cloud Dedicated
+description: >
+  Manage tables in your InfluxDB Cloud Dedicated cluster.
+  A table is a collection of related data stored in table format.
+  In previous versions of InfluxDB, tables were known as "measurements."
+menu:
+  influxdb_cloud_dedicated:
+    parent: Administer InfluxDB Cloud
+weight: 101
+influxdb/cloud-dedicated/tags: [tables]
+---
+
+Manage tables in your {{< product-name omit=" Clustered" >}} cluster.
+A table is a collection of related data stored in table format.
+
+{{% note %}}
+In previous versions of InfluxDB and in the context of InfluxQL, tables are
+known as "measurements."
+{{% /note %}}
+
+{{< children hlevel="h2" >}}

--- a/content/influxdb/cloud-dedicated/admin/tables/create.md
+++ b/content/influxdb/cloud-dedicated/admin/tables/create.md
@@ -1,0 +1,71 @@
+---
+title: Create a table
+description: >
+  Use the [`influxctl table create` command](/influxdb/cloud-dedicated/reference/cli/influxctl/table/create/)
+  to create a new table in a specified database your InfluxDB cluster.
+  Provide the database name and a table name.
+menu:
+  influxdb_cloud_dedicated:
+    parent: Manage tables
+weight: 201
+list_code_example: |
+  ```sh
+  influxctl table create <DATABASE_NAME> <TABLE_NAME>
+  ```
+related:
+  - /influxdb/cloud-dedicated/reference/cli/influxctl/table/create/
+  - /influxdb/cloud-dedicated/admin/custom-partitions/
+---
+
+Use the [`influxctl table create` command](/influxdb/cloud-dedicated/reference/cli/influxctl/table/create/)
+to create a table in a specified database in your
+{{< product-name omit=" Clustered" >}} cluster.
+
+With {{< product-name >}}, tables and measurements are synonymous.
+Typically, tables are created automatically on write using the measurement name
+specified in line protocol written to InfluxDB.
+However, to apply a [custom partition template](/influxdb/cloud-dedicated/admin/custom-partitions/)
+to a table, you must manually create the table before you write any data to it.
+
+1.  If you haven't already, [download and install the `influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/#download-and-install-influxctl).
+2.  Run the `influxctl table create` command and provide the following:
+
+    - _Optional_: [InfluxDB tags](/influxdb/cloud-dedicated/reference/glossary/#tag)
+      to use in the partition template _(supports up to 7 different tags)_
+    - _Optional_: A [Rust strftime date and time string](/influxdb/cloud-dedicated/admin/custom-partitions/partition-templates/#time-part-templates)
+      that specifies the time format in the partition template and determines
+      the time interval to partition by _(default is `%Y-%m-%d`)_
+    - The name of the database to create the table in
+    - The name of the table to create
+
+{{% code-placeholders "(DATABASE|TABLE)_NAME" %}}
+```sh
+influxctl table create \
+  --template-tag tag1 \
+  --template-tag tag2 \
+  --template-time '%Y-%m-%d' \
+  DATABASE_NAME \
+  TABLE_NAME
+```
+{{% /code-placeholders %}}
+
+### Custom partitioning
+
+{{< product-name >}} lets you define a custom partitioning strategy for each table.
+A _partition_ is a logical grouping of data stored in [Apache Parquet](https://parquet.apache.org/)
+format in the InfluxDB v3 storage engine. By default, data is partitioned by day,
+but, depending on your schema and workload, customizing the partitioning
+strategy can improve query performance.
+
+Use the `--template-tag` and `--template-time` flags define partition template
+parts used to generate partition keys for the table.
+If no template flags are provided, the table uses the partition template of the
+target database.
+For more information, see [Manage data partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/).
+
+{{% note %}}
+#### Partition templates can only be applied on create
+
+You can only apply a partition template when creating a table.
+There is no way to update a partition template on an existing table.
+{{% /note %}}

--- a/content/influxdb/cloud-dedicated/admin/tables/list.md
+++ b/content/influxdb/cloud-dedicated/admin/tables/list.md
@@ -1,0 +1,85 @@
+---
+title: List tables
+description: >
+  Use the [`SHOW TABLES` SQL statement](/influxdb/cloud-dedicated/query-data/sql/explore-schema/#list-measurements-in-a-database)
+  or the [`SHOW MEASUREMENTS` InfluxQL statement](/influxdb/cloud-dedicated/query-data/influxql/explore-schema/#list-measurements-in-a-database)
+  to list tables in a database.
+menu:
+  influxdb_cloud_dedicated:
+    parent: Manage tables
+weight: 201
+list_code_example: |
+  ###### SQL
+
+  ```sql
+  SHOW TABLES
+  ```
+
+  ###### InfluxQL
+  
+  ```sql
+  SHOW MEASUREMENTS
+  ```
+related:
+  - /influxdb/cloud-dedicated/query-data/sql/explore-schema/
+  - /influxdb/cloud-dedicated/query-data/influxql/explore-schema/
+---
+
+Use the [`SHOW TABLES` SQL statement](/influxdb/cloud-dedicated/query-data/sql/explore-schema/#list-measurements-in-a-database)
+or the [`SHOW MEASUREMENTS` InfluxQL statement](/influxdb/cloud-dedicated/query-data/influxql/explore-schema/#list-measurements-in-a-database)
+to list tables in a database.
+
+{{% note %}}
+With {{< product-name >}}, tables and measurements are synonymous.
+{{% /note %}}
+
+###### SQL
+
+```sql
+SHOW TABLES
+```
+
+###### InfluxQL
+
+```sql
+SHOW MEASUREMENTS
+```
+
+## List tables with the influxctl CLI
+
+To list tables using the influxctl CLI, use the `influxctl query` command to pass
+the `SHOW TABLES` SQL statement.
+
+{{% note %}}
+The `influxctl query` command only supports SQL queries; not InfluxQL.
+{{% /note %}}
+
+Provide the following with your command:
+
+- **Database token**: [Database token](/influxdb/cloud-dedicated/admin/tokens/)
+  with read permissions on the queried database. Uses the `token` setting from
+  the [`influxctl` connection profile](/influxdb/cloud-dedicated/reference/cli/influxctl/#configure-connection-profiles)
+  or the `--token` command flag.
+- **Database name**: Name of the database to query. Uses the `database` setting
+  from the [`influxctl` connection profile](/influxdb/cloud-dedicated/reference/cli/influxctl/#configure-connection-profiles)
+  or the `--database` command flag.
+- **SQL query**: SQL query with the `SHOW TABLES` statement.
+
+{{% code-placeholders "DATABASE_(TOKEN|NAME)" %}}
+
+```sh
+influxctl query \
+  --token DATABASE_TOKEN \
+  --database DATABASE_NAME \
+  "SHOW TABLES"
+```
+
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_TOKEN`{{% /code-placeholder-key %}}:
+  Database token with read access to the queried database
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
+  Name of the database to query
+

--- a/content/influxdb/cloud-dedicated/admin/tables/list.md
+++ b/content/influxdb/cloud-dedicated/admin/tables/list.md
@@ -47,7 +47,7 @@ SHOW MEASUREMENTS
 
 ## List tables with the influxctl CLI
 
-To list tables using the influxctl CLI, use the `influxctl query` command to pass
+To list tables using the `influxctl` CLI, use the `influxctl query` command to pass
 the `SHOW TABLES` SQL statement.
 
 {{% note %}}

--- a/content/influxdb/clustered/admin/tables/_index.md
+++ b/content/influxdb/clustered/admin/tables/_index.md
@@ -1,0 +1,23 @@
+---
+title: Manage tables
+seotitle: Manage tables in InfluxDB Clustered
+description: >
+  Manage tables in your InfluxDB cluster.
+  A table is a collection of related data stored in table format.
+  In previous versions of InfluxDB, tables were known as "measurements."
+menu:
+  influxdb_clustered:
+    parent: Administer InfluxDB Cloud
+weight: 101
+influxdb/clustered/tags: [tables]
+---
+
+Manage tables in your {{< product-name omit=" Clustered" >}} cluster.
+A table is a collection of related data stored in table format.
+
+{{% note %}}
+In previous versions of InfluxDB and in the context of InfluxQL, tables are
+known as "measurements."
+{{% /note %}}
+
+{{< children hlevel="h2" >}}

--- a/content/influxdb/clustered/admin/tables/create.md
+++ b/content/influxdb/clustered/admin/tables/create.md
@@ -1,0 +1,71 @@
+---
+title: Create a table
+description: >
+  Use the [`influxctl table create` command](/influxdb/clustered/reference/cli/influxctl/table/create/)
+  to create a new table in a specified database your InfluxDB cluster.
+  Provide the database name and a table name.
+menu:
+  influxdb_clustered:
+    parent: Manage tables
+weight: 201
+list_code_example: |
+  ```sh
+  influxctl table create <DATABASE_NAME> <TABLE_NAME>
+  ```
+related:
+  - /influxdb/clustered/reference/cli/influxctl/table/create/
+  - /influxdb/clustered/admin/custom-partitions/
+---
+
+Use the [`influxctl table create` command](/influxdb/clustered/reference/cli/influxctl/table/create/)
+to create a table in a specified database in your
+{{< product-name omit=" Clustered" >}} cluster.
+
+With {{< product-name >}}, tables and measurements are synonymous.
+Typically, tables are created automatically on write using the measurement name
+specified in line protocol written to InfluxDB.
+However, to apply a [custom partition template](/influxdb/clustered/admin/custom-partitions/)
+to a table, you must manually create the table before you write any data to it.
+
+1.  If you haven't already, [download and install the `influxctl` CLI](/influxdb/clustered/reference/cli/influxctl/#download-and-install-influxctl).
+2.  Run the `influxctl table create` command and provide the following:
+
+    - _Optional_: [InfluxDB tags](/influxdb/clustered/reference/glossary/#tag)
+      to use in the partition template _(supports up to 7 different tags)_
+    - _Optional_: A [Rust strftime date and time string](/influxdb/clustered/admin/custom-partitions/partition-templates/#time-part-templates)
+      that specifies the time format in the partition template and determines
+      the time interval to partition by _(default is `%Y-%m-%d`)_
+    - The name of the database to create the table in
+    - The name of the table to create
+
+{{% code-placeholders "(DATABASE|TABLE)_NAME" %}}
+```sh
+influxctl table create \
+  --template-tag tag1 \
+  --template-tag tag2 \
+  --template-time '%Y-%m-%d' \
+  DATABASE_NAME \
+  TABLE_NAME
+```
+{{% /code-placeholders %}}
+
+### Custom partitioning
+
+{{< product-name >}} lets you define a custom partitioning strategy for each table.
+A _partition_ is a logical grouping of data stored in [Apache Parquet](https://parquet.apache.org/)
+format in the InfluxDB v3 storage engine. By default, data is partitioned by day,
+but, depending on your schema and workload, customizing the partitioning
+strategy can improve query performance.
+
+Use the `--template-tag` and `--template-time` flags define partition template
+parts used to generate partition keys for the table.
+If no template flags are provided, the table uses the partition template of the
+target database.
+For more information, see [Manage data partitioning](/influxdb/clustered/admin/custom-partitions/).
+
+{{% note %}}
+#### Partition templates can only be applied on create
+
+You can only apply a partition template when creating a table.
+There is no way to update a partition template on an existing table.
+{{% /note %}}

--- a/content/influxdb/clustered/admin/tables/list.md
+++ b/content/influxdb/clustered/admin/tables/list.md
@@ -1,0 +1,85 @@
+---
+title: List tables
+description: >
+  Use the [`SHOW TABLES` SQL statement](/influxdb/clustered/query-data/sql/explore-schema/#list-measurements-in-a-database)
+  or the [`SHOW MEASUREMENTS` InfluxQL statement](/influxdb/clustered/query-data/influxql/explore-schema/#list-measurements-in-a-database)
+  to list tables in a database.
+menu:
+  influxdb_clustered:
+    parent: Manage tables
+weight: 201
+list_code_example: |
+  ###### SQL
+
+  ```sql
+  SHOW TABLES
+  ```
+
+  ###### InfluxQL
+  
+  ```sql
+  SHOW MEASUREMENTS
+  ```
+related:
+  - /influxdb/clustered/query-data/sql/explore-schema/
+  - /influxdb/clustered/query-data/influxql/explore-schema/
+---
+
+Use the [`SHOW TABLES` SQL statement](/influxdb/clustered/query-data/sql/explore-schema/#list-measurements-in-a-database)
+or the [`SHOW MEASUREMENTS` InfluxQL statement](/influxdb/clustered/query-data/influxql/explore-schema/#list-measurements-in-a-database)
+to list tables in a database.
+
+{{% note %}}
+With {{< product-name >}}, tables and measurements are synonymous.
+{{% /note %}}
+
+###### SQL
+
+```sql
+SHOW TABLES
+```
+
+###### InfluxQL
+
+```sql
+SHOW MEASUREMENTS
+```
+
+## List tables with the influxctl CLI
+
+To list tables using the influxctl CLI, use the `influxctl query` command to pass
+the `SHOW TABLES` SQL statement.
+
+{{% note %}}
+The `influxctl query` command only supports SQL queries; not InfluxQL.
+{{% /note %}}
+
+Provide the following with your command:
+
+- **Database token**: [Database token](/influxdb/clustered/admin/tokens/)
+  with read permissions on the queried database. Uses the `token` setting from
+  the [`influxctl` connection profile](/influxdb/clustered/reference/cli/influxctl/#configure-connection-profiles)
+  or the `--token` command flag.
+- **Database name**: Name of the database to query. Uses the `database` setting
+  from the [`influxctl` connection profile](/influxdb/clustered/reference/cli/influxctl/#configure-connection-profiles)
+  or the `--database` command flag.
+- **SQL query**: SQL query with the `SHOW TABLES` statement.
+
+{{% code-placeholders "DATABASE_(TOKEN|NAME)" %}}
+
+```sh
+influxctl query \
+  --token DATABASE_TOKEN \
+  --database DATABASE_NAME \
+  "SHOW TABLES"
+```
+
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_TOKEN`{{% /code-placeholder-key %}}:
+  Database token with read access to the queried database
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
+  Name of the database to query
+

--- a/content/influxdb/clustered/admin/tables/list.md
+++ b/content/influxdb/clustered/admin/tables/list.md
@@ -47,7 +47,7 @@ SHOW MEASUREMENTS
 
 ## List tables with the influxctl CLI
 
-To list tables using the influxctl CLI, use the `influxctl query` command to pass
+To list tables using the `influxctl` CLI, use the `influxctl query` command to pass
 the `SHOW TABLES` SQL statement.
 
 {{% note %}}


### PR DESCRIPTION
Adds task-based documentation for managing tables in Cloud Dedicated and Clustered. It also adds partitioning information to the "Create a database" task-based doc in both.

- [x] Rebased/mergeable
