### PR TITLE
clustered: update kubit version

### DIFF
--- a/content/influxdb/clustered/install/configure-cluster/directly.md
+++ b/content/influxdb/clustered/install/configure-cluster/directly.md
@@ -129,7 +129,7 @@ Use `kubectl` to install the [kubecfg kubit](https://github.com/kubecfg/kubit) o
 <!-- pytest.mark.skip -->
 
 ```sh
-kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.15'
+kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.19'
 ```
 
 ### Configure access to the InfluxDB container registry


### PR DESCRIPTION
Updates the version of Kubit referenced in the Clustered installation steps. The current version is 0.0.19, which includes several important bug fixes that we depend on.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
