### PR TITLE
Update the placeholder URL for dedicated

### DIFF
--- a/api-docs/cloud-dedicated/v2/content/servers.yml
+++ b/api-docs/cloud-dedicated/v2/content/servers.yml
@@ -3,6 +3,6 @@
   variables:
     baseurl:
       enum:
-        - 'cluster-id.influxdb.io'
-      default: 'cluster-id.influxdb.io'
+        - 'cluster-id.a.influxdb.io'
+      default: 'cluster-id.a.influxdb.io'
       description: InfluxDB Cloud Dedicated URL

--- a/api-docs/cloud-dedicated/v2/ref.yml
+++ b/api-docs/cloud-dedicated/v2/ref.yml
@@ -17,8 +17,8 @@ servers:
     variables:
       baseurl:
         enum:
-          - cluster-id.influxdb.io
-        default: cluster-id.influxdb.io
+          - cluster-id.a.influxdb.io
+        default: cluster-id.a.influxdb.io
         description: InfluxDB Cloud Dedicated URL
 security:
   - BearerAuthentication: []
@@ -1996,7 +1996,7 @@ components:
         # Use the --user option with `--user username:DATABASE_TOKEN` syntax
         #######################################
 
-        curl --get "http://cluster-id.influxdb.io/query" \
+        curl --get "http://cluster-id.a.influxdb.io/query" \
           --user "":"DATABASE_TOKEN" \
           --data-urlencode "db=DATABASE_NAME" \
           --data-urlencode "q=SELECT * FROM MEASUREMENT"
@@ -2024,8 +2024,8 @@ components:
         ### Syntax
 
         ```http
-        https://cluster-id.influxdb.io/query/?[u=any]&p=DATABASE_TOKEN
-        https://cluster-id.influxdb.io/write/?[u=any]&p=DATABASE_TOKEN
+        https://cluster-id.a.influxdb.io/query/?[u=any]&p=DATABASE_TOKEN
+        https://cluster-id.a.influxdb.io/write/?[u=any]&p=DATABASE_TOKEN
         ```
 
         ### Example
@@ -2041,7 +2041,7 @@ components:
         #   ?p=DATABASE_TOKEN
         #######################################
 
-        curl --get "https://cluster-id.influxdb.io/query" \
+        curl --get "https://cluster-id.a.influxdb.io/query" \
           --data-urlencode "p=DATABASE_TOKEN" \
           --data-urlencode "db=DATABASE_NAME" \
           --data-urlencode "q=SELECT * FROM MEASUREMENT"
@@ -2078,7 +2078,7 @@ components:
         # to write data.
         ########################################################
 
-        curl --request post "https://cluster-id.influxdb.io/api/v2/write?bucket=DATABASE_NAME&precision=s" \
+        curl --request post "https://cluster-id.a.influxdb.io/api/v2/write?bucket=DATABASE_NAME&precision=s" \
           --header "Authorization: Bearer DATABASE_TOKEN" \
           --data-binary 'home,room=kitchen temp=72 1463683075'
         ```
@@ -2109,7 +2109,7 @@ components:
         # to write data.
         ########################################################
 
-        curl --request post "https://cluster-id.influxdb.io/api/v2/write?bucket=DATABASE_NAME&precision=s" \
+        curl --request post "https://cluster-id.a.influxdb.io/api/v2/write?bucket=DATABASE_NAME&precision=s" \
           --header "Authorization: Token DATABASE_TOKEN" \
           --data-binary 'home,room=kitchen temp=72 1463683075'
         ```

--- a/api-docs/clustered/v2/ref.yml
+++ b/api-docs/clustered/v2/ref.yml
@@ -1980,7 +1980,7 @@ components:
         # Use the --user option with `--user username:DATABASE_TOKEN` syntax
         #######################################
 
-        curl --get "http://cluster-id.influxdb.io/query" \
+        curl --get "http://cluster-id.a.influxdb.io/query" \
           --user "":"DATABASE_TOKEN" \
           --data-urlencode "db=DATABASE_NAME" \
           --data-urlencode "q=SELECT * FROM MEASUREMENT"
