### PR TITLE
feat(dedicated): add Management API create and list databases to task-based docs

### DIFF
--- a/content/influxdb/cloud-dedicated/admin/databases/create.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/create.md
@@ -152,17 +152,16 @@ There is no way to update a partition template on an existing database.
 _This example uses [cURL](https://curl.se/) to send a Management HTTP API request, but you can use any HTTP client._
 
 1. If you haven't already, follow the instructions to [install cURL](https://everything.curl.dev/install/index.html) for your system.
-2. In your terminal, use cURL to send a request to the following endpoint:
+2. In your terminal, use cURL to send a request to the following {{% product-name %}} console endpoint:
 
-   {{% api-endpoint endpoint="https://{{< influxdb/host >}}/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" method="post" api-ref="/influxdb/cloud-dedicated/api/management/#operation/CreateClusterDatabase" %}}
+   {{% api-endpoint endpoint="https://console.influxdata.com/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" method="post" api-ref="/influxdb/cloud-dedicated/api/management/#operation/CreateClusterDatabase" %}}
 
    In the URL, provide the following credentials:
 
-   - Your {{% product-name omit="Clustered" %}} cluster URL.
    - `ACCOUNT_ID`: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the cluster belongs to. To view account ID and cluster ID, [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
    - `CLUSTER_ID`: The ID of the [cluster](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that you want to manage. To view account ID and cluster ID, [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
 
-   In request headers, provide the following:
+   Provide the following request headers:
 
    - `Accept: application/json` to ensure the response body is JSON content
    - `Content-Type: application/json` to indicate the request body is JSON content
@@ -193,7 +192,7 @@ The following example shows how to use the Management API to create a database w
 
 ```sh
 curl \
-   --location "https://{{< influxdb/host >}}/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" \
+   --location "https://console.influxdata.com/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" \
    --header "Accept: application/json" \
    --header 'Content-Type: application/json' \
    --header "Authorization: Bearer MANAGEMENT_TOKEN" \

--- a/content/influxdb/cloud-dedicated/admin/databases/create.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/create.md
@@ -1,7 +1,7 @@
 ---
 title: Create a database
 description: >
-  Use the [`influxctl database create` command](/influxdb/cloud-dedicated/reference/cli/influxctl/database/create/)
+  Use the [`influxctl database create` command](/influxdb/cloud-dedicated/reference/cli/influxctl/database/create/) or the Management HTTP API
   to create a new InfluxDB database in your InfluxDB Cloud Dedicated cluster.
   Provide a database name and an optional retention period.
 menu:
@@ -19,55 +19,78 @@ list_code_example: |
 related:
   - /influxdb/cloud-dedicated/reference/cli/influxctl/database/create/
   - /influxdb/cloud-dedicated/admin/custom-partitions/
+  - /influxdb/cloud-dedicated/api/management/#operation/CreateClusterDatabase
 ---
 
-Use the [`influxctl database create` command](/influxdb/cloud-dedicated/reference/cli/influxctl/database/create/)
-to create a database in your {{< product-name omit=" Clustered" >}} cluster.
+Use the [`influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/database/create/)
+or the [Management HTTP API](influxdb/cloud-dedicated/api/management/) to create a database in your {{< product-name omit=" Clustered" >}} cluster.
 
-1.  If you haven't already, [download and install the `influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/#download-and-install-influxctl).
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[influxctl](#)
+[Management API](#)
+{{% /tabs %}}
+{{% tab-content %}}
+
+<!------------------------------- BEGIN INFLUXCTL ----------------------------->
+
+1.  If you haven't already, [download and install the `influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/#download-and-install-influxctl), and then [configure an `influxctl` connection profile](/influxdb/cloud-dedicated/reference/cli/influxctl/#configure-connection-profiles) for your cluster.
+
 2.  Run the `influxctl database create` command and provide the following:
 
     - _Optional:_ Database [retention period](/influxdb/cloud-dedicated/admin/databases/#retention-periods)
-      _(default is infinite)_
-    - _Optional_: Database table (measurement) limit _(default is 500)_
-    - _Optional_: Database column limit _(default is 250)_
+    Default is `0` (infinite).
+    - _Optional_: Database table (measurement) limit. Default is `500`.
+    - _Optional_: Database column limit. Default is `250`.
     - _Optional_: [InfluxDB tags](/influxdb/cloud-dedicated/reference/glossary/#tag)
-      to use in the partition template
+     to use in the partition template. Limit is 7 total tags or tag buckets.
     - _Optional_: [InfluxDB tag buckets](/influxdb/cloud-dedicated/admin/custom-partitions/partition-templates/#tag-bucket-part-templates)
-      to use in the partition template
+     to use in the partition template. Limit is 7 total tags or tag buckets.
     - _Optional_: A [Rust strftime date and time string](/influxdb/cloud-dedicated/admin/custom-partitions/partition-templates/#time-part-templates)
-      that specifies the time format in the partition template and determines
-      the time interval to partition by _(default is `%Y-%m-%d`)_
+     that specifies the time format in the partition template and determines
+     the time interval to partition by. Default is `%Y-%m-%d`.
     - Database name _(see [Database naming restrictions](#database-naming-restrictions))_
 
     {{% note %}}
 _{{< product-name >}} supports up to 7 total tags or tag buckets in the partition template._
     {{% /note %}}
 
-{{% code-placeholders "DATABASE_NAME|30d|500|200" %}}
+{{% code-placeholders "DATABASE_NAME|30d|500|100|300|(TAG_KEY(_\d)?)" %}}
+
 ```sh
 influxctl database create \
   --retention-period 30d \
   --max-tables 500 \
   --max-columns 250 \
-  --template-tag tag1 \
-  --template-tag tag2 \
-  --template-tag-bucket tag3,100 \
-  --template-tag-bucket tag4,300 \
+  --template-tag TAG_KEY_1 \
+  --template-tag TAG_KEY_2 \
+  --template-tag-bucket TAG_KEY_3,100 \
+  --template-tag-bucket TAG_KEY_4,300 \
   --template-timeformat '%Y-%m-%d' \
   DATABASE_NAME
 ```
+
 {{% /code-placeholders %}}
 
-- [Retention period syntax](#retention-period-syntax)
+Replace the following in your command:
+
+- {{% code-placeholder-key %}}`ACCOUNT_ID`{{% /code-placeholder-key %}}: the ID of the {{% product-name %}} account to create the database for
+- {{% code-placeholder-key %}}`CLUSTER_ID`{{% /code-placeholder-key %}}: the ID of the {{% product-name %}} cluster to create the database for
+- {{% code-placeholder-key %}}`MANAGEMENT TOKEN`{{% /code-placeholder-key %}}: a [management token](/influxdb/cloud-dedicated/admin/tokens/management/) for your {{% product-name %}} cluster
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}: your {{% product-name %}} database
+- {{% code-placeholder-key %}}`TAG_KEY_1`, `TAG_KEY_2`, `TAG_KEY_3`, and `TAG_KEY_4`{{% /code-placeholder-key %}}: [tag]((/influxdb/cloud-dedicated/reference/glossary/#tag)) keys from your data
+
+## Database attributes
+
+- [Retention period syntax (influxctl CLI)](#retention-period-syntax-influxctl-cli)
+- [Custom partitioning (influxctl CLI)](#custom-partitioning-influxctl-cli)
 - [Database naming restrictions](#database-naming-restrictions)
 - [InfluxQL DBRP naming convention](#influxql-dbrp-naming-convention)
 - [Table and column limits](#table-and-column-limits)
-- [Custom partitioning](#custom-partitioning)
 
-## Retention period syntax
+### Retention period syntax (influxctl CLI)
 
-Use the `--retention-period` flag to define a specific
+Use the `--retention-period` flag to define the
 [retention period](/influxdb/cloud-dedicated/admin/databases/#retention-periods)
 for the database.
 The retention period value is a time duration value made up of a numeric value
@@ -79,7 +102,7 @@ The retention period value cannot be negative or contain whitespace.
 {{< flex >}}
 {{% flex-content "half" %}}
 
-##### Valid durations units include
+#### Valid durations units include
 
 - **m**: minute
 - **h**: hour
@@ -91,7 +114,7 @@ The retention period value cannot be negative or contain whitespace.
 {{% /flex-content %}}
 {{% flex-content "half" %}}
 
-##### Example retention period values
+#### Example retention period values
 
 - `0d`: infinite/none
 - `3d`: 3 days
@@ -104,7 +127,180 @@ The retention period value cannot be negative or contain whitespace.
 {{% /flex-content %}}
 {{< /flex >}}
 
-## Database naming restrictions
+### Custom partitioning (influxctl CLI)
+
+{{< product-name >}} lets you define a custom partitioning strategy for each database.
+A _partition_ is a logical grouping of data stored in [Apache Parquet](https://parquet.apache.org/)
+format in the InfluxDB v3 storage engine. By default, data is partitioned by day,
+but, depending on your schema and workload, customizing the partitioning
+strategy can improve query performance.
+
+Use the `--template-tag`, `--template-tag-bucket`, and `--template-timeformat`
+flags to define partition template parts used to generate partition keys for the database.
+
+For more information, see [Manage data partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/).
+
+{{% note %}}
+#### Partition templates can only be applied on create
+
+You can only apply a partition template when creating a database.
+There is no way to update a partition template on an existing database.
+{{% /note %}}
+
+<!-------------------------------- END INFLUXCTL ------------------------------>
+{{% /tab-content %}}
+{{% tab-content %}}
+<!------------------------------- BEGIN cURL ---------------------------------->
+
+_This example uses [cURL](https://curl.se/) to send a Management HTTP API request, but you can use any HTTP client._
+
+1. If you haven't already, follow the instructions to [install cURL](https://everything.curl.dev/install/index.html) for your system.
+2. Obtain the following credentials for your cluster:
+
+   - `ACCOUNT_ID`: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the cluster belongs to. To view account ID and cluster ID, [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
+   - `CLUSTER_ID`: The ID of the [cluster](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that you want to manage. To view account ID and cluster ID, [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
+   - `Authorization MANAGEMENT_TOKEN`: the `Authorization` HTTP header with a [management token](/influxdb/cloud-dedicated/admin/tokens/management/) _(see how to [create a management token](/influxdb/cloud-dedicated/admin/tokens/management/) for Management API requests)_.
+
+3. In your terminal, use cURL to send a request to the following endpoint:
+
+   {{% api-endpoint endpoint="https://{{< influxdb/host >}}/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" method="post" api-ref="/influxdb/cloud-dedicated/api/management/#operation/CreateClusterDatabase" %}}
+
+   In the URL, provide the following credentials:
+
+   - Your InfluxDB Host URL
+   - Your InfluxDB Account ID
+   - Your InfluxDB Cluster ID
+
+   In request headers, provide the following:
+
+   - `Accept: application/json` to ensure the response body is JSON content
+   - `Content-Type: application/json` to indicate the request body is JSON content
+   - `Authorization: Bearer` and a [Management API token](/influxdb/cloud-dedicated/admin/tokens/management/) for your cluster
+
+   In the request body, provide the following parameters:
+
+   - _Optional:_ Database [retention period](/influxdb/cloud-dedicated/admin/databases/#retention-periods) in nanoseconds.
+    Default is `0` (infinite).
+   - _Optional_: Database table (measurement) limit. Default is `500`.
+   - _Optional_: Database column limit. Default is `250`.
+   - _Optional_: [InfluxDB tags](/influxdb/cloud-dedicated/reference/glossary/#tag)
+    to use in the partition template. Limit is 7 total tags or tag buckets.
+   - _Optional_: [InfluxDB tag buckets](/influxdb/cloud-dedicated/admin/custom-partitions/partition-templates/#tag-bucket-part-templates)
+    to use in the partition template. Limit is 7 total tags or tag buckets.
+   - _Optional_: A [Rust strftime date and time string](/influxdb/cloud-dedicated/admin/custom-partitions/partition-templates/#time-part-templates)
+    that specifies the time format in the partition template and determines
+    the time interval to partition by. Default is `%Y-%m-%d`.
+   - Database name _(see [Database naming restrictions](#database-naming-restrictions))_.
+
+    {{% note %}}
+_{{< product-name >}} supports up to 7 total tags or tag buckets in the partition template._
+    {{% /note %}}
+
+The following example shows how to use the Management API to create a database with custom partitioning:
+
+{{% code-placeholders "DATABASE_NAME|2592000000000|500|100|300|250|ACCOUNT_ID|CLUSTER_ID|MANAGEMENT_TOKEN|(TAG_KEY(_\d)?)" %}}
+
+```sh
+curl \
+   --location "https://{{< influxdb/host >}}/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" \
+   --header "Accept: application/json" \
+   --header 'Content-Type: application/json' \
+   --header "Authorization: Bearer MANAGEMENT_TOKEN" \
+   --data '{
+     "name": "'DATABASE_NAME'",
+     "maxTables": 500,
+     "maxColumnsPerTable": 250,
+     "retentionPeriod": 2592000000000,
+     "partitionTemplate": [
+       {
+         "type": "tag",
+         "value": "TAG_KEY_1"
+       },
+       {
+         "type": "tag",
+         "value": "TAG_KEY_2"
+       },
+       {
+         "type": "bucket",
+         "value": {
+           "tagName": "TAG_KEY_3",
+           "numberOfBuckets": 100
+         }
+       },
+       {
+         "type": "bucket",
+         "value": {
+           "tagName": "TAG_KEY_4",
+           "numberOfBuckets": 300
+         }
+       },
+       {
+         "type": "time",
+         "value": "%Y-%m-%d"
+       }
+     ]
+   }'
+```
+
+{{% /code-placeholders %}}
+
+Replace the following in your request:
+
+- {{% code-placeholder-key %}}`ACCOUNT_ID`{{% /code-placeholder-key %}}: the ID of the {{% product-name %}} account to create the database for
+- {{% code-placeholder-key %}}`CLUSTER_ID`{{% /code-placeholder-key %}}: the ID of the {{% product-name %}} cluster to create the database for
+- {{% code-placeholder-key %}}`MANAGEMENT TOKEN`{{% /code-placeholder-key %}}: a [management token](/influxdb/cloud-dedicated/admin/tokens/management/) for your {{% product-name %}} cluster
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}: your {{% product-name %}} database
+- {{% code-placeholder-key %}}`TAG_KEY_1`, `TAG_KEY_2`, `TAG_KEY_3`, and `TAG_KEY_4`{{% /code-placeholder-key %}}: [tag]((/influxdb/cloud-dedicated/reference/glossary/#tag)) keys from your data
+
+## Database attributes
+
+- [Retention period syntax (Management API)](#retention-period-syntax-management-api)
+- [Custom partitioning (Management API)](#custom-partitioning-management-api)
+- [Database naming restrictions](#database-naming-restrictions)
+- [InfluxQL DBRP naming convention](#influxql-dbrp-naming-convention)
+- [Table and column limits](#table-and-column-limits)
+
+### Retention period syntax (Management API)
+
+Use the `retentionPeriod` property to specify the
+[retention period](/influxdb/cloud-dedicated/admin/databases/#retention-periods)
+for the database.
+The retention period value is an integer (`<int32>`) that represents the number of nanoseconds.
+For example, `2592000000000` means 30 days.
+A zero (`0`) retention period is infinite and data won't expire.
+The retention period value cannot be negative or contain whitespace.
+
+#### Example retention period values
+
+- `0`: infinite/none
+- `259200000000000`: 3 days
+- `2592000000000000`: 30 days
+- `31536000000000000`: 1 standard year (365 days)
+
+### Custom partitioning (Management API)
+
+{{< product-name >}} lets you define a custom partitioning strategy for each database.
+A _partition_ is a logical grouping of data stored in [Apache Parquet](https://parquet.apache.org/)
+format in the InfluxDB v3 storage engine. By default, data is partitioned by day,
+but, depending on your schema and workload, customizing the partitioning
+strategy can improve query performance.
+
+Use the [`partitionTemplate`](/influxdb/cloud-dedicated/api/management/#operation/CreateClusterDatabase) property to define an array of partition template parts used to generate partition keys for the database.
+
+For more information, see [Manage data partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/).
+
+{{% note %}}
+#### Partition templates can only be applied on create
+
+You can only apply a partition template when creating a database.
+There is no way to update a partition template on an existing database.
+{{% /note %}}
+
+<!------------------------------- END cURL ------------------------------------>
+{{% /tab-content %}}
+{{< /tabs-wrapper >}}
+
+### Database naming restrictions
 
 Database names must adhere to the following naming restrictions:
 
@@ -114,7 +310,7 @@ Database names must adhere to the following naming restrictions:
 - Should not start with an underscore (`_`).
 - Maximum length of 64 characters.
 
-## InfluxQL DBRP naming convention
+### InfluxQL DBRP naming convention
 
 In InfluxDB 1.x, data is stored in [databases](/influxdb/v1/concepts/glossary/#database)
 and [retention policies](/influxdb/v1/concepts/glossary/#retention-policy-rp).
@@ -131,7 +327,7 @@ naming convention to automatically map v1 DBRP combinations to an {{% product-na
 database_name/retention_policy_name
 ```
 
-##### Database naming examples
+#### Database naming examples
 
 | v1 Database name | v1 Retention Policy name | New database name         |
 | :--------------- | :----------------------- | :------------------------ |
@@ -139,12 +335,17 @@ database_name/retention_policy_name
 | telegraf         | autogen                  | telegraf/autogen          |
 | webmetrics       | 1w-downsampled           | webmetrics/1w-downsampled |
 
-## Table and column limits
+### Table and column limits
 
 In {{< product-name >}}, table (measurement) and column limits can be
-configured using the `--max-tables` and `--max-columns` flags.
+configured using the following options:
 
-### Table limit
+| Description                   | Default | influxctl CLI flag | Management API property |
+| :---------------------------- | :------ | :-------------- | :------------------- |
+| [Table limit](#table-limit)   | 500     | `--max-tables`  | `maxTables`          |
+| [Column limit](#column-limit) | 250     | `--max-columns` | `maxColumnsPerTable` |
+
+#### Table limit
 
 **Default maximum number of tables**: 500
 
@@ -187,7 +388,7 @@ operating cost of your cluster.
 {{% /expand %}}
 {{< /expand-wrapper >}}
 
-### Column limit
+#### Column limit
 
 **Default maximum number of columns**: 250
 
@@ -208,22 +409,3 @@ threshold beyond which query performance may be affected
 
 {{% /expand %}}
 {{< /expand-wrapper >}}
-
-### Custom partitioning
-
-{{< product-name >}} lets you define a custom partitioning strategy for each database.
-A _partition_ is a logical grouping of data stored in [Apache Parquet](https://parquet.apache.org/)
-format in the InfluxDB v3 storage engine. By default, data is partitioned by day,
-but, depending on your schema and workload, customizing the partitioning
-strategy can improve query performance.
-
-Use the `--template-tag`, `--template-tag-bucket, and `--template-timeformat`
-flags to define partition template parts used to generate partition keys for the database.
-For more information, see [Manage data partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/).
-
-{{% note %}}
-#### Partition templates can only be applied on create
-
-You can only apply a partition template when creating a database.
-There is no way to update a partition template on an existing database.
-{{% /note %}}

--- a/content/influxdb/cloud-dedicated/admin/databases/create.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/create.md
@@ -152,27 +152,21 @@ There is no way to update a partition template on an existing database.
 _This example uses [cURL](https://curl.se/) to send a Management HTTP API request, but you can use any HTTP client._
 
 1. If you haven't already, follow the instructions to [install cURL](https://everything.curl.dev/install/index.html) for your system.
-2. Obtain the following credentials for your cluster:
-
-   - `ACCOUNT_ID`: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the cluster belongs to. To view account ID and cluster ID, [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
-   - `CLUSTER_ID`: The ID of the [cluster](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that you want to manage. To view account ID and cluster ID, [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
-   - `Authorization MANAGEMENT_TOKEN`: the `Authorization` HTTP header with a [management token](/influxdb/cloud-dedicated/admin/tokens/management/) _(see how to [create a management token](/influxdb/cloud-dedicated/admin/tokens/management/) for Management API requests)_.
-
-3. In your terminal, use cURL to send a request to the following endpoint:
+2. In your terminal, use cURL to send a request to the following endpoint:
 
    {{% api-endpoint endpoint="https://{{< influxdb/host >}}/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" method="post" api-ref="/influxdb/cloud-dedicated/api/management/#operation/CreateClusterDatabase" %}}
 
    In the URL, provide the following credentials:
 
-   - Your InfluxDB Host URL
-   - Your InfluxDB Account ID
-   - Your InfluxDB Cluster ID
+   - Your {{% product-name omit="Clustered" %}} cluster URL.
+   - `ACCOUNT_ID`: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the cluster belongs to. To view account ID and cluster ID, [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
+   - `CLUSTER_ID`: The ID of the [cluster](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that you want to manage. To view account ID and cluster ID, [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
 
    In request headers, provide the following:
 
    - `Accept: application/json` to ensure the response body is JSON content
    - `Content-Type: application/json` to indicate the request body is JSON content
-   - `Authorization: Bearer` and a [Management API token](/influxdb/cloud-dedicated/admin/tokens/management/) for your cluster
+   - `Authorization: Bearer` and a [Management API token](/influxdb/cloud-dedicated/admin/tokens/management/) for your cluster _(see how to [create a management token](/influxdb/cloud-dedicated/admin/tokens/management/) for Management API requests)_.
 
    In the request body, provide the following parameters:
 

--- a/content/influxdb/cloud-dedicated/admin/databases/create.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/create.md
@@ -38,7 +38,7 @@ or the [Management HTTP API](influxdb/cloud-dedicated/api/management/) to create
 
 2.  Run the `influxctl database create` command and provide the following:
 
-    - _Optional:_ Database [retention period](/influxdb/cloud-dedicated/admin/databases/#retention-periods)
+    - _Optional_: Database [retention period](/influxdb/cloud-dedicated/admin/databases/#retention-periods)
     Default is `0` (infinite).
     - _Optional_: Database table (measurement) limit. Default is `500`.
     - _Optional_: Database column limit. Default is `250`.
@@ -74,9 +74,6 @@ influxctl database create \
 
 Replace the following in your command:
 
-- {{% code-placeholder-key %}}`ACCOUNT_ID`{{% /code-placeholder-key %}}: the ID of the {{% product-name %}} account to create the database for
-- {{% code-placeholder-key %}}`CLUSTER_ID`{{% /code-placeholder-key %}}: the ID of the {{% product-name %}} cluster to create the database for
-- {{% code-placeholder-key %}}`MANAGEMENT TOKEN`{{% /code-placeholder-key %}}: a [management token](/influxdb/cloud-dedicated/admin/tokens/management/) for your {{% product-name %}} cluster
 - {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}: your {{% product-name %}} database
 - {{% code-placeholder-key %}}`TAG_KEY_1`, `TAG_KEY_2`, `TAG_KEY_3`, and `TAG_KEY_4`{{% /code-placeholder-key %}}: [tag]((/influxdb/cloud-dedicated/reference/glossary/#tag)) keys from your data
 

--- a/content/influxdb/cloud-dedicated/admin/databases/list.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/list.md
@@ -15,31 +15,90 @@ related:
   - /influxdb/cloud-dedicated/reference/cli/influxctl/database/list/
 ---
 
+Use the [`influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/database/create/)
+or the [Management HTTP API](influxdb/cloud-dedicated/api/management/) to create a database in your {{< product-name omit=" Clustered" >}} cluster.
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[influxctl](#)
+[Management API](#)
+{{% /tabs %}}
+{{% tab-content %}}
+
+<!------------------------------- BEGIN INFLUXCTL ----------------------------->
+
 Use the [`influxctl database list` command](/influxdb/cloud-dedicated/reference/cli/influxctl/database/list/)
 to list databases in your InfluxDB Cloud Dedicated cluster.
 
-1.  If you haven't already, [download and install the `influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/#download-and-install-influxctl).
-2.  Run `influxctl database list` with the following:
+1.  If you haven't already, [download and install the `influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/#download-and-install-influxctl), and then [configure an `influxctl` connection profile](/influxdb/cloud-dedicated/reference/cli/influxctl/#configure-connection-profiles) for your cluster.
+2.  Run the `influxctl database list` command and provide the following:
 
-    - _(Optional)_ [Output format](#output-formats)
+    - _Optional_: [Output format](#output-formats)
 
 ```sh
 influxctl database list --format table
 ```
 
-### Output formats
+<!-------------------------------- END INFLUXCTL ------------------------------>
+{{% /tab-content %}}
+{{% tab-content %}}
+<!------------------------------- BEGIN cURL ---------------------------------->
+_This example uses [cURL](https://curl.se/) to send a Management HTTP API request, but you can use any HTTP client._
+
+1. If you haven't already, follow the instructions to [install cURL](https://everything.curl.dev/install/index.html) for your system.
+2. In your terminal, use cURL to send a request to the following endpoint:
+
+   {{% api-endpoint endpoint="https://{{< influxdb/host >}}/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" method="get" api-ref="/influxdb/cloud-dedicated/api/management/#operation/CreateClusterDatabase" %}}
+
+   In the URL, provide the following credentials:
+
+   - Your {{% product-name omit="Clustered" %}} cluster URL.
+   - `ACCOUNT_ID`: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the cluster belongs to. To view account ID and cluster ID, [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
+   - `CLUSTER_ID`: The ID of the [cluster](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that you want to manage. To view account ID and cluster ID, [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
+
+   In request headers, provide the following:
+
+   - `Accept: application/json` to ensure the response body is JSON content
+   - `Content-Type: application/json` to indicate the request body is JSON content
+   - `Authorization: Bearer` and a [Management API token](/influxdb/cloud-dedicated/admin/tokens/management/) for your cluster _(see how to [create a management token](/influxdb/cloud-dedicated/admin/tokens/management/) for Management API requests)_.
+
+   The following example shows how to use the Management API to list databases in a cluster:
+
+   ```sh
+   curl \
+    --location "https://{{< influxdb/host >}}/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" \
+    --header "Accept: application/json" \
+    --header "Authorization: Bearer MANAGEMENT_TOKEN" \
+    ```
+
+<!------------------------------- END cURL ------------------------------------>
+{{% /tab-content %}}
+{{< /tabs-wrapper >}}
+
+### Output format
 
 The `influxctl database list` command supports two output formats: `table` and `json`.
 By default, the command outputs the list of databases formatted as a table.
 For easier programmatic access to the command output, include `--format json`
-with your command to format the database list as JSON.
+with your command to format the output as JSON.
+
+The Management API outputs JSON format in the response body.
+
+#### Retention period syntax
+
+In table format, a retention period is a time duration value made up of a numeric value
+plus a duration unit--for example, `30d` means 30 days.
+An `infinite` retention period means data won't expire.
+
+In JSON format, a retention period value is an integer (`<int32>`) that represents the number of nanoseconds--for example, `2592000000000` means 30 days.
+A zero (`0`) retention period means data won't expire.
 
 #### Example output
 
 {{< code-tabs-wrapper >}}
 {{% code-tabs %}}
 [table](#)
-[json](#)
+[JSON](#)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 

--- a/content/influxdb/cloud-dedicated/admin/databases/list.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/list.md
@@ -46,31 +46,39 @@ influxctl database list --format table
 _This example uses [cURL](https://curl.se/) to send a Management HTTP API request, but you can use any HTTP client._
 
 1. If you haven't already, follow the instructions to [install cURL](https://everything.curl.dev/install/index.html) for your system.
-2. In your terminal, use cURL to send a request to the following endpoint:
+2. In your terminal, use cURL to send a request to the following {{% product-name %}} console endpoint:
 
-   {{% api-endpoint endpoint="https://{{< influxdb/host >}}/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" method="get" api-ref="/influxdb/cloud-dedicated/api/management/#operation/CreateClusterDatabase" %}}
+   {{% api-endpoint endpoint="https://console.influxdata.com/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" method="get" api-ref="/influxdb/cloud-dedicated/api/management/#operation/CreateClusterDatabase" %}}
 
    In the URL, provide the following credentials:
 
-   - Your {{% product-name omit="Clustered" %}} cluster URL.
    - `ACCOUNT_ID`: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the cluster belongs to. To view account ID and cluster ID, [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
    - `CLUSTER_ID`: The ID of the [cluster](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that you want to manage. To view account ID and cluster ID, [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
 
-   In request headers, provide the following:
+   Provide the following request headers:
 
    - `Accept: application/json` to ensure the response body is JSON content
    - `Content-Type: application/json` to indicate the request body is JSON content
    - `Authorization: Bearer` and a [Management API token](/influxdb/cloud-dedicated/admin/tokens/management/) for your cluster _(see how to [create a management token](/influxdb/cloud-dedicated/admin/tokens/management/) for Management API requests)_.
 
-   The following example shows how to use the Management API to list databases in a cluster:
+ The following example shows how to use the Management API to list databases in a cluster:
 
-   ```sh
-   curl \
-    --location "https://{{< influxdb/host >}}/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" \
-    --header "Accept: application/json" \
-    --header "Authorization: Bearer MANAGEMENT_TOKEN" \
-    ```
+{{% code-placeholders "ACCOUNT_ID|CLUSTER_ID|MANAGEMENT_TOKEN" %}}
 
+```sh
+curl \
+   --location "https://console.influxdata.com/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" \
+   --header "Accept: application/json" \
+   --header "Authorization: Bearer MANAGEMENT_TOKEN"
+```
+
+{{% /code-placeholders %}}
+
+Replace the following in your request:
+
+- {{% code-placeholder-key %}}`ACCOUNT_ID`{{% /code-placeholder-key %}}: the ID of the {{% product-name %}} account to create the database for
+- {{% code-placeholder-key %}}`CLUSTER_ID`{{% /code-placeholder-key %}}: the ID of the {{% product-name %}} cluster to create the database for
+- {{% code-placeholder-key %}}`MANAGEMENT TOKEN`{{% /code-placeholder-key %}}: a [management token](/influxdb/cloud-dedicated/admin/tokens/management/) for your {{% product-name %}} cluster
 <!------------------------------- END cURL ------------------------------------>
 {{% /tab-content %}}
 {{< /tabs-wrapper >}}


### PR DESCRIPTION
Part of #5411 

Adds task-based docs for Management API:
- `POST databases`
- `GET databases`

