### PR TITLE
docs(clustered): object versioning recommendation

### DIFF
--- a/content/influxdb/clustered/install/prerequisites.md
+++ b/content/influxdb/clustered/install/prerequisites.md
@@ -14,7 +14,7 @@ weight: 101
 InfluxDB Clustered requires the following prerequisites:
 
 - **Kubernetes cluster**: version 1.25 or higher
-- **Object storage**: AWS S3 or S3-compatible storage used to store the InfluxDB parquet files
+- **Object storage**: AWS S3 or S3-compatible storage used to store the InfluxDB parquet files. It is **highly** recommended to enable object versioning.
 - **PostgreSQL-compatible database** _(AWS Aurora, hosted Postgres, etc.)_:
   Used to store the InfluxDB catalog
   - Supported PostgreSQL versions: **13.8–14.6**


### PR DESCRIPTION
After a lengthy discussion with the IOx core team, I believe we should highly encourage that object versioning is enabled.

This is incredibly useful as it enables a large reduction in deleted files that are present in the catalog, by virtue of being able to greatly reduce the cutoff point at which the garbage collector removes the files from object store. In our Serverless/Dedicated environments, this cutoff is set to 6 hours because object versioning can be used to recover files which have been "deleted". The versioned files from the deletion action are only fully expired after a lifecycle rule of 100 days; however, the number of entries in the catalog is greatly reduced.


_TBD: Object versioning may become a requirement for the object store in use for Clustered._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
