### PR TITLE
clustered: add section for custom CA on egress

### DIFF
--- a/content/influxdb/clustered/install/configure-cluster.md
+++ b/content/influxdb/clustered/install/configure-cluster.md
@@ -821,36 +821,57 @@ spec:
 
 {{% /code-placeholders %}}
 
-### Provide a custom Certificate Authority bundle (optional)
+### Provide a custom certificate authority bundle {metadata="Optional"}
 
-If you do not use a private certificate authority, then you can skip this section.
+InfluxDB attempts to make TLS connections to the services it depends on; notably
+the [Catalog](/influxdb/clustered/reference/internals/storage-engine/#catalog),
+and the [Object store](/influxdb/clustered/reference/internals/storage-engine/#object-store).
+InfluxDB validates the certificates for all of the connections it makes.
 
-InfluxDB will attempt to make TLS connections to the services it depends on; notably the Postgresql catalog, and the object store. InfluxDB validates the certificates for all of the connections it makes. If you host these services yourself, and you use a private or otherwise not well-known certificate authority to issue certificates to those services, then InfluxDB will not recognize the issuer and will not be able to validate them. To allow InfluxDB to validate these certificates, you must provide it with a pem bundle containing your custom certificate chain.
+**If you host these services yourself and you use a private or otherwise not
+well-known certificate authority to issue certificates to theses services**, 
+InfluxDB will not recognize the issuer and will be unable to validate the certificates.
+To allow InfluxDB to validate these certificates, provide a PEM certificate
+bundle containing your custom certificate authority chain.
 
-First, you must create a config map containing your pem bundle. In the example below, `private_ca.pem` is a pem formatted certificate bundle file. It should be provided to you by your certificate authority administrator. Note that this is *not* the certificate that InfluxDB uses to host its own TLS endpoints. This bundle establishes a chain of trust for the external services that InfluxDB depends on.
+1.  Use `kubectl` to create a config map containing your PEM bundle.
+    Your certificate authority administrator should provide you with a
+    PEM-formatted certificate bundle file.
+    
+    {{% note %}}
+This PEM-formatted bundle file is *not* the certificate that InfluxDB uses to
+host its own TLS endpoints. This bundle establishes a chain of trust for the
+external services that InfluxDB depends on.
+    {{% /note %}}
 
-```shell
-kubectl -n influxdb create configmap custom-certs --from-file=certs.pem=/path/to/private_ca.pem
-```
+    In the example below, `private_ca.pem` is the certificate bundle file.
 
-{{% note %}}
+    ```sh
+    kubectl --namespace influxdb create configmap custom-ca --from-file=certs.pem=/path/to/private_ca.pem
+    ```
 
-It's possible to append multiple certificates into the same bundle. This can be helpful if you need to include intermediate certificates, or to explicitly include your leaf certificates. If you do so, leaf certificates should be included before any intermediates they depend on, and the root certificate should be the last one in the bundle.
+    {{% note %}}
+It's possible to append multiple certificates into the same bundle.
+This can help if you need to include intermediate certificates or explicitly
+include leaf certificates. Leaf certificates should be included before any
+intermediate certificates they depend on. The root certificate should
+be last in the bundle.
+    {{% /note %}}
 
-{{% /note %}}
+2.  Update your `AppInstance` resource in your `myinfluxdb.yml` to refer to your
+    certificate authority config map. Update the `.spec.package.spec.egress`
+    property to refer to that config map. For example:
 
-Then, in your `myinflux.yml`, update the AppInstance `.spec.package.spec.egress` property to refer to that config map. For example:
-
-```yml
-spec:
-  package:
+    ```yml
     spec:
-      egress:
-        customCertificates:
-          valueFrom:
-            configMapKeyRef:
-              key: ca.pem
-              name: custom-ca
-```
+      package:
+        spec:
+          egress:
+            customCertificates:
+              valueFrom:
+                configMapKeyRef:
+                  key: ca.pem
+                  name: custom-ca
+    ```
 
 {{< page-nav prev="/influxdb/clustered/install/auth/" prevText="Set up authentication" next="/influxdb/clustered/install/deploy/" nextText="Deploy your cluster" >}}

--- a/content/influxdb/clustered/install/configure-cluster.md
+++ b/content/influxdb/clustered/install/configure-cluster.md
@@ -821,4 +821,36 @@ spec:
 
 {{% /code-placeholders %}}
 
+### Provide a custom Certificate Authority bundle (optional)
+
+If you do not use a private certificate authority, then you can skip this section.
+
+InfluxDB will attempt to make TLS connections to the services it depends on; notably the Postgresql catalog, and the object store. InfluxDB validates the certificates for all of the connections it makes. If you host these services yourself, and you use a private or otherwise not well-known certificate authority to issue certificates to those services, then InfluxDB will not recognize the issuer and will not be able to validate them. To allow InfluxDB to validate these certificates, you must provide it with a pem bundle containing your custom certificate chain.
+
+First, you must create a config map containing your pem bundle. In the example below, `private_ca.pem` is a pem formatted certificate bundle file. It should be provided to you by your certificate authority administrator. Note that this is *not* the certificate that InfluxDB uses to host its own TLS endpoints. This bundle establishes a chain of trust for the external services that InfluxDB depends on.
+
+```shell
+kubectl -n influxdb create configmap custom-certs --from-file=certs.pem=/path/to/private_ca.pem
+```
+
+{{% note %}}
+
+It's possible to append multiple certificates into the same bundle. This can be helpful if you need to include intermediate certificates, or to explicitly include your leaf certificates. If you do so, leaf certificates should be included before any intermediates they depend on, and the root certificate should be the last one in the bundle.
+
+{{% /note %}}
+
+Then, in your `myinflux.yml`, update the AppInstance `.spec.package.spec.egress` property to refer to that config map. For example:
+
+```yml
+spec:
+  package:
+    spec:
+      egress:
+        customCertificates:
+          valueFrom:
+            configMapKeyRef:
+              key: ca.pem
+              name: custom-ca
+```
+
 {{< page-nav prev="/influxdb/clustered/install/auth/" prevText="Set up authentication" next="/influxdb/clustered/install/deploy/" nextText="Deploy your cluster" >}}


### PR DESCRIPTION
Closes https://github.com/influxdata/project-clustered/issues/114

Adds a section to the Clustered install guide on configuring a custom certificate bundle for private CAs.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
