### PR TITLE
chore: Update option names, release date

### DIFF
--- a/content/influxdb/cloud-dedicated/query-data/execute-queries/influxctl-cli.md
+++ b/content/influxdb/cloud-dedicated/query-data/execute-queries/influxctl-cli.md
@@ -229,10 +229,10 @@ When using the `table` [output format](#output-format), you can specify which of
 the following timestamp formats to use to display timestamp values in the query
 results:
 
-- `rfc3339`: _(Default)_
-  [RFC3339-formatted timestamp](/influxdb/cloud-dedicated/reference/glossary/#rfc3339-timestamp)--for example:
+- `rfc3339nano`: _(Default)_
+  [RFC3339Nano-formatted timestamp](/influxdb/cloud-dedicated/reference/glossary/#rfc3339nano-timestamp)--for example:
   `2024-01-01T00:00:00.000000000Z`
-- `unix`: [Unix nanosecond timestamp](/influxdb/cloud-dedicated/reference/glossary/#unix-timestamp)
+- `unixnano`: [Unix nanosecond timestamp](/influxdb/cloud-dedicated/reference/glossary/#unix-timestamp)
 
 {{% influxdb/custom-timestamps %}}
 ```sh

--- a/content/influxdb/cloud-dedicated/query-data/execute-queries/influxctl-cli.md
+++ b/content/influxdb/cloud-dedicated/query-data/execute-queries/influxctl-cli.md
@@ -187,35 +187,35 @@ influxctl query \
     "hum": 35.9,
     "room": "Kitchen",
     "temp": 21,
-    "time": "2022-01-01T08:00:00Z"
+    "time": 1641024000000000000
   },
   {
     "co": 0,
     "hum": 36.2,
     "room": "Kitchen",
     "temp": 23,
-    "time": "2022-01-01T09:00:00Z"
+    "time": 1641027600000000000
   },
   {
     "co": 0,
     "hum": 36.1,
     "room": "Kitchen",
     "temp": 22.7,
-    "time": "2022-01-01T10:00:00Z"
+    "time": 1641031200000000000
   },
   {
     "co": 0,
     "hum": 36,
     "room": "Kitchen",
     "temp": 22.4,
-    "time": "2022-01-01T11:00:00Z"
+    "time": 1641034800000000000
   },
   {
     "co": 0,
     "hum": 36,
     "room": "Kitchen",
     "temp": 22.5,
-    "time": "2022-01-01T12:00:00Z"
+    "time": 1641038400000000000
   }
 ]
 ```
@@ -223,3 +223,41 @@ influxctl query \
 {{% /expand %}}
 {{< /expand-wrapper >}}
 
+## Timestamp format
+
+When using the `table` [output format](#output-format), you can specify which of
+the following timestamp formats to use to display timestamp values in the query
+results:
+
+- `rfc3339`: _(Default)_
+  [RFC3339-formatted timestamp](/influxdb/cloud-dedicated/reference/glossary/#rfc3339-timestamp)--for example:
+  `2024-01-01T00:00:00.000000000Z`
+- `unix`: [Unix nanosecond timestamp](/influxdb/cloud-dedicated/reference/glossary/#unix-timestamp)
+
+{{% influxdb/custom-timestamps %}}
+```sh
+influxctl query \
+  --time-format unix \
+  "SELECT * FROM home WHERE time >= '2022-01-01T08:00:00Z' LIMIT 5"
+```
+{{% /influxdb/custom-timestamps %}}
+
+{{< expand-wrapper >}}
+{{% expand "View example results with unix nanosecond timestamps" %}}
+{{% influxdb/custom-timestamps %}}
+```
++-------+--------+---------+------+---------------------+
+|    co |    hum | room    | temp |                time |
++-------+--------+---------+------+---------------------+
+|     0 |   35.9 | Kitchen |   21 | 1641024000000000000 |
+|     0 |   36.2 | Kitchen |   23 | 1641027600000000000 |
+|     0 |   36.1 | Kitchen | 22.7 | 1641031200000000000 |
+|     0 |     36 | Kitchen | 22.4 | 1641034800000000000 |
+|     0 |     36 | Kitchen | 22.5 | 1641038400000000000 |
++-------+--------+---------+------+---------------------+
+| TOTAL | 5 ROWS |         |      |                     |
++-------+--------+---------+------+---------------------+
+```
+{{% /influxdb/custom-timestamps %}}
+{{% /expand %}}
+{{< /expand-wrapper >}}

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/query.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/query.md
@@ -49,6 +49,14 @@ The `--format` flag lets you print the output in other formats.
 The `json` format is available for programmatic parsing by other tooling.
 Default: `table`.
 
+When using the `table` format, by default, timestamps are formatted as RFC3339
+timestamps. Use the `--time-format` flag to specify one of the available time formats:
+
+- `rfc3339`: _(Default)_
+  [RFC3339-formatted timestamp](/influxdb/cloud-dedicated/reference/glossary/#rfc3339-timestamp)--for example:
+  `2024-01-01T00:00:00.000000000Z`
+- `unix`: [Unix nanosecond timestamp](/influxdb/cloud-dedicated/reference/glossary/#unix-timestamp)
+
 ## Usage
 
 ```sh
@@ -63,14 +71,15 @@ influxctl query [flags] <QUERY>
 
 ## Flags
 
-| Flag |                          | Description                                                  |
-| :--- | :----------------------- | :----------------------------------------------------------- |
-|      | `--database`             | Database to query                                            |
-|      | `--enable-system-tables` | Enable ability to query system tables                        |
-|      | `--format`               | Output format (`table` _(default)_ or `json`)                |
-|      | `--language`             | Query language (`sql` _(default)_ or `influxql`)             |
-|      | `--token`                | Database token with read permissions on the queried database |
-| `-h` | `--help`                 | Output command help                                          |
+| Flag |                          | Description                                                    |
+| :--- | :----------------------- | :------------------------------------------------------------- |
+|      | `--database`             | Database to query                                              |
+|      | `--enable-system-tables` | Enable ability to query system tables                          |
+|      | `--format`               | Output format (`table` _(default)_ or `json`)                  |
+|      | `--language`             | Query language (`sql` _(default)_ or `influxql`)               |
+|      | `--time-format`          | Time format for table output (`rfc3339` _(default)_ or `unix`) |
+|      | `--token`                | Database token with read permissions on the queried database   |
+| `-h` | `--help`                 | Output command help                                            |
 
 {{% caption %}}
 _Also see [`influxctl` global flags](/influxdb/cloud-dedicated/reference/cli/influxctl/#global-flags)._
@@ -82,6 +91,7 @@ _Also see [`influxctl` global flags](/influxdb/cloud-dedicated/reference/cli/inf
 - [Query InfluxDB v3 with InfluxQL](#query-influxdb-v3-with-influxql)
 - [Query InfluxDB v3 and return results in table format](#query-influxdb-v3-and-return-results-in-table-format)
 - [Query InfluxDB v3 and return results in JSON format](#query-influxdb-v3-and-return-results-in-json-format)
+- [Query InfluxDB v3 and return results with Unix nanosecond timestamps](#query-influxdb-v3-and-return-results-with-unix-nanosecond-timestamps)
 - [Query InfluxDB v3 using credentials from the connection profile](#query-influxdb-v3-using-credentials-from-the-connection-profile)
 - [Query data from InfluxDB v3 system tables](#query-data-from-influxdb-v3-system-tables)
 
@@ -288,37 +298,100 @@ cat ./query.sql | influxctl query \
     "hum": 35.9,
     "room": "Kitchen",
     "temp": 21,
-    "time": "2022-01-01T08:00:00Z"
+    "time": 1641024000000000000
   },
   {
     "co": 0,
     "hum": 36.2,
     "room": "Kitchen",
     "temp": 23,
-    "time": "2022-01-01T09:00:00Z"
+    "time": 1641027600000000000
   },
   {
     "co": 0,
     "hum": 36.1,
     "room": "Kitchen",
     "temp": 22.7,
-    "time": "2022-01-01T10:00:00Z"
+    "time": 1641031200000000000
   },
   {
     "co": 0,
     "hum": 36,
     "room": "Kitchen",
     "temp": 22.4,
-    "time": "2022-01-01T11:00:00Z"
+    "time": 1641034800000000000
   },
   {
     "co": 0,
     "hum": 36,
     "room": "Kitchen",
     "temp": 22.5,
-    "time": "2022-01-01T12:00:00Z"
+    "time": 1641038400000000000
   }
 ]
+```
+{{% /influxdb/custom-timestamps %}}
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+### Query InfluxDB v3 and return results with Unix nanosecond timestamps
+
+{{% code-placeholders "DATABASE_(TOKEN|NAME)" %}}
+
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[string](#)
+[file](#)
+[stdin](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+{{% influxdb/custom-timestamps %}}
+```sh
+influxctl query \
+  --token DATABASE_TOKEN \
+  --database DATABASE_NAME \
+  --time-format unix \
+  "SELECT * FROM home WHERE time >= '2022-01-01T08:00:00Z' LIMIT 5"
+```
+{{% /influxdb/custom-timestamps %}}
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+```sh
+influxctl query \
+  --token DATABASE_TOKEN \
+  --database DATABASE_NAME \
+  --time-format unix \
+  /path/to/query.sql
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+```sh
+cat ./query.sql | influxctl query \
+  --token DATABASE_TOKEN \
+  --database DATABASE_NAME \
+  --time-format unix \
+  - 
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+
+{{% /code-placeholders %}}
+
+{{< expand-wrapper >}}
+{{% expand "View example table-formatted results" %}}
+{{% influxdb/custom-timestamps %}}
+```
++-------+--------+---------+------+---------------------+
+|    co |    hum | room    | temp |                time |
++-------+--------+---------+------+---------------------+
+|     0 |   35.9 | Kitchen |   21 | 1641024000000000000 |
+|     0 |   36.2 | Kitchen |   23 | 1641027600000000000 |
+|     0 |   36.1 | Kitchen | 22.7 | 1641031200000000000 |
+|     0 |     36 | Kitchen | 22.4 | 1641034800000000000 |
+|     0 |     36 | Kitchen | 22.5 | 1641038400000000000 |
++-------+--------+---------+------+---------------------+
+| TOTAL | 5 ROWS |         |      |                     |
++-------+--------+---------+------+---------------------+
 ```
 {{% /influxdb/custom-timestamps %}}
 {{% /expand %}}
@@ -389,6 +462,11 @@ cat ./query.sql | influxctl query \
 {{% /code-placeholders %}}
 
 {{% expand "View command updates" %}}
+
+#### v2.9.0 {date="2024-05-03"}
+
+- Add `--time-format` flag to specify which timestamp format to use in the
+  `table` output format.
 
 #### v2.8.0 {date="2024-04-11"}
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/query.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/query.md
@@ -49,13 +49,14 @@ The `--format` flag lets you print the output in other formats.
 The `json` format is available for programmatic parsing by other tooling.
 Default: `table`.
 
-When using the `table` format, by default, timestamps are formatted as RFC3339
-timestamps. Use the `--time-format` flag to specify one of the available time formats:
+When using the `table` format, by default, timestamps are formatted as
+RFC3339Nano timestamps. Use the `--time-format` flag to specify one of the
+available time formats:
 
-- `rfc3339`: _(Default)_
-  [RFC3339-formatted timestamp](/influxdb/cloud-dedicated/reference/glossary/#rfc3339-timestamp)--for example:
+- `rfc3339nano`: _(Default)_
+  [RFC3339Nano-formatted timestamp](/influxdb/cloud-dedicated/reference/glossary/#rfc3339nano-timestamp)--for example:
   `2024-01-01T00:00:00.000000000Z`
-- `unix`: [Unix nanosecond timestamp](/influxdb/cloud-dedicated/reference/glossary/#unix-timestamp)
+- `unixnano`: [Unix nanosecond timestamp](/influxdb/cloud-dedicated/reference/glossary/#unix-timestamp)
 
 ## Usage
 
@@ -71,15 +72,15 @@ influxctl query [flags] <QUERY>
 
 ## Flags
 
-| Flag |                          | Description                                                    |
-| :--- | :----------------------- | :------------------------------------------------------------- |
-|      | `--database`             | Database to query                                              |
-|      | `--enable-system-tables` | Enable ability to query system tables                          |
-|      | `--format`               | Output format (`table` _(default)_ or `json`)                  |
-|      | `--language`             | Query language (`sql` _(default)_ or `influxql`)               |
-|      | `--time-format`          | Time format for table output (`rfc3339` _(default)_ or `unix`) |
-|      | `--token`                | Database token with read permissions on the queried database   |
-| `-h` | `--help`                 | Output command help                                            |
+| Flag |                          | Description                                                            |
+| :--- | :----------------------- | :--------------------------------------------------------------------- |
+|      | `--database`             | Database to query                                                      |
+|      | `--enable-system-tables` | Enable ability to query system tables                                  |
+|      | `--format`               | Output format (`table` _(default)_ or `json`)                          |
+|      | `--language`             | Query language (`sql` _(default)_ or `influxql`)                       |
+|      | `--time-format`          | Time format for table output (`rfc3339nano` _(default)_ or `unixnano`) |
+|      | `--token`                | Database token with read permissions on the queried database           |
+| `-h` | `--help`                 | Output command help                                                    |
 
 {{% caption %}}
 _Also see [`influxctl` global flags](/influxdb/cloud-dedicated/reference/cli/influxctl/#global-flags)._
@@ -350,7 +351,7 @@ cat ./query.sql | influxctl query \
 influxctl query \
   --token DATABASE_TOKEN \
   --database DATABASE_NAME \
-  --time-format unix \
+  --time-format unixnano \
   "SELECT * FROM home WHERE time >= '2022-01-01T08:00:00Z' LIMIT 5"
 ```
 {{% /influxdb/custom-timestamps %}}
@@ -360,7 +361,7 @@ influxctl query \
 influxctl query \
   --token DATABASE_TOKEN \
   --database DATABASE_NAME \
-  --time-format unix \
+  --time-format unixnano \
   /path/to/query.sql
 ```
 {{% /code-tab-content %}}
@@ -369,8 +370,8 @@ influxctl query \
 cat ./query.sql | influxctl query \
   --token DATABASE_TOKEN \
   --database DATABASE_NAME \
-  --time-format unix \
-  - 
+  --time-format unixnano \
+  -
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
@@ -463,7 +464,7 @@ cat ./query.sql | influxctl query \
 
 {{% expand "View command updates" %}}
 
-#### v2.9.0 {date="2024-05-03"}
+#### v2.9.0 {date="2024-05-06"}
 
 - Add `--time-format` flag to specify which timestamp format to use in the
   `table` output format.

--- a/content/influxdb/clustered/query-data/execute-queries/influxctl-cli.md
+++ b/content/influxdb/clustered/query-data/execute-queries/influxctl-cli.md
@@ -227,10 +227,10 @@ When using the `table` [output format](#output-format), you can specify which of
 the following timestamp formats to use to display timestamp values in the query
 results:
 
-- `rfc3339`: _(Default)_
-  [RFC3339-formatted timestamp](/influxdb/clustered/reference/glossary/#rfc3339-timestamp)--for example:
+- `rfc3339nano`: _(Default)_
+  [RFC3339Nano-formatted timestamp](/influxdb/clustered/reference/glossary/#rfc3339nano-timestamp)--for example:
   `2024-01-01T00:00:00.000000000Z`
-- `unix`: [Unix nanosecond timestamp](/influxdb/clustered/reference/glossary/#unix-timestamp)
+- `unixnano`: [Unix nanosecond timestamp](/influxdb/clustered/reference/glossary/#unix-timestamp)
 
 {{% influxdb/custom-timestamps %}}
 ```sh

--- a/content/influxdb/clustered/query-data/execute-queries/influxctl-cli.md
+++ b/content/influxdb/clustered/query-data/execute-queries/influxctl-cli.md
@@ -141,7 +141,6 @@ Replace the following:
 - {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
   Name of the database to query
 
-
 ## Output format
 
 The `influxctl query` command supports the following output formats:
@@ -186,37 +185,76 @@ influxctl query \
     "hum": 35.9,
     "room": "Kitchen",
     "temp": 21,
-    "time": "2022-01-01T08:00:00Z"
+    "time": 1641024000000000000
   },
   {
     "co": 0,
     "hum": 36.2,
     "room": "Kitchen",
     "temp": 23,
-    "time": "2022-01-01T09:00:00Z"
+    "time": 1641027600000000000
   },
   {
     "co": 0,
     "hum": 36.1,
     "room": "Kitchen",
     "temp": 22.7,
-    "time": "2022-01-01T10:00:00Z"
+    "time": 1641031200000000000
   },
   {
     "co": 0,
     "hum": 36,
     "room": "Kitchen",
     "temp": 22.4,
-    "time": "2022-01-01T11:00:00Z"
+    "time": 1641034800000000000
   },
   {
     "co": 0,
     "hum": 36,
     "room": "Kitchen",
     "temp": 22.5,
-    "time": "2022-01-01T12:00:00Z"
+    "time": 1641038400000000000
   }
 ]
+```
+{{% /influxdb/custom-timestamps %}}
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+## Timestamp format
+
+When using the `table` [output format](#output-format), you can specify which of
+the following timestamp formats to use to display timestamp values in the query
+results:
+
+- `rfc3339`: _(Default)_
+  [RFC3339-formatted timestamp](/influxdb/clustered/reference/glossary/#rfc3339-timestamp)--for example:
+  `2024-01-01T00:00:00.000000000Z`
+- `unix`: [Unix nanosecond timestamp](/influxdb/clustered/reference/glossary/#unix-timestamp)
+
+{{% influxdb/custom-timestamps %}}
+```sh
+influxctl query \
+  --time-format unix \
+  "SELECT * FROM home WHERE time >= '2022-01-01T08:00:00Z' LIMIT 5"
+```
+{{% /influxdb/custom-timestamps %}}
+
+{{< expand-wrapper >}}
+{{% expand "View example results with unix nanosecond timestamps" %}}
+{{% influxdb/custom-timestamps %}}
+```
++-------+--------+---------+------+---------------------+
+|    co |    hum | room    | temp |                time |
++-------+--------+---------+------+---------------------+
+|     0 |   35.9 | Kitchen |   21 | 1641024000000000000 |
+|     0 |   36.2 | Kitchen |   23 | 1641027600000000000 |
+|     0 |   36.1 | Kitchen | 22.7 | 1641031200000000000 |
+|     0 |     36 | Kitchen | 22.4 | 1641034800000000000 |
+|     0 |     36 | Kitchen | 22.5 | 1641038400000000000 |
++-------+--------+---------+------+---------------------+
+| TOTAL | 5 ROWS |         |      |                     |
++-------+--------+---------+------+---------------------+
 ```
 {{% /influxdb/custom-timestamps %}}
 {{% /expand %}}

--- a/content/influxdb/clustered/reference/cli/influxctl/query.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/query.md
@@ -47,6 +47,14 @@ The `--format` flag lets you print the output in other formats.
 The `json` format is available for programmatic parsing by other tooling.
 Default: `table`.
 
+When using the `table` format, by default, timestamps are formatted as RFC3339
+timestamps. Use the `--time-format` flag to specify one of the available time formats:
+
+- `rfc3339`: _(Default)_
+  [RFC3339-formatted timestamp](/influxdb/clustered/reference/glossary/#rfc3339-timestamp)--for example:
+  `2024-01-01T00:00:00.000000000Z`
+- `unix`: [Unix nanosecond timestamp](/influxdb/clustered/reference/glossary/#unix-timestamp)
+
 ## Usage
 
 ```sh
@@ -61,14 +69,15 @@ influxctl query [flags] <QUERY>
 
 ## Flags
 
-| Flag |                          | Description                                                  |
-| :--- | :----------------------- | :----------------------------------------------------------- |
-|      | `--database`             | Database to query                                            |
-|      | `--enable-system-tables` | Enable ability to query system tables                        |
-|      | `--format`               | Output format (`table` _(default)_ or `json`)                |
-|      | `--language`             | Query language (`sql` _(default)_ or `influxql`)             |
-|      | `--token`                | Database token with read permissions on the queried database |
-| `-h` | `--help`                 | Output command help                                          |
+| Flag |                          | Description                                                    |
+| :--- | :----------------------- | :------------------------------------------------------------- |
+|      | `--database`             | Database to query                                              |
+|      | `--enable-system-tables` | Enable ability to query system tables                          |
+|      | `--format`               | Output format (`table` _(default)_ or `json`)                  |
+|      | `--language`             | Query language (`sql` _(default)_ or `influxql`)               |
+|      | `--time-format`          | Time format for table output (`rfc3339` _(default)_ or `unix`) |
+|      | `--token`                | Database token with read permissions on the queried database   |
+| `-h` | `--help`                 | Output command help                                            |
 
 {{% caption %}}
 _Also see [`influxctl` global flags](/influxdb/clustered/reference/cli/influxctl/#global-flags)._
@@ -80,6 +89,7 @@ _Also see [`influxctl` global flags](/influxdb/clustered/reference/cli/influxctl
 - [Query InfluxDB v3 with InfluxQL](#query-influxdb-v3-with-influxql)
 - [Query InfluxDB v3 and return results in table format](#query-influxdb-v3-and-return-results-in-table-format)
 - [Query InfluxDB v3 and return results in JSON format](#query-influxdb-v3-and-return-results-in-json-format)
+- [Query InfluxDB v3 and return results with Unix nanosecond timestamps](#query-influxdb-v3-and-return-results-with-unix-nanosecond-timestamps)
 - [Query InfluxDB v3 using credentials from the connection profile](#query-influxdb-v3-using-credentials-from-the-connection-profile)
 - [Query data from InfluxDB v3 system tables](#query-data-from-influxdb-v3-system-tables)
 
@@ -286,37 +296,100 @@ cat ./query.sql | influxctl query \
     "hum": 35.9,
     "room": "Kitchen",
     "temp": 21,
-    "time": "2022-01-01T08:00:00Z"
+    "time": 1641024000000000000
   },
   {
     "co": 0,
     "hum": 36.2,
     "room": "Kitchen",
     "temp": 23,
-    "time": "2022-01-01T09:00:00Z"
+    "time": 1641027600000000000
   },
   {
     "co": 0,
     "hum": 36.1,
     "room": "Kitchen",
     "temp": 22.7,
-    "time": "2022-01-01T10:00:00Z"
+    "time": 1641031200000000000
   },
   {
     "co": 0,
     "hum": 36,
     "room": "Kitchen",
     "temp": 22.4,
-    "time": "2022-01-01T11:00:00Z"
+    "time": 1641034800000000000
   },
   {
     "co": 0,
     "hum": 36,
     "room": "Kitchen",
     "temp": 22.5,
-    "time": "2022-01-01T12:00:00Z"
+    "time": 1641038400000000000
   }
 ]
+```
+{{% /influxdb/custom-timestamps %}}
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+### Query InfluxDB v3 and return results with Unix nanosecond timestamps
+
+{{% code-placeholders "DATABASE_(TOKEN|NAME)" %}}
+
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[string](#)
+[file](#)
+[stdin](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+{{% influxdb/custom-timestamps %}}
+```sh
+influxctl query \
+  --token DATABASE_TOKEN \
+  --database DATABASE_NAME \
+  --time-format unix \
+  "SELECT * FROM home WHERE time >= '2022-01-01T08:00:00Z' LIMIT 5"
+```
+{{% /influxdb/custom-timestamps %}}
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+```sh
+influxctl query \
+  --token DATABASE_TOKEN \
+  --database DATABASE_NAME \
+  --time-format unix \
+  /path/to/query.sql
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+```sh
+cat ./query.sql | influxctl query \
+  --token DATABASE_TOKEN \
+  --database DATABASE_NAME \
+  --time-format unix \
+  - 
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+
+{{% /code-placeholders %}}
+
+{{< expand-wrapper >}}
+{{% expand "View example table-formatted results" %}}
+{{% influxdb/custom-timestamps %}}
+```
++-------+--------+---------+------+---------------------+
+|    co |    hum | room    | temp |                time |
++-------+--------+---------+------+---------------------+
+|     0 |   35.9 | Kitchen |   21 | 1641024000000000000 |
+|     0 |   36.2 | Kitchen |   23 | 1641027600000000000 |
+|     0 |   36.1 | Kitchen | 22.7 | 1641031200000000000 |
+|     0 |     36 | Kitchen | 22.4 | 1641034800000000000 |
+|     0 |     36 | Kitchen | 22.5 | 1641038400000000000 |
++-------+--------+---------+------+---------------------+
+| TOTAL | 5 ROWS |         |      |                     |
++-------+--------+---------+------+---------------------+
 ```
 {{% /influxdb/custom-timestamps %}}
 {{% /expand %}}
@@ -387,6 +460,11 @@ cat ./query.sql | influxctl query \
 {{% /code-placeholders %}}
 
 {{% expand "View command updates" %}}
+
+#### v2.9.0 {date="2024-05-03"}
+
+- Add `--time-format` flag to specify which timestamp format to use in the
+  `table` output format.
 
 #### v2.8.0 {date="2024-04-11"}
 

--- a/content/influxdb/clustered/reference/cli/influxctl/query.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/query.md
@@ -52,7 +52,7 @@ RFC3339Nano timestamps. Use the `--time-format` flag to specify one of the
 available time formats:
 
 - `rfc3339nano`: _(Default)_
-  [RFC3339-formatted timestamp](/influxdb/clustered/reference/glossary/#rfc3339-timestamp)--for example:
+  [RFC3339Nano-formatted timestamp](/influxdb/clustered/reference/glossary/#rfc3339nano-timestamp)--for example:
   `2024-01-01T00:00:00.000000000Z`
 - `unixnano`: [Unix nanosecond timestamp](/influxdb/clustered/reference/glossary/#unix-timestamp)
 

--- a/content/influxdb/clustered/reference/cli/influxctl/query.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/query.md
@@ -47,13 +47,14 @@ The `--format` flag lets you print the output in other formats.
 The `json` format is available for programmatic parsing by other tooling.
 Default: `table`.
 
-When using the `table` format, by default, timestamps are formatted as RFC3339
-timestamps. Use the `--time-format` flag to specify one of the available time formats:
+When using the `table` format, by default, timestamps are formatted as
+RFC3339Nano timestamps. Use the `--time-format` flag to specify one of the
+available time formats:
 
-- `rfc3339`: _(Default)_
+- `rfc3339nano`: _(Default)_
   [RFC3339-formatted timestamp](/influxdb/clustered/reference/glossary/#rfc3339-timestamp)--for example:
   `2024-01-01T00:00:00.000000000Z`
-- `unix`: [Unix nanosecond timestamp](/influxdb/clustered/reference/glossary/#unix-timestamp)
+- `unixnano`: [Unix nanosecond timestamp](/influxdb/clustered/reference/glossary/#unix-timestamp)
 
 ## Usage
 
@@ -69,15 +70,15 @@ influxctl query [flags] <QUERY>
 
 ## Flags
 
-| Flag |                          | Description                                                    |
-| :--- | :----------------------- | :------------------------------------------------------------- |
-|      | `--database`             | Database to query                                              |
-|      | `--enable-system-tables` | Enable ability to query system tables                          |
-|      | `--format`               | Output format (`table` _(default)_ or `json`)                  |
-|      | `--language`             | Query language (`sql` _(default)_ or `influxql`)               |
-|      | `--time-format`          | Time format for table output (`rfc3339` _(default)_ or `unix`) |
-|      | `--token`                | Database token with read permissions on the queried database   |
-| `-h` | `--help`                 | Output command help                                            |
+| Flag |                          | Description                                                            |
+| :--- | :----------------------- | :--------------------------------------------------------------------- |
+|      | `--database`             | Database to query                                                      |
+|      | `--enable-system-tables` | Enable ability to query system tables                                  |
+|      | `--format`               | Output format (`table` _(default)_ or `json`)                          |
+|      | `--language`             | Query language (`sql` _(default)_ or `influxql`)                       |
+|      | `--time-format`          | Time format for table output (`rfc3339nano` _(default)_ or `unixnano`) |
+|      | `--token`                | Database token with read permissions on the queried database           |
+| `-h` | `--help`                 | Output command help                                                    |
 
 {{% caption %}}
 _Also see [`influxctl` global flags](/influxdb/clustered/reference/cli/influxctl/#global-flags)._
@@ -348,7 +349,7 @@ cat ./query.sql | influxctl query \
 influxctl query \
   --token DATABASE_TOKEN \
   --database DATABASE_NAME \
-  --time-format unix \
+  --time-format unixnano \
   "SELECT * FROM home WHERE time >= '2022-01-01T08:00:00Z' LIMIT 5"
 ```
 {{% /influxdb/custom-timestamps %}}
@@ -358,7 +359,7 @@ influxctl query \
 influxctl query \
   --token DATABASE_TOKEN \
   --database DATABASE_NAME \
-  --time-format unix \
+  --time-format unixnano \
   /path/to/query.sql
 ```
 {{% /code-tab-content %}}
@@ -367,8 +368,8 @@ influxctl query \
 cat ./query.sql | influxctl query \
   --token DATABASE_TOKEN \
   --database DATABASE_NAME \
-  --time-format unix \
-  - 
+  --time-format unixnano \
+  -
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
@@ -461,7 +462,7 @@ cat ./query.sql | influxctl query \
 
 {{% expand "View command updates" %}}
 
-#### v2.9.0 {date="2024-05-03"}
+#### v2.9.0 {date="2024-05-06"}
 
 - Add `--time-format` flag to specify which timestamp format to use in the
   `table` output format.


### PR DESCRIPTION
_Describe your proposed changes here._

* Updates the option names `rfc3339` -> `rfc3339nano` and `unix` -> `unixnano`
* Updates the release date to Monday, May 6

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
