### PR TITLE
docs: Add docker compose workflow for running docs locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ including our GPG key, can be found at https://www.influxdata.com/how-to-report-
 
 ### Alternative: Use docker compose
 
-1. [**Clone this repository**](https://help.github.com/articles/cloning-a-repository/) to your local machine.
+1. Clone this repository to your local machine. See how to [clone a repository](https://help.github.com/articles/cloning-a-repository/).
 
 2. **Install Docker & Compose Plugin**
 

--- a/README.md
+++ b/README.md
@@ -52,3 +52,18 @@ including our GPG key, can be found at https://www.influxdata.com/how-to-report-
       npx hugo server
       ```
 5. View the docs at [localhost:1313](http://localhost:1313).
+
+### Alternative: Use docker compose
+
+1. [**Clone this repository**](https://help.github.com/articles/cloning-a-repository/) to your local machine.
+
+2. **Install Docker & Compose Plugin**
+
+3. **Start the Hugo Server**
+
+  In your terminal use `docker compose` to start the Hugo server in dev mode:
+
+    ```sh
+    docker compose up local-dev
+    ```
+4. View the docs at [localhost:1313](http://localhost:1313).

--- a/README.md
+++ b/README.md
@@ -59,9 +59,7 @@ including our GPG key, can be found at https://www.influxdata.com/how-to-report-
 
 2. Follow the instructions to [install Docker Desktop](https://docs.docker.com/desktop/) and [Docker Compose](https://docs.docker.com/compose/) to your local machine.
 
-3. **Start the Hugo Server**
-
-  In your terminal use `docker compose` to start the Hugo server in dev mode:
+3. Use Docker Compose to start the Hugo server in development mode--for example, enter the following command in your terminal:
 
     ```sh
     docker compose up local-dev

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ including our GPG key, can be found at https://www.influxdata.com/how-to-report-
 
 1. Clone this repository to your local machine. See how to [clone a repository](https://help.github.com/articles/cloning-a-repository/).
 
-2. **Install Docker & Compose Plugin**
+2. Follow the instructions to [install Docker Desktop](https://docs.docker.com/desktop/) and [Docker Compose](https://docs.docker.com/compose/) to your local machine.
 
 3. **Start the Hugo Server**
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,5 @@
-# For examples, see the Awesome Compose repository:
-# https://github.com/docker/awesome-compose
+# This is a Docker Compose file for the InfluxData documentation site.
+## Run documentation tests for code samples.
 services:
   test:
     image: docs-v2-tests
@@ -19,13 +19,18 @@ services:
       args:
         - SOURCE_DIR=test
         - DOCKER_IMAGE=docs-v2-tests
-  # documentation for hugomods/hugo can be found at
-  # https://docker.hugomods.com/docs/development/docker-compose/
+  ## Run InfluxData documentation with the hugo development server on port 1313.
+  ## For more information about the hugomods/hugo image, see
+  ## https://docker.hugomods.com/docs/development/docker-compose/
   local-dev:
     image: hugomods/hugo:exts-0.123.8
     command: hugo server --bind 0.0.0.0
     ports:
       - 1313:1313
     volumes:
-      - $PWD:/src
-      - $HOME/hugo_cache:/tmp/hugo_cache
+      - type: bind
+        source: "$PWD"
+        target: /src
+      - type: bind
+        source: $HOME/hugo_cache
+        target: /tmp/hugo_cache

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,3 +19,13 @@ services:
       args:
         - SOURCE_DIR=test
         - DOCKER_IMAGE=docs-v2-tests
+  # documentation for hugomods/hugo can be found at
+  # https://docker.hugomods.com/docs/development/docker-compose/
+  local-dev:
+    image: hugomods/hugo:exts-0.123.8
+    command: hugo server --bind 0.0.0.0
+    ports:
+      - 1313:1313
+    volumes:
+      - $PWD:/src
+      - $HOME/hugo_cache:/tmp/hugo_cache


### PR DESCRIPTION
Closes #5399

Definitely open to feedback here. It seems to just work when I run `docker compose up local-dev` -- the rendered site looks fine without running any additional npm commands or whatever.


- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
