### PR TITLE
Add JSON page lists for use in the v3 UI

### DIFF
--- a/content/influxdb/cloud-dedicated/pages.md
+++ b/content/influxdb/cloud-dedicated/pages.md
@@ -1,0 +1,9 @@
+---
+layout: page-list
+outputs: [json]
+omit_from_sitemap: true
+---
+
+This file is used to generate a JSON file containing the navigation structure
+for this product. The InfluxDB v3 UI retrieves this JSON to build documentation
+links in the UI.

--- a/content/influxdb/cloud-serverless/pages.md
+++ b/content/influxdb/cloud-serverless/pages.md
@@ -1,0 +1,9 @@
+---
+layout: page-list
+outputs: [json]
+omit_from_sitemap: true
+---
+
+This file is used to generate a JSON file containing the navigation structure
+for this product. The InfluxDB v3 UI retrieves this JSON to build documentation
+links in the UI.

--- a/content/influxdb/clustered/pages.md
+++ b/content/influxdb/clustered/pages.md
@@ -1,0 +1,9 @@
+---
+layout: page-list
+outputs: [json]
+omit_from_sitemap: true
+---
+
+This file is used to generate a JSON file containing the navigation structure
+for this product. The InfluxDB v3 UI retrieves this JSON to build documentation
+links in the UI.

--- a/hugo.staging.toml
+++ b/hugo.staging.toml
@@ -46,3 +46,8 @@ smartDashes = false
   [privacy.youtube]
     disable = false
     privacyEnhanced = true
+
+[outputFormats.json]
+  mediaType = "application/json"
+  baseName = "pages"
+  isPlainText = true

--- a/hugo.toml
+++ b/hugo.toml
@@ -42,3 +42,8 @@ smartDashes = false
   [privacy.youtube]
     disable = false
     privacyEnhanced = true
+
+[outputFormats.json]
+  mediaType = "application/json"
+  baseName = "pages"
+  isPlainText = true

--- a/layouts/_default/page-list.json
+++ b/layouts/_default/page-list.json
@@ -1,0 +1,81 @@
+{{- $productPathData := findRE "[^/]+.*?" .RelPermalink -}}
+{{- $product := index $productPathData 0 -}}
+{{- $version := index $productPathData 1 -}}
+{{- $menuKey := print $product "_" (replaceRE `-` "_" $version) -}}
+{{- $menu := index .Site.Menus $menuKey -}}
+[
+{{ range $index, $entry := $menu }}
+  {{- if $index -}},{{- end }}
+  {
+    "name": {{ .Name | jsonify }},
+    "url": {{ absURL (cond (isset .Params "url") .Params.url .URL) | jsonify }},
+    "children": [
+      {{- range $index, $entry := .Children -}}
+        {{- if $index -}},{{- end }}
+        {
+          "name": {{ .Name | jsonify }},
+          "url": {{ absURL (cond (isset .Params "url") .Params.url .URL) | jsonify }},
+          "children": [
+            {{- range $index, $entry := .Children -}}
+            {{- if $index -}},{{- end }}
+            {
+              "name": {{ .Name | jsonify }},
+              "url": {{ absURL (cond (isset .Params "url") .Params.url .URL) | jsonify }},
+              "children": [
+                {{- range $index, $entry := .Children -}}
+                {{- if $index -}},{{- end }}
+                {
+                  "name": {{ .Name | jsonify }},
+                  "url": {{ absURL (cond (isset .Params "url") .Params.url .URL) | jsonify }},
+                  "children": [
+                    {{- range $index, $entry := .Children -}}
+                    {{- if $index -}},{{- end }}
+                    {
+                      "name": {{ .Name | jsonify }},
+                      "url": {{ absURL (cond (isset .Params "url") .Params.url .URL) | jsonify }},
+                      "children": [
+                        {{- range $index, $entry := .Children -}}
+                        {{- if $index -}},{{- end }}
+                        {
+                          "name": {{ .Name | jsonify }},
+                          "url": {{ absURL (cond (isset .Params "url") .Params.url .URL) | jsonify }},
+                          "children": [
+                            {{- range $index, $entry := .Children -}}
+                            {{- if $index -}},{{- end }}
+                            {
+                              "name": {{ .Name | jsonify }},
+                              "url": {{ absURL (cond (isset .Params "url") .Params.url .URL) | jsonify }},
+                              "children": [
+                                {{- range $index, $entry := .Children -}}
+                                {{- if $index -}},{{- end }}
+                                {
+                                  "name": {{ .Name | jsonify }},
+                                  "url": {{ absURL (cond (isset .Params "url") .Params.url .URL) | jsonify }},
+                                  "children": [
+                                    {{ range .Children }}
+                                    {{ end }}
+                                  ]
+                                }
+                              {{ end }}
+                              ]
+                            }
+                          {{ end }}
+                          ]
+                        }
+                      {{ end }}
+                      ]
+                    }
+                  {{ end }}
+                  ]
+                }
+              {{ end }}
+              ]
+            }
+          {{ end }}
+          ]
+        }
+      {{ end }}
+    ]
+  }
+{{ end }}
+]

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,21 +1,23 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
-  <url>
-    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
-    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
-    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
-    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
-    <xhtml:link
-                rel="alternate"
-                hreflang="{{ .Lang }}"
-                href="{{ .Permalink }}"
-                />{{ end }}
-    <xhtml:link
-                rel="alternate"
-                hreflang="{{ .Lang }}"
-                href="{{ .Permalink }}"
-                />{{ end }}
-  </url>
+    {{ if not .Params.omit_from_sitemap }}
+      <url>
+        <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+        <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+        <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+        <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+        <xhtml:link
+                    rel="alternate"
+                    hreflang="{{ .Lang }}"
+                    href="{{ .Permalink }}"
+                    />{{ end }}
+        <xhtml:link
+                    rel="alternate"
+                    hreflang="{{ .Lang }}"
+                    href="{{ .Permalink }}"
+                    />{{ end }}
+      </url>
+    {{ end }}
   {{ end }}
 </urlset>


### PR DESCRIPTION
This change generates `pages.json` files for Dedicated, Serverless, and Clustered docs that provide the product docs navigation structure with doc names, URLs, and children. This will be used to link to documentation from the InfluxDB v3 management UI.

- [x] Rebased/mergeable
