### PR TITLE
Add note about using timeformat for partition templates

### DIFF
--- a/content/influxdb/cloud-dedicated/admin/custom-partitions/define-custom-partitions.md
+++ b/content/influxdb/cloud-dedicated/admin/custom-partitions/define-custom-partitions.md
@@ -61,8 +61,8 @@ _View [partition template part restrictions](/influxdb/cloud-dedicated/admin/cus
 
 When defining a custom partition template for your database or table using any
 of the `influxctl` `--template-*` flags, always include the `--template-timeformat`
-flag with a time format to use in your partition template. Otherwise time will
-be omitted from the partition template and partitions won't be able to be compacted.
+flag with a time format to use in your partition template.
+Otherwise, InfluxDB omits time from the partition template and won't compact partitions.
 {{% /note %}}
 
 ## Create a database with a custom partition template

--- a/content/influxdb/cloud-dedicated/admin/custom-partitions/define-custom-partitions.md
+++ b/content/influxdb/cloud-dedicated/admin/custom-partitions/define-custom-partitions.md
@@ -56,6 +56,15 @@ and only 1 time part.
 
 _View [partition template part restrictions](/influxdb/cloud-dedicated/admin/custom-partitions/partition-templates/#restrictions)._
 
+{{% note %}}
+#### Always provide a time format when using custom partitioning
+
+When defining a custom partition template for your database or table using any
+of the `influxctl` `--template-*` flags, always include the `--template-timeformat`
+flag with a time format to use in your partition template. Otherwise time will
+be omitted from the partition template and partitions won't be able to be compacted.
+{{% /note %}}
+
 ## Create a database with a custom partition template
 
 The following example creates a new `example-db` database and applies a partition

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/create.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/database/create.md
@@ -60,6 +60,15 @@ into a specified number of "buckets."
 Each of these can be used as part of the partition template.
 Be sure to follow [partitioning best practices](/influxdb/cloud-dedicated/admin/custom-partitions/best-practices/).
 
+{{% note %}}
+#### Always provide a time format when using custom partitioning
+
+If defining a custom partition template for your database with any of the
+`--template-*` flags, always include the `--template-timeformat` flag with a
+time format to use in your partition template. Otherwise time will be omitted
+from the partition template and partitions won't be able to be compacted.
+{{% /note %}}
+
 ## Usage
 
 ```sh
@@ -81,7 +90,7 @@ influxctl database create [flags] <DATABASE_NAME>
 |      | `--max-columns`         | Maximum columns per table (default is 250, 0 uses default)                                                                               |
 |      | `--template-tag`        | Tag to add to partition template (can include multiple of this flag)                                                                     |
 |      | `--template-tag-bucket` | Tag and number of buckets to partition tag values into separated by a comma--for example: `tag1,100` (can include multiple of this flag) |
-|      | `--template-timeformat` | Timestamp format for partition template (default is `%Y-%m-%d`)                                                                          |
+|      | `--template-timeformat` | Timestamp format for partition template <!--(default is `%Y-%m-%d`) -->                                                                  |
 | `-h` | `--help`                | Output command help                                                                                                                      |
 
 {{% caption %}}

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/table/create.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/table/create.md
@@ -29,8 +29,8 @@ Be sure to follow [partitioning best practices](/influxdb/cloud-dedicated/admin/
 
 If defining a custom partition template for your table with any of the
 `--template-*` flags, always include the `--template-timeformat` flag with a
-time format to use in your partition template. Otherwise time will be omitted
-from the partition template and partitions won't be able to be compacted.
+time format to use in your partition template.
+Otherwise, InfluxDB omits time from the partition template and won't compact partitions.
 {{% /note %}}
 
 ## Usage

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/table/create.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/table/create.md
@@ -24,6 +24,15 @@ into a specified number of "buckets."
 Each of these can be used as part of the partition template.
 Be sure to follow [partitioning best practices](/influxdb/cloud-dedicated/admin/custom-partitions/best-practices/).
 
+{{% note %}}
+#### Always provide a time format when using custom partitioning
+
+If defining a custom partition template for your table with any of the
+`--template-*` flags, always include the `--template-timeformat` flag with a
+time format to use in your partition template. Otherwise time will be omitted
+from the partition template and partitions won't be able to be compacted.
+{{% /note %}}
+
 ## Usage
 
 ```sh
@@ -43,7 +52,7 @@ influxctl table create [flags] <DATABASE_NAME> <TABLE_NAME>
 | :--- | :---------------------- | :--------------------------------------------------------------------------------------------------------------------------------------- |
 |      | `--template-tag`        | Tag to add to partition template (can include multiple of this flag)                                                                     |
 |      | `--template-tag-bucket` | Tag and number of buckets to partition tag values into separated by a comma--for example: `tag1,100` (can include multiple of this flag) |
-|      | `--template-timeformat` | Timestamp format for partition template (default is `%Y-%m-%d`)                                                                          |
+|      | `--template-timeformat` | Timestamp format for partition template <!--(default is `%Y-%m-%d`)-->                                                                   |
 | `-h` | `--help`                | Output command help                                                                                                                      |
 
 {{% caption %}}

--- a/content/influxdb/clustered/admin/custom-partitions/define-custom-partitions.md
+++ b/content/influxdb/clustered/admin/custom-partitions/define-custom-partitions.md
@@ -56,6 +56,15 @@ and only 1 time part.
 
 _View [partition template part restrictions](/influxdb/clustered/admin/custom-partitions/partition-templates/#restrictions)._
 
+{{% note %}}
+#### Always provide a time format when using custom partitioning
+
+When defining a custom partition template for your database or table using any
+of the `influxctl` `--template-*` flags, always include the `--template-timeformat`
+flag with a time format to use in your partition template. Otherwise time will
+be omitted from the partition template and partitions won't be able to be compacted.
+{{% /note %}}
+
 ## Create a database with a custom partition template
 
 The following example creates a new `example-db` database and applies a partition

--- a/content/influxdb/clustered/admin/custom-partitions/define-custom-partitions.md
+++ b/content/influxdb/clustered/admin/custom-partitions/define-custom-partitions.md
@@ -61,8 +61,8 @@ _View [partition template part restrictions](/influxdb/clustered/admin/custom-pa
 
 When defining a custom partition template for your database or table using any
 of the `influxctl` `--template-*` flags, always include the `--template-timeformat`
-flag with a time format to use in your partition template. Otherwise time will
-be omitted from the partition template and partitions won't be able to be compacted.
+flag with a time format to use in your partition template.
+Otherwise, InfluxDB omits time from the partition template and won't compact partitions.
 {{% /note %}}
 
 ## Create a database with a custom partition template

--- a/content/influxdb/clustered/reference/cli/influxctl/database/create.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/database/create.md
@@ -59,6 +59,15 @@ into a specified number of "buckets."
 Each of these can be used as part of the partition template.
 Be sure to follow [partitioning best practices](/influxdb/clustered/admin/custom-partitions/best-practices/).
 
+{{% note %}}
+#### Always provide a time format when using custom partitioning
+
+If defining a custom partition template for your database with any of the
+`--template-*` flags, always include the `--template-timeformat` flag with a
+time format to use in your partition template. Otherwise time will be omitted
+from the partition template and partitions won't be able to be compacted.
+{{% /note %}}
+
 ## Usage
 
 ```sh
@@ -80,7 +89,7 @@ influxctl database create [flags] <DATABASE_NAME>
 |      | `--max-columns`         | Maximum columns per table (default is 250, 0 uses default)                                                                               |
 |      | `--template-tag`        | Tag to add to partition template (can include multiple of this flag)                                                                     |
 |      | `--template-tag-bucket` | Tag and number of buckets to partition tag values into separated by a comma--for example: `tag1,100` (can include multiple of this flag) |
-|      | `--template-timeformat` | Timestamp format for partition template (default is `%Y-%m-%d`)                                                                          |
+|      | `--template-timeformat` | Timestamp format for partition template <!--(default is `%Y-%m-%d`)-->                                                                   |
 | `-h` | `--help`                | Output command help                                                                                                                      |
 
 {{% caption %}}

--- a/content/influxdb/clustered/reference/cli/influxctl/database/create.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/database/create.md
@@ -64,8 +64,8 @@ Be sure to follow [partitioning best practices](/influxdb/clustered/admin/custom
 
 If defining a custom partition template for your database with any of the
 `--template-*` flags, always include the `--template-timeformat` flag with a
-time format to use in your partition template. Otherwise time will be omitted
-from the partition template and partitions won't be able to be compacted.
+time format to use in your partition template.
+Otherwise, InfluxDB omits time from the partition template and won't compact partitions.
 {{% /note %}}
 
 ## Usage

--- a/content/influxdb/clustered/reference/cli/influxctl/table/create.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/table/create.md
@@ -24,6 +24,15 @@ into a specified number of "buckets."
 Each of these can be used as part of the partition template.
 Be sure to follow [partitioning best practices](/influxdb/clustered/admin/custom-partitions/best-practices/).
 
+{{% note %}}
+#### Always provide a time format when using custom partitioning
+
+If defining a custom partition template for your table with any of the
+`--template-*` flags, always include the `--template-timeformat` flag with a
+time format to use in your partition template. Otherwise time will be omitted
+from the partition template and partitions won't be able to be compacted.
+{{% /note %}}
+
 ## Usage
 
 ```sh
@@ -43,7 +52,7 @@ influxctl table create [flags] <DATABASE_NAME> <TABLE_NAME>
 | :--- | :---------------------- | :--------------------------------------------------------------------------------------------------------------------------------------- |
 |      | `--template-tag`        | Tag to add to partition template (can include multiple of this flag)                                                                     |
 |      | `--template-tag-bucket` | Tag and number of buckets to partition tag values into separated by a comma--for example: `tag1,100` (can include multiple of this flag) |
-|      | `--template-timeformat` | Timestamp format for partition template (default is `%Y-%m-%d`)                                                                          |
+|      | `--template-timeformat` | Timestamp format for partition template <!--(default is `%Y-%m-%d`)-->                                                                   |
 | `-h` | `--help`                | Output command help                                                                                                                      |
 
 {{% caption %}}

--- a/content/influxdb/clustered/reference/cli/influxctl/table/create.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/table/create.md
@@ -29,8 +29,8 @@ Be sure to follow [partitioning best practices](/influxdb/clustered/admin/custom
 
 If defining a custom partition template for your table with any of the
 `--template-*` flags, always include the `--template-timeformat` flag with a
-time format to use in your partition template. Otherwise time will be omitted
-from the partition template and partitions won't be able to be compacted.
+time format to use in your partition template.
+Otherwise, InfluxDB omits time from the partition template and won't compact partitions.
 {{% /note %}}
 
 ## Usage


### PR DESCRIPTION
It was discovered that if users omit the time format when defining custom partition templates, the template will not include time. This means that partitions never age out, are always "hot," and will never compact. This PR updates the partitioning documentation with notes to call this out.

This behavior will likely change in the future, requiring a time format at the API/service level or at least providing a reasonable default. That's why some things are just commented out.

- [x] Rebased/mergeable
