### PR TITLE
Adds operator token requirement to org and user docs in v2

### DIFF
--- a/content/influxdb/v2/admin/organizations/create-org.md
+++ b/content/influxdb/v2/admin/organizations/create-org.md
@@ -16,6 +16,7 @@ to create an organization.
 
 {{% note %}}
 #### Organization and bucket limits
+
 A single InfluxDB {{< current-version >}} OSS instance supports approximately 20 buckets actively being
 written to or queried across all organizations depending on the use case.
 Any more than that can adversely affect performance.
@@ -35,14 +36,26 @@ Because each organization is created with a bucket, we do not recommend more tha
 ## Create an organization using the influx CLI
 
 Use the [`influx org create` command](/influxdb/v2/reference/cli/influx/org/create)
-to create a new organization. A new organization requires the following:
+to create a new organization. Provide the following:
 
-- A name for the organization
+- An [operator token](/influxdb/v2/admin/tokens/#operator-token) using your
+  [`influx` CLI connection configuration](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials),
+  `INFLUX_TOKEN` environment variable, or the `--token, -t` flag.
+- A name for the organization with the `--name, -n` flag.
+- _Optional:_ A description of the organization with the `--description, -d` flag.
 
+
+{{% code-placeholders "ORG_(NAME|DESCRIPTION)" %}}
 ```sh
-# Syntax
-influx org create -n <org-name>
-
-# Example
-influx org create -n my-org
+influx org create \
+  --name ORG_NAME \
+  --description "ORG_DESCRIPTION"
 ```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`ORG_NAME`{{% /code-placeholder-key %}}:
+  The name of the organization to create
+- {{% code-placeholder-key %}}`ORG_DESCRIPTION`{{% /code-placeholder-key %}}:
+  A description of the organization

--- a/content/influxdb/v2/admin/organizations/delete-org.md
+++ b/content/influxdb/v2/admin/organizations/delete-org.md
@@ -29,14 +29,19 @@ to delete an organization.
 ## Delete an organization using the influx CLI
 
 Use the [`influx org delete` command](/influxdb/v2/reference/cli/influx/org/delete)
-to delete an organization. Deleting an organization requires the following:
+to delete an organization. Provide the following:
 
-- The organization ID _(provided in the output of `influx org list`)_
+- An [operator token](/influxdb/v2/admin/tokens/#operator-token) using your
+  [`influx` CLI connection configuration](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials),
+  `INFLUX_TOKEN` environment variable, or the `--token, -t` flag.
+- The [ID of the organization](/influxdb/v2/admin/organizations/view-orgs/#view-your-organization-id)
+  to delete
 
+{{% code-placeholders "ORG_ID" %}}
 ```sh
-# Syntax
-influx org delete -i <org-id>
-
-# Example
-influx org delete -i 034ad714fdd6f000
+influx org delete -i ORG_ID
 ```
+{{% /code-placeholders %}}
+
+Replace {{% code-placeholder-key %}}`ORG_ID`{{% /code-placeholder-key %}} with
+the ID of the organization to delete.

--- a/content/influxdb/v2/admin/organizations/switch-org.md
+++ b/content/influxdb/v2/admin/organizations/switch-org.md
@@ -11,7 +11,9 @@ aliases:
   - /influxdb/v2/organizations/switch-org/
 ---
 
-Use the InfluxDB user interface (UI) to switch from one organization to another. The organization you're currently viewing determines what dashboards, tasks, buckets, members, and other assets you can access.
+Use the InfluxDB user interface (UI) to switch from one organization to another.
+The organization you're currently viewing determines what dashboards, tasks,
+buckets, members, and other assets you can access.
 
 ## Switch organizations in the InfluxDB UI
 

--- a/content/influxdb/v2/admin/organizations/update-org.md
+++ b/content/influxdb/v2/admin/organizations/update-org.md
@@ -27,7 +27,7 @@ If you change an organization name, be sure to update the organization in the ab
 
 1. In the navigation menu on the left, click the user icon > **About**.
 
-    {{< img-hd src="/img/influxdb/user-icon.png" alt="User Icon" />}}
+    {{< nav-icon "account" >}}
 
 2. Click **{{< icon "edit" >}} Rename**. A verification window appears.
 3. Review the information, and then click **I understand, let's rename my organization**.
@@ -36,16 +36,33 @@ If you change an organization name, be sure to update the organization in the ab
 ## Update an organization using the influx CLI
 
 Use the [`influx org update` command](/influxdb/v2/reference/cli/influx/org/update)
-to update an organization. Updating an organization requires the following:
+to update an organization. Provide the following:
 
-- The org ID _(provided in the output of `influx org list`)_
+- An [operator token](/influxdb/v2/admin/tokens/#operator-token) using your
+  [`influx` CLI connection configuration](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials),
+  `INFLUX_TOKEN` environment variable, or the `--token, -t` flag.
+- The [ID of the organization](/influxdb/v2/admin/organizations/view-orgs/#view-your-organization-id)
+  to update using the `--org-id, -i` flag.
+- _Optional:_ The updated name for the organization with the `--name, -n` flag.
+- _Optional:_ The updated description for the organization with the
+  `--description, -d` flag.
 
 ##### Update the name of a organization
 
+{{% code-placeholders "ORG_ID|NEW_ORG_(NAME|DESCRIPTION)" %}}
 ```sh
-# Syntax
-influx org update -i <org-id> -n <new-org-name>
-
-# Example
-influx org update -i 034ad714fdd6f000 -n my-new-org
+influx org update \
+  --org-id ORG_ID \
+  --name NEW_ORG_NAME \
+  --description NEW_ORG_DESCRIPTION \
 ```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`ORG_ID`{{% /code-placeholder-key %}}:
+  The ID of the organization to update.
+- {{% code-placeholder-key %}}`NEW_ORG_NAME`{{% /code-placeholder-key %}}:
+  The new name for the organization.
+- {{% code-placeholder-key %}}`NEW_ORG_DESCRIPTION`{{% /code-placeholder-key %}}:
+  The new description for the organization.

--- a/content/influxdb/v2/admin/organizations/update-org.md
+++ b/content/influxdb/v2/admin/organizations/update-org.md
@@ -47,7 +47,7 @@ to update an organization. Provide the following:
 - _Optional:_ The updated description for the organization with the
   `--description, -d` flag.
 
-##### Update the name of a organization
+##### Update the name of an organization
 
 {{% code-placeholders "ORG_ID|NEW_ORG_(NAME|DESCRIPTION)" %}}
 ```sh

--- a/content/influxdb/v2/admin/organizations/view-orgs.md
+++ b/content/influxdb/v2/admin/organizations/view-orgs.md
@@ -25,7 +25,11 @@ to view organizations.
 ## View organizations using the influx CLI
 
 Use the [`influx org list` command](/influxdb/v2/reference/cli/influx/org/list)
-to view organizations.
+to view organizations. Provide the following:
+
+- An [operator token](/influxdb/v2/admin/tokens/#operator-token) using your
+  [`influx` CLI connection configuration](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials),
+  `INFLUX_TOKEN` environment variable, or the `--token, -t` flag.
 
 ```sh
 influx org list
@@ -52,11 +56,20 @@ http://localhost:8086/orgs/03a2bbf46249a000/...
 
 ### Organization ID in the CLI
 
-Use [`influx org list`](#view-organizations-using-the-influx-cli) to view your organization ID.
+Use [`influx org list`](#view-organizations-using-the-influx-cli) to view your
+organization ID. Provide the following:
+
+- An [operator token](/influxdb/v2/admin/tokens/#operator-token) using your
+  [`influx` CLI connection configuration](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials),
+  `INFLUX_TOKEN` environment variable, or the `--token, -t` flag.
 
 ```sh
-> influx org list
+influx org list
+```
 
+The command returns output similar to:
+
+```
 ID                  Name
 03a2bbf46249a000    org-1
 03ace3a859669000    org-2

--- a/content/influxdb/v2/admin/users/change-password.md
+++ b/content/influxdb/v2/admin/users/change-password.md
@@ -27,7 +27,7 @@ to update a password for a user. Provide the following:
   `INFLUX_TOKEN` environment variable, or the `--token, -t` flag.
 - The username (with the `--name, -n` flag) or the user ID (with the `--id, -i` flag).
   View usernames and IDs in the output of `influx user list`.
-- A new password with the `--password, -p` flag. If no password flag is provided
+- _Optional_: the `--password, -p` flag and the new password. If you don't provide a password flag,
   enter the new password when prompted.
 
 ##### Update a password

--- a/content/influxdb/v2/admin/users/change-password.md
+++ b/content/influxdb/v2/admin/users/change-password.md
@@ -20,19 +20,29 @@ User passwords cannot be updated in the InfluxDB UI.
 ## Change your password using the influx CLI
 
 Use the [`influx user password` command](/influxdb/v2/reference/cli/influx/user/password)
-to update a password for a user. To update a password, you need the following:
+to update a password for a user. Provide the following:
 
-- Username or user ID _(provided in the output of `influx user list`)_
-- New password
-- [Operator token](/influxdb/v2/admin/tokens/#operator-token)
+- An [operator token](/influxdb/v2/admin/tokens/#operator-token) using your
+  [`influx` CLI connection configuration](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials),
+  `INFLUX_TOKEN` environment variable, or the `--token, -t` flag.
+- The username (with the `--name, -n` flag) or the user ID (with the `--id, -i` flag).
+  View usernames and IDs in the output of `influx user list`.
+- A new password with the `--password, -p` flag. If no password flag is provided
+  enter the new password when prompted.
 
 ##### Update a password
+
+{{% code-placeholders "USERNAME|PASSWORD" %}}
 ```sh
-# Syntax
-influx user password -n <username> -t <token>
-
-# Example
-influx user password -n johndoe -t My5uPErSecR37t0k3n
+influx user password \
+  --name USERNAME \
+  --password PASSWORD
 ```
+{{% /code-placeholders %}}
 
-When prompted, enter and confirm the new password.
+Replace the following:
+
+- {{% code-placeholder-key %}}`USERNAME`{{% /code-placeholder-key %}}:
+  The username to change the password for
+- {{% code-placeholder-key %}}`PASSWORD`{{% /code-placeholder-key %}}:
+  The new password

--- a/content/influxdb/v2/admin/users/create-user.md
+++ b/content/influxdb/v2/admin/users/create-user.md
@@ -28,8 +28,7 @@ and provide the following:
 - The [organization name or ID](/influxdb/v2/admin/organizations/view-orgs/) to
   add the new user to.
 - A username for the new user with the `--name, -n` flag.
-- _Optional:_ A password for the new user. If no password is provided, the new
-  user will be prompted to provide one.
+- _Optional_: the `--password, -p` flag and a password for the user. If you don't provide a password, the new user will be prompted to provide one.
 
 {{< cli/influx-creds-note >}}
 

--- a/content/influxdb/v2/admin/users/create-user.md
+++ b/content/influxdb/v2/admin/users/create-user.md
@@ -19,36 +19,34 @@ Additional users cannot be created in the InfluxDB UI.
 
 To create a new user, you must have an [operator token](/influxdb/v2/reference/glossary/#token).
 For more information, see how to [create an operator token](/influxdb/v2/admin/tokens/create-token/#create-an-operator-token).
-Use the [`influx user create` command](/influxdb/v2/reference/cli/influx/user/create) and include the following:
+Use the [`influx user create` command](/influxdb/v2/reference/cli/influx/user/create)
+and provide the following:
 
-- Username
-- Organization name or organization ID to add the user to _(provided in the output of
-  [`influx org list`](/influxdb/v2/reference/cli/influx/org/list/))_
+- An [operator token](/influxdb/v2/admin/tokens/#operator-token) using your
+  [`influx` CLI connection configuration](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials),
+  `INFLUX_TOKEN` environment variable, or the `--token, -t` flag.
+- The [organization name or ID](/influxdb/v2/admin/organizations/view-orgs/) to
+  add the new user to.
+- A username for the new user with the `--name, -n` flag.
+- _Optional:_ A password for the new user. If no password is provided, the new
+  user will be prompted to provide one.
 
 {{< cli/influx-creds-note >}}
 
+{{% code-placeholders "(USER|ORG)_(NAME|PASSWORD)" %}}
 ```sh
-# Syntax
-influx user create -n <username> -o <org-name>
-
-# Example
-influx user create -n johndoe -o example-org
+influx user create \
+  --org ORG_NAME \
+  --name USER_NAME \
+  --password USER_PASSWORD
 ```
+{{% /code-placeholders %}}
 
-### Create a user with a password and organization
+Replace the following:
 
-To create a new user with a password and add the user as a member of an organization,
-include a password and organization ID with the `influx user create` command.
-
-- Username
-- Organization name or organization ID to add the user to _(provided in the output of
-  [`influx org list`](/influxdb/v2/reference/cli/influx/org/list/))_
-- Password
-
-```sh
-# Syntax
-influx user create -n <username> -p <password> -o <org-name>
-
-# Example
-influx user create -n johndoe -p PaSsWoRd -o example-org
-```
+- {{% code-placeholder-key %}}`ORG_NAME`{{% /code-placeholder-key %}}:
+  The name of the organization to add the new user to
+- {{% code-placeholder-key %}}`USER_NAME`{{% /code-placeholder-key %}}:
+  The username of the new user
+- {{% code-placeholder-key %}}`USER_PASSWORD`{{% /code-placeholder-key %}}:
+  The password for the new user

--- a/content/influxdb/v2/admin/users/delete-user.md
+++ b/content/influxdb/v2/admin/users/delete-user.md
@@ -29,14 +29,18 @@ Users cannot be deleted from the InfluxDB UI.
 ## Delete a user using the influx CLI
 
 Use the [`influx user delete` command](/influxdb/v2/reference/cli/influx/user/delete)
-to delete a user. Deleting a user requires the following:
+to delete a user. Provide the following:
 
+- An [operator token](/influxdb/v2/admin/tokens/#operator-token) using your
+  [`influx` CLI connection configuration](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials),
+  `INFLUX_TOKEN` environment variable, or the `--token, -t` flag.
 - The user ID _(provided in the output of `influx user list`)_
 
+{{% code-placeholders "USER_ID" %}}
 ```sh
-# Syntax
-influx user delete -i <user-id>
-
-# Example
-influx user delete -i 034ad714fdd6f000
+influx user delete --id USER_ID
 ```
+{{% /code-placeholders %}}
+
+Replace {{% code-placeholder-key %}}`USER_ID`{{% /code-placeholder-key %}} with
+the ID of the user to delete.

--- a/content/influxdb/v2/admin/users/recover-credentials.md
+++ b/content/influxdb/v2/admin/users/recover-credentials.md
@@ -13,7 +13,9 @@ related:
   - /influxdb/v2/reference/cli/influxd/recovery/
 ---
 
-Use the `influxd` command line interface (CLI) to recover user credentials and regain access to your InfluxDB instance:
+Use the `influxd` command line interface (CLI) to recover user credentials and
+regain access to your InfluxDB instance:
+
 - [Update a password](#update-a-password)
 - [List existing users in the InfluxDB instance](#list-existing-users-in-the-influxdb-instance)
 - [Create a user for recovery purposes](#create-a-user-for-recovery-purposes)

--- a/content/influxdb/v2/admin/users/update-user.md
+++ b/content/influxdb/v2/admin/users/update-user.md
@@ -23,15 +23,27 @@ User information cannot be updated in the InfluxDB UI.
 ## Update a user using the influx CLI
 
 Use the [`influx user update` command](/influxdb/v2/reference/cli/influx/user/update)
-to update a user. Updating a user requires the following:
+to update a user. Provide the following:
 
-- The user ID _(provided in the output of `influx user list`)_
+- An [operator token](/influxdb/v2/admin/tokens/#operator-token) using your
+  [`influx` CLI connection configuration](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials),
+  `INFLUX_TOKEN` environment variable, or the `--token, -t` flag.
+- The user ID _(provided in the output of `influx user list`)_ using the `--id, -i` flag.
+- The new username for the user using the `--name, -n` flag.
 
 ##### Update the name of a user
-```sh
-# Syntax
-influx user update -i <user-id> -n <new-username>
 
-# Example
-influx user update -i 034ad714fdd6f000 -n janedoe
+{{% code-placeholders "USER_ID|NEW_USERNAME" %}}
+```sh
+influx user update \
+  --id USER_ID \
+  --name NEW_USERNAME
 ```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`USER_ID`{{% /code-placeholder-key %}}:
+  The ID of the user to update
+- {{% code-placeholder-key %}}`NEW_USERNAME`{{% /code-placeholder-key %}}:
+  The new username for the user

--- a/content/influxdb/v2/admin/users/view-users.md
+++ b/content/influxdb/v2/admin/users/view-users.md
@@ -11,19 +11,16 @@ aliases:
   - /influxdb/v2/users/view-users/
 ---
 
-Use the InfluxDB user interface (UI) or the `influx` command line interface (CLI)
-to view users.
-
-## View users in the InfluxDB UI
-
-{{% note %}}
-There is no list of users in the InfluxDB UI.
-{{% /note %}}
+Use the `influx` command line interface (CLI) to view users.
 
 ## View users using the influx CLI
 
 Use the [`influx user list` command](/influxdb/v2/reference/cli/influx/user/list)
-to view users.
+to view users. Provide the following:
+
+- An [operator token](/influxdb/v2/admin/tokens/#operator-token) using your
+  [`influx` CLI connection configuration](/influxdb/v2/reference/cli/influx/#provide-required-authentication-credentials),
+  `INFLUX_TOKEN` environment variable, or the `--token, -t` flag.
 
 ```sh
 influx user list


### PR DESCRIPTION
Closes influxdata/influxdb#24817
Closes #4829
Closes #4517

It wasn't clear in the v2 organization and user management docs that an operator token is required to perform these actions. I added the requirement and updated the code examples to use code placeholders.

- [x] Rebased/mergeable