@@ -2008,8 +2008,8 @@ components:
         ### Syntax
 
         ```http
-        https://cluster-id.influxdb.io/query/?[u=any]&p=DATABASE_TOKEN
-        https://cluster-id.influxdb.io/write/?[u=any]&p=DATABASE_TOKEN
+        https://cluster-id.a.influxdb.io/query/?[u=any]&p=DATABASE_TOKEN
+        https://cluster-id.a.influxdb.io/write/?[u=any]&p=DATABASE_TOKEN
         ```
 
         ### Example
@@ -2025,7 +2025,7 @@ components:
         #   ?p=DATABASE_TOKEN
         #######################################
 
-        curl --get "https://cluster-id.influxdb.io/query" \
+        curl --get "https://cluster-id.a.influxdb.io/query" \
           --data-urlencode "p=DATABASE_TOKEN" \
           --data-urlencode "db=DATABASE_NAME" \
           --data-urlencode "q=SELECT * FROM MEASUREMENT"
@@ -2062,7 +2062,7 @@ components:
         # to write data.
         ########################################################
 
-        curl --request post "https://cluster-id.influxdb.io/api/v2/write?bucket=DATABASE_NAME&precision=s" \
+        curl --request post "https://cluster-id.a.influxdb.io/api/v2/write?bucket=DATABASE_NAME&precision=s" \
           --header "Authorization: Bearer DATABASE_TOKEN" \
           --data-binary 'home,room=kitchen temp=72 1463683075'
         ```
@@ -2093,7 +2093,7 @@ components:
         # to write data.
         ########################################################
 
-        curl --request post "https://cluster-id.influxdb.io/api/v2/write?bucket=DATABASE_NAME&precision=s" \
+        curl --request post "https://cluster-id.a.influxdb.io/api/v2/write?bucket=DATABASE_NAME&precision=s" \
           --header "Authorization: Token DATABASE_TOKEN" \
           --data-binary 'home,room=kitchen temp=72 1463683075'
         ```

--- a/assets/js/cookies.js
+++ b/assets/js/cookies.js
@@ -93,7 +93,7 @@ var defaultUrls = {
   oss: 'http://localhost:8086',
   cloud: 'https://us-west-2-1.aws.cloud2.influxdata.com',
   serverless: 'https://us-east-1-1.aws.cloud2.influxdata.com',
-  dedicated: 'cluster-id.influxdb.io',
+  dedicated: 'cluster-id.a.influxdb.io',
   clustered: 'cluster-host.com',
 };
 

