### PR TITLE
Replace query plan ASCII diagrams with HTML

### DIFF
--- a/assets/styles/layouts/article/_captions.scss
+++ b/assets/styles/layouts/article/_captions.scss
@@ -26,3 +26,7 @@ h2,h3,h4,h5,h6 {
     opacity: 1;
   }
 }
+
+#query-plan-diagram + .caption {
+  margin-top: 0;
+}

--- a/assets/styles/layouts/article/_html-diagrams.scss
+++ b/assets/styles/layouts/article/_html-diagrams.scss
@@ -457,6 +457,82 @@ table tr.point{
   }
 }
 
+////////////////////////////// QUERY PLAN DIAGRAM //////////////////////////////
+
+#query-plan-diagram {
+  display: flex;
+  flex-direction: column;
+  font-size: 1rem;
+  margin: 3rem 0 3.5rem;
+  max-width: 800px;
+  
+  .plan-column {
+    padding: 0 .5rem;
+  }
+  
+  .plan-block {
+    background: $article-code-bg;
+    color: $article-code;
+    text-align: center;
+    padding: 1rem 1.5rem;
+    border-radius: $radius * 2;
+  }
+  .plan-arrow {
+    margin: .5rem auto;
+    height: 1.5rem;
+    width: 1px;
+    border-left: 1px solid $article-code;
+    position: relative;
+    
+    &:before {
+      content: "\25B2";
+      position: absolute;
+      top: .25rem;
+      left: -.32rem;
+      color: $article-code;
+      line-height: 0;
+    }
+    &.split {
+      width: 50%;
+      margin-top: 2rem;
+      height: 1rem;
+      display: flex;
+      justify-content: center;
+      border-width: 1px 1px 0 1px;
+      border-style: solid;
+      border-color: $article-code;
+
+      &:before {
+        position: relative;
+        top: -1.25rem;
+        left: -0.26rem;
+        width: 0;
+        margin-left: .2rem;
+      }
+      &:after {
+        content: "";
+        display: block;
+        height: 1rem;
+        width: 0;
+        border-left: 1px solid $article-code;
+        margin: -1rem 0;
+      }
+    }
+  }
+  .plan-single-column {
+    display: flex;
+    justify-content: center;
+  }
+  .plan-double-column {
+    display: flex;
+    justify-content: space-around;
+
+    .plan-column {
+      // width: 50%;
+    }
+  }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////// MEDIA QUERIES ////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////

