### PR TITLE
docs(clustered): mention use of `DOCKER_CONFIG` with `kubit local apply`

### DIFF
--- a/content/influxdb/clustered/install/deploy.md
+++ b/content/influxdb/clustered/install/deploy.md
@@ -76,10 +76,12 @@ kubectl apply \
     and related tools on your local machine.
 
 2.  Use the `kubit local apply` command to apply your custom-configured
-    `myinfluxdb.yml` and deploy your InfluxDB Cluster.
+    `myinfluxdb.yml` and deploy your InfluxDB Cluster. You should also specify the
+    directory containing your Clustered pull secret credentials, provided by InfluxData,
+    in the `DOCKER_CONFIG` environment variable.
 
     ```sh
-    kubit local apply myinfuxdb.yml
+    DOCKER_CONFIG=/path/to/pullsecrets kubit local apply myinfuxdb.yml
     ```
 
 **NOTE:** By default, `kubit` will use tools that are installed on your local system.

--- a/content/influxdb/clustered/install/deploy.md
+++ b/content/influxdb/clustered/install/deploy.md
@@ -76,9 +76,9 @@ kubectl apply \
     and related tools on your local machine.
 
 2.  Use the `kubit local apply` command to apply your custom-configured
-    `myinfluxdb.yml` and deploy your InfluxDB Cluster. You should also specify the
-    directory containing your Clustered pull secret credentials, provided by InfluxData,
-    in the `DOCKER_CONFIG` environment variable.
+    `myinfluxdb.yml` and deploy your InfluxDB Cluster.
+    Set the `DOCKER_CONFIG` environment variable to the directory path of
+    your InfluxDB Clustered pull secret credentials provided by InfluxData.
 
     ```sh
     DOCKER_CONFIG=/path/to/pullsecrets kubit local apply myinfuxdb.yml


### PR DESCRIPTION
When customers use `kubit local apply` for their manifest application or rendering, `kubit` will use either the locally installed tooling or `docker` containers (with the `--docker` flag).

For Influxers, we do not have to specify a `DOCKER_CONFIG` modification because our docker configuration already contains the correct access to our own registries; however, Clustered customers are given access via a pull secret (which is a docker configuration JSON file with access to pull images). In order for this to be used, a customer must ensure that `docker` itself knows to look at this file we've given them, which can be done with the `DOCKER_CONFIG` variable and passing the directory in which the file exists.

Without this variable setting, it will look to the default location which is `${HOME}/.docker` and this will not have the relevant access for our registries, causing a `403 Forbidden` error.

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