--- a/assets/js/influxdb-url.js
+++ b/assets/js/influxdb-url.js
@@ -13,7 +13,7 @@ var placeholderUrls = {
 var elementSelector = '.article--content pre:not(.preserve)';
 
 // Return the page context (cloud, serverless, oss/enterprise, dedicated, clustered, other)
-function context () {
+function context() {
   if (/\/influxdb\/cloud\//.test(window.location.pathname)) {
     return 'cloud';
   } else if (/\/influxdb\/cloud-serverless/.test(window.location.pathname)) {
@@ -37,12 +37,12 @@ function context () {
 
 // Retrieve the user's InfluxDB preference (cloud or oss) from the influxdb_pref session cookie
 // Default is cloud.
-function getURLPreference () {
+function getURLPreference() {
   return getPreference('influxdb_url');
 }
 
 // Set the user's selected InfluxDB preference (cloud or oss)
-function setURLPreference (preference) {
+function setURLPreference(preference) {
   setPreference('influxdb_url', preference);
 }
 
@@ -61,7 +61,7 @@ function setURLPreference (preference) {
 */
 
 // Store URLs in the urls session cookies
-function storeUrl (context, newUrl, prevUrl) {
+function storeUrl(context, newUrl, prevUrl) {
   urlsObj = {};
   urlsObj['prev_' + context] = prevUrl;
   urlsObj[context] = newUrl;
@@ -71,20 +71,20 @@ function storeUrl (context, newUrl, prevUrl) {
 
 // Store custom URL in the url session cookie.
 // Used to populate the custom URL field
-function storeCustomUrl (customUrl) {
+function storeCustomUrl(customUrl) {
   setInfluxDBUrls({ custom: customUrl });
   $('input#custom[type=radio]').val(customUrl);
 }
 
 // Set a URL in the urls session cookie to an empty string
 // Used to clear the form when custom url input is left empty
-function removeCustomUrl () {
+function removeCustomUrl() {
   removeInfluxDBUrl('custom');
 }
 
 // Store a product URL in the urls session cookie
 // Used to populate the custom URL field
-function storeProductUrl (product, productUrl) {
+function storeProductUrl(product, productUrl) {
   urlsObj = {};
   urlsObj[product] = productUrl;
 
@@ -94,7 +94,7 @@ function storeProductUrl (product, productUrl) {
 
 // Set a product URL in the urls session cookie to an empty string
 // Used to clear the form when dedicated url input is left empty
-function removeProductUrl (product) {
+function removeProductUrl(product) {
   removeInfluxDBUrl(product);
 }
 
@@ -104,7 +104,7 @@ function removeProductUrl (product) {
 
 // Preserve URLs in codeblocks that come just after or are inside a div
 // with the class, .keep-url
-function addPreserve () {
+function addPreserve() {
   $('.keep-url').each(function () {
     // For code blocks with no syntax highlighting
     $(this).next('pre').addClass('preserve');
@@ -119,7 +119,7 @@ function addPreserve () {
 }
 
 // Retrieve the currently selected URLs from the urls session cookie.
-function getUrls () {
+function getUrls() {
   var storedUrls = getInfluxDBUrls();
   var currentCloudUrl = storedUrls.cloud;
   var currentOSSUrl = storedUrls.oss;
@@ -138,7 +138,7 @@ function getUrls () {
 
 // Retrieve the previously selected URLs from the from the urls session cookie.
 // This is used to update URLs whenever you switch between browser tabs.
-function getPrevUrls () {
+function getPrevUrls() {
   var storedUrls = getInfluxDBUrls();
   var prevCloudUrl = storedUrls.prev_cloud;
   var prevOSSUrl = storedUrls.prev_oss;
@@ -156,7 +156,7 @@ function getPrevUrls () {
 }
 
 // Iterate through code blocks and update InfluxDB urls
-function updateUrls (prevUrls, newUrls) {
+function updateUrls(prevUrls, newUrls) {
   var preference = getURLPreference();
   var prevUrlsParsed = {
     oss: {},
@@ -244,7 +244,7 @@ function updateUrls (prevUrls, newUrls) {
     }
   });
 
-  function replaceWholename (startStr, endStr, replacement) {
+  function replaceWholename(startStr, endStr, replacement) {
     var startsWithSeparator = new RegExp('[/.]');
     var endsWithSeparator = new RegExp('[-.:]');
     if (
@@ -278,7 +278,7 @@ function updateUrls (prevUrls, newUrls) {
 }
 
 // Append the URL selector button to each codeblock containing a placeholder URL
-function appendUrlSelector () {
+function appendUrlSelector() {
   var appendToUrls = [
     placeholderUrls.oss,
     placeholderUrls.cloud,
@@ -290,15 +290,15 @@ function appendUrlSelector () {
   getBtnText = (context) => {
     contextText = {
       'oss/enterprise': 'Change InfluxDB URL',
-      'cloud': 'InfluxDB Cloud Region',
-      'serverless': 'InfluxDB Cloud Region',
-      'dedicated': 'Set Dedicated cluster URL',
-      'clustered': 'Set InfluxDB cluster URL',
-      'other': 'InfluxDB Cloud or OSS?'
-    }
-    
-    return contextText[context]
-  }
+      cloud: 'InfluxDB Cloud Region',
+      serverless: 'InfluxDB Cloud Region',
+      dedicated: 'Set Dedicated cluster URL',
+      clustered: 'Set InfluxDB cluster URL',
+      other: 'InfluxDB Cloud or OSS?',
+    };
+
+    return contextText[context];
+  };
 
   appendToUrls.forEach(function (url) {
     $(elementSelector).each(function () {
@@ -344,7 +344,7 @@ $('.url-trigger').click(function (e) {
 });
 
 // Set the selected URL radio buttons to :checked
-function setRadioButtons () {
+function setRadioButtons() {
   currentUrls = getUrls();
   $('input[name="influxdb-cloud-url"][value="' + currentUrls.cloud + '"]').prop(
     'checked',
@@ -426,7 +426,7 @@ $('input[name="influxdb-clustered-url"]').change(function () {
 });
 
 // Toggle preference tabs
-function togglePrefBtns (el) {
+function togglePrefBtns(el) {
   preference = el.length ? el.attr('id').replace('pref-', '') : 'cloud';
   prefUrls = $('#' + preference + '-urls');
 
@@ -443,7 +443,7 @@ $('#pref-tabs .pref-tab').click(function () {
 });
 
 // Select preference tab from cookie
-function showPreference () {
+function showPreference() {
   var preference = getPreference('influxdb_url');
   prefTab = $('#pref-' + preference);
   togglePrefBtns(prefTab);
@@ -457,7 +457,7 @@ showPreference();
 ////////////////////////////////////////////////////////////////////////////////
 
 // Validate custom URLs
-function validateUrl (url) {
+function validateUrl(url) {
   /** validDomain = (Named host | IPv6 host | IPvFuture host)(:Port)? **/
   var validDomain = new RegExp(
     `([a-z0-9\-._~%]+` +
@@ -505,19 +505,19 @@ function validateUrl (url) {
 }
 
 // Show validation errors
-function showValidationMessage (validation) {
+function showValidationMessage(validation) {
   $('#custom-url').addClass('error');
   $('#custom-url').attr('data-message', validation.error);
 }
 
 // Hide validation messages and replace the message attr with empty string
-function hideValidationMessage () {
+function hideValidationMessage() {
   $('#custom-url').removeClass('error').attr('data-message', '');
 }
 
 // Set the custom URL cookie and apply the change
 // If the custom URL field is empty, it defaults to the OSS default
-function applyCustomUrl () {
+function applyCustomUrl() {
   var custUrl = $('#custom-url-field').val();
   let urlValidation = validateUrl(custUrl);
   if (custUrl.length > 0) {
@@ -540,7 +540,7 @@ function applyCustomUrl () {
 
 // Set the product URL cookie and apply the change
 // If the product URL field is empty, it defaults to the product default
-function applyProductUrl (product) {
+function applyProductUrl(product) {
   var productUrl = $(`#${product}-url-field`).val();
   let urlValidation = validateUrl(productUrl);
   if (productUrl.length > 0) {
@@ -605,7 +605,7 @@ $(urlValueElements).blur(function () {
 /** Delay execution of a function `fn` for a number of milliseconds `ms`
  * e.g., delay a validation handler to avoid annoying the user.
  */
-function delay (fn, ms) {
+function delay(fn, ms) {
   let timer = 0;
   return function (...args) {
     clearTimeout(timer);
@@ -613,7 +613,7 @@ function delay (fn, ms) {
   };
 }
 
-function handleUrlValidation () {
+function handleUrlValidation() {
   let url = $(urlValueElements).val();
   let urlValidation = validateUrl(url);
   if (urlValidation.valid) {
@@ -657,4 +657,14 @@ if (cloudUrls.includes(referrerHost)) {
   setRadioButtons();
   setURLPreference('cloud');
   showPreference();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Dedicated URL Migration ///////////////////////////
+///////////////////////// REMOVE AFTER AUGUST 22, 2024 /////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+if (getUrls().dedicated == 'cluster-id.influxdb.io') {
+  storeUrl('dedicated', 'cluster-id.a.influxdb.io', getUrls().dedicated);
+  updateUrls(getPrevUrls(), getUrls());
 }

--- a/assets/js/influxdb-url.js
+++ b/assets/js/influxdb-url.js
@@ -2,7 +2,7 @@ var placeholderUrls = {
   oss: 'http://localhost:8086',
   cloud: 'https://cloud2.influxdata.com',
   serverless: 'https://cloud2.influxdata.com',
-  dedicated: 'cluster-id.influxdb.io',
+  dedicated: 'cluster-id.a.influxdb.io',
   clustered: 'cluster-host.com',
 };
 

--- a/assets/js/notifications.js
+++ b/assets/js/notifications.js
@@ -6,16 +6,16 @@
 */
 
 // Get notification ID
-function notificationID (el) {
+function notificationID(el) {
   return $(el).attr('id');
 }
 
 // Show notifications that are within scope and haven't been read
-function showNotifications () {
+function showNotifications() {
   $('#docs-notifications > .notification').each(function () {
     // Check if the path includes paths defined in the data-scope attribute
     // of the notification html element
-    function inScope (path, scope) {
+    function inScope(path, scope) {
       for (let i = 0; i < scope.length; i++) {
         if (path.includes(scope[i])) {
           return true;
@@ -24,14 +24,14 @@ function showNotifications () {
       return false;
     }
 
-    function excludePage (path, exclude) {
+    function excludePage(path, exclude) {
       if (exclude[0].length > 0) {
         for (let i = 0; i < exclude.length; i++) {
           if (path.includes(exclude[i])) {
             return true;
           }
         }
-      }  
+      }
       return false;
     }
 
@@ -41,8 +41,6 @@ function showNotifications () {
     var pageExcluded = excludePage(window.location.pathname, exclude);
     var notificationRead = notificationIsRead(notificationID(this), 'message');
 
-    console.log(pageExcluded)
-
     if (pageInScope && !pageExcluded && !notificationRead) {
       $(this).show().animate({ right: 0, opacity: 1 }, 200, 'swing');
     }
@@ -50,7 +48,7 @@ function showNotifications () {
 }
 
 // Hide a notification and set the notification as read
-function hideNotification (el) {
+function hideNotification(el) {
   $(el)
     .closest('.notification')
     .animate({ height: 0, opacity: 0 }, 200, 'swing', function () {

--- a/content/influxdb/cloud-dedicated/query-data/execute-queries/client-libraries/go.md
+++ b/content/influxdb/cloud-dedicated/query-data/execute-queries/client-libraries/go.md
@@ -26,7 +26,7 @@ list_code_example: |
 
     func Query() error {
         client, err := influxdb3.New(influxdb3.ClientConfig{
-            Host:       "https://cluster-id.influxdb.io",
+            Host:       "https://cluster-id.a.influxdb.io",
             Token:      "DATABASE_TOKEN",
             Database:   "DATABASE_NAME",
         })

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/flight/java-flightsql.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/flight/java-flightsql.md
@@ -486,7 +486,7 @@ Follow these steps to build and run the application using Docker:
     ```sh
     docker build \
     --build-arg DATABASE_NAME=INFLUX_DATABASE \
-    --build-arg HOST=cluster-id.influxdb.io \
+    --build-arg HOST={{% influxdb/host %}}\
     --build-arg TOKEN=INFLUX_TOKEN \
     -t javaflight .
     ```

--- a/content/influxdb/clustered/query-data/execute-queries/client-libraries/go.md
+++ b/content/influxdb/clustered/query-data/execute-queries/client-libraries/go.md
@@ -26,7 +26,7 @@ list_code_example: |
 
     func Query() error {
         client, err := influxdb3.New(influxdb3.ClientConfig{
-            Host:       "https://cluster-id.influxdb.io",
+            Host:       "https://cluster-host.com",
             Token:      "DATABASE_TOKEN",
             Database:   "DATABASE_NAME",
         })

--- a/content/influxdb/clustered/reference/client-libraries/flight/java-flightsql.md
+++ b/content/influxdb/clustered/reference/client-libraries/flight/java-flightsql.md
@@ -487,7 +487,7 @@ Follow these steps to build and run the application using Docker:
     ```sh
     docker build \
     --build-arg DATABASE_NAME=INFLUX_DATABASE \
-    --build-arg HOST=cluster-id.influxdb.io \
+    --build-arg HOST={{% influxdb/host %}} \
     --build-arg TOKEN=INFLUX_TOKEN \
     -t javaflight .
     ```

--- a/data/products.yml
+++ b/data/products.yml
@@ -56,7 +56,7 @@ influxdb_cloud_dedicated:
   latest: cloud-dedicated
   link: "https://www.influxdata.com/contact-sales-form/"
   latest_cli: 2.9.3
-  placeholder_host: cluster-id.influxdb.io
+  placeholder_host: cluster-id.a.influxdb.io
 
 influxdb_clustered:
   name: InfluxDB Clustered

--- a/layouts/partials/footer/javascript.html
+++ b/layouts/partials/footer/javascript.html
@@ -34,9 +34,6 @@
   ]
 </script>
 
-<!-- Load footer.js -->
-<script type="text/javascript" src="{{ $footerjs.RelPermalink }}"></script>
-
 {{ if .Page.HasShortcode "diagram" }}
 <!-- Load mermaid.js for diagrams -->
 <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
@@ -78,3 +75,6 @@
 {{ if .Page.HasShortcode "code-placeholders" }}
 <script type="text/javascript" src="{{ $codePlaceholdersjs.RelPermalink }}"></script>
 {{ end }}
+
+<!-- Load footer.js -->
+<script type="text/javascript" src="{{ $footerjs.RelPermalink }}"></script>

--- a/layouts/partials/footer/modals/influxdb-url.html
+++ b/layouts/partials/footer/modals/influxdb-url.html
@@ -150,7 +150,7 @@
     {{ else if $isServerless }}
       {{ template "productSection" dict "product" .Site.Data.influxdb_urls.cloud "formID" "serverless" "filterServerless" true }}
     {{ else if $isDedicated }}
-      {{ template "productSpecificForm" dict "product" nil "formID" "dedicated" "placeholder" "cluster-id.influxdb.io" }}
+      {{ template "productSpecificForm" dict "product" nil "formID" "dedicated" "placeholder" "cluster-id.a.influxdb.io" }}
     {{ else if $isClustered }}
       {{ template "productSpecificForm" dict "product" nil "formID" "clustered" "placeholder" "cluster-host.com" }}
     {{ end }}

--- a/shared/text/api/cloud-dedicated/basic-auth.sh
+++ b/shared/text/api/cloud-dedicated/basic-auth.sh
@@ -4,7 +4,7 @@
 #######################################
 
 
-curl --get "https://cluster-id.influxdb.io/query" \
+curl --get "https://cluster-id.a.influxdb.io/query" \
   --user "":"DATABASE_TOKEN" \
   --data-urlencode "db=DATABASE_NAME" \
   --data-urlencode "q=SELECT * FROM MEASUREMENT"

--- a/shared/text/api/cloud-dedicated/bearer-auth-v1-query.sh
+++ b/shared/text/api/cloud-dedicated/bearer-auth-v1-query.sh
@@ -3,7 +3,7 @@
 # to query the InfluxDB v1 API
 ########################################################
 
-curl --get "https://cluster-id.influxdb.io/query" \
+curl --get "https://cluster-id.a.influxdb.io/query" \
   --header "Authorization: Bearer DATABASE_TOKEN" \
   --header 'Content-type: application/json' \
   --data-urlencode "db=DATABASE_NAME" \

--- a/shared/text/api/cloud-dedicated/bearer-auth-v1-write.sh
+++ b/shared/text/api/cloud-dedicated/bearer-auth-v1-write.sh
@@ -3,7 +3,7 @@
 # to write data.
 ########################################################
 
-curl -i "https://cluster-id.influxdb.io/write?db=DATABASE_NAME&precision=ms" \
+curl -i "https://cluster-id.a.influxdb.io/write?db=DATABASE_NAME&precision=ms" \
     --header "Authorization: Bearer DATABASE_TOKEN" \
     --header "Content-type: text/plain; charset=utf-8" \
     --data-binary 'home,room=kitchen temp=72 1682358973500'

--- a/shared/text/api/cloud-dedicated/bearer-auth-v2-write.sh
+++ b/shared/text/api/cloud-dedicated/bearer-auth-v2-write.sh
@@ -3,6 +3,6 @@
 # to write data.
 ########################################################
 
-curl --request post 'https://cluster-id.influxdb.io/api/v2/write?bucket=DATABASE_NAME&precision=s' \
+curl --request post 'https://cluster-id.a.influxdb.io/api/v2/write?bucket=DATABASE_NAME&precision=s' \
   --header 'Authorization: Bearer DATABASE_TOKEN' \
   --data-binary 'home,room=kitchen temp=72 1463683075'

--- a/shared/text/api/cloud-dedicated/querystring-auth.sh
+++ b/shared/text/api/cloud-dedicated/querystring-auth.sh
@@ -6,7 +6,7 @@
 #   ?p=DATABASE_TOKEN
 #######################################
 
-curl --get "https://cluster-id.influxdb.io/query" \
+curl --get "https://cluster-id.a.influxdb.io/query" \
   --data-urlencode "p=DATABASE_TOKEN" \
   --data-urlencode "db=DATABASE_NAME" \
   --data-urlencode "q=SELECT * FROM MEASUREMENT"

--- a/shared/text/api/cloud-dedicated/token-auth-v1-query.sh
+++ b/shared/text/api/cloud-dedicated/token-auth-v1-query.sh
@@ -3,7 +3,7 @@
 # to query the InfluxDB v1 API
 ########################################################
 
-curl --get "https://cluster-id.influxdb.io/query" \
+curl --get "https://cluster-id.a.influxdb.io/query" \
   --header "Authorization: Token DATABASE_TOKEN" \
   --header 'Content-type: application/json' \
   --data-urlencode "db=DATABASE_NAME" \

--- a/shared/text/api/cloud-dedicated/token-auth-v1-write.sh
+++ b/shared/text/api/cloud-dedicated/token-auth-v1-write.sh
@@ -3,7 +3,7 @@
 # to write data.
 ########################################################
 
-curl -i "https://cluster-id.influxdb.io/write?db=DATABASE_NAME&precision=ms" \
+curl -i "https://cluster-id.a.influxdb.io/write?db=DATABASE_NAME&precision=ms" \
     --header "Authorization: Token DATABASE_TOKEN" \
     --header "Content-type: text/plain; charset=utf-8" \
     --data-binary 'home,room=kitchen temp=72 1682358973500'

--- a/shared/text/api/cloud-dedicated/token-auth-v2-write.sh
+++ b/shared/text/api/cloud-dedicated/token-auth-v2-write.sh
@@ -3,6 +3,6 @@
 # to write data.
 ########################################################
 
-curl --request post "https://cluster-id.influxdb.io/api/v2/write?bucket=DATABASE_NAME&precision=s" \
+curl --request post "https://cluster-id.a.influxdb.io/api/v2/write?bucket=DATABASE_NAME&precision=s" \
   --header "Authorization: Token DATABASE_TOKEN" \
   --data-binary 'home,room=kitchen temp=72 1463683075'


### PR DESCRIPTION
When we first assigned the placeholder URL for InfluxDB Cloud Dedicated, the placeholder did not include the provider-specific piece of the URL (`cluster-id.influxdb.io` vs `cluster-id.a.influxdb.io`). The `a` identifies the underlying provider as AWS. This was left out of the original placeholder URL in case other providers were added. At this point, there isn't much demand for other providers and nothing in the works to make Dedicated available on other providers, so we have been asked to update the Dedicated placeholder URL to `cluster-id.a.influxdb.io`.

- [x] Rebased/mergeable
