### PR TITLE
docs(clustered): update ingester scaling strategy recommendation

### DIFF
--- a/content/influxdb/clustered/reference/internals/storage-engine.md
+++ b/content/influxdb/clustered/reference/internals/storage-engine.md
@@ -68,7 +68,7 @@ In this process, the Ingester does the following:
 
 The Ingester can be scaled both [vertically](#vertical-scaling) and
 [horizontally](#horizontal-scaling).
-Horizontal scaling increases write throughput and is typically the most
+Vertical scaling increases write throughput and is typically the most
 effective scaling strategy for the Ingester.
 
 ### Querier


### PR DESCRIPTION
Helps with our continued [Clustered docs](https://github.com/influxdata/project-clustered/issues/443) work.

Whilst the ingesters _can_ be horizontally scaled, the usual recommendation is to actually vertically scale them first.

If we are recommending horizontal scaling by default in Clustered, this is going to cause more catalog load and extra work for the queriers. Whereas having beefier ingesters should be sought after first, as there are far more trade-offs which need to be considered when adding more ingesters.


- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
