### PR TITLE
Fix errors when building site with latest hugo version v0.123.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/node:20.10.0
+      - image: cimg/node:20.11.1
         environment:
           S3DEPLOY_VERSION: "2.11.0"
           # From https://github.com/bep/s3deploy/releases
@@ -49,7 +49,7 @@ jobs:
 
   deploy:
     docker:
-      - image: cimg/go:1.21.6
+      - image: cimg/go:1.22.1
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ including our GPG key, can be found at https://www.influxdata.com/how-to-report-
           yarn install
           ```
 
-       _**Note:** The most recent version of Hugo tested with this documentation is **0.122.0**._
+       _**Note:** The most recent version of Hugo tested with this documentation is **0.123.8**._
 
 3. To generate the API docs, see [api-docs/README.md](api-docs/README.md).
 

--- a/content/resources/videos/API-Invokable-Scripts.md
+++ b/content/resources/videos/API-Invokable-Scripts.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 140
 youtubeID: JwuPpuY-ZF8
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S4]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Aggregator-&-Processor-Plugins-in-Telegraf.md
+++ b/content/resources/videos/Aggregator-&-Processor-Plugins-in-Telegraf.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 146
 youtubeID: gfHIh7UU7UQ
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S5]
 metadata: [Meet the Developer Series]
 related: 

--- a/content/resources/videos/Architecture-Overview-for-IoT-and-InfluxDB.md
+++ b/content/resources/videos/Architecture-Overview-for-IoT-and-InfluxDB.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 152
 youtubeID: gYPFihq72Wc
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S5]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Basics-of-Geo-temporal-data-and-InfluxDB.md
+++ b/content/resources/videos/Basics-of-Geo-temporal-data-and-InfluxDB.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 148
 youtubeID: OlT1-kMNdCs
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S5]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Batching-Data-with-the-Python-Client-Library.md
+++ b/content/resources/videos/Batching-Data-with-the-Python-Client-Library.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 158
 youtubeID: MZrwhbNdrVk
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S6]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Checks-&-Notification-in-Action.md
+++ b/content/resources/videos/Checks-&-Notification-in-Action.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 145
 youtubeID: 3Th_OcwJ47s
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S4]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Edge-Data-Replication.md
+++ b/content/resources/videos/Edge-Data-Replication.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 141
 youtubeID: qsj_TTpDyf4
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S4]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Explicit-Schemas-in-InfluxDB.md
+++ b/content/resources/videos/Explicit-Schemas-in-InfluxDB.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 163
 youtubeID: MkbhvurkekE
-date: 2022-7-12
+date: 2022-07-12
 series: [Meet the Developers S7]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Flux-Data-Structure.md
+++ b/content/resources/videos/Flux-Data-Structure.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 142
 youtubeID: 5-AwY8ly6NA
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S4]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Flux-Functions.md
+++ b/content/resources/videos/Flux-Functions.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 143
 youtubeID: 8gt_MdCFw3k
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S4]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Flux-and-S2-Geometry.md
+++ b/content/resources/videos/Flux-and-S2-Geometry.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 149
 youtubeID: comMs1cxYT4
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S5]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Getting-Started-with-the-Node-js-Client-Library-in-InfluxDB.md
+++ b/content/resources/videos/Getting-Started-with-the-Node-js-Client-Library-in-InfluxDB.md
@@ -8,7 +8,7 @@ menu:
     name: Getting Started with the Node.js Client Library in InfluxDB
 weight: 164
 youtubeID: VxQVda-ilIo
-date: 2022-7-12
+date: 2022-07-12
 series: [Meet the Developers S7]
 metadata: [Meet the Developer Series]
 aliases:

--- a/content/resources/videos/InfluxDB-in-the-IoT-stack.md
+++ b/content/resources/videos/InfluxDB-in-the-IoT-stack.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 151
 youtubeID: yURE_xJRhp0
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S5]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Intro-to-Check-&-Notifications.md
+++ b/content/resources/videos/Intro-to-Check-&-Notifications.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 144
 youtubeID: -QdldB3RxMw
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S4]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Intro-to-Client-Libraries.md
+++ b/content/resources/videos/Intro-to-Client-Libraries.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 139
 youtubeID: 2q-QbvXm_2Y
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S4]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Invocable-Scripts-and-Tasks.md
+++ b/content/resources/videos/Invocable-Scripts-and-Tasks.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 156
 youtubeID: QfwYnPaQ5Yo
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S6]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Invocable-Scripts-for-Alerting.md
+++ b/content/resources/videos/Invocable-Scripts-for-Alerting.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 157
 youtubeID: MDXhUeF-TQ0
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S6]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Optimizing-Flux-Functions.md
+++ b/content/resources/videos/Optimizing-Flux-Functions.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 143
 youtubeID: ZorlId2_XEg
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S4]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Querying-Data-with-the-Python-Client-Library.md
+++ b/content/resources/videos/Querying-Data-with-the-Python-Client-Library.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 159
 youtubeID: MvVsBBThYag
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S6]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Retaining-Data-Shape-When-Downsampling-To-Cloud.md
+++ b/content/resources/videos/Retaining-Data-Shape-When-Downsampling-To-Cloud.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 154
 youtubeID: ZZ7KfVVUE44
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S6]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Using-Flux-to-query-geo-temporal-data.md
+++ b/content/resources/videos/Using-Flux-to-query-geo-temporal-data.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 150
 youtubeID: iT_qKqDWm98
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S5]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Using-MQTT-and-InfluxDB-for-IoT.md
+++ b/content/resources/videos/Using-MQTT-and-InfluxDB-for-IoT.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 147
 youtubeID: pCmzR6FiTMk
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S5]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Using-Pandas-Dataframes-in-InfluxDB-with-Python.md
+++ b/content/resources/videos/Using-Pandas-Dataframes-in-InfluxDB-with-Python.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 165
 youtubeID: cMkQXLCbFQY
-date: 2022-9-12
+date: 2022-09-12
 series: [Meet the Developers S7]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Using-Scripts-in-InfluxDB.md
+++ b/content/resources/videos/Using-Scripts-in-InfluxDB.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 155
 youtubeID: 0AhgTy4OduA
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S6]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/Using-the-InfluxDB-Python-Client-Library-Administrative-API.md
+++ b/content/resources/videos/Using-the-InfluxDB-Python-Client-Library-Administrative-API.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 160
 youtubeID: xw46AxSQc_c
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S6]
 metadata: [Meet the Developer Series]
 ---

--- a/content/resources/videos/configuring-replications-for-downsampling-to-cloud.md
+++ b/content/resources/videos/configuring-replications-for-downsampling-to-cloud.md
@@ -7,7 +7,7 @@ menu:
     parent: Videos
 weight: 153
 youtubeID: yCComgh-B74
-date: 2022-6-30
+date: 2022-06-30
 series: [Meet the Developers S6]
 metadata: [Meet the Developer Series]
 ---

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,10 +50,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-5.6.0.tgz#41dd6093d34652cddb5d5bdeee04eafc33826668"
   integrity sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==
 
-"@sindresorhus/merge-streams@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-1.0.0.tgz#9cd84cc15bc865a5ca35fcaae198eb899f7b5c90"
-  integrity sha512-rUV5WyJrJLoloD4NDN1V1+LDMDWOa4OTsT4yYJwQNpTU6FWxkxHpL7eu4w+DmiH8x/EAM1otkPE1+LaspIbplw==
+"@sindresorhus/merge-streams@^2.1.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz#719df7fb41766bc143369eaa0dd56d8dc87c9958"
+  integrity sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==
 
 "@szmarczak/http-timer@^5.0.1":
   version "5.0.1"
@@ -110,23 +110,23 @@ asynckit@^0.4.0:
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 autoprefixer@>=10.2.5:
-  version "10.4.16"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.16.tgz#fad1411024d8670880bdece3970aa72e3572feb8"
-  integrity sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==
+  version "10.4.18"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.18.tgz#fcb171a3b017be7cb5d8b7a825f5aacbf2045163"
+  integrity sha512-1DKbDfsr6KUElM6wg+0zRNkB/Q7WcKYAaK+pzXn+Xqmszm/5Xa9coeNdtP88Vi+dPzZnMjhge8GIV49ZQkDa+g==
   dependencies:
-    browserslist "^4.21.10"
-    caniuse-lite "^1.0.30001538"
-    fraction.js "^4.3.6"
+    browserslist "^4.23.0"
+    caniuse-lite "^1.0.30001591"
+    fraction.js "^4.3.7"
     normalize-range "^0.1.2"
     picocolors "^1.0.0"
     postcss-value-parser "^4.2.0"
 
 axios@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.0.tgz#f1e5292f26b2fd5c2e66876adc5b06cdbd7d2102"
-  integrity sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
+  integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
   dependencies:
-    follow-redirects "^1.15.0"
+    follow-redirects "^1.15.4"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
@@ -155,13 +155,13 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-browserslist@^4.21.10:
-  version "4.22.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.2.tgz#704c4943072bd81ea18997f3bd2180e89c77874b"
-  integrity sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==
+browserslist@^4.23.0:
+  version "4.23.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.0.tgz#8f3acc2bbe73af7213399430890f86c63a5674ab"
+  integrity sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==
   dependencies:
-    caniuse-lite "^1.0.30001565"
-    electron-to-chromium "^1.4.601"
+    caniuse-lite "^1.0.30001587"
+    electron-to-chromium "^1.4.668"
     node-releases "^2.0.14"
     update-browserslist-db "^1.0.13"
 
@@ -214,10 +214,10 @@ cacheable-request@^10.2.8:
     normalize-url "^8.0.0"
     responselike "^3.0.0"
 
-caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001565:
-  version "1.0.30001574"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001574.tgz#fb4f1359c77f6af942510493672e1ec7ec80230c"
-  integrity sha512-BtYEK4r/iHt/txm81KBudCUcTy7t+s9emrIaHqjYurQ10x71zJ5VQ9x1dYPcz/b+pKSp4y/v1xSI67A+LzpNyg==
+caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001591:
+  version "1.0.30001597"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001597.tgz#8be94a8c1d679de23b22fbd944232aa1321639e6"
+  integrity sha512-7LjJvmQU6Sj7bL0j5b5WY/3n7utXUJvAe1lxhsHDbLmwX9mdL86Yjtr+5SRCyf8qME4M7pU2hswj0FpyBVCv9w==
 
 careful-downloader@^3.0.0:
   version "3.0.0"
@@ -246,9 +246,9 @@ chalk@^5.0.0:
   integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
 
 chokidar@^3.3.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
-  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
   dependencies:
     anymatch "~3.1.2"
     braces "~3.0.2"
@@ -399,10 +399,10 @@ dependency-graph@^0.11.0:
   resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.11.0.tgz#ac0ce7ed68a54da22165a85e97a01d53f5eb2e27"
   integrity sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==
 
-electron-to-chromium@^1.4.601:
-  version "1.4.623"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.623.tgz#0f7400114ac3425500e9244d2b0e9c3107c331cb"
-  integrity sha512-lKoz10iCYlP1WtRYdh5MvocQPWVRoI7ysp6qf18bmeBgR8abE6+I2CsfyNKztRDZvhdWc+krKT6wS7Neg8sw3A==
+electron-to-chromium@^1.4.668:
+  version "1.4.700"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.700.tgz#0270c9f57d6782af031f71e16ef810d0588a1e2f"
+  integrity sha512-40dqKQ3F7C8fbBEmjSeJ+qEHCKzPyrP9SkeIBZ3wSCUH9nhWStrDz030XlDzlhNhlul1Z0fz7TpDFnsIzo4Jtg==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -424,9 +424,9 @@ error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 escalade@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
-  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.2.tgz#54076e9ab29ea5bf3d8f1ed62acffbb88272df27"
+  integrity sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -445,9 +445,9 @@ fast-glob@^3.3.2:
     micromatch "^4.0.4"
 
 fastq@^1.6.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.16.0.tgz#83b9a9375692db77a822df081edb6a9cf6839320"
-  integrity sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.17.1.tgz#2a523f07a4e7b1e81a42b91b8bf2254107753b47"
+  integrity sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==
   dependencies:
     reusify "^1.0.4"
 
@@ -488,10 +488,10 @@ find-up@^6.3.0:
     locate-path "^7.1.0"
     path-exists "^5.0.0"
 
-follow-redirects@^1.15.0:
-  version "1.15.4"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
-  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
+follow-redirects@^1.15.4:
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
+  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
 
 form-data-encoder@^2.1.2:
   version "2.1.4"
@@ -507,7 +507,7 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
-fraction.js@^4.3.6:
+fraction.js@^4.3.7:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.3.7.tgz#06ca0085157e42fda7f9e726e79fefc4068840f7"
   integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
@@ -567,11 +567,11 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
     is-glob "^4.0.1"
 
 globby@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-14.0.0.tgz#ea9c062a3614e33f516804e778590fcf055256b9"
-  integrity sha512-/1WM/LNHRAOH9lZta77uGbq0dAEQM+XjNesWwhlERDVenqothRbnzTrL3/LrIoEPPjeUHC3vrS6TwoyxeHs7MQ==
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-14.0.1.tgz#a1b44841aa7f4c6d8af2bc39951109d77301959b"
+  integrity sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==
   dependencies:
-    "@sindresorhus/merge-streams" "^1.0.0"
+    "@sindresorhus/merge-streams" "^2.1.0"
     fast-glob "^3.3.2"
     ignore "^5.2.4"
     path-type "^5.0.0"
@@ -606,9 +606,9 @@ has-flag@^3.0.0:
   integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
 hasown@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz#f4c513d454a57b7c7e1650778de226b11700546c"
-  integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
 
@@ -633,9 +633,9 @@ http2-wrapper@^2.1.10:
     resolve-alpn "^1.2.0"
 
 hugo-extended@>=0.101.0:
-  version "0.122.0"
-  resolved "https://registry.yarnpkg.com/hugo-extended/-/hugo-extended-0.122.0.tgz#80ed2fcb165cf4a809230cb0ab3b2756a45402a6"
-  integrity sha512-f9kPVSKxk5mq62wmw1tbhg5CV7n93Tbt7jZoy+C3yfRlEZhGqBlxaEJ3MeeNoilz3IPy5STHB7R0Bdhuap7mHA==
+  version "0.123.8"
+  resolved "https://registry.yarnpkg.com/hugo-extended/-/hugo-extended-0.123.8.tgz#0925aea40c201f28c88a2f63079e8923c54cf99d"
+  integrity sha512-EudplT9MZRhDemli+8SleR8SuxBvwdaf4mCCd1yFUcV+YtM1M92Doc2+AadQn+Mf+znamk2vEIM5Q/YUKvQkeg==
   dependencies:
     careful-downloader "^3.0.0"
     log-symbols "^5.1.0"
@@ -647,9 +647,9 @@ ieee754@^1.1.13:
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^5.2.4:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
-  integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
+  integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
 
 inherits@~2.0.3:
   version "2.0.4"
@@ -766,9 +766,9 @@ keyv@^4.5.3:
     json-buffer "3.0.1"
 
 lilconfig@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.0.0.tgz#f8067feb033b5b74dab4602a5f5029420be749bc"
-  integrity sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.1.tgz#9d8a246fa753106cfc205fd2d77042faca56e5e3"
+  integrity sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -880,9 +880,9 @@ normalize-range@^0.1.2:
   integrity sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==
 
 normalize-url@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-8.0.0.tgz#593dbd284f743e8dcf6a5ddf8fadff149c82701a"
-  integrity sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-8.0.1.tgz#9b7d96af9836577c58f5883e939365fa15623a4a"
+  integrity sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==
 
 object-assign@^4.0.1:
   version "4.1.1"
@@ -991,17 +991,17 @@ postcss-cli@>=9.1.0:
     yargs "^17.0.0"
 
 postcss-load-config@^5.0.0:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-5.0.2.tgz#3d4261d616428e3d6e41c8236c3e456c0f49266f"
-  integrity sha512-Q8QR3FYbqOKa0bnC1UQ2bFq9/ulHX5Bi34muzitMr8aDtUelO5xKeJEYC/5smE0jNE9zdB/NBnOwXKexELbRlw==
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-5.0.3.tgz#f4927637d907de900c4828615077646844545820"
+  integrity sha512-90pBBI5apUVruIEdCxZic93Wm+i9fTrp7TXbgdUCH+/L+2WnfpITSpq5dFU/IPvbv7aNiMlQISpUkAm3fEcvgQ==
   dependencies:
     lilconfig "^3.0.0"
     yaml "^2.3.4"
 
 postcss-reporter@^7.0.0:
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-7.0.5.tgz#e55bd0fdf8d17e4f25fb55e9143fcd79349a2ceb"
-  integrity sha512-glWg7VZBilooZGOFPhN9msJ3FQs19Hie7l5a/eE6WglzYqVeH3ong3ShFcp9kDWJT1g2Y/wd59cocf9XxBtkWA==
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-7.1.0.tgz#5ec476d224e2fe25a054e3c66d9b2901d4fab422"
+  integrity sha512-/eoEylGWyy6/DOiMP5lmFRdmDKThqgn7D6hP2dXKJI/0rJSO1ADFNngZfDzxL0YAxFvws+Rtpuji1YIHj4mySA==
   dependencies:
     picocolors "^1.0.0"
     thenby "^1.3.4"
@@ -1012,9 +1012,9 @@ postcss-value-parser@^4.2.0:
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss@>=8.4.31:
-  version "8.4.33"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.33.tgz#1378e859c9f69bf6f638b990a0212f43e2aaa742"
-  integrity sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==
+  version "8.4.35"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.35.tgz#60997775689ce09011edf083a549cea44aabe2f7"
+  integrity sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==
   dependencies:
     nanoid "^3.3.7"
     picocolors "^1.0.0"
@@ -1138,9 +1138,9 @@ seek-bzip@^1.0.5:
     commander "^2.8.1"
 
 semver@^7.3.4:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
-  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -1163,9 +1163,9 @@ spdx-correct@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-exceptions@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.4.0.tgz#c07a4ede25b16e4f78e6707bbd84b15a45c19c1b"
-  integrity sha512-hcjppoJ68fhxA/cjbN4T8N6uCUejN8yFw69ttpqtBeCbF3u13n7mb31NB9jKwGTTWWnt9IbRA/mf1FprYS8wfw==
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz#5d607d27fc806f66d7b64a766650fa890f04ed66"
+  integrity sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==
 
 spdx-expression-parse@^3.0.0:
   version "3.0.1"
@@ -1176,9 +1176,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.16"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz#a14f64e0954f6e25cc6587bd4f392522db0d998f"
-  integrity sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz#887da8aa73218e51a1d917502d79863161a93f9c"
+  integrity sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==
 
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
@@ -1353,9 +1353,9 @@ yallist@^4.0.0:
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^2.3.4:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.4.tgz#53fc1d514be80aabf386dc6001eb29bf3b7523b2"
-  integrity sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.4.1.tgz#2e57e0b5e995292c25c75d2658f0664765210eed"
+  integrity sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==
 
 yargs-parser@^21.1.1:
   version "21.1.1"


### PR DESCRIPTION
When previewing the site with latest hugo version v0.123.8, various errors occur.
This PR fixes these issues and bumps hugo to its latest version.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