--- a/content/influxdb/cloud-dedicated/query-data/troubleshoot-and-optimize/analyze-query-plan.md
+++ b/content/influxdb/cloud-dedicated/query-data/troubleshoot-and-optimize/analyze-query-plan.md
@@ -174,28 +174,9 @@ Data flows _up_ in a query plan.
 
 The following diagram shows the data flow and sequence of nodes in the [`EXPLAIN` report](#explain-report) physical plan:
 
-```text
-                   ┌─────────────────────────┐
-                   │ SortPreservingMergeExec │
-                   └─────────────────────────┘
-                                ▲
-                                │
-                   ┌─────────────────────────┐
-                   │        UnionExec        │
-                   └─────────────────────────┘
-                                ▲
-             ┌──────────────────┴─────────────────┐
-             │                                    │
-┌─────────────────────────┐          ┌─────────────────────────┐
-│        SortExec         │          │        SortExec         │
-└─────────────────────────┘          └─────────────────────────┘
-             ▲                                    ▲
-             │                                    │
-             │                                    │
-┌─────────────────────────┐          ┌─────────────────────────┐
-│       ParquetExec       │          │       ParquetExec       │
-└─────────────────────────┘          └─────────────────────────┘
-```
+<!-- BEGIN Query plan diagram -->
+{{< html-diagram/query-plan >}}
+<!-- END Query plan diagram -->
 
 {{% caption %}}
 Execution and data flow in the [`EXPLAIN` report](explain-report) physical plan.

--- a/content/influxdb/cloud-dedicated/reference/internals/query-plan.md
+++ b/content/influxdb/cloud-dedicated/reference/internals/query-plan.md
@@ -102,28 +102,9 @@ A [physical plan](#physical-plan) node represents a specific implementation of `
 
 The following diagram shows the data flow and sequence of `ExecutionPlan` nodes in the [Figure 1](#figure-1-explain-report) physical plan:
 
-```text
-                   ┌─────────────────────────┐
-                   │ SortPreservingMergeExec │
-                   └─────────────────────────┘
-                                ▲
-                                │
-                   ┌─────────────────────────┐
-                   │        UnionExec        │
-                   └─────────────────────────┘
-                                ▲
-             ┌──────────────────┴─────────────────┐
-             │                                    │
-┌─────────────────────────┐          ┌─────────────────────────┐
-│        SortExec         │          │        SortExec         │
-└─────────────────────────┘          └─────────────────────────┘
-             ▲                                    ▲
-             │                                    │
-             │                                    │
-┌─────────────────────────┐          ┌─────────────────────────┐
-│       ParquetExec       │          │       ParquetExec       │
-└─────────────────────────┘          └─────────────────────────┘
-```
+<!-- BEGIN Query plan diagram -->
+{{< html-diagram/query-plan >}}
+<!-- END Query plan diagram -->
 
 {{% product-name %}} includes the following plan expressions:
 

--- a/content/influxdb/cloud-serverless/query-data/troubleshoot-and-optimize/analyze-query-plan.md
+++ b/content/influxdb/cloud-serverless/query-data/troubleshoot-and-optimize/analyze-query-plan.md
@@ -172,28 +172,9 @@ Data flows _up_ in a query plan.
 
 The following diagram shows the data flow and sequence of nodes in the [`EXPLAIN` report](#explain-report) physical plan:
 
-```text
-                   ┌─────────────────────────┐
-                   │ SortPreservingMergeExec │
-                   └─────────────────────────┘
-                                ▲
-                                │
-                   ┌─────────────────────────┐
-                   │        UnionExec        │
-                   └─────────────────────────┘
-                                ▲
-             ┌──────────────────┴─────────────────┐
-             │                                    │
-┌─────────────────────────┐          ┌─────────────────────────┐
-│        SortExec         │          │        SortExec         │
-└─────────────────────────┘          └─────────────────────────┘
-             ▲                                    ▲
-             │                                    │
-             │                                    │
-┌─────────────────────────┐          ┌─────────────────────────┐
-│       ParquetExec       │          │       ParquetExec       │
-└─────────────────────────┘          └─────────────────────────┘
-```
+<!-- BEGIN Query plan diagram -->
+{{< html-diagram/query-plan >}}
+<!-- END Query plan diagram -->
 
 {{% caption %}}
 Execution and data flow in the [`EXPLAIN` report](explain-report) physical plan.

--- a/content/influxdb/cloud-serverless/reference/internals/query-plan.md
+++ b/content/influxdb/cloud-serverless/reference/internals/query-plan.md
@@ -102,28 +102,9 @@ A [physical plan](#physical-plan) node represents a specific implementation of `
 
 The following diagram shows the data flow and sequence of `ExecutionPlan` nodes in the [Figure 1](#figure-1-explain-report) physical plan:
 
-```text
-                   ┌─────────────────────────┐
-                   │ SortPreservingMergeExec │
-                   └─────────────────────────┘
-                                ▲
-                                │
-                   ┌─────────────────────────┐
-                   │        UnionExec        │
-                   └─────────────────────────┘
-                                ▲
-             ┌──────────────────┴─────────────────┐
-             │                                    │
-┌─────────────────────────┐          ┌─────────────────────────┐
-│        SortExec         │          │        SortExec         │
-└─────────────────────────┘          └─────────────────────────┘
-             ▲                                    ▲
-             │                                    │
-             │                                    │
-┌─────────────────────────┐          ┌─────────────────────────┐
-│       ParquetExec       │          │       ParquetExec       │
-└─────────────────────────┘          └─────────────────────────┘
-```
+<!-- BEGIN Query plan diagram -->
+{{< html-diagram/query-plan >}}
+<!-- END Query plan diagram -->
 
 {{% product-name %}} includes the following plan expressions:
 

--- a/content/influxdb/clustered/query-data/troubleshoot-and-optimize/analyze-query-plan.md
+++ b/content/influxdb/clustered/query-data/troubleshoot-and-optimize/analyze-query-plan.md
@@ -174,28 +174,9 @@ Data flows _up_ in a query plan.
 
 The following diagram shows the data flow and sequence of nodes in the [`EXPLAIN` report](#explain-report) physical plan:
 
-```text
-                   ┌─────────────────────────┐
-                   │ SortPreservingMergeExec │
-                   └─────────────────────────┘
-                                ▲
-                                │
-                   ┌─────────────────────────┐
-                   │        UnionExec        │
-                   └─────────────────────────┘
-                                ▲
-             ┌──────────────────┴─────────────────┐
-             │                                    │
-┌─────────────────────────┐          ┌─────────────────────────┐
-│        SortExec         │          │        SortExec         │
-└─────────────────────────┘          └─────────────────────────┘
-             ▲                                    ▲
-             │                                    │
-             │                                    │
-┌─────────────────────────┐          ┌─────────────────────────┐
-│       ParquetExec       │          │       ParquetExec       │
-└─────────────────────────┘          └─────────────────────────┘
-```
+<!-- BEGIN Query plan diagram -->
+{{< html-diagram/query-plan >}}
+<!-- END Query plan diagram -->
 
 {{% caption %}}
 Execution and data flow in the [`EXPLAIN` report](explain-report) physical plan.

--- a/content/influxdb/clustered/reference/internals/query-plan.md
+++ b/content/influxdb/clustered/reference/internals/query-plan.md
@@ -102,28 +102,9 @@ A [physical plan](#physical-plan) node represents a specific implementation of `
 
 The following diagram shows the data flow and sequence of `ExecutionPlan` nodes in the [Figure 1](#figure-1-explain-report) physical plan:
 
-```text
-                   ┌─────────────────────────┐
-                   │ SortPreservingMergeExec │
-                   └─────────────────────────┘
-                                ▲
-                                │
-                   ┌─────────────────────────┐
-                   │        UnionExec        │
-                   └─────────────────────────┘
-                                ▲
-             ┌──────────────────┴─────────────────┐
-             │                                    │
-┌─────────────────────────┐          ┌─────────────────────────┐
-│        SortExec         │          │        SortExec         │
-└─────────────────────────┘          └─────────────────────────┘
-             ▲                                    ▲
-             │                                    │
-             │                                    │
-┌─────────────────────────┐          ┌─────────────────────────┐
-│       ParquetExec       │          │       ParquetExec       │
-└─────────────────────────┘          └─────────────────────────┘
-```
+<!-- BEGIN Query plan diagram -->
+{{< html-diagram/query-plan >}}
+<!-- END Query plan diagram -->
 
 {{% product-name %}} includes the following plan expressions:
 

--- a/layouts/shortcodes/html-diagram/query-plan.html
+++ b/layouts/shortcodes/html-diagram/query-plan.html
@@ -1,0 +1,34 @@
+<div id="query-plan-diagram">
+  <div class="plan-single-column">
+    <div class="plan-column">
+      <div class="plan-block">
+        <code>SortPreservingMergeExec</code>
+      </div>
+      <div class="plan-arrow"></div>
+      <div class="plan-block">
+        <code>UnionExec</code>
+      </div>
+    </div>
+  </div>
+  <div class="plan-arrow split"></div>
+  <div class="plan-double-column">
+    <div class="plan-column">
+      <div class="plan-block">
+        <code>SortExec</code>
+      </div>
+      <div class="plan-arrow"></div>
+      <div class="plan-block">
+        <code>ParquetExec</code>
+      </div>
+    </div>
+    <div class="plan-column">
+      <div class="plan-block">
+        <code>SortExec</code>
+      </div>
+      <div class="plan-arrow"></div>
+      <div class="plan-block">
+        <code>ParquetExec</code>
+      </div>  
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This replaces all of the ASCII query plan diagrams with an HTML diagram that scales to the viewing size and shouldn't require horizontal scrolling on smaller screens.

<img width="594" alt="image" src="https://github.com/influxdata/docs-v2/assets/181484/583b9172-d9c5-47ef-a84c-40d285734ed5">

- [x] Rebased/mergeable
