### PR TITLE
docs(clustered): update ingress to mention grpc

### DIFF
--- a/content/influxdb/clustered/install/configure-cluster.md
+++ b/content/influxdb/clustered/install/configure-cluster.md
@@ -315,10 +315,10 @@ spec:
 
 ### Set up cluster ingress
 
-{{% warn %}}
-Components of Clustered utilise gRPC/HTTP2. You may need to explicitly allow this
-on any external load balancers you use.
-{{% /warn %}}
+{{% note %}}
+InfluxDB Clustered components use gRPC/HTTP2 protocols. If using an external load balancer,
+you may need to explicitly enable these protocols on your load balancers.
+{{% /note %}}
 
 [Kubernetes ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) routes HTTP/S requests to services within the cluster and requires deploying an [ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/).
 

--- a/content/influxdb/clustered/install/configure-cluster.md
+++ b/content/influxdb/clustered/install/configure-cluster.md
@@ -315,6 +315,11 @@ spec:
 
 ### Set up cluster ingress
 
+{{% warn %}}
+Components of Clustered utilise gRPC/HTTP2. You may need to explicitly allow this
+on any external load balancers you use.
+{{% /warn %}}
+
 [Kubernetes ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) routes HTTP/S requests to services within the cluster and requires deploying an [ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/).
 
 You can provide your own ingress or you can install [Nginx Ingress Controller](https://github.com/kubernetes/ingress-nginx) to use the InfluxDB-defined ingress.


### PR DESCRIPTION
Clustered customers which are running on-premise need to know that components of the product utilise gRPC/HTTP2 as this may have to be configured
on other load balancers outside of their Kubernetes cluster.

We have ran into this with a customer recently, so no doubt it can happen with others.

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
