### PR TITLE
fix: correct definition of `commit-timeout`

### DIFF
--- a/content/enterprise_influxdb/v1/administration/configure/config-meta-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/configure/config-meta-nodes.md
@@ -238,8 +238,8 @@ Environment variable: `INFLUXDB_META_LEADER_LEASE_TIMEOUT`
 
 Default is `"50ms"`.
 
-The commit timeout is the amount of time a Raft node will tolerate between
-commands before issuing a heartbeat to tell the leader it is alive.
+The commit timeout is the interval the leader waits between sending messages with
+the leader's commit index to followerers.
 The default setting should work for most systems.
 
 Environment variable: `INFLUXDB_META_COMMIT_TIMEOUT`


### PR DESCRIPTION
Correct definition of `commit-timeout` to match its use in Raft. See https://github.com/hashicorp/raft/issues/28 for more information.
