### PR TITLE
Fix test product environments

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -38,8 +38,6 @@ services:
   cloud-pytest:
     image: influxdata/docs-pytest
     build:
-      args:
-        - CONTENT_PATH=content/influxdb/cloud
       context: .
       dockerfile: Dockerfile.pytest
     entrypoint:
@@ -50,6 +48,8 @@ services:
       # In the command, pass file paths to test.
       # The container preprocesses the files for testing and runs the tests.
       - content/influxdb/cloud/**/*.md
+    environment:
+      - CONTENT_PATH=content/influxdb/cloud
     profiles:
       - test
       - v2
@@ -87,8 +87,6 @@ services:
   cloud-dedicated-pytest:
     image: influxdata/docs-pytest
     build:
-      args:
-        - CONTENT_PATH=content/influxdb/cloud-dedicated
       context: .
       dockerfile: Dockerfile.pytest
     entrypoint:
@@ -99,6 +97,8 @@ services:
       # In the command, pass file paths to test.
       # The container preprocesses the files for testing and runs the tests.
       - content/influxdb/cloud-dedicated/**/*.md
+    environment:
+      - CONTENT_PATH=content/influxdb/cloud-dedicated
     profiles:
       - test
       - v3
@@ -141,8 +141,6 @@ services:
   cloud-serverless-pytest:
     image: influxdata/docs-pytest
     build:
-      args:
-        - CONTENT_PATH=content/influxdb/cloud-serverless
       context: .
       dockerfile: Dockerfile.pytest
     entrypoint:
@@ -153,6 +151,8 @@ services:
       # In the command, pass file paths to test.
       # The container preprocesses the files for testing and runs the tests.
       - content/influxdb/cloud-serverless/**/*.md
+    environment:
+      - CONTENT_PATH=content/influxdb/cloud-serverless
     profiles:
       - test
       - v3
@@ -190,8 +190,6 @@ services:
   clustered-pytest:
     image: influxdata/docs-pytest
     build:
-      args:
-        - CONTENT_PATH=content/influxdb/clustered
       context: .
       dockerfile: Dockerfile.pytest
     entrypoint:
@@ -202,6 +200,8 @@ services:
       # In the command, pass file paths to test.
       # The container preprocesses the files for testing and runs the tests.
       - content/influxdb/clustered/**/*.md
+    environment:
+      - CONTENT_PATH=content/influxdb/clustered
     profiles:
       - test
       - v3
@@ -244,8 +244,6 @@ services:
   telegraf-pytest:
     image: influxdata/docs-pytest
     build:
-      args:
-        - CONTENT_PATH=content/telegraf
       context: .
       dockerfile: Dockerfile.pytest
     entrypoint:
@@ -256,6 +254,8 @@ services:
       # In the command, pass file paths to test.
       # The container preprocesses the files for testing and runs the tests.
       - content/telegraf/**/*.md
+    environment:
+      - CONTENT_PATH=content/telegraf
     profiles:
       - test
     stdin_open: true
@@ -292,8 +292,6 @@ services:
   v2-pytest:
     image: influxdata/docs-pytest
     build:
-      args:
-        - CONTENT_PATH=content/influxdb/v2
       context: .
       dockerfile: Dockerfile.pytest
     entrypoint:
@@ -304,6 +302,8 @@ services:
       # In the command, pass file paths to test.
       # The container preprocesses the files for testing and runs the tests.
       - content/influxdb/v2/**/*.md
+    environment:
+      - CONTENT_PATH=content/influxdb/v2
     profiles:
       - test
       - v2
@@ -348,7 +348,9 @@ services:
       DOCKER_INFLUXDB_INIT_PASSWORD_FILE: /run/secrets/influxdb2-admin-password
       DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE: /run/secrets/influxdb2-admin-token
       DOCKER_INFLUXDB_INIT_ORG: docs
