### PR TITLE
v2: move setup process instructions to get-started/setup page

### DIFF
--- a/content/influxdb/cloud/get-started/setup.md
+++ b/content/influxdb/cloud/get-started/setup.md
@@ -28,11 +28,11 @@ you need is in place.
     command line. For detailed installation and setup instructions,
     see [Use the influx CLI](/influxdb/cloud/tools/influx-cli/).
 
-2.  **Create an all-access API token.**
+2.  **Create an All-Access API token.**
     <span id="create-an-all-access-api-token"></span>
 
     Use the **InfluxDB UI**, **`influx` CLI**, or **InfluxDB API** to create an
-    all-access token.
+    All-Access token.
 
     {{< tabs-wrapper >}}
 {{% tabs %}}
@@ -59,7 +59,7 @@ you need is in place.
 
 1.  If you haven't already, [download, install, and configure the `influx` CLI](/influxdb/cloud/tools/influx-cli/).
 2.  Use the [`influx auth create` command](/influxdb/cloud/reference/cli/influx/auth/create/)
-    to create an all-access token.
+    to create an All-Access token.
     
     **Provide the following**:
 
@@ -107,7 +107,7 @@ Include the following with your request:
             _For information about what InfluxDB resource types exist, use the
             [`/api/v2/resources` endpoint](/influxdb/cloud/api/#operation/GetResources)._
 
-The following example uses cURL and the InfluxDB API to generate an all-access token:
+The following example uses cURL and the InfluxDB API to generate an All-Access token:
 
 {{% truncate %}}
 ```sh
@@ -205,7 +205,7 @@ sensitive tokens.
     which client you use to interact with InfluxDB.
 
     {{% note %}}
-When configuring your token, use the [all-access token you created](#create-an-all-access-api-token).
+When configuring your token, use the [All-Access token you created](#create-an-all-access-api-token).
     {{% /note %}}
 
     {{< tabs-wrapper >}}

--- a/content/influxdb/cloud/get-started/setup.md
+++ b/content/influxdb/cloud/get-started/setup.md
@@ -28,11 +28,11 @@ you need is in place.
     command line. For detailed installation and setup instructions,
     see [Use the influx CLI](/influxdb/cloud/tools/influx-cli/).
 
-2.  **Create an All Access API token.**
+2.  **Create an all-access API token.**
     <span id="create-an-all-access-api-token"></span>
 
     Use the **InfluxDB UI**, **`influx` CLI**, or **InfluxDB API** to create an
-    all access token.
+    all-access token.
 
     {{< tabs-wrapper >}}
 {{% tabs %}}
@@ -59,7 +59,7 @@ you need is in place.
 
 1.  If you haven't already, [download, install, and configure the `influx` CLI](/influxdb/cloud/tools/influx-cli/).
 2.  Use the [`influx auth create` command](/influxdb/cloud/reference/cli/influx/auth/create/)
-    to create an all access token.
+    to create an all-access token.
     
     **Provide the following**:
 
@@ -107,7 +107,7 @@ Include the following with your request:
             _For information about what InfluxDB resource types exist, use the
             [`/api/v2/resources` endpoint](/influxdb/cloud/api/#operation/GetResources)._
 
-The following example uses cURL and the InfluxDB API to generate an all access token:
+The following example uses cURL and the InfluxDB API to generate an all-access token:
 
 {{% truncate %}}
 ```sh
@@ -205,7 +205,7 @@ sensitive tokens.
     which client you use to interact with InfluxDB.
 
     {{% note %}}
-When configuring your token, use the [all access token you created](#create-an-all-access-api-token).
+When configuring your token, use the [all-access token you created](#create-an-all-access-api-token).
     {{% /note %}}
 
     {{< tabs-wrapper >}}

--- a/content/influxdb/cloud/tools/influxdb-templates/monitor-enterprise.md
+++ b/content/influxdb/cloud/tools/influxdb-templates/monitor-enterprise.md
@@ -111,7 +111,7 @@ On each InfluxDB Enterprise instance you want to monitor, do the following:
 3. Complete the Telegraf Setup instructions. If you are using environment variables, set them up now. 
 
       {{% note %}}
-For your API token, generate a new token or use an existing All Access token. If you run Telegraf as a service, edit your init script to set the environment variable and ensure its available to the service.
+For your API token, generate a new token or use an existing All-Access token. If you run Telegraf as a service, edit your init script to set the environment variable and ensure its available to the service.
       {{% /note %}}
 
 Telegraf runs quietly in the background (no immediate output appears), and Telegraf begins pushing metrics to your InfluxDB Cloud account.

--- a/content/influxdb/v2/admin/tokens/_index.md
+++ b/content/influxdb/v2/admin/tokens/_index.md
@@ -21,7 +21,7 @@ Learn how to create, view, update, or delete an API token.
 ## API token types
 
 - [Operator API token](#operator-token)
-- [All-Access API token](#all-access-token)
+- [All Access API token](#all-access-token)
 - [Read/Write token](#readwrite-token)
 
 #### Operator token
@@ -34,12 +34,12 @@ To create a new Operator token without using an existing one, see how to use the
 
 {{% note %}}
 Because Operator tokens have full read and write access to all organizations in the database,
-we recommend [creating an All-Access token](/influxdb/v2/admin/tokens/create-token/)
+we recommend [creating an All Access token](/influxdb/v2/admin/tokens/create-token/)
 for each organization and using those to manage InfluxDB.
 This helps to prevent accidental interactions across organizations.
 {{% /note %}}
 
-#### All-Access token
+#### All Access token
 Grants full read and write access to all resources in an organization.
 
 #### Read/Write token

--- a/content/influxdb/v2/admin/tokens/create-token.md
+++ b/content/influxdb/v2/admin/tokens/create-token.md
@@ -72,7 +72,7 @@ click **{{< icon "plus" >}} Generate** and select a token type
 
 {{% cloud-only %}}
 
-### Create an all-access token
+### Create an All Access token
 
 1. From the [API Tokens management page](#manage-tokens-in-the-influxdb-ui),
 click the **{{< icon "plus" >}} {{< caps >}}Generate API Token{{< /caps >}}** button.
@@ -115,9 +115,9 @@ influx auth create -o <org-name> [permission-flags]
 ```
 
 ### Examples
-#### Create an all-access token
+#### Create an All Access token
 
-Create an All-Access token to grant permissions to all resources in an organization.
+Create an All Access token to grant permissions to all resources in an organization.
 
 ```sh
 influx auth create \

--- a/content/influxdb/v2/api-guide/tutorials/nodejs.md
+++ b/content/influxdb/v2/api-guide/tutorials/nodejs.md
@@ -40,7 +40,7 @@ If you haven't already, [create an InfluxDB Cloud account](https://www.influxdat
 ### Authenticate with an InfluxDB API token
 
 For convenience in development,
-[create an _All-Access_ token](/influxdb/v2/admin/tokens/create-token/)
+[create an _All Access_ token](/influxdb/v2/admin/tokens/create-token/)
 for your application. This grants your application full read and write
 permissions on all resources within your InfluxDB organization.
 
@@ -157,7 +157,7 @@ create a `./.env.local` file and set the variables--for example, set your Influx
 
 # INFLUX_TOKEN
 # InfluxDB API token used by the application server to send requests to InfluxDB.
-# For convenience in development, use an **All-Access** token.
+# For convenience in development, use an **All Access** token.
 
 INFLUX_TOKEN=29Xx1KH9VkASPR2DSfRfFd82OwGD...
 

--- a/content/influxdb/v2/api-guide/tutorials/python.md
+++ b/content/influxdb/v2/api-guide/tutorials/python.md
@@ -44,7 +44,7 @@ If you haven't already, [create an InfluxDB Cloud account](https://www.influxdat
 ### Authenticate with an InfluxDB API token
 
 For convenience in development,
-[create an _All-Access_ token](/influxdb/v2/admin/tokens/create-token/)
+[create an _All Access_ token](/influxdb/v2/admin/tokens/create-token/)
 for your application. This grants your application full read and write
 permissions on all resources within your InfluxDB organization.
 

--- a/content/influxdb/v2/get-started/setup.md
+++ b/content/influxdb/v2/get-started/setup.md
@@ -34,7 +34,7 @@ you need is in place.
    After you [install and start InfluxDB](/influxdb/v2/install/), run the initial setup process to create the following:
 
    - An [organization](/influxdb/v2/admin/organizations/) with the name you provide.
-   - A primary [bucket](/influxdb/v2/admin/buckets/)with the name you provide.
+   - A [bucket](/influxdb/v2/admin/buckets/) with the name you provide.
    - An admin [authorization](/influxdb/v2/admin/tokens/) with the following properties:
      - The username and password that you provide.
      - An API [Operator token](/influxdb/v2/admin/tokens/#operator-token).

--- a/content/influxdb/v2/get-started/setup.md
+++ b/content/influxdb/v2/get-started/setup.md
@@ -23,57 +23,189 @@ related:
 As you get started with this tutorial, do the following to make sure everything
 you need is in place.
 
-1.  If you haven't already, [download, install, and set up InfluxDB {{< current-version >}}](/influxdb/v2/install/).
+- [Run the initial setup process](#run-initial-setup-process)
+- [Create an All-Access API token](#create-an-all-access-api-token)
+- [Configure authentication credentials](#configure-authentication-credentials)
+- [Create a bucket](#create-a-bucket)
 
-    Installation instructions depend on your operating system.
-    Be sure to go through the installation and initialization process fully.
+1. **Run the initial setup process**.
+   <span id="run-initial-setup-process"></span>
 
-2.  **Start InfluxDB**.
+   After you [install and start InfluxDB](/influxdb/v2/install/), run the initial setup process to create the following:
 
-    Run the `influxd` daemon to start the InfluxDB service, HTTP API, and 
-    user interface (UI).
+   - An [organization](/influxdb/v2/admin/organizations/) with the name you provide.
+   - A primary [bucket](/influxdb/v2/admin/buckets/)with the name you provide.
+   - An admin [authorization](/influxdb/v2/admin/tokens/) with the following properties:
+     - The username and password that you provide.
+     - An API [Operator token](/influxdb/v2/admin/tokens/#operator-token).
+     - Read-write permissions for all resources in the InfluxDB instance.
 
-    ```sh
-    influxd
-    ```
+   You can use the InfluxDB UI, the `influx` CLI, or the HTTP API to run the setup process.
 
-     {{% note %}}
-#### Configure InfluxDB
+   - To run an interactive setup that prompts you for the required information,
+   use the InfluxDB user interface (UI) or the `influx` command line interface (CLI).
 
-There are multiple ways to custom-configure InfluxDB.
-For information about what configuration options are available and how to set them,
-see [InfluxDB configuration options](/influxdb/v2/reference/config-options/).
+   - To automate the setup--for example, with a script that you write--
+   use the `influx` command line interface (CLI) or the `/api/v2/setup` InfluxDB API endpoint.
+
+   {{% note %}}
+   #### Automated setup with Docker
+
+   If you installed InfluxDB using [Docker with initial setup options](/influxdb/v2/install/?t=docker/#install-and-setup-influxdb-in-a-container), then you've already completed the setup process.
+
+   {{% /note %}}
+
+   {{< tabs-wrapper >}}
+{{% tabs %}}
+[Set up with the UI](#)
+[Set up with the CLI](#)
+[Set up with the API](#)
+{{% /tabs %}}
+
+<!------------------------------- BEGIN UI Setup ------------------------------>
+{{% tab-content %}}
+
+1. With InfluxDB running, visit [http://localhost:8086](http://localhost:8086).
+2. Click **Get Started**
+
+#### Set up your initial user
+
+1. Enter a **Username** for your initial user.
+2. Enter a **Password** and **Confirm Password** for your user.
+3. Enter your initial **Organization Name**.
+4. Enter your initial **Bucket Name**.
+5. Click **Continue**.
+6. Copy the provided **operator API token** and store it for safe keeping.
+
+    {{% note %}}
+We recommend using a password manager or a secret store to securely store
+sensitive tokens.
     {{% /note %}}
 
-    Once running, the InfluxDB UI is accessible at [localhost:8086](http://localhost:8086).
+Your InfluxDB instance is now initialized.
 
-3.  **Set up and initialize InfluxDB**.
+{{% /tab-content %}}
+<!-------------------------------- END UI Setup ------------------------------->
 
-    If starting InfluxDB for the first time, use the InfluxDB UI or the `influx`
-    CLI to initialize your InfluxDB instance.
-    This process creates a default user, organization, and bucket and provides
-    you with an [operator token](/influxdb/v2/admin/tokens/#operator-token)
-    for managing your InfluxDB instance.
+<!------------------------------ BEGIN CLI Setup ------------------------------>
+{{% tab-content %}}
 
-    For detailed instructions, see [Install InfluxDB – Set up InfluxDB](/influxdb/v2/install/#set-up-influxdb).
-
-4.  {{< req text="(Optional)" color="magenta" >}} **Download, install, and configure the `influx` CLI**.
-    
-    The `influx` CLI provides a simple way to interact with InfluxDB from a 
-    command line. For detailed installation and setup instructions,
+1.  Download and install the `influx` CLI, which provides a simple way to interact with InfluxDB from a
+    command line.
+    For detailed installation and setup instructions,
     see [Use the influx CLI](/influxdb/v2/tools/influx-cli/).
 
-5.  {{< req text="(Optional)" color="magenta" >}} **Create an All Access API token.**
+2.  Use the `influx setup` CLI command to initialize your InfluxDB instance--choose one of the following:
+
+    - **Set up with prompts**.
+      To setup interactively, enter the following command:
+
+      ```sh
+      influx setup
+      ```
+
+      The command walks you through the initial setup process by prompting for a username, password, organization, bucket, and retention period.
+
+    - **Set up non-interactively**.
+      To run setup non-interactively (for example, in your automation scripts), pass [command line flags](/influxdb/v2/reference/cli/influx/setup/#flags) for the initialization values, and pass the `-f, --force` flag to bypass the final confirmation prompt--for example, enter the following command:
+
+      <!--pytest.mark.skip-->
+
+      ```sh
+      influx setup \
+        --username USERNAME \
+        --password PASSWORD \
+        --token TOKEN \
+        --org ORG_NAME \
+        --bucket BUCKET_NAME \
+        --force
+      ```
+
+      Replace the following:
+
+      - `USERNAME`: A name for your initial admin [user](/influxdb/v2/admin/users/)
+      - `PASSWORD`: A password for your initial admin [user](/influxdb/v2/admin/users/)
+      - `TOKEN`: A string value to set for the [_operator_ token](/influxdb/v2/admin/tokens/#operator-token).
+        If you don't include this flag, InfluxDB generates a token for you and stores it in an
+      [`influx` CLI connection configuration](/influxdb/v2/tools/influx-cli/#provide-required-authentication-credentials).
+      - `ORG_NAME`: A name for your initial [organization](/influxdb/v2/admin/organizations/)
+      - `BUCKET_NAME`: A name for your initial [bucket](/influxdb/v2/admin/buckets/)
+
+    InfluxDB is initialized with an
+    [Operator token](/influxdb/v2/admin/tokens/),
+    [user](/influxdb/v2/reference/glossary/#user),
+    [organization](/influxdb/v2/reference/glossary/#organization),
+    and [bucket](/influxdb/v2/reference/glossary/#bucket).
+    The output is similar to the following:
+
+    <!--pytest-codeblocks:expected-output-->
+
+    ```sh
+    User        Organization         Bucket
+    USERNAME    ORGANIZATION_NAME    BUCKET_NAME
+    ```
+
+    InfluxDB stores these values in a `default` connection configuration that provides your
+    InfluxDB URL, organization, and API token to `influx` CLI commands.
+    For more detail about connection configurations, see [`influx config`](/influxdb/v2/reference/cli/influx/config/).
+
+{{% /tab-content %}}
+<!------------------------------- END CLI Setup -------------------------------->
+<!------------------------------BEGIN API SETUP-------------------------------->
+{{% tab-content %}}
+Send a request to the following HTTP API endpoint:
+
+{{< api-endpoint endpoint="http://localhost:8086/api/v2/setup" method="post" api-ref="/influxdb/v2/api/#operation/PostAuthorizations" >}}
+
+{{% warn %}}
+
+The `POST /api/v2/setup` API endpoint doesn't require authentication
+
+{{% /warn %}}
+
+In the request body, specify values for the initial username, password, organization, bucket, and an optional Operator token--for example:
+{{% code-placeholders "BUCKET_NAME|ORG_NAME|USERNAME|PASSWORD|TOKEN" %}}
+
+```sh
+curl http://localhost:8090/api/v2/setup \
+  --data '{
+            "username": "USERNAME",
+            "password": "PASSWORD",
+            "token": "TOKEN",
+            "bucket": "BUCKET_NAME",
+            "org": "ORG_NAME"
+        }'
+```
+
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`USERNAME`{{% /code-placeholder-key %}}: A name for your initial admin [user](/influxdb/v2/admin/users/)
+- {{% code-placeholder-key %}}`PASSWORD`{{% /code-placeholder-key %}}: A password for your initial admin [user](/influxdb/v2/admin/users/)
+- {{% code-placeholder-key %}}`ORG_NAME`{{% /code-placeholder-key %}}: A name for your initial [organization](/influxdb/v2/admin/organizations/)
+- {{% code-placeholder-key %}}`BUCKET_NAME`{{% /code-placeholder-key %}}: A name for your initial [bucket](/influxdb/v2/admin/buckets/)
+- {{% code-placeholder-key %}}`TOKEN`{{% /code-placeholder-key %}}: A string value to set for the [_operator_ token](/influxdb/v2/admin/tokens/#operator-token).
+      If you don't include this flag, InfluxDB generates a token for you.
+
+The response body contains the created resources, including the [Operator token](/influxdb/v2/admin/tokens/#operator-token) and its list of permissions.
+
+For more options and details, see the [`POST /api/v2/setup` API endpoint documentation](/influxdb/v2/api/#operation/PostSetup).
+
+{{% /tab-content%}}
+<!----------------------------------END API SETUP------------------------------>
+  {{< /tabs-wrapper >}}
+
+1.  {{< req text="Recommended:" color="magenta" >}} **Create an All-Access API token.**
     <span id="create-an-all-access-api-token"></span>
 
-    During the [InfluxDB initialization process](/influxdb/v2/install/#set-up-influxdb),
-    you created a user and API token that has permissions to manage everything in your InfluxDB instance.
-    This is known as an **Operator token**. While you can use your Operator token
-    to interact with InfluxDB, we recommend creating an **all access token** that
-    is scoped to an organization.
+    During the [InfluxDB initial set up process](/influxdb/v2/install/#set-up-influxdb), you created an admin user and [Operator token](/influxdb/v2/admin/tokens/#operator-token)
+    that have permissions to manage everything in your InfluxDB instance.
 
-    Use the **InfluxDB UI**, **`influx` CLI**, or **InfluxDB API** to create an
-    all access token.
+    While you can use your Operator token
+    to interact with InfluxDB, we recommend creating an [All-Access token](/influxdb/v2/admin/tokens/#all-access-token) that
+    is scoped to an organization, and then using this token to manage InfluxDB.
+    Use the **InfluxDB UI**, **`influx` CLI**, or **InfluxDB API** to create an All-Access token.
 
     {{< tabs-wrapper >}}
 {{% tabs %}}
@@ -102,10 +234,11 @@ see [InfluxDB configuration options](/influxdb/v2/reference/config-options/).
 <!---------------------------- BEGIN CLI CONTENT ----------------------------->
 
 1.  If you haven't already, [download, install, and configure the `influx` CLI](/influxdb/v2/tools/influx-cli/).
+
 2.  Use the [`influx auth create` command](/influxdb/v2/reference/cli/influx/auth/create/)
-    to create an all access token.
-    
-    **Provide the following**:
+    to create an All-Access token.
+
+    Provide the following:
 
     - `--all-access` flag
     - `--host` flag with your [InfluxDB host URL](/influxdb/v2/reference/urls/)
@@ -121,7 +254,7 @@ see [InfluxDB configuration options](/influxdb/v2/reference/config-options/).
       --token <YOUR_INFLUXDB_OPERATOR_TOKEN>
     ```
 
-3.  Copy the generated token and store it for safe keeping.
+3. Copy the generated token and store it for safe keeping.
 
 <!------------------------------ END CLI CONTENT ------------------------------>
 {{% /tab-content %}}
@@ -151,7 +284,7 @@ Include the following with your request:
             _For information about what InfluxDB resource types exist, use the
             [`/api/v2/resources` endpoint](/influxdb/v2/api/#operation/GetResources)._
 
-The following example uses cURL and the InfluxDB API to generate an all access token:
+The following example uses cURL and the InfluxDB API to generate an All-Access token:
 
 {{% truncate %}}
 ```sh
@@ -216,6 +349,7 @@ curl --request POST \
   }
 '
 ```
+
 {{% /truncate %}}
 
 The response body contains a JSON object with the following properties:
@@ -241,16 +375,16 @@ We recommend using a password manager or a secret store to securely store
 sensitive tokens.
     {{% /note %}}
 
-6. **Configure authentication credentials**. <span id="configure-authentication-credentials"></span>
+3. **Configure authentication credentials**. <span id="configure-authentication-credentials"></span>
 
     As you go through this tutorial, interactions with InfluxDB {{< current-version >}}
     require your InfluxDB **host**, **organization name or ID**, and your **API token**.
-    There are different methods for providing these credentials depending on
-    which client you use to interact with InfluxDB.
+    How you provide credentials depends on which client you use to interact with InfluxDB.
 
     {{% note %}}
-When configuring your token, if you [created an all access token](#create-an-all-access-api-token),
-use that token to interact with InfluxDB. Otherwise, use your operator token.
+When configuring your token, if you [created an All-Access token](#create-an-all-access-api-token),
+use that token to interact with InfluxDB.
+Otherwise, use the Operator token that you created during the setup process.
     {{% /note %}}
 
     {{< tabs-wrapper >}}
@@ -278,23 +412,35 @@ There are three ways to provided authentication credentials to the `influx` CLI:
 
 The `influx` CLI lets you specify connection configuration presets that let
 you store and quickly switch between multiple sets of InfluxDB connection
-credentials. Use the [`influx config create` command](/influxdb/v2/reference/cli/influx/config/create/)
-to create a new CLI connection configuration. Include the following flags:
+credentials. A connection configuration stores your credentials to avoid having to pass your InfluxDB
+API token with each `influx` command.
 
-  - `-n, --config-name`: Connection configuration name. This examples uses `get-started`.
-  - `-u, --host-url`: [InfluxDB host URL](/influxdb/v2/reference/urls/).
-  - `-o, --org`: InfluxDB organization name.
-  - `-t, --token`: InfluxDB API token.
+If you [set up InfluxDB](set-up-influxdb) using the CLI, it creates a default
+[connection configuration](/influxdb/v2/reference/cli/influx/config/) for you.
+
+Use the [`influx config create` command](/influxdb/v2/reference/cli/influx/config/create/)
+to manually create a new CLI connection configuration for the All-Access token you created in the preceding step. Include the following flags:
+
+{{% code-placeholders "API_TOKEN|ORG_NAME|http://localhost:8086|default|USERNAME|PASSWORD" %}}
 
 ```sh
 influx config create \
   --config-name get-started \
   --host-url http://localhost:8086 \
-  --org <YOUR_INFLUXDB_ORG_NAME> \
-  --token <YOUR_INFLUXDB_API_TOKEN>
+  --org ORG_NAME \
+  --token API_TOKEN
 ```
 
-_For more information about CLI connection configurations, see
+{{% /code-placeholders%}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`get-started`{{% /code-placeholder-key %}}: Connection configuration name. Examples in this tutorial use `get-started`.
+- {{% code-placeholder-key %}}`http://localhost:8086`{{% /code-placeholder-key %}}: [InfluxDB host URL](/influxdb/v2/reference/urls/).
+- {{% code-placeholder-key %}}`ORG`{{% /code-placeholder-key %}}: [your organization name](/influxdb/v2/admin/organizations/view-orgs/).
+- {{% code-placeholder-key %}}`API_TOKEN`{{% /code-placeholder-key %}}: [your API token](/influxdb/v2/admin/tokens/view-tokens/).
+
+_For more information about `influx` CLI connection configurations, see
 [Install and use the `influx` CLI](/influxdb/v2/tools/influx-cli/#set-up-the-influx-cli)._
 
 {{% /expand %}}
@@ -310,16 +456,26 @@ Set the following environment variables in your command line session:
 - `INFLUX_ORG_ID`: InfluxDB [organization ID](/influxdb/v2/admin/organizations/view-orgs/#view-your-organization-id).
 - `INFLUX_TOKEN`: InfluxDB API token.
 
+{{% code-placeholders "&lt;(ORG_NAME|ORG_ID|API_TOKEN)&gt;" %}}
+
 ```sh
 export INFLUX_HOST=http://localhost:8086
-export INFLUX_ORG=<YOUR_INFLUXDB_ORG_NAME>
-export INFLUX_ORG_ID=<YOUR_INFLUXDB_ORG_ID>
-export INFLUX_TOKEN=<YOUR_INFLUXDB_API_TOKEN>
+export INFLUX_ORG=<ORG_NAME>
+export INFLUX_ORG_ID=<ORG_ID>
+export INFLUX_TOKEN=<API_TOKEN>
 ```
+
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`<ORG_NAME>`{{% /code-placeholder-key %}}: The name of your [organization](/influxdb/v2/admin/organizations/)
+- {{% code-placeholder-key %}}`<ORG_ID>`{{% /code-placeholder-key %}}: Your [organization ID](/influxdb/v2/admin/organizations/view-orgs/#view-your-organization-id)
+- {{% code-placeholder-key %}}`<API_TOKEN>`{{% /code-placeholder-key %}}: Your [All-Access token](#create-an-all-access-api-token) or operator [token](/influxdb/v2/admin/tokens/)
 
 {{% /expand %}}
 
-{{% expand "Command flags" %}}
+{{% expand "Command line flags" %}}
 
 Use the following `influx` CLI flags to provide required credentials to commands:
 
@@ -347,9 +503,13 @@ When using the InfluxDB API, provide the required connection credentials in the
 following ways:
 
 - **InfluxDB host**: The domain and port to send HTTP(S) requests to.
-- **InfluxDB API Token**: Include an `Authorization` header that uses either 
-  `Bearer` or `Token` scheme and your InfluxDB API token. For example:  
-  `Authorization: Bearer 0xxx0o0XxXxx00Xxxx000xXXxoo0==`.
+- **InfluxDB API Token**: Include an `Authorization` header that uses either the
+  `Bearer` or `Token` scheme and your InfluxDB [API token](/influxdb/v2/admin/tokens/)--for example:
+
+  ```http
+  Authorization: Bearer 0xxx0o0XxXxx00Xxxx000xXXxoo0==
+  ```
+
 - **InfluxDB organization name or ID**: Depending on the API endpoint used, pass
   this as part of the URL path, query string, or in the request body.
 
@@ -357,20 +517,31 @@ All API examples in this tutorial use **cURL** from a command line.
 To provide all the necessary credentials to the example cURL commands, set
 the following environment variables in your command line session.
 
+{{% code-placeholders "&lt;(ORG_NAME|ORG_ID|API_TOKEN)&gt;" %}}
+
 ```sh
 export INFLUX_HOST=http://localhost:8086
-export INFLUX_ORG=<YOUR_INFLUXDB_ORG_NAME>
-export INFLUX_ORG_ID=<YOUR_INFLUXDB_ORG_ID>
-export INFLUX_TOKEN=<YOUR_INFLUXDB_API_TOKEN>
+export INFLUX_ORG=<ORG_NAME>
+export INFLUX_ORG_ID=<ORG_ID>
+export INFLUX_TOKEN=<API_TOKEN>
 ```
+
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`<ORG_NAME>`{{% /code-placeholder-key %}}: The name of your [organization](/influxdb/v2/admin/organizations/)
+- {{% code-placeholder-key %}}`<ORG_ID>`{{% /code-placeholder-key %}}: Your [organization ID](/influxdb/v2/admin/organizations/view-orgs/#view-your-organization-id)
+- {{% code-placeholder-key %}}`<API_TOKEN>`{{% /code-placeholder-key %}}: Your [All-Access token](#create-an-all-access-api-token) or Operator token
 <!------------------------------ END API CONTENT ------------------------------>
 {{% /tab-content %}}
-    {{< /tabs-wrapper >}} 
+    {{< /tabs-wrapper >}}
 
-7.  {{< req text="(Optional)" color="magenta" >}} **Create a bucket**.
+1.  {{< req text="Optional:" color="magenta" >}} **Create a bucket**.
+    <span id="create-a-bucket"></span>
 
-    In the InfluxDB initialization process, you created a bucket.
-    You can use that bucket or create a new one specifically for this getting
+    In the [initial setup process](#run-initial-setup-process), you created a bucket.
+    You can use that bucket or create one specifically for this getting
     started tutorial. All examples in this tutorial assume a bucket named
     _get-started_.
 
@@ -404,9 +575,8 @@ export INFLUX_TOKEN=<YOUR_INFLUXDB_API_TOKEN>
 <!---------------------------- BEGIN CLI CONTENT ----------------------------->
 
 1.  If you haven't already, [download, install, and configure the `influx` CLI](/influxdb/v2/tools/influx-cli/).
-2.  Use the [`influx bucket create` command](/influxdb/v2/reference/cli/influx/bucket/create/)
-    to create a new bucket.
-    
+2.  Use the [`influx bucket create` command](/influxdb/v2/reference/cli/influx/bucket/create/) to create a bucket.
+
     **Provide the following**:
 
     - `-n, --name` flag with the bucket name.
@@ -440,6 +610,8 @@ Include the following with your request:
     - **everySeconds**: Retention period duration in seconds.
       `0` indicates the retention period is infinite. 
 
+The following example shows how to use cURL and the InfluxDB API to create a bucket:
+
 ```sh
 export INFLUX_HOST=http://localhost:8086
 export INFLUX_ORG_ID=<YOUR_INFLUXDB_ORG_ID>
@@ -462,6 +634,6 @@ curl --request POST \
 ```
 <!------------------------------ END API CONTENT ------------------------------>
 {{% /tab-content %}}
-    {{< /tabs-wrapper >}} 
+    {{< /tabs-wrapper >}}
 
 {{< page-nav prev="/influxdb/v2/get-started/" next="/influxdb/v2/get-started/write/" keepTab=true >}}

--- a/content/influxdb/v2/get-started/setup.md
+++ b/content/influxdb/v2/get-started/setup.md
@@ -190,6 +190,11 @@ Replace the following:
 
 The response body contains the created resources, including the [Operator token](/influxdb/v2/admin/tokens/#operator-token) and its list of permissions.
 
+{{% note %}}
+We recommend using a password manager or a secret store to securely store
+sensitive tokens.
+{{% /note %}}
+
 For more options and details, see the [`POST /api/v2/setup` API endpoint documentation](/influxdb/v2/api/#operation/PostSetup).
 
 {{% /tab-content%}}

--- a/content/influxdb/v2/get-started/setup.md
+++ b/content/influxdb/v2/get-started/setup.md
@@ -420,7 +420,7 @@ you store and quickly switch between multiple sets of InfluxDB connection
 credentials. A connection configuration stores your credentials to avoid having to pass your InfluxDB
 API token with each `influx` command.
 
-If you [set up InfluxDB](set-up-influxdb) using the CLI, it creates a default
+If you [set up InfluxDB](#set-up-influxdb) using the CLI, it creates a default
 [connection configuration](/influxdb/v2/reference/cli/influx/config/) for you.
 
 Use the [`influx config create` command](/influxdb/v2/reference/cli/influx/config/create/)

--- a/content/influxdb/v2/get-started/setup.md
+++ b/content/influxdb/v2/get-started/setup.md
@@ -132,7 +132,7 @@ Your InfluxDB instance is now initialized.
       - `BUCKET_NAME`: A name for your initial [bucket](/influxdb/v2/admin/buckets/)
 
     InfluxDB is initialized with an
-    [Operator token](/influxdb/v2/admin/tokens/),
+    [Operator token](/influxdb/v2/admin/tokens/#operator-token),
     [user](/influxdb/v2/reference/glossary/#user),
     [organization](/influxdb/v2/reference/glossary/#organization),
     and [bucket](/influxdb/v2/reference/glossary/#bucket).

--- a/content/influxdb/v2/get-started/setup.md
+++ b/content/influxdb/v2/get-started/setup.md
@@ -24,7 +24,7 @@ As you get started with this tutorial, do the following to make sure everything
 you need is in place.
 
 - [Run the initial setup process](#run-initial-setup-process)
-- [Create an All-Access API token](#create-an-all-access-api-token)
+- [Create an All Access API token](#create-an-all-access-api-token)
 - [Configure authentication credentials](#configure-authentication-credentials)
 - [Create a bucket](#create-a-bucket)
 
@@ -201,16 +201,16 @@ For more options and details, see the [`POST /api/v2/setup` API endpoint documen
 <!----------------------------------END API SETUP------------------------------>
   {{< /tabs-wrapper >}}
 
-1.  {{< req text="Recommended:" color="magenta" >}} **Create an All-Access API token.**
+1.  {{< req text="Recommended:" color="magenta" >}} **Create an All Access API token.**
     <span id="create-an-all-access-api-token"></span>
 
     During the [InfluxDB initial set up process](/influxdb/v2/install/#set-up-influxdb), you created an admin user and [Operator token](/influxdb/v2/admin/tokens/#operator-token)
     that have permissions to manage everything in your InfluxDB instance.
 
     While you can use your Operator token
-    to interact with InfluxDB, we recommend creating an [All-Access token](/influxdb/v2/admin/tokens/#all-access-token) that
+    to interact with InfluxDB, we recommend creating an [All Access token](/influxdb/v2/admin/tokens/#all-access-token) that
     is scoped to an organization, and then using this token to manage InfluxDB.
-    Use the **InfluxDB UI**, **`influx` CLI**, or **InfluxDB API** to create an All-Access token.
+    Use the **InfluxDB UI**, **`influx` CLI**, or **InfluxDB API** to create an All Access token.
 
     {{< tabs-wrapper >}}
 {{% tabs %}}
@@ -241,7 +241,7 @@ For more options and details, see the [`POST /api/v2/setup` API endpoint documen
 1.  If you haven't already, [download, install, and configure the `influx` CLI](/influxdb/v2/tools/influx-cli/).
 
 2.  Use the [`influx auth create` command](/influxdb/v2/reference/cli/influx/auth/create/)
-    to create an All-Access token.
+    to create an All Access token.
 
     Provide the following:
 
@@ -289,7 +289,7 @@ Include the following with your request:
             _For information about what InfluxDB resource types exist, use the
             [`/api/v2/resources` endpoint](/influxdb/v2/api/#operation/GetResources)._
 
-The following example uses cURL and the InfluxDB API to generate an All-Access token:
+The following example uses cURL and the InfluxDB API to generate an All Access token:
 
 {{% truncate %}}
 ```sh
@@ -387,7 +387,7 @@ sensitive tokens.
     How you provide credentials depends on which client you use to interact with InfluxDB.
 
     {{% note %}}
-When configuring your token, if you [created an All-Access token](#create-an-all-access-api-token),
+When configuring your token, if you [created an All Access token](#create-an-all-access-api-token),
 use that token to interact with InfluxDB.
 Otherwise, use the Operator token that you created during the setup process.
     {{% /note %}}
@@ -424,7 +424,7 @@ If you [set up InfluxDB](#set-up-influxdb) using the CLI, it creates a default
 [connection configuration](/influxdb/v2/reference/cli/influx/config/) for you.
 
 Use the [`influx config create` command](/influxdb/v2/reference/cli/influx/config/create/)
-to manually create a new CLI connection configuration for the All-Access token you created in the preceding step. Include the following flags:
+to manually create a new CLI connection configuration for the All Access token you created in the preceding step. Include the following flags:
 
 {{% code-placeholders "API_TOKEN|ORG_NAME|http://localhost:8086|default|USERNAME|PASSWORD" %}}
 
@@ -476,7 +476,7 @@ Replace the following:
 
 - {{% code-placeholder-key %}}`<ORG_NAME>`{{% /code-placeholder-key %}}: The name of your [organization](/influxdb/v2/admin/organizations/)
 - {{% code-placeholder-key %}}`<ORG_ID>`{{% /code-placeholder-key %}}: Your [organization ID](/influxdb/v2/admin/organizations/view-orgs/#view-your-organization-id)
-- {{% code-placeholder-key %}}`<API_TOKEN>`{{% /code-placeholder-key %}}: Your [All-Access token](#create-an-all-access-api-token) or operator [token](/influxdb/v2/admin/tokens/)
+- {{% code-placeholder-key %}}`<API_TOKEN>`{{% /code-placeholder-key %}}: Your [All Access token](#create-an-all-access-api-token) or operator [token](/influxdb/v2/admin/tokens/)
 
 {{% /expand %}}
 
@@ -537,7 +537,7 @@ Replace the following:
 
 - {{% code-placeholder-key %}}`<ORG_NAME>`{{% /code-placeholder-key %}}: The name of your [organization](/influxdb/v2/admin/organizations/)
 - {{% code-placeholder-key %}}`<ORG_ID>`{{% /code-placeholder-key %}}: Your [organization ID](/influxdb/v2/admin/organizations/view-orgs/#view-your-organization-id)
-- {{% code-placeholder-key %}}`<API_TOKEN>`{{% /code-placeholder-key %}}: Your [All-Access token](#create-an-all-access-api-token) or Operator token
+- {{% code-placeholder-key %}}`<API_TOKEN>`{{% /code-placeholder-key %}}: Your [All Access token](#create-an-all-access-api-token) or Operator token
 <!------------------------------ END API CONTENT ------------------------------>
 {{% /tab-content %}}
     {{< /tabs-wrapper >}}

--- a/content/influxdb/v2/get-started/setup.md
+++ b/content/influxdb/v2/get-started/setup.md
@@ -464,7 +464,7 @@ Set the following environment variables in your command line session:
 {{% code-placeholders "&lt;(ORG_NAME|ORG_ID|API_TOKEN)&gt;" %}}
 
 ```sh
-export INFLUX_HOST=http://localhost:8086
+export INFLUX_HOST={{< influxdb/host >}}
 export INFLUX_ORG=<ORG_NAME>
 export INFLUX_ORG_ID=<ORG_ID>
 export INFLUX_TOKEN=<API_TOKEN>

--- a/content/influxdb/v2/get-started/setup.md
+++ b/content/influxdb/v2/get-started/setup.md
@@ -65,7 +65,7 @@ you need is in place.
 <!------------------------------- BEGIN UI Setup ------------------------------>
 {{% tab-content %}}
 
-1. With InfluxDB running, visit [http://localhost:8086](http://localhost:8086).
+1. With InfluxDB running, visit <http://localhost:8086>.
 2. Click **Get Started**
 
 #### Set up your initial user

--- a/content/influxdb/v2/get-started/setup.md
+++ b/content/influxdb/v2/get-started/setup.md
@@ -147,7 +147,7 @@ Your InfluxDB instance is now initialized.
 
     InfluxDB stores these values in a `default` connection configuration that provides your
     InfluxDB URL, organization, and API token to `influx` CLI commands.
-    For more detail about connection configurations, see [`influx config`](/influxdb/v2/reference/cli/influx/config/).
+    For information about connection configurations, see [`influx config`](/influxdb/v2/reference/cli/influx/config/).
 
 {{% /tab-content %}}
 <!------------------------------- END CLI Setup -------------------------------->

--- a/content/influxdb/v2/install/_index.md
+++ b/content/influxdb/v2/install/_index.md
@@ -782,7 +782,7 @@ To start InfluxDB using Kubernetes, follow instructions to [install InfluxDB in 
 {{% /tab-content %}}
    {{< /tabs-wrapper >}}
 
-   If successful, you can view the InfluxDB UI at [http://localhost:8086](http://localhost:8086).
+   If successful, you can view the InfluxDB UI at <http://localhost:8086>.
 
    InfluxDB starts with default settings, including the following:
 

--- a/content/influxdb/v2/install/_index.md
+++ b/content/influxdb/v2/install/_index.md
@@ -15,15 +15,13 @@ The InfluxDB v2 time series platform is purpose-built to collect, store,
 process and visualize metrics and events.
 
 - [Download and install InfluxDB v2](#download-and-install-influxdb-v2)
-- [Configure and start InfluxDB](#configure-and-start-influxdb)
-- [Download and install the influx CLI](#download-and-install-the-influx-cli)
-- [Set up InfluxDB](#set-up-influxdb)
-- [Optional: Configure and use the influx CLI](#optional-configure-and-use-the-influx-cli)
-- [Optional: Create All-Access tokens](#optional-create-all-access-tokens)
+- [Start InfluxDB](#start-influxdb)
+- [Download, install, and configure the `influx` CLI](#download-install-and-configure-influx-cli)
 
-## Download and install InfluxDB v2
+1. **Download and install InfluxDB v2**.
+   <span id="download-and-install-influxdb-v2"></span>
 
-{{< tabs-wrapper >}}
+   {{< tabs-wrapper >}}
 {{% tabs %}}
 [macOS](#)
 [Linux](#)
@@ -190,7 +188,6 @@ or rename them before putting them in your `$PATH`.
 If you rename the binaries, all references to `influxd` and `influx` in this documentation refer to your renamed binaries.
 {{% /note %}}
 
-
 {{% /tab-content %}}
 <!--------------------------------- END macOS --------------------------------->
 <!-------------------------------- BEGIN Linux -------------------------------->
@@ -275,7 +272,7 @@ see [File system layout](/influxdb/v2/reference/internals/file-system-layout/?t=
 
 You can use systemd to customize [InfluxDB configuration options](/influxdb/v2/reference/config-options/#configuration-options) and pass them to the InfluxDB service.
 
-1.  Edit the `/etc/default/influxdb2` service configuration file to assign configuration directives to `influxd` command line flags--for example, add one or more `<ENV_VARIABLE_NAME>=<COMMAND_LINE_FLAG>` lines like the following:
+1. Edit the `/etc/default/influxdb2` service configuration file to assign configuration directives to `influxd` command line flags--for example, add one or more `<ENV_VARIABLE_NAME>=<COMMAND_LINE_FLAG>` lines like the following:
 
    <!--pytest.mark.skip-->
 
@@ -409,8 +406,6 @@ To install `gpg`, see the [GnuPG installation instructions](https://gnupg.org/do
 {{% /expand %}}
 {{< /expand-wrapper >}}
 
-
-
 {{% /tab-content %}}
 <!--------------------------------- END Linux --------------------------------->
 
@@ -476,12 +471,12 @@ $acl | Set-Acl "C:\Users\<username>\.influxdbv2"
 <!-------------------------------- BEGIN Docker ------------------------------->
 {{% tab-content %}}
 
-### Install and setup InfluxDB in a container
+### Install and set up InfluxDB in a container
 
 The following guide uses [Docker CLI commands](https://docs.docker.com/reference/cli/docker/) to set Docker and InfluxDB options, but you can also use Dockerfiles and Docker Compose.
 
-1. Follow instructions to install Docker for your system.
-2. Create a Docker container from the [`influxdb` Dockerhub image](https://hub.docker.com/_/influxdb)--for example, in your terminal, enter the `docker run influxdb:{{< latest-patch >}}` command with command line flags for initial setup options and file system mounts.
+1. Follow instructions to install [Docker Desktop](https://www.docker.com/get-started/) for your system.
+2. Start a Docker container from the [`influxdb` Docker Hub image](https://hub.docker.com/_/influxdb)--for example, in your terminal, enter the `docker run influxdb:2` command with command line flags for initial setup options and file system mounts.
 
    The following example uses the Docker `--mount` option to persist InfluxDB configuration and data to [volumes](https://docs.docker.com/storage/volumes/).
    _Persisting your data to a file system outside the container ensures that your data isn't deleted if you delete the container._
@@ -499,37 +494,37 @@ The following guide uses [Docker CLI commands](https://docs.docker.com/reference
     --env DOCKER_INFLUXDB_INIT_PASSWORD=<PASSWORD> \
     --env DOCKER_INFLUXDB_INIT_ORG=<ORG_NAME> \
     --env DOCKER_INFLUXDB_INIT_BUCKET=<BUCKET_NAME> \
-    influxdb:{{< latest-patch >}}
+    influxdb:2
    ```
 
    The command passes the following arguments:
 
-   - `--publish 8086:8086`: Exposes the container port `8086` for the InfluxDB [UI](/influxdb/v2/get-started/#influxdb-user-interface-ui) and [HTTP API](/influxdb/v2/reference/api/) on the host port `8086`.
-   - `--mount type=volume,source=influxdb2-data,target=/var/lib/influxdb2`: Creates a volume named `influxdb2-data` mapped to the [InfluxDB Dockerhub data directory](/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) to persist data outside the container.
-   - `--mount type=volume,source=influxdb2-config,target=/etc/influxdb2`: Creates a volume named `influxdb2-config` mapped to the [InfluxDB Dockerhub configuration directory](/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) to make configurations available outside the container.
-   - `--env DOCKER_INFLUXDB_INIT_MODE=setup`: Environment variable that invokes the automated setup for the initial organization, user, bucket, and token when creating the container.
-   - `--env DOCKER_INFLUXDB_INIT_<SETUP_OPTION>`: Environment variables for initial setup options--replace the following with your own values:
-     - `<USERNAME>`: The username for the initial [user](/influxdb/v2/admin/users/).
+   - `--publish 8086:8086`: Exposes the InfluxDB [UI](/influxdb/v2/get-started/#influxdb-user-interface-ui) and [HTTP API](/influxdb/v2/reference/api/) on the host's `8086` port.
+   - `--mount type=volume,source=influxdb2-data,target=/var/lib/influxdb2`: Creates a volume named `influxdb2-data` mapped to the [InfluxDB data directory](/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) to persist data outside the container.
+   - `--mount type=volume,source=influxdb2-config,target=/etc/influxdb2`: Creates a volume named `influxdb2-config` mapped to the [InfluxDB configuration directory](/influxdb/v2/reference/internals/file-system-layout/?t=docker#file-system-layout) to make configurations available outside the container.
+   - `-e DOCKER_INFLUXDB_INIT_MODE=setup`: Environment variable that invokes the automated setup of the initial organization, user, bucket, and token when creating the container.
+   - `-e DOCKER_INFLUXDB_INIT_<SETUP_OPTION>`: Environment variables for initial setup options--replace the following with your own values:
+     - `<USERNAME>`: The username for the initial [user](/influxdb/v2/admin/users/)--an admin user with an API [Operator token](/influxdb/v2/admin/tokens/#operator-token).
      - `<PASSWORD>`: The password for the initial [user](/influxdb/v2/admin/users/).
      - `<ORG_NAME>`: The name for the initial [organization](/influxdb/v2/admin/organizations/).
      - `<BUCKET_NAME>`: The name for the initial [bucket](/influxdb/v2/admin/buckets/).
 
-    For more options, see the [`influxdb` Dockerhub image](https://hub.docker.com/_/influxdb) documentation.
-    _If you don't specify InfluxDB initial setup options, you can [setup manually](#set-up-influxdb) later using the UI or CLI in a running container._
+    For more options, see the [`influxdb` Docker Hub image](https://hub.docker.com/_/influxdb) documentation.
+    _If you don't specify InfluxDB initial setup options, you can [set up manually](#set-up-influxdb) later using the UI or CLI in a running container._
 
 If successful, the command starts InfluxDB initialized with the user, organization, bucket,
-and _[operator token](/influxdb/v2/admin/tokens/#operator-token)_, and logs to stdout.
-You can view the operator token in the `/etc/influxdb2/influx-configs` file and use it to authorize [creating an All-Access token](#optional-create-all-access-tokens).
+and _[Operator token](/influxdb/v2/admin/tokens/#operator-token)_, and logs to stdout.
+You can view the Operator token in the `/etc/influxdb2/influx-configs` file and use it to authorize [creating an All-Access token](#optional-create-all-access-tokens).
 
 _To run the InfluxDB container in [detached mode](https://docs.docker.com/engine/reference/run/#detached-vs-foreground),
  include the `--detach` flag in the `docker run` command._
 
 ### Run InfluxDB CLI commands in a container
 
-When you start a container using the `influxdb` Dockerhub image, it also installs the [`influx` CLI](https://docs.influxdata.com/influxdb/v2/tools/influx-cli/) in the container.
+When you start a container using the `influxdb` Docker Hub image, it also installs the [`influx` CLI](/influxdb/v2/tools/influx-cli/) in the container.
 With InfluxDB setup and running in the container, you can use the Docker CLI [`docker exec`](https://docs.docker.com/reference/cli/docker/container/exec/) command to interact with the `influx` and `influxd` CLIs inside the container.
 
-To use the `influx` CLI in the container, run `docker exec -it <CONTAINER_NAME> <INFLUX_CLI_COMMAND>`--for example:
+To use the `influx` CLI in the container, run `docker exec -it <CONTAINER_NAME> influx <COMMAND>`--for example:
 
 <!--pytest.mark.skip-->
 
@@ -655,59 +650,12 @@ to collect and send data to:
 <!--------------------------------- END Raspberry Pi --------------------------->
 {{< /tabs-wrapper >}}
 
-## Configure and start InfluxDB
+2. **Start InfluxDB**.
+<span id="start-influxdb"></span>
 
-- [Optional: Customize InfluxDB server configuration](#optional-customize-influxdb-server-configuration)
-- [Start InfluxDB](#start-influxdb)
+   If it isn't already running, follow the instructions to start InfluxDB on your system:
 
-### Optional: Customize InfluxDB server configuration
-
-To customize your InfluxDB server configuration, specify [configuration options](/influxdb/v2/reference/config-options/) in command line arguments, environment variables, or a configuration file.
-
-#### InfluxDB telemetry reporting
-
-By default, InfluxDB sends telemetry data back to InfluxData.
-The [InfluxData telemetry](https://www.influxdata.com/telemetry) page provides
-information about what data is collected and how it is used.
-
-To opt-out of sending telemetry data back to InfluxData, include the
-`--reporting-disabled` flag when starting `influxd`--for example:
-
-{{< code-tabs-wrapper >}}
-{{% code-tabs %}}
-[Linux](#)
-[Windows Powershell](#)
-{{% /code-tabs %}}
-{{% code-tab-content %}}
-
-<!--pytest.mark.skip-->
-
-```sh
-influxd --reporting-disabled
-```
-
-{{% /code-tab-content %}}
-{{% code-tab-content %}}
-
-<!--pytest.mark.skip-->
-
-```powershell
-./influxd --reporting-disabled
-```
-
-{{% /code-tab-content %}}
-{{< /code-tabs-wrapper >}}
-
-#### Networking ports
-
-By default, InfluxDB uses TCP port `8086` for  client-server communication through the [UI](/influxdb/v2/get-started/#influxdb-user-interface-ui) and the [HTTP API](/influxdb/v2/reference/api/).
-To specify a different port or address, use the [`http-bind-address` option](/influxdb/v2/reference/config-options/#http-bind-address).
-
-### Start InfluxDB
-
-If it isn't already running, follow the instructions to start InfluxDB on your system:
-
-{{< tabs-wrapper >}}
+   {{< tabs-wrapper >}}
 {{% tabs %}}
 [macOS](#)
 [Linux](#)
@@ -832,217 +780,105 @@ To start a new container, follow instructions to [install and set up InfluxDB in
 To start InfluxDB using Kubernetes, follow instructions to [install InfluxDB in a Kubernetes cluster](?t=kubernetes#download-and-install-influxdb-v2).
 
 {{% /tab-content %}}
-{{< /tabs-wrapper >}}
+   {{< /tabs-wrapper >}}
 
-## Download and install the influx CLI
+   If successful, you can view the InfluxDB UI at [http://localhost:8086](http://localhost:8086).
 
-The [`influx` CLI](/influxdb/v2/reference/cli/influx/) lets you manage InfluxDB
-from your command line.
+   InfluxDB starts with default settings, including the following:
 
-### InfluxDB and the influx CLI are separate packages
+   - `http-bind-address=:8086`: Uses port `8086` (TCP) for InfluxDB UI and HTTP API client-server communication.
+   - `reporting-disabled=false`: Sends InfluxDB telemetry information back to InfluxData.
+
+   To override default settings, specify [configuration options](/influxdb/v2/reference/config-options) when starting InfluxDB--for example:
+
+   {{< expand-wrapper >}}
+{{% expand "Configure the port or address" %}}
+By default, the InfluxDB UI and HTTP API use port `8086`.
+
+To specify a different port or address, override the [`http-bind-address` option](/influxdb/v2/reference/config-options/#http-bind-address) when starting `influxd`--for example:
+
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[Linux](#)
+[Windows Powershell](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+
+<!--pytest.mark.skip-->
+
+```sh
+influxd --http-bind-address
+```
+
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+
+<!--pytest.mark.skip-->
+
+```powershell
+./influxd --http-bind-address
+```
+
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+{{% /expand %}}
+
+{{% expand "Opt-out of telemetry reporting" %}}
+
+By default, InfluxDB sends telemetry data back to InfluxData.
+The [InfluxData telemetry](https://www.influxdata.com/telemetry) page provides
+information about what data is collected and how it is used.
+
+To opt-out of sending telemetry data back to InfluxData, specify the
+[`reporting-disabled` option](/influxdb/v2/reference/config-options/#reporting-disabled) when starting `influxd`--for example:
+
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[Linux](#)
+[Windows Powershell](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+
+<!--pytest.mark.skip-->
+
+```sh
+influxd --reporting-disabled
+```
+
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+
+<!--pytest.mark.skip-->
+
+```powershell
+./influxd --reporting-disabled
+```
+
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+{{% /expand %}}
+   {{< /expand-wrapper >}}
+
+   For information about InfluxDB v2 default settings and how to override them,
+   see [InfluxDB configuration options](/influxdb/v2/reference/config-options/).
+
+3. {{< req text="Recommended:" color="magenta" >}} **Download, install, and configure the `influx` CLI**.
+   <span id="download-install-and-configure-influx-cli"></span>
+
+   We recommend installing the `influx` CLI, which provides a simple way to interact with InfluxDB from a
+   command line.
+   For detailed installation and setup instructions,
+   see [Use the influx CLI](/influxdb/v2/tools/influx-cli/).
+
+   {{% note %}}
+
+#### InfluxDB and the influx CLI are separate packages
 
 The InfluxDB server ([`influxd`](/influxdb/v2/reference/cli/influxd/)) and the
 [`influx` CLI](/influxdb/v2/reference/cli/influx/) are packaged and
 versioned separately.
-Some install methods (for example, the InfluxDB Dockerhub image) include both.
+Some install methods (for example, the InfluxDB Docker Hub image) include both.
 
-For more information about `influx` CLI for your system, see how to [install and use the influx CLI](/influxdb/v2/tools/influx-cli/).
+   {{% /note %}}
 
-<a class="btn" href="/influxdb/v2/tools/influx-cli/" target="_blank">Download and install the influx CLI</a>
-
-## Set up InfluxDB
-
-The initial setup process for an InfluxDB instance creates the following:
-
-- An organization with the name you provide.
-- A primary bucket with the name you provide.
-- An admin [authorization](/influxdb/v2/admin/tokens/) with the following properties:
-  - The username and password that you provide.
-  - An API token (_[operator token](/influxdb/v2/admin/tokens/#operator-token)_).
-  - Read-write permissions for all resources in the InfluxDB instance.
-
-{{% note %}}
-
-If you installed InfluxDB using [Docker with initial setup options](?t=docker/#install-and-setup-influxdb-in-a-container), then you've already completed the setup process.
-
-{{% /note %}}
-
-To run an interactive setup that prompts you for the required information,
-use the InfluxDB user interface (UI) or the `influx` command line interface (CLI).
-
-To automate the setup--for example, with a script that you write--
-use the `influx` command line interface (CLI) or the InfluxDB `/api/v2` API.
-
-{{< tabs-wrapper >}}
-{{% tabs %}}
-[Set up with the UI](#)
-[Set up with the CLI](#)
-{{% /tabs %}}
-
-<!------------------------------- BEGIN UI Setup ------------------------------>
-{{% tab-content %}}
-
-1. With InfluxDB running, visit [http://localhost:8086](http://localhost:8086).
-2. Click **Get Started**
-
-#### Set up your initial user
-
-1. Enter a **Username** for your initial user.
-2. Enter a **Password** and **Confirm Password** for your user.
-3. Enter your initial **Organization Name**.
-4. Enter your initial **Bucket Name**.
-5. Click **Continue**.
-6. Copy the provided **operator API token** and store it for safe keeping.
-
-    {{% note %}}
-We recommend using a password manager or a secret store to securely store
-sensitive tokens.
-    {{% /note %}}
-
-Your InfluxDB instance is now initialized.
-
-{{% /tab-content %}}
-<!-------------------------------- END UI Setup ------------------------------->
-
-<!------------------------------ BEGIN CLI Setup ------------------------------>
-{{% tab-content %}}
-
-Use the `influx setup` CLI command in interactive or non-interactive (_headless_) mode to initialize
-your InfluxDB instance.
-
-Do one of the following:
-
-- [Run `influx setup` without user interaction](#run-influx-setup-without-user-interaction)
-- [Run `influx setup` with user prompts](#run-influx-setup-with-user-prompts)
-
-#### Run `influx setup` without user interaction
-
-To run the InfluxDB setup process with your automation scripts, pass [flags](/influxdb/v2/reference/cli/influx/setup/#flags)
-with the required information to the `influx setup` command.
-Pass the `-f, --force` flag to bypass screen prompts.
-
-The following example command shows how to set up InfluxDB in non-interactive
-mode with an initial admin user,
-[operator token](/influxdb/v2/admin/tokens/#operator-token),
-and bucket:
-
-<!--pytest.mark.skip-->
-
-```sh
-influx setup \
-  --username USERNAME \
-  --password PASSWORD \
-  --token TOKEN \
-  --org ORGANIZATION_NAME \
-  --bucket BUCKET_NAME \
-  --force
-```
-
-The command outputs the following:
-
-<!--pytest-codeblocks:expected-output-->
-
-```sh
-User        Organization         Bucket
-USERNAME    ORGANIZATION_NAME    BUCKET_NAME
-```
-
-{{% note %}}
-If you run `influx setup` without the `-t, --token` flag, InfluxDB
-automatically generates an operator API token and stores it in an
-[`influx` CLI connection configuration](/influxdb/v2/tools/influx-cli/#provide-required-authentication-credentials).
-{{% /note %}}
-
-Once setup completes, InfluxDB is initialized with an
-[operator token](/influxdb/v2/admin/tokens/),
-[user](/influxdb/v2/reference/glossary/#user),
-[organization](/influxdb/v2/reference/glossary/#organization),
-and [bucket](/influxdb/v2/reference/glossary/#bucket).
-
-InfluxDB creates a `default` configuration profile for you that provides your
-InfluxDB URL, organization, and API token to `influx` CLI commands.
-For more detail about configuration profiles, see [`influx config`](/influxdb/v2/reference/cli/influx/config/).
-
-Once you have the `default` configuration profile, you're ready to [create All-Access tokens](#create-all-access-tokens)
-or get started [collecting and writing data](/influxdb/v2/write-data).
-
-#### Run `influx setup` with user prompts
-
-To run setup with prompts for the required information, enter the following
-command in your terminal:
-
-<!--pytest.mark.skip-->
-
-```sh
-influx setup
-```
-
-Complete the following steps as prompted by the CLI:
-
-1. Enter a **primary username**.
-2. Enter a **password** for your user.
-3. **Confirm your password** by entering it again.
-4. Enter a name for your **primary organization**.
-5. Enter a name for your **primary bucket**.
-6. Enter a **retention period** for your primary bucket—valid units are
-   nanoseconds (`ns`), microseconds (`us` or `µs`), milliseconds (`ms`),
-   seconds (`s`), minutes (`m`), hours (`h`), days (`d`), and weeks (`w`).
-   Enter nothing for an infinite retention period.
-7. Confirm the details for your primary user, organization, and bucket.
-
-Once setup completes, InfluxDB is initialized with the user, organization, bucket,
-and _[operator token](/influxdb/v2/admin/tokens/#operator-token)_.
-
-InfluxDB creates a `default` configuration profile for you that provides your
-InfluxDB URL, organization, and API token to `influx` CLI commands.
-For more detail about configuration profiles, see [`influx config`](/influxdb/v2/reference/cli/influx/config/).
-
-Once you have the `default` configuration profile, you're ready to [create All-Access tokens](#optional-create-all-access-tokens)
-or get started [collecting and writing data](/influxdb/v2/write-data).
-
-{{% /tab-content %}}
-<!------------------------------- END CLI Setup -------------------------------->
-{{< /tabs-wrapper >}}
-
-## Optional: Configure and use the influx CLI
-
-If you [set up InfluxDB](set-up-influxdb) using the CLI, it creates a default [configuration profile](/influxdb/v2/reference/cli/influx/config/) for you.
-A configuration profile stores your credentials to avoid having to pass your InfluxDB
-API token with each `influx` command.
-
-To manually create a configuration profile use the [`influx config`](/influxdb/v2/reference/cli/influx/config/) CLI command--for example,
-enter the following code in your terminal:
-
-<!--pytest.mark.xfail-->
-
-{{% code-placeholders "API_TOKEN|ORG|http://localhost:8086|default|USERNAME|PASSWORD" %}}
-
-```sh
-# Set up a configuration profile
-influx config create \
-  --config-name default \
-  --host-url http://localhost:8086 \
-  --org ORG \
-  --token API_TOKEN \
-  --active
-```
-
-{{% /code-placeholders %}}
-
-Replace the following:
-
-- {{% code-placeholder-key %}}`ORG`{{% /code-placeholder-key %}}: [your organization name](/influxdb/v2/admin/organizations/view-orgs/).
-- {{% code-placeholder-key %}}`API_TOKEN`{{% /code-placeholder-key %}}: [your API token](/influxdb/v2/admin/tokens/view-tokens/).
-
-This configures a new profile named `default` and makes the profile _active_--`influx` CLI commands run against the specified InfluxDB instance.
-
-Once you have the `default` configuration profile, you're ready to [create All-Access tokens](optional-create-all-access-tokens)
-or get started [collecting and writing data](/influxdb/v2/write-data).
-
-## Optional: Create All-Access tokens
-
-Because [Operator tokens](/influxdb/v2/admin/tokens/#operator-token)
-have full read and write access to all organizations in the database,
-we recommend
-[creating an All-Access token](/influxdb/v2/admin/tokens/create-token/)
-for each organization and using those tokens to manage InfluxDB.
+With InfluxDB installed and initialized, [get started](/influxdb/v2/get-started/) writing and querying data.

--- a/content/influxdb/v2/install/_index.md
+++ b/content/influxdb/v2/install/_index.md
@@ -514,7 +514,7 @@ The following guide uses [Docker CLI commands](https://docs.docker.com/reference
 
 If successful, the command starts InfluxDB initialized with the user, organization, bucket,
 and _[Operator token](/influxdb/v2/admin/tokens/#operator-token)_, and logs to stdout.
-You can view the Operator token in the `/etc/influxdb2/influx-configs` file and use it to authorize [creating an All-Access token](#optional-create-all-access-tokens).
+You can view the Operator token in the `/etc/influxdb2/influx-configs` file and use it to authorize [creating an All Access token](#optional-create-all-access-tokens).
 
 _To run the InfluxDB container in [detached mode](https://docs.docker.com/engine/reference/run/#detached-vs-foreground),
  include the `--detach` flag in the `docker run` command._

--- a/content/influxdb/v2/monitor-alert/templates/monitor.md
+++ b/content/influxdb/v2/monitor-alert/templates/monitor.md
@@ -96,7 +96,7 @@ On each InfluxDB OSS instance you want to monitor, do the following:
    Telegraf configuration stored in InfluxDB Cloud.
 
       {{% note %}}
-For your API token, generate a new token or use an existing All Access token. If you run Telegraf as a service, edit your init script to set the environment variable and ensure its available to the service.
+For your API token, generate a new token or use an existing All-Access token. If you run Telegraf as a service, edit your init script to set the environment variable and ensure its available to the service.
       {{% /note %}}
 
 Telegraf runs quietly in the background (no immediate output appears), and begins

--- a/content/influxdb/v2/monitor-alert/templates/monitor.md
+++ b/content/influxdb/v2/monitor-alert/templates/monitor.md
@@ -96,7 +96,7 @@ On each InfluxDB OSS instance you want to monitor, do the following:
    Telegraf configuration stored in InfluxDB Cloud.
 
       {{% note %}}
-For your API token, generate a new token or use an existing All-Access token. If you run Telegraf as a service, edit your init script to set the environment variable and ensure its available to the service.
+For your API token, generate a new token or use an existing All Access token. If you run Telegraf as a service, edit your init script to set the environment variable and ensure its available to the service.
       {{% /note %}}
 
 Telegraf runs quietly in the background (no immediate output appears), and begins

--- a/content/influxdb/v2/reference/cli/influx/auth/create.md
+++ b/content/influxdb/v2/reference/cli/influx/auth/create.md
@@ -71,14 +71,14 @@ influx auth create [flags]
 
 {{< cli/influx-creds-note >}}
 
-- [Create an All-Access API token](#create-an-all-access-api-token) {{% oss-only %}} or [Create an Operator API token](#create-an-operator-api-token){{% /oss-only %}}
+- [Create an All Access API token](#create-an-all-access-api-token) {{% oss-only %}} or [Create an Operator API token](#create-an-operator-api-token){{% /oss-only %}}
 - [Create an API token with specified read and write permissions](#create-an-api-token-with-specified-read-and-write-permissions)
 - [Create a token with read and write access to specific buckets](#create-an-api-token-with-read-and-write-access-to-specific-buckets)
 - [Create a read-only API token](#create-a-read-only-api-token)
 
-### Create an All-Access API token
+### Create an All Access API token
 
-Create an [All-Access token](/influxdb/cloud/admin/tokens/#all-access-token) to grant permissions to all resources in an organization.
+Create an [All Access token](/influxdb/cloud/admin/tokens/#all-access-token) to grant permissions to all resources in an organization.
 
 ```sh
 influx auth create \

--- a/content/influxdb/v2/reference/cli/influx/export/all.md
+++ b/content/influxdb/v2/reference/cli/influx/export/all.md
@@ -21,8 +21,8 @@ _For detailed examples of exporting InfluxDB templates, see
 
 {{% note %}}
 To export resources as a template, you must use the **Operator token** created for
-the initial InfluxDB user or an **All-Access token**.
-For information about creating an All-Access API token, see [Create an API token](/influxdb/v2/admin/tokens/create-token/).
+the initial InfluxDB user or an **All Access token**.
+For information about creating an All Access API token, see [Create an API token](/influxdb/v2/admin/tokens/create-token/).
 {{% /note %}}
 
 ## Usage

--- a/content/influxdb/v2/reference/cli/influx/export/stack.md
+++ b/content/influxdb/v2/reference/cli/influx/export/stack.md
@@ -18,8 +18,8 @@ All `metadata.name` fields remain the same.
 
 {{% note %}}
 To export resources as a template, you must use the **Operator token** created for
-the initial InfluxDB user or an **All-Access token**.
-For information about creating an All-Access API token, see [Create an API token](/influxdb/v2/admin/tokens/create-token/).
+the initial InfluxDB user or an **All Access token**.
+For information about creating an All Access API token, see [Create an API token](/influxdb/v2/admin/tokens/create-token/).
 {{% /note %}}
 
 ## Usage

--- a/content/influxdb/v2/reference/cli/influx/setup/_index.md
+++ b/content/influxdb/v2/reference/cli/influx/setup/_index.md
@@ -54,12 +54,14 @@ milliseconds (`ms`), seconds (`s`), minutes (`m`), hours (`h`), days (`d`), and 
 
 ## Examples
 
-##### Start interactive InfluxDB setup
+##### Set up InfluxDB interactively with prompts for required information
+
 ```sh
 influx setup
 ```
 
 ##### Set up InfluxDB with all required information and skip confirmation
+
 ```sh
 influx setup \
   --org example-org \

--- a/content/influxdb/v2/reference/cli/influx/task/retry-failed.md
+++ b/content/influxdb/v2/reference/cli/influx/task/retry-failed.md
@@ -42,7 +42,7 @@ influx task retry-failed [flags]
 
 {{% note %}}
 #### Required permissions
-Use an [{{% oss-only %}}**Operator** or{{% /oss-only %}} **All-Access** token](/influxdb/v2/admin/tokens/) to retry failed tasks.
+Use an [{{% oss-only %}}**Operator** or{{% /oss-only %}} **All Access** token](/influxdb/v2/admin/tokens/) to retry failed tasks.
 {{% /note %}}
 
 - [Retry failed task runs for a specific task ID](#retry-failed-task-runs-for-a-specific-task-id)

--- a/content/influxdb/v2/reference/cli/influx/task/run/retry.md
+++ b/content/influxdb/v2/reference/cli/influx/task/run/retry.md
@@ -34,7 +34,7 @@ influx task run retry [flags]
 
 {{% note %}}
 #### Required permissions
-Use an [{{% oss-only %}}**Operator** or{{% /oss-only %}} <span>**All-Access**</span> token](/influxdb/v2/admin/tokens/) to retry tasks.
+Use an [{{% oss-only %}}**Operator** or{{% /oss-only %}} <span>**All Access**</span> token](/influxdb/v2/admin/tokens/) to retry tasks.
 {{% /note %}}
 
 ##### Retry a task run

--- a/content/influxdb/v2/reference/faq.md
+++ b/content/influxdb/v2/reference/faq.md
@@ -223,7 +223,7 @@ InfluxDB {{< current-version >}} provides different ways to monitor its status:
 InfluxDB {{< current-version >}} supports the following token types:
 
 - {{% oss-only %}}Operator tokens{{% /oss-only %}}
-- All-Access tokens
+- All Access tokens
 - {{% cloud-only %}}Custom tokens{{% /cloud-only %}}
 - {{% oss-only %}}Read/Write tokens{{% /oss-only %}}
 

--- a/content/influxdb/v2/reference/glossary.md
+++ b/content/influxdb/v2/reference/glossary.md
@@ -1164,13 +1164,13 @@ There are different types of API tokens:
 {{% oss-only %}}
 
 - **Operator token:** grants full read and write access to all resources in **all organizations in InfluxDB OSS 2.x**. _InfluxDB Cloud does not support Operator tokens._
-- **All-Access token:** grants full read and write access to all resources in an organization.
+- **All Access token:** grants full read and write access to all resources in an organization.
 - **Read/Write token:** grants read or write access to specific resources in an organization.
 
 {{% /oss-only %}}
 {{% cloud-only %}}
 
-- **All-Access token:** grants full read and write access to all resources in an organization.
+- **All Access token:** grants full read and write access to all resources in an organization.
 - **Read/Write token:** grants read or write access to specific resources in an organization.
 
 {{% /cloud-only %}}

--- a/content/influxdb/v2/reference/release-notes/influx-cli.md
+++ b/content/influxdb/v2/reference/release-notes/influx-cli.md
@@ -153,9 +153,9 @@ Add the ability to use the `influx` CLI to [create an Operator token](/influxdb/
 
 {{% /oss-only %}}
 
-#### Create an All-Access token in the influx CLI
+#### Create an All Access token in the influx CLI
 
-Add the ability to use the `influx` CLI to [create an All-Access API token](/influxdb/cloud/admin/tokens/create-token/#create-a-token-using-the-influx-cli) with read and write permissions to all resources in an organization.
+Add the ability to use the `influx` CLI to [create an All Access API token](/influxdb/cloud/admin/tokens/create-token/#create-a-token-using-the-influx-cli) with read and write permissions to all resources in an organization.
 
 #### View more buckets in the influx CLI
 

--- a/content/influxdb/v2/reference/release-notes/influxdb.md
+++ b/content/influxdb/v2/reference/release-notes/influxdb.md
@@ -28,7 +28,7 @@ _Internal changes only._
 
 ### Bug Fixes
 
-- Update user interface to resolve dashboard crashes and all-access token creation.
+- Update user interface to resolve dashboard crashes and All Access token creation.
 - Show replication queue size and replication TCP errors.
 - Correctly handle when the replication queue cannot be found.
 - Rename stored replication fields to be more clear.
@@ -56,7 +56,7 @@ _Internal changes only._
 ### Bug Fixes
 
 - Update user interface (UI) to fix dashboard page crash issue.
-- Fix `All-Access` token creation issue.
+- Fix `All Access` token creation issue.
 
 ## v2.6.0 {date="2022-12-15"}
 
@@ -518,7 +518,7 @@ New features include:
 
 #### API updates
 
-- Add a new route `/api/v2/resources` that returns a list of known resources to the platform, including the following resource types. Makes it easier to update all-access tokens with current resources:
+- Add a new route `/api/v2/resources` that returns a list of known resources to the platform, including the following resource types. Makes it easier to update All Access tokens with current resources:
 
    - `AuthorizationsResourceType`
    - `BucketsResourceType`
@@ -1761,7 +1761,7 @@ Before upgrading, [export all existing tasks](/influxdb/v2/process-data/manage-t
 - Add org profile tab with ability to edit organization name.
 - Add org name to dashboard page title.
 - Add cautioning to bucket renaming.
-- Add option to generate all access token in tokens tab.
+- Add option to generate All Access token in tokens tab.
 - Add option to generate read/write token in tokens tab.
 - Add new Local Metrics Dashboard template that is created during Quick Start.
 

--- a/content/influxdb/v2/tools/influxdb-templates/create.md
+++ b/content/influxdb/v2/tools/influxdb-templates/create.md
@@ -38,7 +38,7 @@ Follow these steps to create a template from a new organization.
 1. [Start InfluxDB](/influxdb/v2/get-started/).
 2. [Create an organization](/influxdb/v2/admin/organizations/create-org/).
 3. In the InfluxDB UI, add one or more [resources](/influxdb/v2/tools/influxdb-templates/#template-resources).
-4. [Create an **All-Access** API token](/influxdb/v2/admin/tokens/create-token/) (or a token that has **read** access to the organization).
+4. [Create an **All Access** API token](/influxdb/v2/admin/tokens/create-token/) (or a token that has **read** access to the organization).
 5. Use the API token from **Step 4** with the [`influx export all` subcommand](/influxdb/v2/reference/cli/influx/export/all/) to [export all resources]() in the organization to a template file.
 
    ```sh

--- a/layouts/shortcodes/influxdb/host.html
+++ b/layouts/shortcodes/influxdb/host.html
@@ -1,6 +1,6 @@
 {{- $productPathData := findRE "[^/]+.*?" .Page.RelPermalink -}}
 {{- $currentVersion := index $productPathData 1 -}}
-{{- $isOSS := ne (len (findRE `^v[0-9]\.` $currentVersion)) 0 -}}
+{{- $isOSS := ne (len (findRE `^v[0-9]` $currentVersion)) 0 -}}
 {{- $parsedProductKey := cond $isOSS "oss" $currentVersion -}}
 {{- $productKey := .Get 0 | default $parsedProductKey -}}
 {{- $productAliases := dict "oss" "influxdb" "cloud" "influxdb_cloud" "cloud-tsm" "influxdb_cloud" "cloud-serverless" "influxdb_cloud_serverless" "serverless" "influxdb_cloud_serverless" "cloud-dedicated" "influxdb_cloud_dedicated" "dedicated" "influxdb_cloud_dedicated" "clustered" "influxdb_clustered" -}}


### PR DESCRIPTION
- Refactors v2/install and moves setup process instructions to get-started/setup.
- Tries to simplify/remove some alternatives to keep the tutorial simple
- Adds an API setup example
- Applies placeholder styles for examples
- Makes `All-Access` consistent in cloud and v2 pages.
