### PR TITLE
Remove limited access banner from Clustered

### DIFF
--- a/content/influxdb/clustered/install/_index.md
+++ b/content/influxdb/clustered/install/_index.md
@@ -10,6 +10,14 @@ InfluxDB Clustered is deployed and managed using Kubernetes.
 This multi-page guide walks through setting up prerequisites and configuring
 your InfluxDB cluster deployment.
 
+InfluxDB Clustered is a licensed InfluxDB product.
+Before installing and configuring your InfluxDB cluster, contact InfluxData
+Sales to obtain a license.
+
+<a class="btn" href="{{< cta-link >}}">Contact InfluxData Sales</a>
+
+## Setup, configure, and deploy InfluxDB Clustered
+
 {{< children type="ordered-list" >}}
 
 

--- a/content/influxdb/clustered/install/_index.md
+++ b/content/influxdb/clustered/install/_index.md
@@ -10,9 +10,9 @@ InfluxDB Clustered is deployed and managed using Kubernetes.
 This multi-page guide walks through setting up prerequisites and configuring
 your InfluxDB cluster deployment.
 
-InfluxDB Clustered is a licensed InfluxDB product.
-Before installing and configuring your InfluxDB cluster, contact InfluxData
-Sales to obtain a license.
+InfluxDB Clustered is a commercial product offered by InfluxData, the creators
+of InfluxDB. Please contact InfluxData Sales to obtain a license before
+installing InfluxDB Clustered.
 
 <a class="btn" href="{{< cta-link >}}">Contact InfluxData Sales</a>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -33,7 +33,7 @@
       <div class="category">
         <h4>Self-managed</h4>
         <div class="category-card">
-          <div class="product limited">
+          <div class="product new">
             <h3><a href="/influxdb/clustered/">InfluxDB Clustered</a></h3>
             <p>Highly available InfluxDB 3.0 cluster built for high write and query workloads on your own infrastructure.</p>
             <div class="product-links">

--- a/layouts/partials/article/limited-availability.html
+++ b/layouts/partials/article/limited-availability.html
@@ -1,4 +1,4 @@
-<!-- This partial is no longer used by may be repurposed later for other InfluxDB products -->
+<!-- This partial is no longer used but may be repurposed later for other InfluxDB products -->
 {{ $productPathData := findRE "[^/]+.*?" .RelPermalink }}
 {{ $product := index $productPathData 0 }}
 {{ $version := index $productPathData 1 }}

--- a/layouts/partials/article/limited-availability.html
+++ b/layouts/partials/article/limited-availability.html
@@ -1,8 +1,9 @@
+<!-- This partial is no longer used by may be repurposed later for other InfluxDB products -->
 {{ $productPathData := findRE "[^/]+.*?" .RelPermalink }}
 {{ $product := index $productPathData 0 }}
 {{ $version := index $productPathData 1 }}
 {{ $productData := index $.Site.Data.products (print $product "_" (replaceRE "-" "_" $version)) }}
-{{ $earlyAccessList := slice "influxdb/clustered" }}
+{{ $earlyAccessList := slice " " }}
 
 {{ if in $earlyAccessList (print $product "/" $version )}}
 <div class="block cloud">


### PR DESCRIPTION
Closes #5523

- Removes the limited access banner from InfluxDB Clustered docs
- Updates the "Limited Access" flag next to InfluxDB Clustered to "New" on the homepage.
- Adds information to the Clustered install page about contacting sales for a license.

---

- [x] Rebased/mergeable
