### PR TITLE
Clustered: simplify public pull secrets

### DIFF
--- a/content/influxdb/clustered/install/configure-cluster/directly.md
+++ b/content/influxdb/clustered/install/configure-cluster/directly.md
@@ -145,7 +145,7 @@ When pulling InfluxDB Clustered images, there are two main scenarios:
 - You run in an environment with no network interfaces ("air-gapped") and you
   can only access a private container registry.
 
-In both scenarios, you need a valid pull secret.
+In both scenarios, you need a valid _pull secret_.
 
 {{< tabs-wrapper >}}
 {{% tabs %}}
@@ -198,7 +198,7 @@ from our container registry, do the following:
 
 We recommend using [crane](https://github.com/google/go-containerregistry/tree/main/cmd/crane) to copy images into your private registry.
 
-1.  [Install crane](https://github.com/google/go-containerregistry/tree/main/cmd/crane#installation)
+1.  [Install crane](https://github.com/google/go-containerregistry/tree/main/cmd/crane#installation) for your system.
 2.  Use the following command to create a container registry secret file and
     retrieve the necessary secrets:
 
@@ -263,7 +263,7 @@ Error: fetching manifest us-docker.pkg.dev/influxdb2-artifacts/clustered/influxd
 ```
 
 The list of images that you need to copy is included in the package metadata.
-You can obtain it with any standard OCI image inspection tool. For example:
+You can obtain it with any standard OCI image inspection tool--for example:
 
 {{% code-placeholders "PACKAGE_VERSION" %}}
 

--- a/content/influxdb/clustered/install/configure-cluster/directly.md
+++ b/content/influxdb/clustered/install/configure-cluster/directly.md
@@ -75,15 +75,6 @@ The `AppInstance` resource contains key information, such as:
 
 ## Configure your cluster
 
-<<<<<<< HEAD:content/influxdb/clustered/install/configure-cluster.md
-1. [Create a cluster configuration file](#create-a-cluster-configuration-file)
-2. [Create a namespace for InfluxDB](#create-a-namespace-for-influxdb)
-3. [Install kubecfg kubit operator](#install-kubecfg-kubit-operator)
-4. [Configure access to the InfluxDB container registry](#configure-access-to-the-influxdb-container-registry)
-5. [Set up cluster ingress](#set-up-cluster-ingress)
-6. [Modify the configuration file to point to prerequisites](#modify-the-configuration-file-to-point-to-prerequisites)
-7. _Optional_: [Provide a custom certificate authority bundle](#provide-a-custom-certificate-authority-bundle)
-=======
 1.  [Create a cluster configuration file](#create-a-cluster-configuration-file)
 2.  [Create a namespace for InfluxDB](#create-a-namespace-for-influxdb)
 3.  [Install kubecfg kubit operator](#install-kubecfg-kubit-operator)
@@ -92,7 +83,6 @@ The `AppInstance` resource contains key information, such as:
 6.  [Modify the configuration file to point to prerequisites](#modify-the-configuration-file-to-point-to-prerequisites)
 7.  [Provide a custom certificate authority bundle](#provide-a-custom-certificate-authority-bundle)
     <em class="op65">(Optional)</em>
->>>>>>> 78b99259bc315360c21aed77da837e7366e6a8a5:content/influxdb/clustered/install/configure-cluster/directly.md
 
 ### Create a cluster configuration file
 
@@ -156,7 +146,6 @@ When pulling InfluxDB Clustered images, there are two main scenarios:
   can only access a private container registry.
 
 In both scenarios, you need a valid pull secret.
-
 
 {{< tabs-wrapper >}}
 {{% tabs %}}
@@ -881,32 +870,6 @@ spec:
 
 {{% /code-placeholders %}}
 
-<<<<<<< HEAD:content/influxdb/clustered/install/configure-cluster.md
-### Provide a custom certificate authority bundle {metadata="Optional"}
-
-InfluxDB attempts to make TLS connections to the services it depends on; notably
-the [Catalog](/influxdb/clustered/reference/internals/storage-engine/#catalog),
-and the [Object store](/influxdb/clustered/reference/internals/storage-engine/#object-store).
-InfluxDB validates the certificates for all of the connections it makes.
-
-**If you host these services yourself and you use a private or otherwise not
-well-known certificate authority to issue certificates to theses services**, 
-InfluxDB will not recognize the issuer and will be unable to validate the certificates.
-To allow InfluxDB to validate these certificates, provide a PEM certificate
-bundle containing your custom certificate authority chain.
-
-1.  Use `kubectl` to create a config map containing your PEM bundle.
-    Your certificate authority administrator should provide you with a
-    PEM-formatted certificate bundle file.
-    
-    {{% note %}}
-This PEM-formatted bundle file is *not* the certificate that InfluxDB uses to
-secure its own TLS endpoints. This bundle establishes a chain of trust for the
-external services that InfluxDB depends on.
-    {{% /note %}}
-
-    In the example below, `private_ca.pem` is the certificate bundle file.
-=======
 ### Provide a custom certificate authority bundle {note="Optional"}
 
 InfluxDB attempts to make TLS connections to the services it depends on--notably,
@@ -936,25 +899,12 @@ host its own TLS endpoints.
     In the example, replace `/path/to/private_ca.pem` with the path to your PEM-formatted certificate bundle file:
 
     <!-- pytest.mark.skip -->
->>>>>>> 78b99259bc315360c21aed77da837e7366e6a8a5:content/influxdb/clustered/install/configure-cluster/directly.md
 
     ```sh
     kubectl --namespace influxdb create configmap custom-ca --from-file=certs.pem=/path/to/private_ca.pem
     ```
 
     {{% note %}}
-<<<<<<< HEAD:content/influxdb/clustered/install/configure-cluster.md
-It's possible to append multiple certificates into the same bundle.
-This can help if you need to include intermediate certificates or explicitly
-include leaf certificates. Leaf certificates should be included before any
-intermediate certificates they depend on. The root certificate should
-be last in the bundle.
-    {{% /note %}}
-
-2.  Update your `AppInstance` resource in your `myinfluxdb.yml` to refer to your
-    certificate authority config map. Update the `.spec.package.spec.egress`
-    property to refer to that config map. For example:
-=======
 #### Bundle multiple certificates
 
 You can append multiple certificates into the same bundle.
@@ -969,7 +919,6 @@ Include certificates in the bundle in the following order:
 
 2.  In `myinfluxdb.yml`, update the `.spec.package.spec.egress` field to refer
     to the config map that you generated in the preceding step--for example:
->>>>>>> 78b99259bc315360c21aed77da837e7366e6a8a5:content/influxdb/clustered/install/configure-cluster/directly.md
 
     ```yml
     spec:
@@ -983,8 +932,4 @@ Include certificates in the bundle in the following order:
                   name: custom-ca
     ```
 
-<<<<<<< HEAD:content/influxdb/clustered/install/configure-cluster.md
-{{< page-nav prev="/influxdb/clustered/install/auth/" prevText="Set up authentication" next="/influxdb/clustered/install/deploy/" nextText="Deploy your cluster" >}}
-=======
 {{< page-nav prev="/influxdb/clustered/install/auth/" prevText="Set up authentication" next="/influxdb/clustered/install/licensing/" nextText="Install your license" >}}
->>>>>>> 78b99259bc315360c21aed77da837e7366e6a8a5:content/influxdb/clustered/install/configure-cluster/directly.md


### PR DESCRIPTION
Crane is not actually required when using the InfluxData public image registry. It seems like referring to it before the public/private branch in the docs can cause some confusion. This moves all of the crane steps into the private branch, where it's needed.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
