### PR TITLE
Add 'influxctl management' commands

### DIFF
--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/_index.md
@@ -30,16 +30,17 @@ influxctl [flags] [command]
 
 ## Commands
 
-| Command                                                                 | Description                            |
-| :---------------------------------------------------------------------- | :------------------------------------- |
-| [cluster](/influxdb/cloud-dedicated/reference/cli/influxctl/cluster/)   | List InfluxDB v3 cluster information   |
-| [database](/influxdb/cloud-dedicated/reference/cli/influxctl/database/) | Manage InfluxDB v3 databases           |
-| [help](/influxdb/cloud-dedicated/reference/cli/influxctl/help/)         | Output `influxctl` help information    |
-| [query](/influxdb/cloud-dedicated/reference/cli/influxctl/query/)       | Query data from InfluxDB v3            |
-| [token](/influxdb/cloud-dedicated/reference/cli/influxctl/token/)       | Manage InfluxDB v3 database tokens     |
-| [user](/influxdb/cloud-dedicated/reference/cli/influxctl/user/)         | Manage InfluxDB v3 cluster users       |
-| [version](/influxdb/cloud-dedicated/reference/cli/influxctl/version/)   | Output the current `influxctl` version |
-| [write](/influxdb/cloud-dedicated/reference/cli/influxctl/write/)       | Write line protocol to InfluxDB v3     |
+| Command                                                                     | Description                            |
+| :-------------------------------------------------------------------------- | :------------------------------------- |
+| [cluster](/influxdb/cloud-dedicated/reference/cli/influxctl/cluster/)       | List InfluxDB v3 cluster information   |
+| [database](/influxdb/cloud-dedicated/reference/cli/influxctl/database/)     | Manage InfluxDB v3 databases           |
+| [help](/influxdb/cloud-dedicated/reference/cli/influxctl/help/)             | Output `influxctl` help information    |
+| [management](/influxdb/cloud-dedicated/reference/cli/influxctl/management/) | Manage InfluxDB v3 management tokens   |
+| [query](/influxdb/cloud-dedicated/reference/cli/influxctl/query/)           | Query data from InfluxDB v3            |
+| [token](/influxdb/cloud-dedicated/reference/cli/influxctl/token/)           | Manage InfluxDB v3 database tokens     |
+| [user](/influxdb/cloud-dedicated/reference/cli/influxctl/user/)             | Manage InfluxDB v3 cluster users       |
+| [version](/influxdb/cloud-dedicated/reference/cli/influxctl/version/)       | Output the current `influxctl` version |
+| [write](/influxdb/cloud-dedicated/reference/cli/influxctl/write/)           | Write line protocol to InfluxDB v3     |
 
 ## Global flags
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/cluster/get.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/cluster/get.md
@@ -12,9 +12,9 @@ weight: 301
 The `influxctl cluster get` command returns information about an InfluxDB
 Cloud Dedicated cluster.
 
-The `--format` option lets you print the output in other formats.
-By default, the 'table' format is used, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 ## Usage
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/cluster/list.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/cluster/list.md
@@ -12,9 +12,9 @@ weight: 301
 The `influxctl cluster list` command returns information about all InfluxDB
 Cloud Dedicated clusters associated with your account ID.
 
-The `--format` option lets you print the output in other formats.
-By default, the 'table' format is used, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 ## Usage
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/list.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/list.md
@@ -12,9 +12,9 @@ weight: 301
 The `influxctl database list` command lists all databases in an InfluxDB Cloud
 Dedicated cluster.
 
