### PR TITLE
Release influxctl v2.9.5 and v2.9.6

### DIFF
--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/_index.md
@@ -32,6 +32,7 @@ influxctl [flags] [command]
 
 | Command                                                                     | Description                            |
 | :-------------------------------------------------------------------------- | :------------------------------------- |
+| [auth](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/)             | Login or logout of InfluxDB v3         |
 | [cluster](/influxdb/cloud-dedicated/reference/cli/influxctl/cluster/)       | List InfluxDB v3 cluster information   |
 | [database](/influxdb/cloud-dedicated/reference/cli/influxctl/database/)     | Manage InfluxDB v3 databases           |
 | [help](/influxdb/cloud-dedicated/reference/cli/influxctl/help/)             | Output `influxctl` help information    |

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/_index.md
@@ -32,7 +32,7 @@ influxctl [flags] [command]
 
 | Command                                                                     | Description                            |
 | :-------------------------------------------------------------------------- | :------------------------------------- |
-| [auth](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/)             | Login or logout of InfluxDB v3         |
+| [auth](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/)             | Log in to or log out of InfluxDB v3         |
 | [cluster](/influxdb/cloud-dedicated/reference/cli/influxctl/cluster/)       | List InfluxDB v3 cluster information   |
 | [database](/influxdb/cloud-dedicated/reference/cli/influxctl/database/)     | Manage InfluxDB v3 databases           |
 | [help](/influxdb/cloud-dedicated/reference/cli/influxctl/help/)             | Output `influxctl` help information    |

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/_index.md
@@ -1,16 +1,15 @@
 ---
 title: influxctl auth
 description: >
-  The `influxctl auth` command and its subcommands provide the ability to
-  login and logout.
+  The `influxctl auth` command and its subcommands let a user
+  log in to and log out of an InfluxDB cluster.
 menu:
   influxdb_cloud_dedicated:
     parent: influxctl
 weight: 201
 ---
 
-The `influxctl auth` command and its subcommands provide information about
-{{< product-name >}} clusters.
+The `influxctl auth` command and its subcommands let a user log in to and log out of an {{< product-name omit="Clustered" >}} cluster.
 
 ## Usage
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/_index.md
@@ -10,7 +10,7 @@ weight: 201
 ---
 
 The `influxctl auth` command and its subcommands provide information about
-{{< product-name omit="Clustered" >}} clusters.
+{{< product-name >}} clusters.
 
 ## Usage
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/_index.md
@@ -22,8 +22,8 @@ influxctl auth [subcommand] [subcommand options] [arguments...]
 
 | Subcommand                                                               | Description                     |
 | :----------------------------------------------------------------------- | :------------------------------ |
-| [login](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login/)   | Log in using InfluxData Auth0   |
-| [logout](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout/) | Remove local authorization tokens to log out of an InfluxDB cluster            |
+| [login](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login/)   | Log in to an InfluxDB cluster using InfluxData Auth0 |
+| [logout](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout/) | Log out of an InfluxDB cluster; remove local authorization tokens |
 | help, h                                                                  | Output command help             |
 
 ## Flags

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/_index.md
@@ -4,7 +4,7 @@ description: >
   The `influxctl auth` command and its subcommands provide the ability to
   login and logout.
 menu:
-  influxdb_clustered:
+  influxdb_cloud_dedicated:
     parent: influxctl
 weight: 201
 ---
@@ -22,7 +22,7 @@ influxctl auth [subcommand] [subcommand options] [arguments...]
 
 | Subcommand                                                               | Description                     |
 | :----------------------------------------------------------------------- | :------------------------------ |
-| [login](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login/)   | Log in using InfluxData Auth0 or an InfluxDB Clustered identity provider |
+| [login](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login/)   | Log in using InfluxData Auth0   |
 | [logout](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout/) | Remove local authorization tokens to log out of an InfluxDB cluster            |
 | help, h                                                                  | Output command help             |
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/_index.md
@@ -22,8 +22,8 @@ influxctl auth [subcommand] [subcommand options] [arguments...]
 
 | Subcommand                                                               | Description                     |
 | :----------------------------------------------------------------------- | :------------------------------ |
