### PR TITLE
fix: use int64 for retention period in API spec

### DIFF
--- a/api-docs/cloud-dedicated/management/openapi.yml
+++ b/api-docs/cloud-dedicated/management/openapi.yml
@@ -1597,7 +1597,7 @@ components:
 
         If the retention period is not set or is set to 0, the database will have infinite retention
       type: integer
-      format: int32
+      format: int64
       default: 0
       examples:
         - 300000000000

--- a/api-docs/getswagger.sh
+++ b/api-docs/getswagger.sh
@@ -155,7 +155,7 @@ function updateCloudDedicatedManagement {
   then
     echo "Using existing $outFile"
   else
-    curl $UPDATE_OPTIONS https://raw.githubusercontent.com/influxdata/granite/3117fb47d5e56afaadcebc226ff4b25785d95b5a/openapi.yaml -o $outFile
+    curl $UPDATE_OPTIONS https://raw.githubusercontent.com/influxdata/granite/ab7ee2aceacfae7f415d15ffbcf8c9d0f6f3e015/openapi.yaml -o $outFile
   fi
   postProcess $outFile 'cloud-dedicated/.config.yml' management@0
 }


### PR DESCRIPTION
Closes influxdata/granite#2502.

This updates the Cloud Dedicated Management API spec to use the `int64` format for the `ClusterDatabaseRetentionPeriod` schema, which matches the corresponding type in IOx's namespace API. The source spec was change in influxdata/granite#2503

I haven't done an API update to the docs before, but looking at how the `getswagger.sh` script works for the `cloud-dedicated-management` product case, I'm guessing an automated updated isn't really supported for the Cloud Dedicated Management API right now. I did go ahead and update the commit SHA that's referenced in the script, but the link won't work without adding a valid `token` query param to it since the Granite repo is private. When I did try to use that script, there were quite a few changes that looked like it was overriding manual documentation, so I just opted for manually updating the spec. Let me know if there's a different preferred approach for this.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
