### PR TITLE
Add information about database token wildcard permissions

### DIFF
--- a/content/influxdb/cloud-dedicated/admin/tokens/database/create.md
+++ b/content/influxdb/cloud-dedicated/admin/tokens/database/create.md
@@ -31,6 +31,11 @@ to create a token that grants access to databases in your InfluxDB Cloud Dedicat
     - Token permissions (read and write)
       - `--read-database`: Grants read permissions to the specified database. Repeatable.
       - `--write-database`: Grants write permissions to the specified database. Repeatable.
+
+      Both of these flags support the `*` wildcard which grants read or write
+      permissions to all databases. Enclose wildcards in single or double
+      quotes--for example: `'*'` or `"*"`.
+
     - Token description
 
 {{% code-placeholders "DATABASE_NAME|TOKEN_DESCRIPTION" %}}
@@ -63,6 +68,7 @@ For example, see how to [authenticate Telegraf using tokens in your OS secret st
 ### Examples
 
 - [Create a token with read and write access to a database](#create-a-token-with-read-and-write-access-to-a-database)
+- [Create a token with read and write access to all databases](#create-a-token-with-read-and-write-access-to-all-databases)
 - [Create a token with read-only access to a database](#create-a-token-with-read-only-access-to-a-database)
 - [Create a token with read-only access to multiple databases](#create-a-token-with-read-only-access-to-multiple-databases)
 - [Create a token with mixed permissions to multiple databases](#create-a-token-with-mixed-permissions-to-multiple-databases)
@@ -82,6 +88,15 @@ influxctl token create \
   "Read/write token for DATABASE_NAME"
 ```
 {{% /code-placeholders %}}
+
+#### Create a token with read and write access to all databases
+
+```sh
+influxctl token create \
+  --read-database "*" \
+  --write-database "*" \
+  "Read/write token for all databases"
+```
 
 #### Create a token with read-only access to a database
 

--- a/content/influxdb/cloud-dedicated/admin/tokens/database/update.md
+++ b/content/influxdb/cloud-dedicated/admin/tokens/database/update.md
@@ -30,6 +30,11 @@ to update a database token's permissions in your {{< product-name omit=" Cluster
     - Token permissions (read and write)
       - `--read-database`: Grants read permissions to the specified database. Repeatable.
       - `--write-database`: Grants write permissions to the specified database. Repeatable.
+
+      Both of these flags support the `*` wildcard which grants read or write
+      permissions to all databases. Enclose wildcards in single or double
+      quotes--for example: `'*'` or `"*"`.
+
     - Token ID
 
 {{% code-placeholders "DATABASE_NAME|TOKEN_ID" %}}
@@ -57,6 +62,7 @@ To retain existing permissions, include them in the update command.
 ### Examples
 
 - [Update a token with read and write access to a database](#update-a-token-with-read-and-write-access-to-a-database)
+- [Update a token with read and write access to all databases](#update-a-token-with-read-and-write-access-to-all-databases)
 - [Update a token with read-only access to a database](#update-a-token-with-read-only-access-to-a-database)
 - [Update a token with read-only access to multiple databases](#update-a-token-with-read-only-access-to-multiple-databases)
 - [Update a token with mixed permissions to multiple databases](#update-a-token-with-mixed-permissions-to-multiple-databases)
@@ -74,6 +80,17 @@ In the examples below, Replace the following:
 influxctl token update \
   --read-database DATABASE_NAME \
   --write-database DATABASE_NAME \
+  TOKEN_ID
+```
+{{% /code-placeholders %}}
+
+#### Update a token with read and write access to all databases
+
+{{% code-placeholders "TOKEN_ID" %}}
+```sh
+influxctl token update \
+  --read-database "*" \
+  --write-database "*" \
   TOKEN_ID
 ```
 {{% /code-placeholders %}}

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/create.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/create.md
@@ -13,6 +13,10 @@ The `influxctl token create` command creates a database token with specified
 permissions to resources in an InfluxDB Cloud Dedicated cluster and outputs
 the token string.
 
+The `--read-database` and `--write-database` flags support the `*` wildcard
+which grants read or write permissions to all databases. Enclose wildcards in
+single or double quotes--for example: `'*'` or `"*"`.
+
 The `--format` flag lets you print the output in other formats.
 The `json` format is available for programmatic parsing by other tooling.
 Default: `table`.
@@ -55,6 +59,7 @@ _Also see [`influxctl` global flags](/influxdb/cloud-dedicated/reference/cli/inf
 ## Examples
 
 - [Create a token with read and write access to a database](#create-a-token-with-read-and-write-access-to-a-database)
+- [Create a token with read and write access to all databases](#create-a-token-with-read-and-write-access-to-all-databases)
 - [Create a token with read-only access to a database](#create-a-token-with-read-only-access-to-a-database)
 - [Create a token with read-only access to multiple databases](#create-a-token-with-read-only-access-to-multiple-databases)
 - [Create a token with mixed permissions to multiple databases](#create-a-token-with-mixed-permissions-on-multiple-databases)
@@ -75,6 +80,15 @@ influxctl token create \
   "Read/write token for DATABASE_NAME"
 ```
 {{% /code-placeholders %}}
+
+### Create a token with read and write access to all databases
+
+```sh
+influxctl token create \
+  --read-database "*" \
+  --write-database "*" \
+  "Read/write token for all databases"
+```
 
 ### Create a token with read-only access to a database
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/update.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/token/update.md
@@ -12,6 +12,10 @@ weight: 301
 The `influxctl token update` command updates a database token with specified
 permissions to resources in an InfluxDB Cloud Dedicated cluster.
 
+The `--read-database` and `--write-database` flags support the `*` wildcard
+which grants read or write permissions to all databases. Enclose wildcards in
+single or double quotes--for example: `'*'` or `"*"`.
+
 ## Usage
 
 ```sh
@@ -50,6 +54,7 @@ _Also see [`influxctl` global flags](/influxdb/cloud-dedicated/reference/cli/inf
 ## Examples
 
 - [Update a token's permissions](#update-a-tokens-permissions)
+- [Update a token with read and write access to all databases](#update-a-token-with-read-and-write-access-to-all-databases)
 - [Update a token with read-only access to multiple databases](#update-a-token-with-read-only-access-to-multiple-databases)
 - [Update a token with mixed permissions to multiple databases](#update-a-token-with-mixed-permissions-to-multiple-databases)
 
@@ -66,6 +71,17 @@ In the examples below, replace the following:
 influxctl token update \
   --read-database DATABASE_NAME \
   --write-database DATABASE_NAME \
+  TOKEN_ID
+```
+{{% /code-placeholders %}}
+
+### Update a token with read and write access to all databases
+
+{{% code-placeholders "TOKEN_ID" %}}
+```sh
+influxctl token update \
+  --read-database "*" \
+  --write-database "*" \
   TOKEN_ID
 ```
 {{% /code-placeholders %}}

--- a/content/influxdb/clustered/admin/tokens/database/create.md
+++ b/content/influxdb/clustered/admin/tokens/database/create.md
@@ -32,6 +32,11 @@ to create a token that grants access to databases in your InfluxDB cluster.
     - Token permissions (read and write)
       - `--read-database`: Grants read permissions to the specified database. Repeatable.
       - `--write-database`: Grants write permissions to the specified database. Repeatable.
+
+      Both of these flags support the `*` wildcard which grants read or write
+      permissions to all databases. Enclose wildcards in single or double
+      quotes--for example: `'*'` or `"*"`.
+
     - Token description
 
 {{% code-placeholders "DATABASE_NAME|TOKEN_DESCRIPTION" %}}
@@ -63,7 +68,7 @@ For example, see how to [authenticate Telegraf using tokens in your OS secret st
 
 #### Examples
 
-- [Create a token with read and write access to a database](#create-a-token-with-read-and-write-access-to-a-database)
+- [Create a token with read and write access to a database](#create-a-token-with-read-and-write-access-to-a-database)- [Create a token with read and write access to all databases](#create-a-token-with-read-and-write-access-to-all-databases)
 - [Create a token with read-only access to a database](#create-a-token-with-read-only-access-to-a-database)
 - [Create a token with read-only access to multiple databases](#create-a-token-with-read-only-access-to-multiple-databases)
 - [Create a token with mixed permissions to multiple databases](#create-a-token-with-mixed-permissions-to-multiple-databases)
@@ -83,6 +88,15 @@ influxctl token create \
   "Read/write token for DATABASE_NAME"
 ```
 {{% /code-placeholders %}}
+
+#### Create a token with read and write access to all databases
+
+```sh
+influxctl token create \
+  --read-database "*" \
+  --write-database "*" \
+  "Read/write token for all databases"
+```
 
 #### Create a token with read-only access to a database
 

--- a/content/influxdb/clustered/admin/tokens/database/create.md
+++ b/content/influxdb/clustered/admin/tokens/database/create.md
@@ -68,7 +68,8 @@ For example, see how to [authenticate Telegraf using tokens in your OS secret st
 
 #### Examples
 
-- [Create a token with read and write access to a database](#create-a-token-with-read-and-write-access-to-a-database)- [Create a token with read and write access to all databases](#create-a-token-with-read-and-write-access-to-all-databases)
+- [Create a token with read and write access to a database](#create-a-token-with-read-and-write-access-to-a-database)
+- [Create a token with read and write access to all databases](#create-a-token-with-read-and-write-access-to-all-databases)
 - [Create a token with read-only access to a database](#create-a-token-with-read-only-access-to-a-database)
 - [Create a token with read-only access to multiple databases](#create-a-token-with-read-only-access-to-multiple-databases)
 - [Create a token with mixed permissions to multiple databases](#create-a-token-with-mixed-permissions-to-multiple-databases)

--- a/content/influxdb/clustered/admin/tokens/database/update.md
+++ b/content/influxdb/clustered/admin/tokens/database/update.md
@@ -30,6 +30,11 @@ to update a database token's permissions in your {{< product-name omit=" Cluster
     - Token permissions (read and write)
       - `--read-database`: Grants read permissions to the specified database. Repeatable.
       - `--write-database`: Grants write permissions to the specified database. Repeatable.
+
+      Both of these flags support the `*` wildcard which grants read or write
+      permissions to all databases. Enclose wildcards in single or double
+      quotes--for example: `'*'` or `"*"`.
+
     - Token ID
 
 {{% code-placeholders "DATABASE_NAME|TOKEN_ID" %}}
@@ -57,6 +62,7 @@ To retain existing permissions, include them in the update command.
 ### Examples
 
 - [Update a token with read and write access to a database](#update-a-token-with-read-and-write-access-to-a-database)
+- [Update a token with read and write access to all databases](#update-a-token-with-read-and-write-access-to-all-databases)
 - [Update a token with read-only access to a database](#update-a-token-with-read-only-access-to-a-database)
 - [Update a token with read-only access to multiple databases](#update-a-token-with-read-only-access-to-multiple-databases)
 - [Update a token with mixed permissions to multiple databases](#update-a-token-with-mixed-permissions-to-multiple-databases)
@@ -74,6 +80,17 @@ In the examples below, Replace the following:
 influxctl token update \
   --read-database DATABASE_NAME \
   --write-database DATABASE_NAME \
+  TOKEN_ID
+```
+{{% /code-placeholders %}}
+
+#### Update a token with read and write access to all databases
+
+{{% code-placeholders "TOKEN_ID" %}}
+```sh
+influxctl token update \
+  --read-database "*" \
+  --write-database "*" \
   TOKEN_ID
 ```
 {{% /code-placeholders %}}

--- a/content/influxdb/clustered/reference/cli/influxctl/token/create.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/token/create.md
@@ -13,6 +13,10 @@ The `influxctl token create` command creates a database token with specified
 permissions to resources in an InfluxDB cluster and outputs
 the token string.
 
+The `--read-database` and `--write-database` flags support the `*` wildcard
+which grants read or write permissions to all databases. Enclose wildcards in
+single or double quotes--for example: `'*'` or `"*"`.
+
 The `--format` flag lets you print the output in other formats.
 The `json` format is available for programmatic parsing by other tooling.
 Default: `table`.
@@ -55,6 +59,7 @@ _Also see [`influxctl` global flags](/influxdb/clustered/reference/cli/influxctl
 ## Examples
 
 - [Create a token with read and write access to a database](#create-a-token-with-read-and-write-access-to-a-database)
+- [Create a token with read and write access to all databases](#create-a-token-with-read-and-write-access-to-all-databases)
 - [Create a token with read-only access to a database](#create-a-token-with-read-only-access-to-a-database)
 - [Create a token with read-only access to multiple databases](#create-a-token-with-read-only-access-to-multiple-databases)
 - [Create a token with mixed permissions to multiple databases](#create-a-token-with-mixed-permissions-on-multiple-databases)
@@ -75,6 +80,15 @@ influxctl token create \
   "Read/write token for DATABASE_NAME"
 ```
 {{% /code-placeholders %}}
+
+### Create a token with read and write access to all databases
+
+```sh
+influxctl token create \
+  --read-database "*" \
+  --write-database "*" \
+  "Read/write token for all databases"
+```
 
 ### Create a token with read-only access to a database
 

--- a/content/influxdb/clustered/reference/cli/influxctl/token/update.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/token/update.md
@@ -12,6 +12,10 @@ weight: 301
 The `influxctl token update` command updates a database token with specified
 permissions to resources in an InfluxDB cluster.
 
+The `--read-database` and `--write-database` flags support the `*` wildcard
+which grants read or write permissions to all databases. Enclose wildcards in
+single or double quotes--for example: `'*'` or `"*"`.
+
 ## Usage
 
 ```sh
@@ -50,6 +54,7 @@ _Also see [`influxctl` global flags](/influxdb/clustered/reference/cli/influxctl
 ## Examples
 
 - [Update a token's permissions](#update-a-tokens-permissions)
+- [Update a token with read and write access to all databases](#update-a-token-with-read-and-write-access-to-all-databases)
 - [Update a token with read-only access to multiple databases](#update-a-token-with-read-only-access-to-multiple-databases)
 - [Update a token with mixed permissions to multiple databases](#update-a-token-with-mixed-permissions-to-multiple-databases)
 
@@ -66,6 +71,17 @@ In the examples below, replace the following:
 influxctl token update \
   --read-database DATABASE_NAME \
   --write-database DATABASE_NAME \
+  TOKEN_ID
+```
+{{% /code-placeholders %}}
+
+### Update a token with read and write access to all databases
+
+{{% code-placeholders "TOKEN_ID" %}}
+```sh
+influxctl token update \
+  --read-database "*" \
+  --write-database "*" \
   TOKEN_ID
 ```
 {{% /code-placeholders %}}


### PR DESCRIPTION
Users can use wildcards (`*`) to grant permissions to database tokens in InfluxDB Cloud Dedicated and InfluxDB Clustered. This PR updates token create and update documentation with information about using wildcards.

- [x] Rebased/mergeable