-| [login](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login/)   | Login with InfluxData Auth0 or InfluxDB Clustered identity provider |
-| [logout](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout/) | Remove local tokens             |
+| [login](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login/)   | Log in using InfluxData Auth0 or an InfluxDB Clustered identity provider |
+| [logout](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout/) | Remove local authorization tokens to log out of an InfluxDB cluster            |
 | help, h                                                                  | Output command help             |
 
 ## Flags

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/_index.md
@@ -1,0 +1,33 @@
+---
+title: influxctl auth
+description: >
+  The `influxctl auth` command and its subcommands provide the ability to
+  login and logout.
+menu:
+  influxdb_clustered:
+    parent: influxctl
+weight: 201
+---
+
+The `influxctl auth` command and its subcommands provide information about
+{{< product-name omit="Clustered" >}} clusters.
+
+## Usage
+
+```sh
+influxctl auth [subcommand] [subcommand options] [arguments...]
+```
+
+## Subcommands
+
+| Subcommand                                                               | Description                     |
+| :----------------------------------------------------------------------- | :------------------------------ |
+| [login](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login/)   | Login with InfluxData Auth0 or InfluxDB Clustered identity provider |
+| [logout](/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout/) | Remove local tokens             |
+| help, h                                                                  | Output command help             |
+
+## Flags
+
+| Flag |          | Description         |
+| :--- | :------- | :------------------ |
+| `-h` | `--help` | Output command help |

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login.md
@@ -1,0 +1,29 @@
+---
+title: influxctl auth login
+description: >
+  The `influxctl auth login` command logins with InfluxData Auth0 or InfluxDB
+  Clustered identity provider
+menu:
+  influxdb_clustered:
+    parent: influxctl auth
+weight: 301
+---
+
+The `influxctl auth login` command logins with InfluxData Auth0 or InfluxDB
+Clustered identity provider
+
+## Usage
+
+```sh
+influxctl auth login
+```
+
+## Flags
+
+| Flag |            | Description                                   |
+| :--- | :--------- | :-------------------------------------------- |
+| `-h` | `--help`   | Output command help                           |
+
+{{% caption %}}
+_Also see [`influxctl` global flags](/influxdb/cloud-dedicated/reference/cli/influxctl/#global-flags)._
+{{% /caption %}}

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login.md
@@ -9,7 +9,7 @@ menu:
 weight: 301
 ---
 
-The `influxctl auth login` command lets a user log in to an {{< product-name >}}
+The `influxctl auth login` command lets a user log in to an {{< product-name omit="Clustered" >}}
 cluster using InfluxData Auth0.
 
 ## Usage

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login.md
@@ -1,16 +1,16 @@
 ---
 title: influxctl auth login
 description: >
-  The `influxctl auth login` command logins with InfluxData Auth0 or InfluxDB
+  The `influxctl auth login` command lets a user log in to an InfluxDB cluster using InfluxData Auth0 or an InfluxDB
   Clustered identity provider
 menu:
-  influxdb_clustered:
+  influxdb_cloud_dedicated:
     parent: influxctl auth
 weight: 301
 ---
 
-The `influxctl auth login` command logins with InfluxData Auth0 or InfluxDB
-Clustered identity provider
+The `influxctl auth login` command lets a user log in to an {{< product-name >}}
+cluster using InfluxData Auth0.
 
 ## Usage
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login.md
@@ -1,8 +1,8 @@
 ---
 title: influxctl auth login
 description: >
-  The `influxctl auth login` command lets a user log in to an InfluxDB cluster using InfluxData Auth0 or an InfluxDB
-  Clustered identity provider
+  The `influxctl auth login` command lets a user log in to an InfluxDB cluster using
+  {{< product-name omit="Clustered" >}} identity provider
 menu:
   influxdb_cloud_dedicated:
     parent: influxctl auth

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/login.md
@@ -2,7 +2,7 @@
 title: influxctl auth login
 description: >
   The `influxctl auth login` command lets a user log in to an InfluxDB cluster using
-  {{< product-name omit="Clustered" >}} identity provider
+  the InfluxDB Cloud Dedicated identity provider.
 menu:
   influxdb_cloud_dedicated:
     parent: influxctl auth

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout.md
@@ -1,0 +1,27 @@
+---
+title: influxctl auth logout
+description: >
+  The `influxctl auth logout` command removes local tokens
+menu:
+  influxdb_clustered:
+    parent: influxctl auth
+weight: 301
+---
+
+The `influxctl auth logout` command removes local tokens
+
+## Usage
+
+```sh
+influxctl auth logout
+```
+
+## Flags
+
+| Flag |            | Description                                   |
+| :--- | :--------- | :-------------------------------------------- |
+| `-h` | `--help`   | Output command help                           |
+
+{{% caption %}}
+_Also see [`influxctl` global flags](/influxdb/cloud-dedicated/reference/cli/influxctl/#global-flags)._
+{{% /caption %}}

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout.md
@@ -3,7 +3,7 @@ title: influxctl auth logout
 description: >
   The `influxctl auth logout` command logs out a user by removing local authorization tokens
 menu:
-  influxdb_clustered:
+  influxdb_cloud_dedicated:
     parent: influxctl auth
 weight: 301
 ---

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout.md
@@ -1,14 +1,14 @@
 ---
 title: influxctl auth logout
 description: >
-  The `influxctl auth logout` command removes local tokens
+  The `influxctl auth logout` command logs out a user by removing local authorization tokens
 menu:
   influxdb_clustered:
     parent: influxctl auth
 weight: 301
 ---
 
-The `influxctl auth logout` command removes local tokens
+The `influxctl auth logout` command logs out a user by removing local authorization tokens.
 
 ## Usage
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout.md
@@ -1,14 +1,16 @@
 ---
 title: influxctl auth logout
 description: >
-  The `influxctl auth logout` command logs out a user by removing local authorization tokens
+  The `influxctl auth logout` command lets a user logout of an InfluxDB 
+  cluster; removes the user's local authorization tokens.  
 menu:
   influxdb_cloud_dedicated:
     parent: influxctl auth
 weight: 301
 ---
 
-The `influxctl auth logout` command logs out a user by removing local authorization tokens.
+The `influxctl auth logout` command lets a user logout of an {{< product-name omit="Clustered" >}} 
+cluster; removes the user's local authorization tokens.
 
 ## Usage
 

--- a/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout.md
+++ b/content/influxdb/cloud-dedicated/reference/cli/influxctl/auth/logout.md
@@ -1,16 +1,16 @@
 ---
 title: influxctl auth logout
 description: >
-  The `influxctl auth logout` command lets a user logout of an InfluxDB 
-  cluster; removes the user's local authorization tokens.  
+  The `influxctl auth logout` command lets a user log out of an InfluxDB 
+  cluster and removes the user's local authorization tokens.  
 menu:
   influxdb_cloud_dedicated:
     parent: influxctl auth
 weight: 301
 ---
 
-The `influxctl auth logout` command lets a user logout of an {{< product-name omit="Clustered" >}} 
-cluster; removes the user's local authorization tokens.
+The `influxctl auth logout` command lets a user log out of an {{< product-name omit="Clustered" >}} 
+cluster and removes the user's local authorization tokens.
 
 ## Usage
 

--- a/content/influxdb/cloud-dedicated/reference/release-notes/influxctl.md
+++ b/content/influxdb/cloud-dedicated/reference/release-notes/influxctl.md
@@ -11,6 +11,18 @@ menu:
 weight: 202
 ---
 
+## v2.9.5 {date="2024-08-13"}
+
+### Bug Fixes
+
+- Introduce auth login and logout commands.
+
+### Dependency Updates
+
+- Update `github.com/urfave/cli/v2` from 2.27.2 to 2.27.4
+- Update `golang.org/x/mod` from 0.19.0 to 0.20.0
+- Update `golang.org/x/oauth2` from 0.21.0 to 0.22.0
+
 ## v2.9.4 {date="2024-07-25"}
 
 ### Bug Fixes

--- a/content/influxdb/cloud-dedicated/reference/release-notes/influxctl.md
+++ b/content/influxdb/cloud-dedicated/reference/release-notes/influxctl.md
@@ -11,6 +11,12 @@ menu:
 weight: 202
 ---
 
+## v2.9.6 {date="2024-08-15"}
+
+### Bug Fixes
+
+- Update query to wait for EOF on stdin instead of the first newline.
+
 ## v2.9.5 {date="2024-08-13"}
 
 ### Bug Fixes

--- a/content/influxdb/clustered/reference/cli/influxctl/_index.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/_index.md
@@ -32,6 +32,7 @@ influxctl [flags] [command]
 
 | Command                                                               | Description                            |
 | :-------------------------------------------------------------------- | :------------------------------------- |
+| [auth](/influxdb/clustered/reference/cli/influxctl/auth/)             | Login or logout of InfluxDB v3         |
 | [cluster](/influxdb/clustered/reference/cli/influxctl/cluster/)       | List InfluxDB v3 cluster information   |
 | [database](/influxdb/clustered/reference/cli/influxctl/database/)     | Manage InfluxDB v3 databases           |
 | [help](/influxdb/clustered/reference/cli/influxctl/help/)             | Output `influxctl` help information    |

--- a/content/influxdb/clustered/reference/cli/influxctl/_index.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/_index.md
@@ -32,7 +32,7 @@ influxctl [flags] [command]
 
 | Command                                                               | Description                            |
 | :-------------------------------------------------------------------- | :------------------------------------- |
-| [auth](/influxdb/clustered/reference/cli/influxctl/auth/)             | Login or logout of InfluxDB v3         |
+| [auth](/influxdb/clustered/reference/cli/influxctl/auth/)             | Log in to or log out of InfluxDB v3     |
 | [cluster](/influxdb/clustered/reference/cli/influxctl/cluster/)       | List InfluxDB v3 cluster information   |
 | [database](/influxdb/clustered/reference/cli/influxctl/database/)     | Manage InfluxDB v3 databases           |
 | [help](/influxdb/clustered/reference/cli/influxctl/help/)             | Output `influxctl` help information    |

--- a/content/influxdb/clustered/reference/cli/influxctl/auth/_index.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/auth/_index.md
@@ -1,16 +1,15 @@
 ---
 title: influxctl auth
 description: >
-  The `influxctl auth` command and its subcommands provide the ability to
-  login and logout.
+  The `influxctl auth` command and its subcommands let a user
+  log in to and log out of an InfluxDB cluster.
 menu:
   influxdb_clustered:
     parent: influxctl
 weight: 201
 ---
 
-The `influxctl auth` command and its subcommands provide information about
-{{< product-name omit="Clustered" >}} clusters.
+The `influxctl auth` command and its subcommands let a user log in to and log out of an {{< product-name omit="Clustered" >}} cluster.
 
 ## Usage
 

--- a/content/influxdb/clustered/reference/cli/influxctl/auth/_index.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/auth/_index.md
@@ -22,7 +22,7 @@ influxctl auth [subcommand] [subcommand options] [arguments...]
 
 | Subcommand                                                         | Description                     |
 | :----------------------------------------------------------------- | :------------------------------ |
-| [login](/influxdb/clustered/reference/cli/influxctl/auth/login/)   | Login with InfluxDB Clustered identity provider |
+| [login](/influxdb/clustered/reference/cli/influxctl/auth/login/)   | Log in to an InfluxDB cluster using the cluster's identity provider |
 | [logout](/influxdb/clustered/reference/cli/influxctl/auth/logout/) | Remove local tokens             |
 | help, h                                                            | Output command help             |
 

--- a/content/influxdb/clustered/reference/cli/influxctl/auth/_index.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/auth/_index.md
@@ -1,0 +1,33 @@
+---
+title: influxctl auth
+description: >
+  The `influxctl auth` command and its subcommands provide the ability to
+  login and logout.
+menu:
+  influxdb_clustered:
+    parent: influxctl
+weight: 201
+---
+
+The `influxctl auth` command and its subcommands provide information about
+{{< product-name omit="Clustered" >}} clusters.
+
+## Usage
+
+```sh
+influxctl auth [subcommand] [subcommand options] [arguments...]
+```
+
+## Subcommands
+
+| Subcommand                                                         | Description                     |
+| :----------------------------------------------------------------- | :------------------------------ |
+| [login](/influxdb/clustered/reference/cli/influxctl/auth/login/)   | Login with InfluxData Auth0 or InfluxDB Clustered identity provider |
+| [logout](/influxdb/clustered/reference/cli/influxctl/auth/logout/) | Remove local tokens             |
+| help, h                                                            | Output command help             |
+
+## Flags
+
+| Flag |          | Description         |
+| :--- | :------- | :------------------ |
+| `-h` | `--help` | Output command help |

--- a/content/influxdb/clustered/reference/cli/influxctl/auth/_index.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/auth/_index.md
@@ -22,7 +22,7 @@ influxctl auth [subcommand] [subcommand options] [arguments...]
 
 | Subcommand                                                         | Description                     |
 | :----------------------------------------------------------------- | :------------------------------ |
-| [login](/influxdb/clustered/reference/cli/influxctl/auth/login/)   | Login with InfluxData Auth0 or InfluxDB Clustered identity provider |
+| [login](/influxdb/clustered/reference/cli/influxctl/auth/login/)   | Login with InfluxDB Clustered identity provider |
 | [logout](/influxdb/clustered/reference/cli/influxctl/auth/logout/) | Remove local tokens             |
 | help, h                                                            | Output command help             |
 

--- a/content/influxdb/clustered/reference/cli/influxctl/auth/login.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/auth/login.md
@@ -1,0 +1,29 @@
+---
+title: influxctl auth login
+description: >
+  The `influxctl auth login` command logins with InfluxData Auth0 or InfluxDB
+  Clustered identity provider
+menu:
+  influxdb_clustered:
+    parent: influxctl auth
+weight: 301
+---
+
+The `influxctl auth login` command logins with InfluxData Auth0 or InfluxDB
+Clustered identity provider
+
+## Usage
+
+```sh
+influxctl auth login
+```
+
+## Flags
+
+| Flag |            | Description                                   |
+| :--- | :--------- | :-------------------------------------------- |
+| `-h` | `--help`   | Output command help                           |
+
+{{% caption %}}
+_Also see [`influxctl` global flags](/influxdb/clustered/reference/cli/influxctl/#global-flags)._
+{{% /caption %}}

--- a/content/influxdb/clustered/reference/cli/influxctl/auth/login.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/auth/login.md
@@ -1,10 +1,9 @@
 ---
 title: influxctl auth login
 description: >
-  The `influxctl auth login` command logins with InfluxData Auth0 or InfluxDB
-  Clustered identity provider
-  The `influxctl auth login` command lets a user log in to an InfluxDB cluster using
-  the cluster's configured identity provider.
+  The `influxctl auth login` command lets a user log in to an InfluxDB cluster
+  using the cluster's configured identity provider.
+menu:
   influxdb_clustered:
     parent: influxctl auth
 weight: 301
@@ -14,7 +13,7 @@ The `influxctl auth login` command logins with InfluxData Auth0 or InfluxDB
 Clustered identity provider
 The `influxctl auth login` command lets a user log in to an
 {{< product-name omit="Clustered" >}} cluster using the cluster's configured
-identity provider.  
+identity provider.
 ## Usage
 
 ```sh

--- a/content/influxdb/clustered/reference/cli/influxctl/auth/login.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/auth/login.md
@@ -9,11 +9,8 @@ menu:
 weight: 301
 ---
 
-The `influxctl auth login` command logins with InfluxData Auth0 or InfluxDB
-Clustered identity provider
-The `influxctl auth login` command lets a user log in to an
-{{< product-name omit="Clustered" >}} cluster using the cluster's configured
-identity provider.
+The `influxctl auth login` command lets a user log in to an {{< product-name omit="Clustered" >}}
+cluster using the cluster's configured identity provider. 
 ## Usage
 
 ```sh

--- a/content/influxdb/clustered/reference/cli/influxctl/auth/login.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/auth/login.md
@@ -3,7 +3,8 @@ title: influxctl auth login
 description: >
   The `influxctl auth login` command logins with InfluxData Auth0 or InfluxDB
   Clustered identity provider
-menu:
+  The `influxctl auth login` command lets a user log in to an InfluxDB cluster using
+  the cluster's configured identity provider.
   influxdb_clustered:
     parent: influxctl auth
 weight: 301
@@ -11,7 +12,9 @@ weight: 301
 
 The `influxctl auth login` command logins with InfluxData Auth0 or InfluxDB
 Clustered identity provider
-
+The `influxctl auth login` command lets a user log in to an
+{{< product-name omit="Clustered" >}} cluster using the cluster's configured
+identity provider.  
 ## Usage
 
 ```sh

--- a/content/influxdb/clustered/reference/cli/influxctl/auth/login.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/auth/login.md
@@ -11,6 +11,7 @@ weight: 301
 
 The `influxctl auth login` command lets a user log in to an {{< product-name omit="Clustered" >}}
 cluster using the cluster's configured identity provider. 
+
 ## Usage
 
 ```sh

--- a/content/influxdb/clustered/reference/cli/influxctl/auth/logout.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/auth/logout.md
@@ -1,16 +1,16 @@
 ---
 title: influxctl auth logout
 description: >
-  The `influxctl auth logout` command lets a user logout of an InfluxDB 
-  cluster; removes the user's local authorization tokens.
+  The `influxctl auth logout` command lets a user log out of an InfluxDB 
+  cluster and removes the user's local authorization tokens.
 menu:
   influxdb_clustered:
     parent: influxctl auth
 weight: 301
 ---
 
-The `influxctl auth logout` command lets a user logout of an {{< product-name omit="Clustered" >}}
-cluster; removes the user's local authorization tokens.
+The `influxctl auth logout` command lets a user log out of an {{< product-name omit="Clustered" >}}
+cluster and removes the user's local authorization tokens.
 
 ## Usage
 

--- a/content/influxdb/clustered/reference/cli/influxctl/auth/logout.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/auth/logout.md
@@ -11,6 +11,7 @@ weight: 301
 
 The `influxctl auth logout` command lets a user logout of an {{< product-name omit="Clustered" >}}
 cluster; removes the user's local authorization tokens.
+
 ## Usage
 
 ```sh

--- a/content/influxdb/clustered/reference/cli/influxctl/auth/logout.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/auth/logout.md
@@ -1,15 +1,16 @@
 ---
 title: influxctl auth logout
 description: >
-  The `influxctl auth logout` command removes local tokens
+  The `influxctl auth logout` command lets a user logout of an InfluxDB 
+  cluster; removes the user's local authorization tokens.
 menu:
   influxdb_clustered:
     parent: influxctl auth
 weight: 301
 ---
 
-The `influxctl auth logout` command removes local tokens
-
+The `influxctl auth logout` command lets a user logout of an {{< product-name omit="Clustered" >}}
+cluster; removes the user's local authorization tokens.
 ## Usage
 
 ```sh

--- a/content/influxdb/clustered/reference/cli/influxctl/auth/logout.md
+++ b/content/influxdb/clustered/reference/cli/influxctl/auth/logout.md
@@ -1,0 +1,27 @@
+---
+title: influxctl auth logout
+description: >
+  The `influxctl auth logout` command removes local tokens
+menu:
+  influxdb_clustered:
+    parent: influxctl auth
+weight: 301
+---
+
+The `influxctl auth logout` command removes local tokens
+
+## Usage
+
+```sh
+influxctl auth logout
+```
+
+## Flags
+
+| Flag |            | Description                                   |
+| :--- | :--------- | :-------------------------------------------- |
+| `-h` | `--help`   | Output command help                           |
+
+{{% caption %}}
+_Also see [`influxctl` global flags](/influxdb/clustered/reference/cli/influxctl/#global-flags)._
+{{% /caption %}}

--- a/content/influxdb/clustered/reference/release-notes/influxctl.md
+++ b/content/influxdb/clustered/reference/release-notes/influxctl.md
@@ -12,6 +12,12 @@ weight: 202
 canonical: /influxdb/cloud-dedicated/reference/release-notes/influxctl/
 ---
 
+## v2.9.6 {date="2024-08-15"}
+
+### Bug Fixes
+
+- Update query subcommand to wait for EOF on stdin instead of the first newline.
+
 ## v2.9.5 {date="2024-08-13"}
 
 ### Bug Fixes

--- a/content/influxdb/clustered/reference/release-notes/influxctl.md
+++ b/content/influxdb/clustered/reference/release-notes/influxctl.md
@@ -12,6 +12,19 @@ weight: 202
 canonical: /influxdb/cloud-dedicated/reference/release-notes/influxctl/
 ---
 
+## v2.9.5 {date="2024-08-13"}
+
+### Bug Fixes
+
+- Introduce auth login and logout commands.
+- Attempt to refresh OAuth tokens when refresh token is present.
+
+### Dependency Updates
+
+- Update `github.com/urfave/cli/v2` from 2.27.2 to 2.27.4
+- Update `golang.org/x/mod` from 0.19.0 to 0.20.0
+- Update `golang.org/x/oauth2` from 0.21.0 to 0.22.0
+
 ## v2.9.4 {date="2024-07-25"}
 
 ### Bug Fixes

--- a/data/products.yml
+++ b/data/products.yml
@@ -55,7 +55,7 @@ influxdb_cloud_dedicated:
   list_order: 3
   latest: cloud-dedicated
   link: "https://www.influxdata.com/contact-sales-form/"
-  latest_cli: 2.9.4
+  latest_cli: 2.9.5
   placeholder_host: cluster-id.a.influxdb.io
 
 influxdb_clustered:

--- a/data/products.yml
+++ b/data/products.yml
@@ -55,7 +55,7 @@ influxdb_cloud_dedicated:
   list_order: 3
   latest: cloud-dedicated
   link: "https://www.influxdata.com/contact-sales-form/"
-  latest_cli: 2.9.5
+  latest_cli: 2.9.6
   placeholder_host: cluster-id.a.influxdb.io
 
 influxdb_clustered:


### PR DESCRIPTION
Introduces the new auth subcommand with logout and login commands. The change logs are different as only clustered will get the refresh token attempts.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
