### PR TITLE
Dedicated: Add task-based for the DELETE database management endpoint, fix others

### DIFF
--- a/content/influxdb/cloud-dedicated/admin/databases/create.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/create.md
@@ -1,7 +1,8 @@
 ---
 title: Create a database
 description: >
-  Use the [`influxctl database create` command](/influxdb/cloud-dedicated/reference/cli/influxctl/database/create/) or the Management HTTP API
+  Use the [`influxctl database create` command](/influxdb/cloud-dedicated/reference/cli/influxctl/database/create/)
+  or the Management HTTP API
   to create a new InfluxDB database in your InfluxDB Cloud Dedicated cluster.
   Provide a database name and an optional retention period.
 menu:
@@ -9,6 +10,7 @@ menu:
     parent: Manage databases
 weight: 201
 list_code_example: |
+  ##### CLI
   ```sh
   influxctl database create \
     --retention-period 30d \
@@ -16,13 +18,57 @@ list_code_example: |
     --max-columns 250 \
     <DATABASE_NAME>
   ```
+
+  ##### API
+  ```sh
+  curl \
+    --location "https://console.influxdata.com/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" \
+    --request POST
+    --header "Accept: application/json" \
+    --header 'Content-Type: application/json' \
+    --header "Authorization: Bearer MANAGEMENT_TOKEN" \
+    --data '{
+      "name": "'DATABASE_NAME'",
+      "maxTables": 500,
+      "maxColumnsPerTable": 250,
+      "retentionPeriod": 2592000000000,
+      "partitionTemplate": [
+        {
+          "type": "tag",
+          "value": "TAG_KEY_1"
+        },
+        {
+          "type": "tag",
+          "value": "TAG_KEY_2"
+        },
+        {
+          "type": "bucket",
+          "value": {
+            "tagName": "TAG_KEY_3",
+            "numberOfBuckets": 100
+          }
+        },
+        {
+          "type": "bucket",
+          "value": {
+            "tagName": "TAG_KEY_4",
+            "numberOfBuckets": 300
+          }
+        },
+        {
+          "type": "time",
+          "value": "%Y-%m-%d"
+        }
+        ]
+      }'
+  ```
 related:
   - /influxdb/cloud-dedicated/reference/cli/influxctl/database/create/
   - /influxdb/cloud-dedicated/admin/custom-partitions/
-  - /influxdb/cloud-dedicated/api/management/#operation/CreateClusterDatabase
+  - /influxdb/cloud-dedicated/reference/api/
 ---
 
-Use the [`influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/database/create/)
+Use the [`influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/)
 or the [Management HTTP API](influxdb/cloud-dedicated/api/management/) to create a database in your {{< product-name omit=" Clustered" >}} cluster.
 
 {{< tabs-wrapper >}}
@@ -138,6 +184,7 @@ flags to define partition template parts used to generate partition keys for the
 For more information, see [Manage data partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/).
 
 {{% note %}}
+
 #### Partition templates can only be applied on create
 
 You can only apply a partition template when creating a database.