-The `--format` option lets you print the output in other formats.
-By default, the 'table' format is used, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 ## Usage
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/management/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/management/_index.md
@@ -1,0 +1,42 @@
+---
+title: influxctl management
+description: >
+  The `influxctl management` command and its subcommands manage management
+  tokens in an InfluxDB Cloud Dedicated cluster.
+menu:
+  influxdb_cloud_dedicated:
+    parent: influxctl
+weight: 201
+---
+
+The `influxctl management` command and its subcommands manage management tokens
+in an {{< product-name omit=" Clustered" >}} cluster.
+
+Management tokens allow the user to perform administrative tasks on the
+InfluxDB instance. This includes creating and deleting databases, managing
+users, and other administrative tasks.
+
+Management tokens do not provide access to databases or data in databases.
+Only _database tokens_ with "read" or "write" permissions can access data in
+databases.
+
+## Usage
+
+```sh
+influxctl management [subcommand] [flags]
+```
+
+## Subcommands
+
+| Subcommand                                                                     | Description                     |
+| :----------------------------------------------------------------------------- | :------------------------------ |
+| [create](/influxdb/cloud-dedicated/reference/cli/influxctl/management/create/) | Create a management token       |
+| [list](/influxdb/cloud-dedicated/reference/cli/influxctl/management/list/)     | List all management tokens      |
+| [revoke](/influxdb/cloud-dedicated/reference/cli/influxctl/management/revoke/) | Revoke a management token by ID |
+| help, h                                                                        | Output command help             |
+
+## Flags
+
+| Flag |          | Description         |
+| :--- | :------- | :------------------ |
+| `-h` | `--help` | Output command help |

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/management/create.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/management/create.md
@@ -1,0 +1,85 @@
+---
+title: influxctl management create
+description: >
+  The `influxctl management create` command creates a management token used to
+  perform administrative tasks in an InfluxDB Cloud Dedicated cluster.
+menu:
+  influxdb_cloud_dedicated:
+    parent: influxctl management
+weight: 301
+---
+
+The `influxctl management create` command creates a management token to be used
+with an {{< product-name omit=" Clustered" >}} cluster.
+Management tokens authorize a user to perform administrative tasks on the
+InfluxDB instance such as creating and deleting databases, managing users, and
+other administrative tasks.
+
+{{% note %}}
+Management tokens do not provide access to databases or data in databases.
+Only _database tokens_ with "read" or "write" permissions can access data in
+databases.
+{{% /note %}}
+
+The optional `--expires-at` flag defines the token expiration date and time.
+Provide an RFC3999 date string--for example: `{{< datetime/current-date offset=1 >}}`.
+If not set, the token does not expire until revoked.
+
+The `--format` flag lets you print the output in other formats.
+By default, the 'table' format is used, but the 'json' format is
+available for programmatic parsing by other tooling.
+
+{{% note %}}
+#### Store secure tokens in a secret store
+
+Management token strings are returned _only_ on token creation.
+We recommend storing management tokens in a **secure secret store**.
+{{% /note %}}
+
+## Usage
+
+```sh
+influxctl management create [flags]
+```
+
+## Flags
+
+| Flag |                 | Description                                   |
+| :--- | :-------------- | :-------------------------------------------- |
+|      | `--description` | Management token description                  |
+|      | `--expires-at`  | Token expiration date                         |
+|      | `--format`      | Output format (`table` _(default)_ or `json`) |
+| `-h` | `--help`        | Output command help                           |
+
+{{% caption %}}
+_Also see [`influxctl` global flags](/influxdb/cloud-dedicated/reference/cli/influxctl/#global-flags)._
+{{% /caption %}}
+
+## Examples
+
+- [Create a management token with no expiration](#create-a-management-token-with-no-expiration)
+- [Create a management token with an expiration and description](#create-a-management-token-with-an-expiration-and-description)
+
+### Create a management token with no expiration
+
+```sh
+influxctl management create
+```
+
+### Create a management token with an expiration and description
+
+{{% code-placeholders "RFC3339_EXPIRATION|TOKEN_DESCRIPTION" %}}
+```sh
+influxctl management create \
+  --expire-at RFC3339_EXPIRATION \
+  --description TOKEN_DESCRIPTION
+```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`RFC3339_EXPIRATION`{{% /code-placeholder-key %}}:
+  An RFC3339 date string to expire the token at--for example:
+  `{{< datetime/current-date offset=1 >}}`.
+- {{% code-placeholder-key %}}`TOKEN_DESCRIPTION`{{% /code-placeholder-key %}}:
+  Management token description.

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/management/list.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/management/list.md
@@ -1,0 +1,47 @@
+---
+title: influxctl management list
+description: >
+  The `influxctl management list` command lists all management tokens used to
+  perform administrative tasks in an InfluxDB Cloud Dedicated cluster.
+menu:
+  influxdb_cloud_dedicated:
+    parent: influxctl management
+weight: 301
+---
+
+The `influxctl management list` command lists all management tokens used to
+perform administrative tasks in an {{< product-name omit=" Clustered" >}} cluster.
+It returns the token description and other relevant information.
+
+{{% note %}}
+#### Management token strings are not retrievable
+
+The actual management token string is not printed and is only returned when
+creating the token.
+
+#### Revoked tokens are included in output
+
+Revoked tokens still appear when listing management tokens, but they are no
+longer valid for any operations.
+{{% /note %}}
+
+The `--format` flag lets you print the output in other formats.
+By default, the `table` format is used, but the `json` format is
+available for programmatic parsing by other tooling.
+
+## Usage
+
+```sh
+influxctl management list [--format=table|json]
+```
+
+## Flags
+
+| Flag |            | Description                                   |
+| :--- | :--------- | :-------------------------------------------- |
+|      | `--format` | Output format (`table` _(default)_ or `json`) |
+| `-h` | `--help`   | Output command help                           |
+
+{{% caption %}}
+_Also see [`influxctl` global flags](/influxdb/cloud-dedicated/reference/cli/influxctl/#global-flags)._
+{{% /caption %}}

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/management/list.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/management/list.md
@@ -25,9 +25,9 @@ Revoked tokens still appear when listing management tokens, but they are no
 longer valid for any operations.
 {{% /note %}}
 
-The `--format` flag lets you print the output in other formats.
-By default, the `table` format is used, but the `json` format is
+The `--format` flag lets you print the output in other formats. The `json` format is
 available for programmatic parsing by other tooling.
+Default: `table`
 
 ## Usage
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/management/revoke.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/management/revoke.md
@@ -24,14 +24,14 @@ but they are no longer valid for any operations.
 ## Usage
 
 ```sh
-influxctl management revoke [flags] <TOKEN_ID>
+influxctl management revoke [flags] <TOKEN_ID>[ ... TOKEN_ID_N]
 ```
 
 ## Arguments
 
 | Argument     | Description                                                |
 | :----------- | :--------------------------------------------------------- |
-| **TOKEN_ID** | Token ID to revoke access for (space-delimit multiple IDs) |
+| **TOKEN_ID** | Token ID(s) to revoke access from (space-delimit multiple IDs) |
 
 ## Flags
 
@@ -46,9 +46,9 @@ _Also see [`influxctl` global flags](/influxdb/cloud-dedicated/reference/cli/inf
 
 ## Examples
 
-- [Revoke access for a management token](#revoke-access-for-a-management-token)
-- [Revoke access for multiple management tokens](#revoke-access-for-multiple-management-tokens)
-- [Revoke access for a token and skip confirmation](#revoke-access-for-a-token-and-skip-confirmation)
+- [Revoke access from a management token](#revoke-access-from-a-management-token)
+- [Revoke access from multiple management tokens](#revoke-access-from-multiple-management-tokens)
+- [Revoke access from a token and skip confirmation](#revoke-access-from-a-token-and-skip-confirmation)
 
 In the examples below, replace the following:
 
@@ -57,19 +57,19 @@ In the examples below, replace the following:
 
 {{% code-placeholders "TOKEN_ID(_[1-2])?" %}}
 
-### Revoke access for a management token
+### Revoke access from a management token
 
 ```sh
 influxctl management revoke TOKEN_ID
 ```
 
-### Revoke access for multiple management tokens
+### Revoke access from multiple management tokens
 
 ```sh
 influxctl management revoke TOKEN_ID_1 TOKEN_ID_2
 ```
 
-### Revoke access for a token and skip confirmation
+### Revoke access from a token and skip confirmation
 
 ```sh
 influxctl management revoke --force TOKEN_ID

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/management/revoke.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/management/revoke.md
@@ -1,0 +1,78 @@
+---
+title: influxctl management revoke
+description: >
+  The `influxctl management revoke` command revokes management token access
+  to your InfluxDB Cloud Dedicated cluster.
+menu:
+  influxdb_cloud_dedicated:
+    parent: influxctl management
+weight: 301
+---
+
+The `influxctl management revoke` command revokes management token access
+to your {{< product-name omit=" Clustered" >}} cluster.
+**This operation cannot be undone**.
+
+{{% note %}}
+#### Revoked tokens are included when listing tokens
+
+Revoked tokens still appear when
+[listing management tokens](/influxdb/cloud-dedicated/reference/cli/influxctl/management/list/),
+but they are no longer valid for any operations.
+{{% /note %}}
+
+## Usage
+
+```sh
+influxctl management revoke [flags] <TOKEN_ID>
+```
+
+## Arguments
+
+| Argument     | Description                                                |
+| :----------- | :--------------------------------------------------------- |
+| **TOKEN_ID** | Token ID to revoke access for (space-delimit multiple IDs) |
+
+## Flags
+
+| Flag |           | Description                              |
+| :--- | :-------- | :--------------------------------------- |
+|      | `--force` | Do not prompt for confirmation to revoke |
+| `-h` | `--help`  | Output command help                      |
+
+{{% caption %}}
+_Also see [`influxctl` global flags](/influxdb/cloud-dedicated/reference/cli/influxctl/#global-flags)._
+{{% /caption %}}
+
+## Examples
+
+- [Revoke access for a management token](#revoke-access-for-a-management-token)
+- [Revoke access for multiple management tokens](#revoke-access-for-multiple-management-tokens)
+- [Revoke access for a token and skip confirmation](#revoke-access-for-a-token-and-skip-confirmation)
+
+In the examples below, replace the following:
+
+- {{% code-placeholder-key %}}`TOKEN_ID*`{{% /code-placeholder-key %}}:
+  Token ID to revoke access from.
+
+{{% code-placeholders "TOKEN_ID(_[1-2])?" %}}
+
+### Revoke access for a management token
+
+```sh
+influxctl management revoke TOKEN_ID
+```
+
+### Revoke access for multiple management tokens
+
+```sh
+influxctl management revoke TOKEN_ID_1 TOKEN_ID_2
+```
+
+### Revoke access for a token and skip confirmation
+
+```sh
+influxctl management revoke --force TOKEN_ID
+```
+
+{{% /code-placeholder-key %}}

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/query.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/query.md
@@ -44,9 +44,9 @@ Command line flags override settings in the connection profile.
 
 ### Output format
 
-The `--format` option lets you print the output in other formats.
-Default is 'table' format, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 ## Usage
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/_index.md
@@ -10,7 +10,7 @@ weight: 201
 ---
 
 The `influxctl token` command and its subcommands manage database tokens in an
-InfluxDB Cloud Dedicated cluster.
+{{< product-name omit=" Clustered" >}} cluster. cluster.
 
 ## Usage
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/_index.md
@@ -10,7 +10,7 @@ weight: 201
 ---
 
 The `influxctl token` command and its subcommands manage database tokens in an
-{{< product-name omit=" Clustered" >}} cluster. cluster.
+{{< product-name omit=" Clustered" >}} cluster.
 
 ## Usage
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/create.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/create.md
@@ -13,9 +13,9 @@ The `influxctl token create` command creates a database token with specified
 permissions to resources in an InfluxDB Cloud Dedicated cluster and outputs
 the token string.
 
-The `--format` option lets you print the output in other formats.
-By default, the 'table' format is used, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 {{% note %}}
 #### Store secure tokens in a secret store

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/get.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/get.md
@@ -12,9 +12,9 @@ weight: 301
 The `influxctl token get` command returns information about a database token
 in an InfluxDB Cloud Dedicated cluster.
 
-The `--format` option lets you print the output in other formats.
-By default, the 'table' format is used, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 ## Usage
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/list.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/list.md
@@ -12,9 +12,9 @@ weight: 301
 The `influxctl token list` command lists all database tokens in an InfluxDB Cloud
 Dedicated cluster.
 
-The `--format` option lets you print the output in other formats.
-By default, the 'table' format is used, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 ## Usage
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/user/list.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/user/list.md
@@ -12,9 +12,9 @@ weight: 301
 The `influxctl user list` command lists all users associated with your InfluxDB
 Cloud Dedicated account ID.
 
-The `--format` option lets you print the output in other formats.
-By default, the 'table' format is used, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 ## Usage
 

--- a/content/influxdb/clustered/reference/cli/influxctl/_index.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/_index.md
@@ -30,16 +30,17 @@ influxctl [flags] [command]
 
 ## Commands
 
-| Command                                                           | Description                            |
-| :---------------------------------------------------------------- | :------------------------------------- |
-| [cluster](/influxdb/clustered/reference/cli/influxctl/cluster/)   | List InfluxDB v3 cluster information   |
-| [database](/influxdb/clustered/reference/cli/influxctl/database/) | Manage InfluxDB v3 databases           |
-| [help](/influxdb/clustered/reference/cli/influxctl/help/)         | Output `influxctl` help information    |
-| [query](/influxdb/clustered/reference/cli/influxctl/query/)       | Query data from InfluxDB v3            |
-| [token](/influxdb/clustered/reference/cli/influxctl/token/)       | Manage InfluxDB v3 database tokens     |
-| [user](/influxdb/clustered/reference/cli/influxctl/user/)         | Manage InfluxDB v3 cluster users       |
-| [version](/influxdb/clustered/reference/cli/influxctl/version/)   | Output the current `influxctl` version |
-| [write](/influxdb/clustered/reference/cli/influxctl/write/)       | Write line protocol to InfluxDB v3     |
+| Command                                                               | Description                            |
+| :-------------------------------------------------------------------- | :------------------------------------- |
+| [cluster](/influxdb/clustered/reference/cli/influxctl/cluster/)       | List InfluxDB v3 cluster information   |
+| [database](/influxdb/clustered/reference/cli/influxctl/database/)     | Manage InfluxDB v3 databases           |
+| [help](/influxdb/clustered/reference/cli/influxctl/help/)             | Output `influxctl` help information    |
+| [management](/influxdb/clustered/reference/cli/influxctl/management/) | Manage InfluxDB v3 management tokens   |
+| [query](/influxdb/clustered/reference/cli/influxctl/query/)           | Query data from InfluxDB v3            |
+| [token](/influxdb/clustered/reference/cli/influxctl/token/)           | Manage InfluxDB v3 database tokens     |
+| [user](/influxdb/clustered/reference/cli/influxctl/user/)             | Manage InfluxDB v3 cluster users       |
+| [version](/influxdb/clustered/reference/cli/influxctl/version/)       | Output the current `influxctl` version |
+| [write](/influxdb/clustered/reference/cli/influxctl/write/)           | Write line protocol to InfluxDB v3     |
 
 ## Global flags
 

--- a/content/influxdb/clustered/reference/cli/influxctl/cluster/get.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/cluster/get.md
@@ -10,9 +10,9 @@ weight: 301
 
 The `influxctl cluster get` command returns information about an InfluxDB cluster.
 
-The `--format` option lets you print the output in other formats.
-By default, the 'table' format is used, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 ## Usage
 

--- a/content/influxdb/clustered/reference/cli/influxctl/cluster/list.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/cluster/list.md
@@ -12,9 +12,9 @@ weight: 301
 The `influxctl cluster list` command returns information about all InfluxDB
 clusters associated with your account ID.
 
-The `--format` option lets you print the output in other formats.
-By default, the 'table' format is used, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 ## Usage
 

--- a/content/influxdb/clustered/reference/cli/influxctl/database/list.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/database/list.md
@@ -12,9 +12,9 @@ weight: 301
 The `influxctl database list` command lists all databases in an InfluxDB Cloud
 Dedicated cluster.
 
-The `--format` option lets you print the output in other formats.
-By default, the 'table' format is used, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 ## Usage
 

--- a/content/influxdb/clustered/reference/cli/influxctl/management/_index.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/management/_index.md
@@ -1,0 +1,42 @@
+---
+title: influxctl management
+description: >
+  The `influxctl management` command and its subcommands manage management
+  tokens in an InfluxDB cluster.
+menu:
+  influxdb_clustered:
+    parent: influxctl
+weight: 201
+---
+
+The `influxctl management` command and its subcommands manage management tokens
+in an {{< product-name omit=" Clustered" >}} cluster.
+
+Management tokens allow the user to perform administrative tasks on the
+InfluxDB instance. This includes creating and deleting databases, managing
+users, and other administrative tasks.
+
+Management tokens do not provide access to databases or data in databases.
+Only _database tokens_ with "read" or "write" permissions can access data in
+databases.
+
+## Usage
+
+```sh
+influxctl management [subcommand] [flags]
+```
+
+## Subcommands
+
+| Subcommand                                                               | Description                     |
+| :----------------------------------------------------------------------- | :------------------------------ |
+| [create](/influxdb/clustered/reference/cli/influxctl/management/create/) | Create a management token       |
+| [list](/influxdb/clustered/reference/cli/influxctl/management/list/)     | List all management tokens      |
+| [revoke](/influxdb/clustered/reference/cli/influxctl/management/revoke/) | Revoke a management token by ID |
+| help, h                                                                  | Output command help             |
+
+## Flags
+
+| Flag |          | Description         |
+| :--- | :------- | :------------------ |
+| `-h` | `--help` | Output command help |

--- a/content/influxdb/clustered/reference/cli/influxctl/management/create.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/management/create.md
@@ -2,9 +2,9 @@
 title: influxctl management create
 description: >
   The `influxctl management create` command creates a management token used to
-  perform administrative tasks in an InfluxDB Cloud Dedicated cluster.
+  perform administrative tasks in an InfluxDB cluster.
 menu:
-  influxdb_cloud_dedicated:
+  influxdb_clustered:
     parent: influxctl management
 weight: 301
 ---
@@ -52,7 +52,7 @@ influxctl management create [flags]
 | `-h` | `--help`        | Output command help                           |
 
 {{% caption %}}
-_Also see [`influxctl` global flags](/influxdb/cloud-dedicated/reference/cli/influxctl/#global-flags)._
+_Also see [`influxctl` global flags](/influxdb/clustered/reference/cli/influxctl/#global-flags)._
 {{% /caption %}}
 
 ## Examples

--- a/content/influxdb/clustered/reference/cli/influxctl/management/list.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/management/list.md
@@ -2,9 +2,9 @@
 title: influxctl management list
 description: >
   The `influxctl management list` command lists all management tokens used to
-  perform administrative tasks in an InfluxDB Cloud Dedicated cluster.
+  perform administrative tasks in an InfluxDB cluster.
 menu:
-  influxdb_cloud_dedicated:
+  influxdb_clustered:
     parent: influxctl management
 weight: 301
 ---
@@ -43,5 +43,5 @@ influxctl management list [--format=table|json]
 | `-h` | `--help`   | Output command help                           |
 
 {{% caption %}}
-_Also see [`influxctl` global flags](/influxdb/cloud-dedicated/reference/cli/influxctl/#global-flags)._
+_Also see [`influxctl` global flags](/influxdb/clustered/reference/cli/influxctl/#global-flags)._
 {{% /caption %}}

--- a/content/influxdb/clustered/reference/cli/influxctl/management/revoke.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/management/revoke.md
@@ -1,0 +1,78 @@
+---
+title: influxctl management revoke
+description: >
+  The `influxctl management revoke` command revokes management token access
+  to your InfluxDB cluster.
+menu:
+  influxdb_clustered:
+    parent: influxctl management
+weight: 301
+---
+
+The `influxctl management revoke` command revokes management token access
+to your {{< product-name omit=" Clustered" >}} cluster.
+**This operation cannot be undone**.
+
+{{% note %}}
+#### Revoked tokens are included when listing tokens
+
+Revoked tokens still appear when
+[listing management tokens](/influxdb/clustered/reference/cli/influxctl/management/list/),
+but they are no longer valid for any operations.
+{{% /note %}}
+
+## Usage
+
+```sh
+influxctl management revoke [flags] <TOKEN_ID>[ ... TOKEN_ID_N]
+```
+
+## Arguments
+
+| Argument     | Description                                                |
+| :----------- | :--------------------------------------------------------- |
+| **TOKEN_ID** | Token ID(s) to revoke access from (space-delimit multiple IDs) |
+
+## Flags
+
+| Flag |           | Description                              |
+| :--- | :-------- | :--------------------------------------- |
+|      | `--force` | Do not prompt for confirmation to revoke |
+| `-h` | `--help`  | Output command help                      |
+
+{{% caption %}}
+_Also see [`influxctl` global flags](/influxdb/clustered/reference/cli/influxctl/#global-flags)._
+{{% /caption %}}
+
+## Examples
+
+- [Revoke access from a management token](#revoke-access-from-a-management-token)
+- [Revoke access from multiple management tokens](#revoke-access-from-multiple-management-tokens)
+- [Revoke access from a token and skip confirmation](#revoke-access-from-a-token-and-skip-confirmation)
+
+In the examples below, replace the following:
+
+- {{% code-placeholder-key %}}`TOKEN_ID*`{{% /code-placeholder-key %}}:
+  Token ID to revoke access from.
+
+{{% code-placeholders "TOKEN_ID(_[1-2])?" %}}
+
+### Revoke access from a management token
+
+```sh
+influxctl management revoke TOKEN_ID
+```
+
+### Revoke access from multiple management tokens
+
+```sh
+influxctl management revoke TOKEN_ID_1 TOKEN_ID_2
+```
+
+### Revoke access from a token and skip confirmation
+
+```sh
+influxctl management revoke --force TOKEN_ID
+```
+
+{{% /code-placeholder-key %}}

--- a/content/influxdb/clustered/reference/cli/influxctl/query.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/query.md
@@ -44,9 +44,9 @@ Command line flags override settings in the connection profile.
 
 ### Output format
 
-The `--format` option lets you print the output in other formats.
-Default is 'table' format, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 ## Usage
 

--- a/content/influxdb/clustered/reference/cli/influxctl/token/_index.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/token/_index.md
@@ -10,7 +10,7 @@ weight: 201
 ---
 
 The `influxctl token` command and its subcommands manage database tokens in an
-InfluxDB cluster.
+{{< product-name omit=" Clustered" >}} cluster.
 
 ## Usage
 

--- a/content/influxdb/clustered/reference/cli/influxctl/token/create.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/token/create.md
@@ -13,9 +13,9 @@ The `influxctl token create` command creates a database token with specified
 permissions to resources in an InfluxDB cluster and outputs
 the token string.
 
-The `--format` option lets you print the output in other formats.
-By default, the 'table' format is used, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 {{% note %}}
 #### Store secure tokens in a secret store

--- a/content/influxdb/clustered/reference/cli/influxctl/token/get.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/token/get.md
@@ -12,9 +12,9 @@ weight: 301
 The `influxctl token get` command returns information about a database token
 in an InfluxDB cluster.
 
-The `--format` option lets you print the output in other formats.
-By default, the 'table' format is used, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 ## Usage
 

--- a/content/influxdb/clustered/reference/cli/influxctl/token/list.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/token/list.md
@@ -11,9 +11,9 @@ weight: 301
 The `influxctl token list` command lists all database tokens in an InfluxDB Cloud
 Dedicated cluster.
 
-The `--format` option lets you print the output in other formats.
-By default, the 'table' format is used, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 ## Usage
 

--- a/content/influxdb/clustered/reference/cli/influxctl/user/list.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/user/list.md
@@ -12,9 +12,9 @@ weight: 301
 The `influxctl user list` command lists all users associated with your
 InfluxDB account ID.
 
-The `--format` option lets you print the output in other formats.
-By default, the 'table' format is used, but the 'json' format is
-available for programmatic parsing by other tooling.
+The `--format` flag lets you print the output in other formats.
+The `json` format is available for programmatic parsing by other tooling.
+Default: `table`.
 
 ## Usage
 


### PR DESCRIPTION
Adds the following command documentation:

- `influxctl management`
- `influxctl management create`
- `influxctl management list`
- `influxctl management revoke`

I'm merging this into a feature branch, `influxctl-next-version`, that will hold all content for the next `influxctl` update. This initial draft only includes content for InfluxDB Cloud Dedicated, but once reviewed, I'll port it all to Clustered.

- [x] Rebased/mergeable
