### PR TITLE
fix(clustered): document the use of special symbols PostgeSQL connection strings

### DIFF
--- a/content/influxdb/clustered/install/configure-cluster/directly.md
+++ b/content/influxdb/clustered/install/configure-cluster/directly.md
@@ -545,11 +545,12 @@ as secrets in your Kubernetes cluster.
 {{% /note %}}
 
 {{% warn %}}
-PostgreSQL DSNs that contain special symbols may need to be percent-encoded in
-order to be parsed correctly by InfluxDB Clustered. This is particularly
-important to keep in mind when dealing with DSNs containing auto-generated
-passwords provided by cloud database providers which may automatically include
-special symbols in order to make their passwords harder to guess.
+#### Percent-encode special symbols in PostgreSQL DSNs
+
+Special symbols in PostgreSQL DSNs should be percent-encoded to ensure they
+are parsed correctly by InfluxDB Clustered. This is important to consider when
+using DSNs containing auto-generated passwords which may include special
+symbols to make passwords more secure.
 
 For example, the following DSN used in InfluxDB Clustered:
 

--- a/content/influxdb/clustered/install/configure-cluster/directly.md
+++ b/content/influxdb/clustered/install/configure-cluster/directly.md
@@ -552,20 +552,20 @@ passwords provided by cloud database providers which may automatically include
 special symbols in order to make their passwords harder to guess.
 
 For example, the following DSN used in InfluxDB Clustered:
-```
+
+```txt
 postgresql://postgres:meow#meow@my-fancy.cloud-database.party:5432/postgres
 ```
 
-Would result in error logs that look like:
+Would result in an error similar to:
 
-```
+```txt
 Catalog DSN error: A catalog error occurred: unhandled external error: error with configuration: invalid port number
 ```
 
-To fix this, the connection string would have to have the password (or any
-other part such as options) percent-encoded like so:
+To fix this, percent-encode special symbols in the connection string:
 
-```
+```txt
 postgresql://postgres:meow%23meow@my-fancy.cloud-database.party:5432/postgres
 ```
 

--- a/content/influxdb/clustered/install/configure-cluster/directly.md
+++ b/content/influxdb/clustered/install/configure-cluster/directly.md
@@ -544,9 +544,38 @@ We recommend storing sensitive credentials, such as your PostgreSQL-compatible D
 as secrets in your Kubernetes cluster.
 {{% /note %}}
 
-- `spec.package.spec.catalog.dsn.valueFrom.secretKeyRef`
-  - `.name`: Secret name
-  - `.key`: Key in the secret that contains the DSN
+{{% warn %}}
+PostgreSQL DSNs that contain special symbols may need to be percent-encoded in
+order to be parsed correctly by InfluxDB Clustered. This is particularly
+important to keep in mind when dealing with DSNs containing auto-generated
+passwords provided by cloud database providers which may automatically include
+special symbols in order to make their passwords harder to guess.
+
+For example, the following DSN used in InfluxDB Clustered:
+```
+postgresql://postgres:meow#meow@my-fancy.cloud-database.party:5432/postgres
+```
+
+Would result in error logs that look like:
+
+```
+Catalog DSN error: A catalog error occurred: unhandled external error: error with configuration: invalid port number
+```
+
+To fix this, the connection string would have to have the password (or any
+other part such as options) percent-encoded like so:
+
+```
+postgresql://postgres:meow%23meow@my-fancy.cloud-database.party:5432/postgres
+```
+
+For more information, see the [PostgreSQL Connection URI
+docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS).
+{{% /warn %}}
+
+- [ ] `spec.package.spec.catalog.dsn.valueFrom.secretKeyRef`
+  - [ ] `.name`: Secret name
+  - [ ] `.key`: Key in the secret that contains the DSN
 
 {{% code-placeholders "SECRET_(NAME|KEY)" %}}
 


### PR DESCRIPTION
This addresses an issue that came up with a Clustered customer who was using a PostgreSQL DSN generated by a cloud service provider's database-as-a-service.

I considered adding this to some kind of self-service troubleshooting section somewhere but didn't see anything like that when briefly looking over the sections we do have. So it seemed best just to put it directly in-line in the configuration section.
