### PR TITLE
Updated download URLs for Telegraf and InfluxDB v1

### DIFF
--- a/content/influxdb/v1/introduction/install.md
+++ b/content/influxdb/v1/introduction/install.md
@@ -213,7 +213,7 @@ If `gpg` is not available, see the [GnuPG homepage](https://gnupg.org/download/)
    For example:
 
     ```
-    wget https://dl.influxdata.com/influxdb/releases/influxdb-{{< latest-patch >}}_linux_amd64.tar.gz.asc
+    wget https://download.influxdata.com/influxdb/releases/influxdb-{{< latest-patch >}}_linux_amd64.tar.gz.asc
     ```
 
 3. Verify the signature with `gpg --verify`:

--- a/content/telegraf/v1/install.md
+++ b/content/telegraf/v1/install.md
@@ -73,7 +73,7 @@ To use the SHA checksum to verify the downloaded file, do the following:
    <!--test:actual
    ```sh
    curl -s --location -O \
-   "https://dl.influxdata.com/telegraf/releases/telegraf-${telegraf_latest_patches_v1}_linux_amd64.tar.gz"
+   "https://download.influxdata.com/telegraf/releases/telegraf-${telegraf_latest_patches_v1}_linux_amd64.tar.gz"
    echo "030182d2dca7bf4793fb741d1bbf9c35cf2afb84e13802ac866914f72271b8ea  telegraf-${telegraf_latest_patches_v1}_linux_amd64.tar.gz" \
    | sha256sum -c -
    ```
@@ -301,7 +301,7 @@ Choose from the following options to install Telegraf binary files for Linux AMD
 
 ```bash
 curl -s --location -O \
-https://dl.influxdata.com/telegraf/releases/telegraf-{{% latest-patch %}}_linux_amd64.tar.gz \
+https://download.influxdata.com/telegraf/releases/telegraf-{{% latest-patch %}}_linux_amd64.tar.gz \
 && echo "030182d2dca7bf4793fb741d1bbf9c35cf2afb84e13802ac866914f72271b8ea  telegraf-{{% latest-patch %}}_linux_amd64.tar.gz" \
 | sha256sum -c -
 ```
@@ -327,7 +327,7 @@ Choose from the following options to install Telegraf binary files for Linux ARM
 
 ```bash
 curl -s --location -O \
-https://dl.influxdata.com/telegraf/releases/telegraf-{{% latest-patch %}}_linux_arm64.tar.gz \
+https://download.influxdata.com/telegraf/releases/telegraf-{{% latest-patch %}}_linux_arm64.tar.gz \
 && echo "0c57ff1a4a3af5fa387d23b0bc743b8eaed3a110d4ae7d422c439d2911cdf9b1  telegraf-{{% latest-patch %}}_linux_arm64.tar.gz" \
 | sha256sum -c -
 ```
@@ -461,7 +461,7 @@ In PowerShell _as an administrator_, do the following:
 
    ```powershell
    wget `
-   https://dl.influxdata.com/telegraf/releases/telegraf-{{% latest-patch %}}_windows_amd64.zip `
+   https://download.influxdata.com/telegraf/releases/telegraf-{{% latest-patch %}}_windows_amd64.zip `
    -UseBasicParsing `
    -OutFile telegraf-{{% latest-patch %}}_windows_amd64.zip
    Expand-Archive .\telegraf-{{% latest-patch %}}_windows_amd64.zip `

--- a/layouts/shortcodes/telegraf/verify.md
+++ b/layouts/shortcodes/telegraf/verify.md
@@ -20,7 +20,7 @@ If `gpg` is not available, see the [GnuPG homepage](https://gnupg.org/download/)
    For example:
 
     ```
-    wget https://dl.influxdata.com/telegraf/releases/telegraf-{{ $latestPatch }}_linux_amd64.tar.gz.asc
+    wget https://download.influxdata.com/telegraf/releases/telegraf-{{ $latestPatch }}_linux_amd64.tar.gz.asc
     ```
 
 3. Verify the signature with `gpg --verify`:


### PR DESCRIPTION
Update InfluxDB OSS v1 and Telegraf download links to a new URL.

_Describe your proposed changes here._

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
