### PR TITLE
fix(flux): Write, Query, and Prometheus menu name

### DIFF
--- a/content/flux/v0/prometheus/_index.md
+++ b/content/flux/v0/prometheus/_index.md
@@ -3,7 +3,9 @@ title: Work with Prometheus
 description: >
   Flux provides tools for scraping and processing raw [Prometheus-formatted metrics](https://prometheus.io/docs/concepts/data_model/)
   from an HTTP-accessible endpoint.
-menu: flux_0_x
+menu:
+  flux_v0:
+    name: Work with Prometheus
 weight: 8
 flux/v0/tags: [prometheus]
 ---

--- a/content/flux/v0/query-data/_index.md
+++ b/content/flux/v0/query-data/_index.md
@@ -2,7 +2,9 @@
 title: Query data sources
 description: >
   Query different data sources with Flux including InfluxDB, SQL databases, CSV, and Prometheus.
-menu: flux_0_x
+menu:
+  flux_v0:
+    name: Query data sources
 weight: 5
 ---
 

--- a/content/flux/v0/write-data/_index.md
+++ b/content/flux/v0/write-data/_index.md
@@ -2,7 +2,9 @@
 title: Write to data sources
 description: >
   Write to different data sources with Flux including InfluxDB, SQL databases, CSV, and Prometheus.
-menu: flux_0_x
+menu:
+  flux_v0:
+    name: Write to data sources
 weight: 5
 ---
 


### PR DESCRIPTION
- Replaces `menu: flux_0_x` with the correct menu attributes in frontmatter.
- These have apparently been broken like this for some time.

Closes #5404 