-      DOCKER_INFLUXDB_INIT_BUCKET: home
+      DOCKER_INFLUXDB_INIT_BUCKET: get-started 
+      INFLUX_ORG: docs
+      INFLUX_BUCKET: get-started
     profiles:
       - v2
       - local 
@@ -367,7 +369,7 @@ services:
     build:
       context: . 
       dockerfile: .ci/Dockerfile.remark
-    command: ["remark", "content/${PRODUCT_PATH}"]
+    command: ["remark", "${CONTENT_PATH}"]
     profiles:
       - lint
     volumes:

--- a/test/scripts/prepare-content.sh
+++ b/test/scripts/prepare-content.sh
@@ -84,8 +84,12 @@ function substitute_placeholders {
       s/example-db/$INFLUX_DATABASE/g;
       s/get-started/$INFLUX_DATABASE/g;
       /os.getenv("MANAGEMENT_TOKEN")/! s/INFLUX_MANAGEMENT_TOKEN/$MANAGEMENT_TOKEN/g;
+      /os.getenv("ORG_NAME")/! s/ORG_NAME/$INFLUX_ORG_NAME/g;
+      /os.getenv("ORG_ID")/! s/ORG_ID/$INFLUX_ORG/g;
+      /os.getenv("PASSWORD")/! s/PASSWORD/$INFLUX_PASSWORD/g;
       /os.getenv("ORG_ID")/! s/ORG_ID/$INFLUX_ORG/g;
       /os.getenv("RETENTION_POLICY")/! s/RETENTION_POLICY_NAME\|RETENTION_POLICY/$INFLUX_RETENTION_POLICY/g;
+      /os.getenv("USERNAME")/! s/USERNAME/$INFLUX_USERNAME/g;
       s/CONFIG_NAME/CONFIG_$(shuf -i 0-100 -n1)/g;
       s/TEST_RUN/TEST_RUN_$(date +%s)/g;
       s|/path/to/custom/assets-dir|/app/custom-assets|g;' \
@@ -109,16 +113,6 @@ function substitute_placeholders {
   done
 }
 
-setup() {
-  # Set up the environment for the tests.
-  # Parse YAML config files into dotenv files to be used by tests.
-  mkdir -p /app/appdata && (parse_yaml /src/data/products.yml > /app/appdata/.env.products)
-
-  # Miscellaneous test setup.
-  # For macOS samples.
-  mkdir -p ~/Downloads && rm -rf ~/Downloads/*
-}
-
 prepare_tests() {
   echo "Preparing test files: $*"
   SRC_FILES="$*"
@@ -130,7 +124,6 @@ prepare_tests() {
   done
   cd /app
   substitute_placeholders
-  setup
 }
 
 prepare_tests "$*"

--- a/test/scripts/run-tests.sh
+++ b/test/scripts/run-tests.sh
@@ -23,6 +23,32 @@ tests="${*:2}"
 rm -rf /app/"${CONTENT_PATH}"/*
 bash /src/test/scripts/prepare-content.sh $tests
 
+
+
+setup() {
+  # Set up the environment for the tests.
+
+  ## Store test configuration in /app/appdata.
+  mkdir -p /app/appdata
+
+  ## Parse YAML config files into dotenv files to be used by tests.
+  ## You must source the parse_yaml function before you can use it.
+  source /usr/local/bin/parse_yaml
+  parse_yaml /src/data/products.yml > /app/appdata/.env.products
+  chmod -R +x /app/appdata/
+
+  ## Source non-sensitive environment variables for all test runners.
+  set -a
+  source /app/appdata/.env.*
+  set +a
+
+  # Miscellaneous test setup.
+  # For macOS samples.
+  mkdir -p ~/Downloads && rm -rf ~/Downloads/*
+}
+
+setup
+
 if [[ $runner == "pytest" ]]; then
     pytest \
     -s \


### PR DESCRIPTION
Resolves important test environment stuff I broke when migrating over to Compose:
- Loads data/product.yml as environment variables.
- Sets the correct CONTENT_PATH value for each product test container.

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
