### PR TITLE
fix(flux): page not found (#5453)

### DIFF
--- a/data/flux_stdlib_frontmatter.yml
+++ b/data/flux_stdlib_frontmatter.yml
@@ -2667,6 +2667,8 @@
     - /influxdb/v2/reference/flux/functions/built-in/transformations/cumulativesum/
     - /influxdb/v2/reference/flux/stdlib/built-in/transformations/cumulativesum/
     - /influxdb/cloud/reference/flux/stdlib/built-in/transformations/cumulativesum/
+    - /flux/v0/stdlib/built-in/transformations/cumulativesum/
+
   related:
     - /influxdb/v2/query-data/flux/cumulativesum/
     - /influxdb/v1/query_language/functions/#cumulative-sum, InfluxQL – CUMULATIVE_SUM()


### PR DESCRIPTION
- Add alias for URL.
- Issue doesn't indicate where the old/incorrect URL was found.

Closes #5453

I'm not sure:
- where the reported URL was found
- whether we want this alias and if this is the place to put it
- if the problem is more widespread