### PR TITLE
Fix template-time flags

### DIFF
--- a/content/influxdb/cloud-dedicated/admin/custom-partitions/define-custom-partitions.md
+++ b/content/influxdb/cloud-dedicated/admin/custom-partitions/define-custom-partitions.md
@@ -42,7 +42,7 @@ Use the following command flags to identify
 - `--template-tag`: An [InfluxDB tag](/influxdb/cloud-dedicated/reference/glossary/#tag)
   to use in the partition template.
   _Supports up to 7 of these flags._
-- `--template-time`: A [Rust strftime date and time](/influxdb/cloud-dedicated/admin/custom-partitions/partition-templates/#time-part-templates)
+- `--template-timeformat`: A [Rust strftime date and time](/influxdb/cloud-dedicated/admin/custom-partitions/partition-templates/#time-part-templates)
   string that specifies the time format in the partition template and determines
   the time interval to partition by.
 
@@ -58,7 +58,7 @@ the time format `%Y wk:%W`:
 influxctl database create \
   --template-tag room \
   --template-tag sensor-type \
-  --template-time '%Y wk:%W' \
+  --template-timeformat '%Y wk:%W' \
   example-db
 ```
 
@@ -72,7 +72,7 @@ database and applies a partition template that partitions by two tags
 influxctl table create \
   --template-tag room \
   --template-tag sensor-type \
-  --template-time '%Y-%m' \
+  --template-timeformat '%Y-%m' \
   example-db \
   example-table
 ```

--- a/content/influxdb/cloud-dedicated/admin/databases/create.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/create.md
@@ -46,7 +46,7 @@ influxctl database create \
   --max-columns 250 \
   --template-tag tag1 \
   --template-tag tag2 \
-  --template-time '%Y-%m-%d' \
+  --template-timeformat '%Y-%m-%d' \
   DATABASE_NAME
 ```
 {{% /code-placeholders %}}
@@ -209,7 +209,7 @@ format in the InfluxDB v3 storage engine. By default, data is partitioned by day
 but, depending on your schema and workload, customizing the partitioning
 strategy can improve query performance.
 
-Use the `--template-tag` and `--template-time` flags define partition template
+Use the `--template-tag` and `--template-timeformat` flags define partition template
 parts used to generate partition keys for the database.
 For more information, see [Manage data partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/).
 

--- a/content/influxdb/cloud-dedicated/admin/tables/create.md
+++ b/content/influxdb/cloud-dedicated/admin/tables/create.md
@@ -43,7 +43,7 @@ to a table, you must manually create the table before you write any data to it.
 influxctl table create \
   --template-tag tag1 \
   --template-tag tag2 \
-  --template-time '%Y-%m-%d' \
+  --template-timeformat '%Y-%m-%d' \
   DATABASE_NAME \
   TABLE_NAME
 ```
@@ -57,8 +57,8 @@ format in the InfluxDB v3 storage engine. By default, data is partitioned by day
 but, depending on your schema and workload, customizing the partitioning
 strategy can improve query performance.
 
-Use the `--template-tag` and `--template-time` flags define partition template
-parts used to generate partition keys for the table.
+Use the `--template-tag` and `--template-timeformat` flags define partition
+template parts used to generate partition keys for the table.
 If no template flags are provided, the table uses the partition template of the
 target database.
 For more information, see [Manage data partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/).

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/create.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/create.md
@@ -53,7 +53,7 @@ The retention period value cannot be negative or contain whitespace.
 #### Custom partitioning
 
 You can override the default partition template (`%Y-%m-%d`) of the database
-with the `--template-tag` and `--template-time` flags when you create the database.
+with the `--template-tag` and `--template-timeformat` flags when you create the database.
 Provide a time format using [Rust strftime](/influxdb/cloud-dedicated/admin/custom-partitions/partition-templates/#time-part-templates)
 and include specific tags to use in the partition template.
 Be sure to follow [partitioning best practices](/influxdb/cloud-dedicated/admin/custom-partitions/best-practices/).
@@ -72,14 +72,14 @@ influxctl database create [--retention-period 0s] <DATABASE_NAME>
 
 ## Flags
 
-| Flag |                      | Description                                                          |
-| :--- | :------------------- | :------------------------------------------------------------------- |
-|      | `--retention-period` | Database retention period (default is 0s or infinite)                |
-|      | `--max-tables`       | Maximum tables per database (default is 500, 0 uses default)         |
-|      | `--max-columns`      | Maximum columns per table (default is 250, 0 uses default)           |
-|      | `--template-tag`     | Tag to add to partition template (can include multiple of this flag) |
-|      | `--template-time`    | Timestamp format for partition template (default is `%Y-%m-%d`)      |
-| `-h` | `--help`             | Output command help                                                  |
+| Flag |                         | Description                                                          |
+| :--- | :---------------------- | :------------------------------------------------------------------- |
+|      | `--retention-period`    | Database retention period (default is 0s or infinite)                |
+|      | `--max-tables`          | Maximum tables per database (default is 500, 0 uses default)         |
+|      | `--max-columns`         | Maximum columns per table (default is 250, 0 uses default)           |
+|      | `--template-tag`        | Tag to add to partition template (can include multiple of this flag) |
+|      | `--template-timeformat` | Timestamp format for partition template (default is `%Y-%m-%d`)      |
+| `-h` | `--help`                | Output command help                                                  |
 
 {{% caption %}}
 _Also see [`influxctl` global flags](/influxdb/cloud-dedicated/reference/cli/influxctl/#global-flags)._
@@ -125,7 +125,7 @@ the time format `%Y wk:%W`:
 influxctl database create \
   --template-tag room \
   --template-tag sensor-type \
-  --template-time '%Y wk:%W' \
+  --template-timeformat '%Y wk:%W' \
   mydb
 ```
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/table/create.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/table/create.md
@@ -17,7 +17,7 @@ database in an {{< product-name omit=" Clustered" >}} cluster.
 #### Custom partitioning
 
 You can override the default partition template (the partition template of the target database)
-with the `--template-tag` and `--template-time` flags when you create the table.
+with the `--template-tag` and `--template-timeformat` flags when you create the table.
 Provide a time format using [Rust strftime](/influxdb/cloud-dedicated/admin/custom-partitions/partition-templates/#time-part-templates)
 and include specific tags to use in the partition template.
 Be sure to follow [partitioning best practices](/influxdb/cloud-dedicated/admin/custom-partitions/best-practices/).
@@ -37,11 +37,11 @@ influxctl table create [flags] <DATABASE_NAME> <TABLE_NAME>
 
 ## Flags
 
-| Flag |                      | Description                                                          |
-| :--- | :------------------- | :------------------------------------------------------------------- |
-|      | `--template-tag`     | Tag to add to partition template (can include multiple of this flag) |
-|      | `--template-time`    | Timestamp format for partition template (default is `%Y-%m-%d`)      |
-| `-h` | `--help`             | Output command help                                                  |
+| Flag |                         | Description                                                          |
+| :--- | :---------------------- | :------------------------------------------------------------------- |
+|      | `--template-tag`        | Tag to add to partition template (can include multiple of this flag) |
+|      | `--template-timeformat` | Timestamp format for partition template (default is `%Y-%m-%d`)      |
+| `-h` | `--help`                | Output command help                                                  |
 
 {{% caption %}}
 _Also see [`influxctl` global flags](/influxdb/cloud-dedicated/reference/cli/influxctl/#global-flags)._
@@ -78,7 +78,7 @@ the time format `%Y wk:%W`:
 influxctl table create \
   --template-tag room \
   --template-tag sensor-type \
-  --template-time '%Y wk:%W' \
+  --template-timeformat '%Y wk:%W' \
   DATABASE_NAME \
   TABLE_NAME
 ```

--- a/content/influxdb/clustered/admin/custom-partitions/define-custom-partitions.md
+++ b/content/influxdb/clustered/admin/custom-partitions/define-custom-partitions.md
@@ -42,7 +42,7 @@ Use the following command flags to identify
 - `--template-tag`: An [InfluxDB tag](/influxdb/clustered/reference/glossary/#tag)
   to use in the partition template.
   _Supports up to 7 of these flags._
-- `--template-time`: A [Rust strftime date and time](/influxdb/clustered/admin/custom-partitions/partition-templates/#time-part-templates)
+- `--template-timeformat`: A [Rust strftime date and time](/influxdb/clustered/admin/custom-partitions/partition-templates/#time-part-templates)
   string that specifies the time format in the partition template and determines
   the time interval to partition by.
 
@@ -58,7 +58,7 @@ the time format `%Y wk:%W`:
 influxctl database create \
   --template-tag room \
   --template-tag sensor-type \
-  --template-time '%Y wk:%W' \
+  --template-timeformat '%Y wk:%W' \
   example-db
 ```
 
@@ -72,7 +72,7 @@ database and applies a partition template that partitions by two tags
 influxctl table create \
   --template-tag room \
   --template-tag sensor-type \
-  --template-time '%Y-%m' \
+  --template-timeformat '%Y-%m' \
   example-db \
   example-table
 ```

--- a/content/influxdb/clustered/admin/databases/create.md
+++ b/content/influxdb/clustered/admin/databases/create.md
@@ -46,7 +46,7 @@ influxctl database create \
   --max-columns 250 \
   --template-tag tag1 \
   --template-tag tag2 \
-  --template-time '%Y-%m-%d' \
+  --template-timeformat '%Y-%m-%d' \
   DATABASE_NAME
 ```
 {{% /code-placeholders %}}
@@ -209,8 +209,8 @@ format in the InfluxDB v3 storage engine. By default, data is partitioned by day
 but, depending on your schema and workload, customizing the partitioning
 strategy can improve query performance.
 
-Use the `--template-tag` and `--template-time` flags define partition template
-parts used to generate partition keys for the database.
+Use the `--template-tag` and `--template-timeformat` flags define partition
+template parts used to generate partition keys for the database.
 For more information, see [Manage data partitioning](/influxdb/clustered/admin/custom-partitions/).
 
 {{% note %}}

--- a/content/influxdb/clustered/admin/tables/create.md
+++ b/content/influxdb/clustered/admin/tables/create.md
@@ -43,7 +43,7 @@ to a table, you must manually create the table before you write any data to it.
 influxctl table create \
   --template-tag tag1 \
   --template-tag tag2 \
-  --template-time '%Y-%m-%d' \
+  --template-timeformat '%Y-%m-%d' \
   DATABASE_NAME \
   TABLE_NAME
 ```
@@ -57,8 +57,8 @@ format in the InfluxDB v3 storage engine. By default, data is partitioned by day
 but, depending on your schema and workload, customizing the partitioning
 strategy can improve query performance.
 
-Use the `--template-tag` and `--template-time` flags define partition template
-parts used to generate partition keys for the table.
+Use the `--template-tag` and `--template-timeformat` flags define partition
+template parts used to generate partition keys for the table.
 If no template flags are provided, the table uses the partition template of the
 target database.
 For more information, see [Manage data partitioning](/influxdb/clustered/admin/custom-partitions/).

--- a/content/influxdb/clustered/reference/cli/influxctl/database/create.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/database/create.md
@@ -51,8 +51,8 @@ The retention period value cannot be negative or contain whitespace.
 
 #### Custom partitioning
 
-You can override the default partition template (`%Y-%m-%d`) of the database
-with the `--template-tag` and `--template-time` flags when you create the database.
+You can override the default partition template (`%Y-%m-%d`) of the database with
+the `--template-tag` and `--template-timeformat` flags when you create the database.
 Provide a time format using [Rust strftime](/influxdb/clustered/admin/custom-partitions/partition-templates/#time-part-templates)
 and include specific tags to use in the partition template.
 Be sure to follow [partitioning best practices](/influxdb/clustered/admin/custom-partitions/best-practices/).
@@ -71,14 +71,14 @@ influxctl database create [--retention-period 0s] <DATABASE_NAME>
 
 ## Flags
 
-| Flag |                      | Description                                                          |
-| :--- | :------------------- | :------------------------------------------------------------------- |
-|      | `--retention-period` | Database retention period (default is 0s or infinite)                |
-|      | `--max-tables`       | Maximum tables per database (default is 500, 0 uses default)         |
-|      | `--max-columns`      | Maximum columns per table (default is 250, 0 uses default)           |
-|      | `--template-tag`     | Tag to add to partition template (can include multiple of this flag) |
-|      | `--template-time`    | Timestamp format for partition template (default is `%Y-%m-%d`)      |
-| `-h` | `--help`             | Output command help                                                  |
+| Flag |                         | Description                                                          |
+| :--- | :---------------------- | :------------------------------------------------------------------- |
+|      | `--retention-period`    | Database retention period (default is 0s or infinite)                |
+|      | `--max-tables`          | Maximum tables per database (default is 500, 0 uses default)         |
+|      | `--max-columns`         | Maximum columns per table (default is 250, 0 uses default)           |
+|      | `--template-tag`        | Tag to add to partition template (can include multiple of this flag) |
+|      | `--template-timeformat` | Timestamp format for partition template (default is `%Y-%m-%d`)      |
+| `-h` | `--help`                | Output command help                                                  |
 
 {{% caption %}}
 _Also see [`influxctl` global flags](/influxdb/clustered/reference/cli/influxctl/#global-flags)._
@@ -124,7 +124,7 @@ the time format `%Y wk:%W`:
 influxctl database create \
   --template-tag room \
   --template-tag sensor-type \
-  --template-time '%Y wk:%W' \
+  --template-timeformat '%Y wk:%W' \
   mydb
 ```
 

--- a/content/influxdb/clustered/reference/cli/influxctl/table/create.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/table/create.md
@@ -17,7 +17,7 @@ database in an {{< product-name omit=" Clustered" >}} cluster.
 #### Custom partitioning
 
 You can override the default partition template (the partition template of the target database)
-with the `--template-tag` and `--template-time` flags when you create the table.
+with the `--template-tag` and `--template-timeformat` flags when you create the table.
 Provide a time format using [Rust strftime](/influxdb/clustered/admin/custom-partitions/partition-templates/#time-part-templates)
 and include specific tags to use in the partition template.
 Be sure to follow [partitioning best practices](/influxdb/clustered/admin/custom-partitions/best-practices/).
@@ -37,11 +37,11 @@ influxctl table create [flags] <DATABASE_NAME> <TABLE_NAME>
 
 ## Flags
 
-| Flag |                      | Description                                                          |
-| :--- | :------------------- | :------------------------------------------------------------------- |
-|      | `--template-tag`     | Tag to add to partition template (can include multiple of this flag) |
-|      | `--template-time`    | Timestamp format for partition template (default is `%Y-%m-%d`)      |
-| `-h` | `--help`             | Output command help                                                  |
+| Flag |                         | Description                                                          |
+| :--- | :---------------------- | :------------------------------------------------------------------- |
+|      | `--template-tag`        | Tag to add to partition template (can include multiple of this flag) |
+|      | `--template-timeformat` | Timestamp format for partition template (default is `%Y-%m-%d`)      |
+| `-h` | `--help`                | Output command help                                                  |
 
 {{% caption %}}
 _Also see [`influxctl` global flags](/influxdb/clustered/reference/cli/influxctl/#global-flags)._
@@ -78,7 +78,7 @@ the time format `%Y wk:%W`:
 influxctl table create \
   --template-tag room \
   --template-tag sensor-type \
-  --template-time '%Y wk:%W' \
+  --template-timeformat '%Y wk:%W' \
   DATABASE_NAME \
   TABLE_NAME
 ```


### PR DESCRIPTION
Closes #5347

The recent released docs for custom partitions included an incorrect flag. `--template-time` should be `--template-timeformat`. This updates all the occurrences of these flags.

- [x] Rebased/mergeable