@@ -193,6 +240,7 @@ The following example shows how to use the Management API to create a database w
 ```sh
 curl \
    --location "https://console.influxdata.com/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" \
+   --request POST
    --header "Accept: application/json" \
    --header 'Content-Type: application/json' \
    --header "Authorization: Bearer MANAGEMENT_TOKEN" \
@@ -280,6 +328,7 @@ Use the [`partitionTemplate`](/influxdb/cloud-dedicated/api/management/#operatio
 For more information, see [Manage data partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/).
 
 {{% note %}}
+
 #### Partition templates can only be applied on create
 
 You can only apply a partition template when creating a database.

--- a/content/influxdb/cloud-dedicated/admin/databases/delete.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/delete.md
@@ -2,6 +2,7 @@
 title: Delete a database
 description: >
   Use the [`influxctl database delete` command](/influxdb/cloud-dedicated/reference/cli/influxctl/database/delete/)
+  or the Management HTTP API
   to delete a database from your InfluxDB Cloud Dedicated cluster.
   Provide the name of the database you want to delete.
 menu:
@@ -9,30 +10,29 @@ menu:
     parent: Manage databases
 weight: 203
 list_code_example: |
+  ##### CLI
   ```sh
   influxctl database delete <DATABASE_NAME>
   ```
+
+  ##### API
+  ```sh
+  curl \
+    --location "https://console.influxdata.com/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases/DATABASE_NAME" \
+    --request DELETE \
+    --header "Accept: application/json" \
+    --header "Authorization: Bearer MANAGEMENT_TOKEN"
+  ```
 related:
   - /influxdb/cloud-dedicated/reference/cli/influxctl/database/delete/
+  - /influxdb/cloud-dedicated/reference/api/
 ---
 
-Use the [`influxctl database delete` command](/influxdb/cloud-dedicated/reference/cli/influxctl/database/delete/)
-to delete a database from your InfluxDB Cloud Dedicated cluster.
-
-1.  If you haven't already, [download and install the `influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/#download-and-install-influxctl).
-2.  Run the `influxctl database delete` command and provide the following:
-
-    - Name of the database to delete
-
-3. Confirm that you want to delete the database.
-
-{{% code-placeholders "DATABASE_NAME" %}}
-```sh
-influxctl database delete DATABASE_NAME
-```
-{{% /code-placeholders %}}
+Use the [`influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/)
+or the Management HTTP API to create a database in your {{< product-name omit=" Clustered" >}} cluster.
 
 {{% warn %}}
+
 #### Deleting a database cannot be undone
 
 Once a database is deleted, data stored in that database cannot be recovered.
@@ -41,3 +41,77 @@ Once a database is deleted, data stored in that database cannot be recovered.
 
 After a database is deleted, you cannot reuse the same name for a new database.
 {{% /warn %}}
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[influxctl](#)
+[Management API](#)
+{{% /tabs %}}
+{{% tab-content %}}
+
+<!------------------------------- BEGIN INFLUXCTL ----------------------------->
+
+1.  If you haven't already, [download and install the `influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/#download-and-install-influxctl), and then [configure an `influxctl` connection profile](/influxdb/cloud-dedicated/reference/cli/influxctl/#configure-connection-profiles) for your cluster.
+
+2.  Run the `influxctl database delete` command and provide the following:
+
+    - Name of the database to delete
+
+3. Confirm that you want to delete the database.
+
+{{% code-placeholders "DATABASE_NAME" %}}
+
+```sh
+influxctl database delete DATABASE_NAME
+```
+
+{{% /code-placeholders %}}
+
+<!-------------------------------- END INFLUXCTL ------------------------------>
+{{% /tab-content %}}
+{{% tab-content %}}
+<!------------------------------- BEGIN cURL ---------------------------------->
+
+_This example uses [cURL](https://curl.se/) to send a Management HTTP API request, but you can use any HTTP client._
+
+1. If you haven't already, follow the instructions to [install cURL](https://everything.curl.dev/install/index.html) for your system.
+2. In your terminal, use cURL to send a request to the following {{% product-name %}} console endpoint:
+
+   {{% api-endpoint endpoint="https://console.influxdata.com/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases/DATABASE_NAME" method="delete" api-ref="/influxdb/cloud-dedicated/api/management/#operation/DeleteClusterDatabase" %}}
+
+   In the URL, provide the following:
+
+   - `ACCOUNT_ID`: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the cluster belongs to _(see how to [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json))_.
+   - `CLUSTER_ID`: The ID of the [cluster](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that you want to manage _(see how to [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json))_.
+   - `DATABASE_NAME`: The name of the [database](/influxdb/cloud-dedicated/admin/databases/) that you want to delete _(see how to [list databases](/influxdb/cloud-dedicated/admin/databases/list/))_.
+
+   Provide the following request headers:
+
+   - `Accept: application/json` to ensure the response body is JSON content
+   - `Authorization: Bearer` and a [Management API token](/influxdb/cloud-dedicated/admin/tokens/management/) for your cluster _(see how to [create a management token](/influxdb/cloud-dedicated/admin/tokens/management/) for Management API requests)_.
+
+   Specify the `DELETE` request method.
+
+The following example shows how to use the Management API to delete a database:
+
+{{% code-placeholders "DATABASE_NAME|ACCOUNT_ID|CLUSTER_ID|MANAGEMENT_TOKEN" %}}
+
+```sh
+curl \
+   --location "https://console.influxdata.com/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases/DATABASE_NAME" \
+   --request DELETE \
+   --header "Accept: application/json" \
+   --header "Authorization: Bearer MANAGEMENT_TOKEN"
+```
+
+{{% /code-placeholders %}}
+
+Replace the following in your request:
+
+- {{% code-placeholder-key %}}`ACCOUNT_ID`{{% /code-placeholder-key %}}: the ID of the {{% product-name %}} account to create the database for
+- {{% code-placeholder-key %}}`CLUSTER_ID`{{% /code-placeholder-key %}}: the ID of the {{% product-name %}} cluster to create the database for
+- {{% code-placeholder-key %}}`MANAGEMENT TOKEN`{{% /code-placeholder-key %}}: a [management token](/influxdb/cloud-dedicated/admin/tokens/management/) for your {{% product-name %}} cluster
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}: your {{% product-name %}} database
+<!------------------------------- END cURL ------------------------------------>
+{{% /tab-content %}}
+{{< /tabs-wrapper >}}

--- a/content/influxdb/cloud-dedicated/admin/databases/list.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/list.md
@@ -8,8 +8,17 @@ menu:
     parent: Manage databases
 weight: 202
 list_code_example: |
+  ##### CLI
   ```sh
   influxctl database list
+  ```
+
+  ##### API
+  ```sh
+  curl \
+    --location "https://console.influxdata.com/api/v0/accounts/$ACCOUNT_ID/clusters/$CLUSTER_ID/databases" \
+    --header "Accept: application/json" \
+    --header "Authorization: Bearer $MANAGEMENT_TOKEN"
   ```
 related:
   - /influxdb/cloud-dedicated/reference/cli/influxctl/database/list/
@@ -33,7 +42,7 @@ to list databases in your InfluxDB Cloud Dedicated cluster.
 1.  If you haven't already, [download and install the `influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/#download-and-install-influxctl), and then [configure an `influxctl` connection profile](/influxdb/cloud-dedicated/reference/cli/influxctl/#configure-connection-profiles) for your cluster.
 2.  Run the `influxctl database list` command and provide the following:
 
-    - _Optional_: [Output format](#output-formats)
+    - _Optional_: [Output format](#output-format)
 
 ```sh
 influxctl database list --format table
@@ -48,7 +57,7 @@ _This example uses [cURL](https://curl.se/) to send a Management HTTP API reques
 1. If you haven't already, follow the instructions to [install cURL](https://everything.curl.dev/install/index.html) for your system.
 2. In your terminal, use cURL to send a request to the following {{% product-name %}} console endpoint:
 
-   {{% api-endpoint endpoint="https://console.influxdata.com/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" method="get" api-ref="/influxdb/cloud-dedicated/api/management/#operation/CreateClusterDatabase" %}}
+   {{% api-endpoint endpoint="https://console.influxdata.com/api/v0/accounts/ACCOUNT_ID/clusters/CLUSTER_ID/databases" method="get" api-ref="/influxdb/cloud-dedicated/api/management/#operation/GetClusterDatabases" %}}
 
    In the URL, provide the following credentials:
 
@@ -58,7 +67,6 @@ _This example uses [cURL](https://curl.se/) to send a Management HTTP API reques
    Provide the following request headers:
 
    - `Accept: application/json` to ensure the response body is JSON content
-   - `Content-Type: application/json` to indicate the request body is JSON content
    - `Authorization: Bearer` and a [Management API token](/influxdb/cloud-dedicated/admin/tokens/management/) for your cluster _(see how to [create a management token](/influxdb/cloud-dedicated/admin/tokens/management/) for Management API requests)_.
 
  The following example shows how to use the Management API to list databases in a cluster:

--- a/content/influxdb/cloud-dedicated/admin/databases/list.md
+++ b/content/influxdb/cloud-dedicated/admin/databases/list.md
@@ -22,6 +22,7 @@ list_code_example: |
   ```
 related:
   - /influxdb/cloud-dedicated/reference/cli/influxctl/database/list/
+  - /influxdb/cloud-dedicated/reference/api/
 ---
 
 Use the [`influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/database/create/)


### PR DESCRIPTION
Part of #5411 

- Adds task-based doc for `DELETE` database using the Management API
- Fixes links and adds list code examples for other methods.
