### PR TITLE
InfluxDB Clustered partial writes

### DIFF
--- a/api-docs/clustered/v2/ref.yml
+++ b/api-docs/clustered/v2/ref.yml
@@ -646,17 +646,34 @@ paths:
         '204':
           description: Write data is correctly formatted and accepted for writing to the database.
         '400':
+           description: |
+            Data from the batch was rejected and not written. The response body indicates if a partial write occurred or all data was rejected.
+            If a partial write occurred, then some points from the batch are written and queryable. 
+            The response body contains details about the [rejected points](/influxdb/clustered/write-data/troubleshoot/#troubleshoot-rejected-points), up to 100 points.
           content:
             application/json:
+              examples:
+                rejectedAllPoints:
+                  summary: Rejected all points
+                  value:
+                    code: invalid
+                    line: 2
+                    message: 'no data written, errors encountered on line(s): error message for first rejected point</n> error message for second rejected point</n> error message for Nth rejected point (up to 100 rejected points)'
+                partialWriteErrorWithRejectedPoints:
+                  summary: Partial write rejects some points
+                  value:
+                    code: invalid
+                    line: 2
+                    message: 'partial write has occurred, errors encountered on line(s): error message for first rejected point</n> error message for second rejected point</n> error message for Nth rejected point (up to 100 rejected points)'
               schema:
                 $ref: '#/components/schemas/LineProtocolError'
-          description: Line protocol poorly formed and no points were written.  Response can be used to determine the first malformed line in the body line-protocol. All data in body was rejected and not written.
+          description: Line protocol poorly formed and no points were written. Response can be used to determine the first malformed line in the body line-protocol. All data in body was rejected and not written.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: Token doesn't have sufficient permissions to write to this  database or the database doesn't exist.
+          description: Token doesn't have sufficient permissions to write to this database or the database doesn't exist.
         '403':
           content:
             application/json:

--- a/content/influxdb/clustered/admin/bypass-identity-provider.md
+++ b/content/influxdb/clustered/admin/bypass-identity-provider.md
@@ -7,7 +7,7 @@ description: >
 menu:
   influxdb_clustered:
     parent: Administer InfluxDB Clustered
-weight: 208
+weight: 209
 ---
 
 {{< product-name >}} generates a valid access token (known as the _admin token_)

--- a/content/influxdb/clustered/admin/env-vars.md
+++ b/content/influxdb/clustered/admin/env-vars.md
@@ -1,24 +1,44 @@
 ---
-title: Manage environment variables for Clustered components
+title: Manage environment variables in your InfluxDB Cluster
 description: >
-  Manage environment variables for Clustered components.
+  Use environment variables to define settings for individual components in your
+  InfluxDB cluster.
 menu:
   influxdb_clustered:
     parent: Administer InfluxDB Clustered
     name: Manage environment variables
-weight: 101
-influxdb/clustered/tags: []
+weight: 208
 ---
 
-There are numerous environment variables available to the components of Clustered.
-This is handled entirely through your `AppInstance` configuration.
+Use environment variables to define settings for individual components in your
+InfluxDB cluster and adjust your cluster's running configuration.
+Define environment variables for each component in your `AppInstance` resource.
 
-Environment variables enable you to tweak the running configuration of Clustered.
-Many of them are already set for you, but you may wish to tune them specifically,
-either by our request or for your own means. 
+There are a number of environment variables available to InfluxDB Clustered components.
+Many environment variables have default settings, but you can override these
+defaults by setting custom values for environment variables.
 
-An example of tuning environment variables for the `garbage-collector` component
-is provided below:
+{{% warn %}}
+#### Overriding default settings may affect overall cluster performance
+
+{{% product-name %}} components have complex interactions with each other that
+can be affected when overriding default configuration settings.
+Before using environment variables to make configuration changes, you should
+consider consulting [InfluxData Support](https://support.influxdata.com/) to
+identify any potential unintended consequences of configuration changes.
+{{% /warn %}}
+
+## AppInstance component schema
+
+In your `AppInstance` resource, configure individual component settings in the
+`spec.package.spec.components` property. This property supports the following
+InfluxDB Clustered component keys:
+
+- `ingester`
+- `querier`
+- `router`
+- `compactor`
+- `garbage-collector`
 
 ```yaml
 apiVersion: kubecfg.dev/v1alpha1
@@ -31,26 +51,67 @@ spec:
     # ...
     spec:
       components:
-       garbage-collector:
-         template:
-           containers:
-             iox:
-               env:
-                 INFLUXDB_IOX_GC_OBJECTSTORE_CUTOFF: '6h'
-                 INFLUXDB_IOX_GC_PARQUETFILE_CUTOFF: '6h'
+        ingester:
+          # Ingester settings ...
+        querier:
+          # Querier settings ...
+        router:
+          # Router settings. ...
+        compactor:
+          # Compactor settings ...
+        garbage-collector:
+          # Garbage collector settings ...
 ```
 
+_For more information about components in the InfluxDB v3 storage engine, see
+the [InfluxDB v3 storage engine architecture](/influxdb/clustered/reference/internals/storage-engine/)._
+
+## Set environment variables for a component
+
+1.  Under the specific component property, use the `<component>.template.containers.iox.env`
+    property to define environment variables.
+2.  In the `env` property, structure each environment variable as a key-value pair.
+    For example, to configure environment variables for the Garbage collector:
+
+    ```yaml
+    apiVersion: kubecfg.dev/v1alpha1
+    kind: AppInstance
+    metadata:
+      name: influxdb
+      namespace: influxdb
+    spec:
+      package:
+        # ...
+        spec:
+          components:
+            garbage-collector:
+            template:
+              containers:
+                iox:
+                  env:
+                    INFLUXDB_IOX_GC_OBJECTSTORE_CUTOFF: '6h'
+                    INFLUXDB_IOX_GC_PARQUETFILE_CUTOFF: '6h'
+    ```
+
+3.  Use `kubectl apply` to apply the configuration changes to your cluster and
+    add or update environment variables in each component.
+
+    ```sh
+    kubectl apply \
+      --filename myinfluxdb.yml \
+      --namespace influxdb
+    ```
 {{% note %}}
-All components can have their environment variables tuned in the same way, by
-specifying their component name in this manner.
+#### Update instead of removing environment variables
+
+Removing environment variables from your `AppInstance` resource configuration
+will not revert those environment variables to their default setting.
+To revert back to the default settings, update the value in your `AppInstance`
+resource to the default value rather than removing the environment variable definition.
 {{% /note %}}
 
-
-{{% expand "All components example" %}}
-
-The following example demonstrates all of the InfluxDB 3 Clustered component names
-being tuned in specific ways.
-
+{{< expand-wrapper >}}
+{{% expand "View example of environment variables in all components" %}}
 
 ```yaml
 apiVersion: kubecfg.dev/v1alpha1
@@ -96,3 +157,4 @@ spec:
                  INFLUXDB_IOX_GC_PARQUETFILE_CUTOFF: '6h'
 ```
 {{% /expand %}}
+{{< /expand-wrapper >}}

--- a/content/influxdb/clustered/admin/env-vars.md
+++ b/content/influxdb/clustered/admin/env-vars.md
@@ -1,0 +1,98 @@
+---
+title: Manage environment variables for Clustered components
+description: >
+  Manage environment variables for Clustered components.
+menu:
+  influxdb_clustered:
+    parent: Administer InfluxDB Clustered
+    name: Manage environment variables
+weight: 101
+influxdb/clustered/tags: []
+---
+
+There are numerous environment variables available to the components of Clustered.
+This is handled entirely through your `AppInstance` configuration.
+
+Environment variables enable you to tweak the running configuration of Clustered.
+Many of them are already set for you, but you may wish to tune them specifically,
+either by our request or for your own means. 
+
+An example of tuning environment variables for the `garbage-collector` component
+is provided below:
+
+```yaml
+apiVersion: kubecfg.dev/v1alpha1
+kind: AppInstance
+metadata:
+  name: influxdb
+  namespace: influxdb
+spec:
+  package:
+    # ...
+    spec:
+      components:
+       garbage-collector:
+         template:
+           containers:
+             iox:
+               env:
+                 INFLUXDB_IOX_GC_OBJECTSTORE_CUTOFF: '6h'
+                 INFLUXDB_IOX_GC_PARQUETFILE_CUTOFF: '6h'
+```
+
+{{% note %}}
+All components can have their environment variables tuned in the same way, by
+specifying their component name in this manner.
+{{% /note %}}
+
+
+{{% expand "All components example" %}}
+
+The following example demonstrates all of the InfluxDB 3 Clustered component names
+being tuned in specific ways.
+
+
+```yaml
+apiVersion: kubecfg.dev/v1alpha1
+kind: AppInstance
+metadata:
+  name: influxdb
+  namespace: influxdb
+spec:
+  package:
+    # ...
+    spec:
+      components:
+       ingester:
+         template:
+           containers:
+             iox:
+               env:
+                 INFLUXDB_IOX_WAL_ROTATION_PERIOD_SECONDS: '360'
+       querier:
+         template:
+           containers:
+             iox:
+               env:
+                 INFLUXDB_IOX_EXEC_MEM_POOL_BYTES: '10737418240' # 10GiB
+       router:
+         template:
+           containers:
+             iox:
+               env:
+                 INFLUXDB_IOX_MAX_HTTP_REQUESTS: '5000'
+       compactor:
+         template:
+           containers:
+             iox:
+               env:
+                 INFLUXDB_IOX_EXEC_MEM_POOL_PERCENT: '80'
+       garbage-collector:
+         template:
+           containers:
+             iox:
+               env:
+                 INFLUXDB_IOX_GC_OBJECTSTORE_CUTOFF: '6h'
+                 INFLUXDB_IOX_GC_PARQUETFILE_CUTOFF: '6h'
+```
+{{% /expand %}}

--- a/content/influxdb/clustered/write-data/troubleshoot.md
+++ b/content/influxdb/clustered/write-data/troubleshoot.md
@@ -5,7 +5,8 @@ weight: 106
 description: >
   Troubleshoot issues writing data.
   Find response codes for failed writes.
-  Discover how writes fail, from exceeding rate or payload limits, to syntax errors and schema conflicts.
+  Discover how writes fail, from exceeding rate or payload limits, to syntax
+  errors and schema conflicts.
 menu:
   influxdb_clustered:
     name: Troubleshoot issues
@@ -17,7 +18,8 @@ related:
   - /influxdb/clustered/reference/internals/durability/
 ---
 
-Learn how to avoid unexpected results and recover from errors when writing to {{% product-name %}}.
+Learn how to avoid unexpected results and recover from errors when writing to
+{{% product-name %}}.
 
 - [Handle write responses](#handle-write-responses)
   - [Review HTTP status codes](#review-http-status-codes)
@@ -26,12 +28,26 @@ Learn how to avoid unexpected results and recover from errors when writing to {{
 
 ## Handle write responses
 
-In {{% product-name %}}, writes are synchronous.
-After InfluxDB validates the request and ingests the data, it sends a _success_ response (HTTP `204` status code) as an acknowledgement that the data is written and queryable.
-To ensure that InfluxDB handles writes in the order you request them, wait for the acknowledgement before you send the next request.
+{{% product-name %}} does the following when you send a write request:
 
-If InfluxDB successfully writes all the request data to the database, it returns _success_ (HTTP `204` status code).
-The first rejected point in a batch causes InfluxDB to reject the entire batch and respond with an [HTTP error status](#review-http-status-codes).
+1.  Validates the request.
+2.  If successful, attempts to ingest data from the request body; otherwise,
+    responds with an [error status](#review-http-status-codes).
+3.  Ingests or rejects data in the batch and returns one of the following HTTP
+    status codes:
+
+    - `204 No Content`: All data in the batch is ingested.
+    - `400 Bad Request`: Some or all of the data has been rejected.
+      Data that has not been rejected is ingested and queryable.
+
+The response body contains error details about
+[rejected points](#troubleshoot-rejected-points), up to 100 points.
+
+Writes are synchronous--the response status indicates the final status of the
+write and all ingested data is queryable.
+
+To ensure that InfluxDB handles writes in the order you request them,
+wait for the response before you send the next request.
 
 ### Review HTTP status codes
 
@@ -42,7 +58,7 @@ Write requests return the following status codes:
 | HTTP response code              | Message                                                                 | Description    |
 | :-------------------------------| :---------------------------------------------------------------        | :------------- |
 | `204 "Success"`                 |                                                                         | If InfluxDB ingested the data |
-| `400 "Bad request"`             | `message` contains the first malformed line                             | If data is malformed    |
+| `400 "Bad request"`             | error details about rejected points, up to 100 points: `line` contains the first rejected line, `message` describes rejections | If some or all request data isn't allowed (for example, if it is malformed or falls outside of the bucket's retention period)--the response body indicates whether a partial write has occurred or if all data has been rejected |
 | `401 "Unauthorized"`            |                                                                         | If the `Authorization` header is missing or malformed or if the [token](/influxdb/clustered/admin/tokens/) doesn't have [permission](/influxdb/clustered/reference/cli/influxctl/token/create/#examples) to write to the database. See [examples using credentials](/influxdb/clustered/get-started/write/#write-line-protocol-to-influxdb) in write requests. |
 | `404 "Not found"`               | requested **resource type** (for example, "organization" or "database"), and **resource name**     | If a requested resource (for example, organization or database) wasn't found |
 | `500 "Internal server error"`   |                                                                         | Default status for an error |
@@ -62,6 +78,10 @@ If you notice data is missing in your database, do the following:
 
 ## Troubleshoot rejected points
 
-InfluxDB rejects points that fall within the same partition (default partitioning is measurement and day) as existing bucket data and have a different data type for an existing field.
+InfluxDB rejects points that fall within the same partition (default partitioning
+is by measurement and day) as existing bucket data and have a different data type
+for an existing field.
 
-Check for [field data type](/influxdb/clustered/reference/syntax/line-protocol/#data-types-and-format) differences between the rejected data point and points within the same database and partition--for example, did you attempt to write `string` data to an `int` field?
+Check for [field data type](/influxdb/clustered/reference/syntax/line-protocol/#data-types-and-format)
+differences between the rejected data point and points within the same database
+and partition--for example, did you attempt to write `string` data to an `int` field?


### PR DESCRIPTION
This lays the groundwork for partial writes in InfluxDB Clustered. Before this PR goes live, we will need to add information about disabling the partial writes feature using the available environment variable. This will like go in the release notes of the next Clustered release and point to the environment variable configuration docs included in this PR.

> [!IMPORTANT]
> Do no merge until the next Clustered release (planned for Sept 16th)

- Updates Clustered API docs with new partial writes behavior
- Adds information about configuring components with environment variables
- Updates write task-based docs with information about new partial writes status codes

---

- [x] Rebased/mergeable
