### PR TITLE
Enterprise 1.11.5 release notes

### DIFF
--- a/content/chronograf/v1/about_the_project/release-notes.md
+++ b/content/chronograf/v1/about_the_project/release-notes.md
@@ -417,7 +417,10 @@ TLS1.2 is now the default minimum required TLS version. If you have clients that
 
 ## v1.8.1 {date="2020-04-06"}
 
-{{% warn %}} **Warning:** Critical bug that impacted table rendering was introduced in 1.8.1. **Do not install this release**, install [v1.8.2](#v182), which includes the features and bug fixes below.
+{{% warn %}}
+**Warning:** Critical bug that impacted table rendering was introduced in 1.8.1.
+**Do not install this release**, install [v1.8.2](#v182), which includes the
+features and bug fixes below.
 {{% /warn %}}
 
 ### Features

--- a/content/enterprise_influxdb/v1/about-the-project/release-notes.md
+++ b/content/enterprise_influxdb/v1/about-the-project/release-notes.md
@@ -26,25 +26,24 @@ InfluxDB Enterprise builds are available. For more information, see
 
 With InfluxDB Enterprise v1.11.4+, InfluxDB can be configured to optionally
 run the `influxd_inspect -compact-series-file` command to [compact series files](/enterprise_influxdb/v1/tools/influx_inspect/#--compact-series-file-) before data nodes are started.
-Series files are stored in `_series` directories in the
-[`/data` directory](/enterprise_influxdb/v1/concepts/file-system-layout/#data-node-file-system-layout)
-(default is `/var/lib/data/<db-name>/_series`).
+Series files are stored in `_series` directories inside the [InfluxDB data directory](/enterprise_influxdb/v1/concepts/file-system-layout/#data-node-file-system-layout).
+Default: `/var/lib/data/<db-name>/_series`.
 
 - If any series files are corrupt, the `influx_inspect` or `influxd` processes on
   the data node may fail to start. In both cases, delete the series file
-  directories before restarting the database. InfluxDB will automatically
-  regenerate the deleted series files when the database is restarted.
+  directories before restarting the database. InfluxDB automatically
+  regenerates the necessary series directories and files when restarting.
 - To check if series files are corrupt before starting the database, run the
   [`influx_inspect verify-seriesfile` command](/enterprise_influxdb/v1/tools/influx_inspect/#verify-seriesfile)
   while the database is off-line.
-- If series files are large (20+ gigabytes), it may also be faster to delete the
+- If series files are large (20+ gigabytes), it may be faster to delete the
   series file directories before starting the database.
 {{% /note %}}
 
 ### Bug Fixes
 
-- Prevent retention service creating orphaned shard files.
-- Address LDAP authentication and authorization issues.
+- Prevent the retention service from creating orphaned shard files.
+- Fix LDAP authentication and authorization issues.
 
 ### Other
 
@@ -54,7 +53,7 @@ Series files are stored in `_series` directories in the
 
 ### Bug Fixes
 
-- Adds `compact-series-file` configuration setting to optionally execute series compaction on startup.
+- Adds the `compact-series-file` configuration setting to optionally execute series compaction during startup.
 
 ### Other
 
@@ -63,13 +62,12 @@ Series files are stored in `_series` directories in the
 ## v1.11.3 {date="2023-10-12"}
 
 {{% warn %}}
-#### Series file compaction on start-up
+#### Series file compaction on startup
 
-With InfluxDB Enterprise v1.11.3, on start-up, InfluxDB will run the
+With InfluxDB Enterprise v1.11.3, on startup, InfluxDB runs the
 `influxd_inspect -compact-series-file` command to [compact series files](/enterprise_influxdb/v1/tools/influx_inspect/#--compact-series-file-) before data nodes are started.
-Series files are stored in `_series` directories in the
-[`/data` directory](/enterprise_influxdb/v1/concepts/file-system-layout/#data-node-file-system-layout)
-(default is `/var/lib/data/<db-name>/_series`).
+Series files are stored in `_series` directories inside the
+[InfluxDB data directory](/enterprise_influxdb/v1/concepts/file-system-layout/#data-node-file-system-layout). Default: `/var/lib/data/<db-name>/_series`
 
 - InfluxDB Enterprise v1.11.4+ introduces a configuration setting to optionally
   compact series on startup.

--- a/content/enterprise_influxdb/v1/about-the-project/release-notes.md
+++ b/content/enterprise_influxdb/v1/about-the-project/release-notes.md
@@ -9,7 +9,7 @@ menu:
     parent: About the project
 ---
 
-## v1.11.3 {date="2023-10-12"}
+## v1.11.5 {date="2024-02-14"}
 
 {{% note %}}
 #### InfluxDB Enterprise and FIPS-compliance
@@ -21,15 +21,58 @@ InfluxDB Enterprise builds are available. For more information, see
 [FIPS-compliant InfluxDB Enterprise builds](/enterprise_influxdb/v1/introduction/installation/fips-compliant/).
 {{% /note %}}
 
+{{% note %}}
+#### Series file compaction
+
+With InfluxDB Enterprise v1.11.4+, InfluxDB can be configured to optionally
+run the `influxd_inspect -compact-series-file` command to [compact series files](/enterprise_influxdb/v1/tools/influx_inspect/#--compact-series-file-) before data nodes are started.
+Series files are stored in `_series` directories in the
+[`/data` directory](/enterprise_influxdb/v1/concepts/file-system-layout/#data-node-file-system-layout)
+(default is `/var/lib/data/<db-name>/_series`).
+
+- If any series files are corrupt, the `influx_inspect` or `influxd` processes on
+  the data node may fail to start. In both cases, delete the series file
+  directories before restarting the database. InfluxDB will automatically
+  regenerate the deleted series files when the database is restarted.
+- To check if series files are corrupt before starting the database, run the
+  [`influx_inspect verify-seriesfile` command](/enterprise_influxdb/v1/tools/influx_inspect/#verify-seriesfile)
+  while the database is off-line.
+- If series files are large (20+ gigabytes), it may also be faster to delete the
+  series file directories before starting the database.
+{{% /note %}}
+
+### Bug Fixes
+
+- Prevent retention service creating orphaned shard files.
+- Address LDAP authentication and authorization issues.
+
+### Other
+
+- Upgrade Flux to v0.194.5.
+
+## v1.11.4 {date="2023-12-14"}
+
+### Bug Fixes
+
+- Adds `compact-series-file` configuration setting to optionally execute series compaction on startup.
+
+### Other
+
+- Update InfluxDB to latest commit in 1.11
+
+## v1.11.3 {date="2023-10-12"}
+
 {{% warn %}}
 #### Series file compaction on start-up
 
-With InfluxDB Enterprise v1.11.3+, on start-up, InfluxDB run the
+With InfluxDB Enterprise v1.11.3, on start-up, InfluxDB will run the
 `influxd_inspect -compact-series-file` command to [compact series files](/enterprise_influxdb/v1/tools/influx_inspect/#--compact-series-file-) before data nodes are started.
 Series files are stored in `_series` directories in the
 [`/data` directory](/enterprise_influxdb/v1/concepts/file-system-layout/#data-node-file-system-layout)
 (default is `/var/lib/data/<db-name>/_series`).
 
+- InfluxDB Enterprise v1.11.4+ introduces a configuration setting to optionally
+  compact series on startup.
 - If any series files are corrupt, the `influx_inspect` or `influxd` processes on
   the data node may fail to start. In both cases, delete the series file
   directories before restarting the database. InfluxDB will automatically

--- a/content/enterprise_influxdb/v1/about-the-project/release-notes.md
+++ b/content/enterprise_influxdb/v1/about-the-project/release-notes.md
@@ -9,8 +9,6 @@ menu:
     parent: About the project
 ---
 
-## v1.11.5 {date="2024-02-14"}
-
 {{% note %}}
 #### InfluxDB Enterprise and FIPS-compliance
 
@@ -21,13 +19,42 @@ InfluxDB Enterprise builds are available. For more information, see
 [FIPS-compliant InfluxDB Enterprise builds](/enterprise_influxdb/v1/introduction/installation/fips-compliant/).
 {{% /note %}}
 
+## v1.11.5 {date="2024-02-14"}
+
+{{% note %}}
+#### Upgrading from InfluxDB Enterprise v1.11.3
+
+If upgrading from InfluxDB Enterprise v1.11.3 to {{< latest-patch >}}, you can
+now configure whether or not InfluxDB compacts series files startup using the
+[`compact-series-file` configuration option](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#compact-series-file)
+in your [InfluxDB Enterprise data node configuration file](/enterprise_influxdb/v1/administration/configure/config-data-nodes/).
+{{% /note %}}
+
+### Bug Fixes
+
+- Prevent the retention service from creating orphaned shard files.
+- Fix LDAP authentication and authorization issues.
+
+### Other
+
+- Upgrade Flux to v0.194.5.
+
+---
+
+## v1.11.4 {date="2023-12-14"}
+
 {{% note %}}
 #### Series file compaction
 
 With InfluxDB Enterprise v1.11.4+, InfluxDB can be configured to optionally
-run the `influxd_inspect -compact-series-file` command to [compact series files](/enterprise_influxdb/v1/tools/influx_inspect/#--compact-series-file-) before data nodes are started.
-Series files are stored in `_series` directories inside the [InfluxDB data directory](/enterprise_influxdb/v1/concepts/file-system-layout/#data-node-file-system-layout).
+[compact series files](/enterprise_influxdb/v1/tools/influx_inspect/#--compact-series-file-)
+before data nodes are started.
+Series files are stored in `_series` directories inside the
+[InfluxDB data directory](/enterprise_influxdb/v1/concepts/file-system-layout/#data-node-file-system-layout).
 Default: `/var/lib/data/<db-name>/_series`.
+
+To compact series files on startup, set the [`compact-series-file` configuration option](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#compact-series-file)
+to `true` in your [InfluxDB Enterprise data node configuration file](/enterprise_influxdb/v1/administration/configure/config-data-nodes/).
 
 - If any series files are corrupt, the `influx_inspect` or `influxd` processes on
   the data node may fail to start. In both cases, delete the series file
@@ -42,22 +69,14 @@ Default: `/var/lib/data/<db-name>/_series`.
 
 ### Bug Fixes
 
-- Prevent the retention service from creating orphaned shard files.
-- Fix LDAP authentication and authorization issues.
-
-### Other
-
-- Upgrade Flux to v0.194.5.
-
-## v1.11.4 {date="2023-12-14"}
-
-### Bug Fixes
-
-- Adds the `compact-series-file` configuration setting to optionally execute series compaction during startup.
+- Adds the `compact-series-file` configuration setting to optionally execute
+  series compaction during startup.
 
 ### Other
 
 - Update InfluxDB to latest commit in 1.11
+
+---
 
 ## v1.11.3 {date="2023-10-12"}
 

--- a/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
@@ -82,6 +82,35 @@ How often to update the cluster with this node's internal status.
 
 Environment variable: `INFLUXDB_GOSSIP_FREQUENCY`
 
+#### compact-series-file
+
+Default is `false`.
+
+Determines if series files should be compacted on startup. If `true`, InfluxDB
+runs [`influxd_inspect -compact-series-file`](/enterprise_influxdb/v1/tools/influx_inspect/#--compact-series-file-)
+before starting the `influxd` server.
+
+{{% note %}}
+##### Series file compaction
+
+Series files are stored in `_series` directories inside the
+[InfluxDB data directory](/enterprise_influxdb/v1/concepts/file-system-layout/#data-node-file-system-layout).
+Default: `/var/lib/data/<db-name>/_series`.
+
+When compacting series files on startup:
+
+- If any series files are corrupt, the `influx_inspect` or `influxd` processes on
+  the data node may fail to start. In both cases, delete the series file
+  directories before restarting the database. InfluxDB automatically
+  regenerates the necessary series directories and files when restarting.
+- To check if series files are corrupt before starting the database, run the
+  [`influx_inspect verify-seriesfile` command](/enterprise_influxdb/v1/tools/influx_inspect/#verify-seriesfile)
+  while the database is off-line.
+- If series files are large (20+ gigabytes), it may be faster to delete the
+  series file directories before starting the database.
+{{% /note %}}
+
+
 -----
 
 ## Enterprise license settings

--- a/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
@@ -82,7 +82,7 @@ How often to update the cluster with this node's internal status.
 
 Environment variable: `INFLUXDB_GOSSIP_FREQUENCY`
 
-#### compact-series-file
+#### compact-series-file {metadata="v1.11.4+"}
 
 Default is `false`.
 

--- a/content/enterprise_influxdb/v1/tools/influx_inspect.md
+++ b/content/enterprise_influxdb/v1/tools/influx_inspect.md
@@ -69,7 +69,9 @@ Optional arguments are in brackets.
 
 The size of the batches written to the index. Default value is `10000`.
 
-{{% warn %}}**Warning:** Setting this value can have adverse effects on performance and heap size.{{% /warn %}}
+{{% warn %}}
+**Warning:** Setting this value can have adverse effects on performance and heap size.
+{{% /warn %}}
 
 ##### `[ -compact-series-file ]`
 
@@ -142,7 +144,10 @@ $ influx_inspect buildtsi -database stress -shard 1 -datadir ~/.influxdb/data -w
 Use `deletetsm -measurement` to delete a measurement in a raw TSM file (from specified shards).
 Use `deletetsm -sanitize` to remove all tag and field keys containing non-printable Unicode characters in a raw TSM file (from specified shards).
 
-{{% warn %}} **Warning:** Use the `deletetsm` command only when your InfluxDB instance is offline (`influxd` service is not running).{{% /warn %}}
+{{% warn %}}
+**Warning:** Use the `deletetsm` command only when your InfluxDB instance is
+offline (`influxd` service is not running).
+{{% /warn %}}
 
 #### Syntax
 

--- a/content/enterprise_influxdb/v1/troubleshooting/frequently-asked-questions.md
+++ b/content/enterprise_influxdb/v1/troubleshooting/frequently-asked-questions.md
@@ -701,7 +701,12 @@ Avoid using the same name for a tag and field key. If you inadvertently add the 
 
     Therefore, queries that reference `leaves_1` don't return values.
 
-{{% warn %}}**Warning:** If you inadvertently add a duplicate key name, follow the steps below to [remove a duplicate key](#remove-a-duplicate-key). Because of memory requirements, if you have large amounts of data, we recommend chunking your data (while selecting it) by a specified interval (for example, date range) to fit the allotted memory.
+{{% warn %}}
+**Warning:** If you inadvertently add a duplicate key name, follow the steps
+below to [remove a duplicate key](#remove-a-duplicate-key). Because of memory
+requirements, if you have large amounts of data, we recommend chunking your data
+(while selecting it) by a specified interval (for example, date range) to fit
+the allotted memory.
 {{% /warn %}}
 
 #### Remove a duplicate key

--- a/content/influxdb/v1/introduction/get-started.md
+++ b/content/influxdb/v1/introduction/get-started.md
@@ -187,8 +187,10 @@ time		                        	 external	  internal	 machine	type
 >
 ```
 
-> **Warning:** Using `*` without a `LIMIT` clause on a large database can cause performance issues.
+{{% warn %}}
+**Warning:** Using `*` without a `LIMIT` clause on a large database can cause performance issues.
 You can use `Ctrl+C` to cancel a query that is taking too long to respond.
+{{%/warn %}}
 
 InfluxQL has many [features and keywords](/influxdb/v1/query_language/spec/) that are not covered here,
 including support for Go-style regex. For example:

--- a/content/influxdb/v1/tools/influx_inspect.md
+++ b/content/influxdb/v1/tools/influx_inspect.md
@@ -69,7 +69,9 @@ Optional arguments are in brackets.
 
 The size of the batches written to the index. Default value is `10000`.
 
-{{% warn %}}**Warning:** Setting this value can have adverse effects on performance and heap size.{{% /warn %}}
+{{% warn %}}
+**Warning:** Setting this value can have adverse effects on performance and heap size.
+{{% /warn %}}
 
 ##### `[ -compact-series-file ]`
 
@@ -142,7 +144,10 @@ $ influx_inspect buildtsi -database stress -shard 1 -datadir ~/.influxdb/data -w
 Use `deletetsm -measurement` to delete a measurement in a raw TSM file (from specified shards).
 Use `deletetsm -sanitize` to remove all tag and field keys containing non-printable Unicode characters in a raw TSM file (from specified shards).
 
-{{% warn %}} **Warning:** Use the `deletetsm` command only when your InfluxDB instance is offline (`influxd` service is not running).{{% /warn %}}
+{{% warn %}}
+**Warning:** Use the `deletetsm` command only when your InfluxDB instance is
+offline (`influxd` service is not running).
+{{% /warn %}}
 
 #### Syntax
 

--- a/content/influxdb/v1/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1/troubleshooting/frequently-asked-questions.md
@@ -683,7 +683,12 @@ Avoid using the same name for a tag and field key. If you inadvertently add the 
 
     Therefore, queries that reference `leaves_1` don't return values.
 
-{{% warn %}}**Warning:** If you inadvertently add a duplicate key name, follow the steps below to [remove a duplicate key](#remove-a-duplicate-key). Because of memory requirements, if you have large amounts of data, we recommend chunking your data (while selecting it) by a specified interval (for example, date range) to fit the allotted memory.
+{{% warn %}}
+**Warning:** If you inadvertently add a duplicate key name, follow the steps
+below to [remove a duplicate key](#remove-a-duplicate-key). Because of memory
+requirements, if you have large amounts of data, we recommend chunking your data
+(while selecting it) by a specified interval (for example, date range) to fit
+the allotted memory.
 {{% /warn %}}
 
 #### Remove a duplicate key

--- a/data/products.yml
+++ b/data/products.yml
@@ -113,7 +113,7 @@ enterprise_influxdb:
     - v1.7
   latest: v1.11
   latest_patches:
-    v1: 1.11.3
+    v1: 1.11.5
 
 flux:
   name: Flux


### PR DESCRIPTION
Closes #5352

I decided to leave the warning about series file compaction in the 1.11.3 section and duplicated the content as a note (not a warning) in the 1.11.5 section. Not sure if it would be better to break out the series file compaction info into a separate page.

_Describe your proposed changes here._

- [x] Rebased/mergeable
