### PR TITLE
chore: remove unnecessary ::timestamp casts

### DIFF
--- a/content/influxdb/cloud-dedicated/get-started/query.md
+++ b/content/influxdb/cloud-dedicated/get-started/query.md
@@ -162,7 +162,7 @@ WHERE
 {{% influxdb/custom-timestamps %}}
 ```sql
 SELECT
-  DATE_BIN(INTERVAL '1 hour', time, '2022-01-01T00:00:00Z'::TIMESTAMP) as _time,
+  DATE_BIN(INTERVAL '1 hour', time, '2022-01-01T00:00:00Z') as _time,
   room,
   selector_max(temp, time)['value'] AS 'max temp'
 FROM

--- a/content/influxdb/cloud-dedicated/query-data/sql/aggregate-select.md
+++ b/content/influxdb/cloud-dedicated/query-data/sql/aggregate-select.md
@@ -28,7 +28,7 @@ list_code_example: |
   ##### Aggregate by time-based intervals
   ```sql
   SELECT
-    DATE_BIN(INTERVAL '1 hour', time, '2022-01-01T00:00:00Z'::TIMESTAMP) AS time,
+    DATE_BIN(INTERVAL '1 hour', time, '2022-01-01T00:00:00Z') AS time,
     mean(field1),
     sum(field2),
     tag1
@@ -206,7 +206,7 @@ groups:
     
     ```sql
     SELECT
-      DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z'::TIMESTAMP) AS time
+      DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z') AS time
     FROM home
     ...
     ```
@@ -225,7 +225,7 @@ groups:
 
   ```sql
   SELECT
-    DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z'::TIMESTAMP) AS time
+    DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z') AS time
   ...
   GROUP BY 1, room
   ...
@@ -235,7 +235,7 @@ groups:
 
   ```sql
   SELECT
-    DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z'::TIMESTAMP) AS _time
+    DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z') AS _time
   FROM home
   ...
   GROUP BY _time, room
@@ -247,7 +247,7 @@ The following example retrieves unique combinations of time intervals and rooms 
 
 ```sql
 SELECT
-  DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z'::TIMESTAMP) AS time,
+  DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z') AS time,
   room,
   selector_max(temp, time)['value'] AS 'max temp',
   selector_min(temp, time)['value'] AS 'min temp',
@@ -288,7 +288,7 @@ If you want to reference a calculated time column by name, use an alias differen
 
 ```sql
 SELECT
-  DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z'::TIMESTAMP)
+  DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z')
   AS _time,
   room,
   selector_max(temp, time)['value'] AS 'max temp',

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/flight/python-flight.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/flight/python-flight.md
@@ -21,7 +21,7 @@ list_code_example: |
   sql="""
     SELECT DATE_BIN(INTERVAL '2 hours',
         time,
-        '1970-01-01T00:00:00Z'::TIMESTAMP) AS time,
+        '1970-01-01T00:00:00Z') AS time,
       room,
       selector_max(temp, time)['value'] AS 'max temp',
       selector_min(temp, time)['value'] AS 'min temp',

--- a/content/influxdb/cloud-dedicated/reference/sql/_index.md
+++ b/content/influxdb/cloud-dedicated/reference/sql/_index.md
@@ -634,7 +634,7 @@ WHERE time >= timestamp '2019-09-10T00:00:00Z' AND time <= timestamp '2019-09-19
 #### Examples
 
 ```sql
-SELECT DATE_BIN(INTERVAL '1 hour', time, '2019-09-18T00:00:00Z'::timestamp) AS "_time",
+SELECT DATE_BIN(INTERVAL '1 hour', time, '2019-09-18T00:00:00Z') AS "_time",
 SUM(water_level)
 FROM "h2o_feet"
 GROUP BY "_time"

--- a/content/influxdb/cloud-dedicated/reference/sql/where.md
+++ b/content/influxdb/cloud-dedicated/reference/sql/where.md
@@ -89,7 +89,7 @@ and a `level description` field value that equals `below 3 feet`.
 SELECT *
 FROM h2o_feet 
 WHERE "location" = 'santa_monica'
-AND "time" >= '2019-08-19T12:00:00Z'::timestamp AND "time" <= '2019-08-19T13:00:00Z'::timestamp 
+AND "time" >= '2019-08-19T12:00:00Z' AND "time" <= '2019-08-19T13:00:00Z'
 ```
 
 {{< expand-wrapper >}}

--- a/content/influxdb/cloud-serverless/get-started/query.md
+++ b/content/influxdb/cloud-serverless/get-started/query.md
@@ -160,7 +160,7 @@ WHERE
 {{% influxdb/custom-timestamps %}}
 ```sql
 SELECT
-  DATE_BIN(INTERVAL '1 hour', time, '2022-01-01T00:00:00Z'::TIMESTAMP) as _time,
+  DATE_BIN(INTERVAL '1 hour', time, '2022-01-01T00:00:00Z') as _time,
   room,
   selector_max(temp, time)['value'] AS 'max temp'
 FROM

--- a/content/influxdb/cloud-serverless/query-data/sql/aggregate-select.md
+++ b/content/influxdb/cloud-serverless/query-data/sql/aggregate-select.md
@@ -28,7 +28,7 @@ list_code_example: |
   ##### Aggregate by time-based intervals
   ```sql
   SELECT
-    DATE_BIN(INTERVAL '1 hour', time, '2022-01-01T00:00:00Z'::TIMESTAMP) AS time,
+    DATE_BIN(INTERVAL '1 hour', time, '2022-01-01T00:00:00Z') AS time,
     mean(field1),
     sum(field2),
     tag1
@@ -206,7 +206,7 @@ groups:
     
     ```sql
     SELECT
-      DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z'::TIMESTAMP) AS time
+      DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z') AS time
     FROM home
     ...
     ```
@@ -224,7 +224,7 @@ groups:
 
   ```sql
   SELECT
-    DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z'::TIMESTAMP) AS time
+    DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z') AS time
   ...
   GROUP BY 1, room
   ...
@@ -234,7 +234,7 @@ groups:
 
   ```sql
   SELECT
-    DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z'::TIMESTAMP) AS _time
+    DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z') AS _time
   FROM home
   ...
   GROUP BY _time, room
@@ -246,7 +246,7 @@ The following example retrieves unique combinations of time intervals and rooms 
 
 ```sql
 SELECT
-  DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z'::TIMESTAMP) AS time,
+  DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z') AS time,
   room,
   selector_max(temp, time)['value'] AS 'max temp',
   selector_min(temp, time)['value'] AS 'min temp',
@@ -287,7 +287,7 @@ If you want to reference a calculated time column by name, use an alias differen
 
 ```sql
 SELECT
-  DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z'::TIMESTAMP)
+  DATE_BIN(INTERVAL '2 hours', time, '1970-01-01T00:00:00Z')
   AS _time,
   room,
   selector_max(temp, time)['value'] AS 'max temp',

--- a/content/influxdb/cloud-serverless/reference/client-libraries/flight/python-flight.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/flight/python-flight.md
@@ -21,7 +21,7 @@ list_code_example: |
   sql="""
     SELECT DATE_BIN(INTERVAL '2 hours',
         time,
-        '1970-01-01T00:00:00Z'::TIMESTAMP) AS time,
+        '1970-01-01T00:00:00Z') AS time,
       room,
       selector_max(temp, time)['value'] AS 'max temp',
       selector_min(temp, time)['value'] AS 'min temp',
@@ -80,7 +80,7 @@ import tabulate
 sql="""
   SELECT DATE_BIN(INTERVAL '2 hours',
       time,
-      '1970-01-01T00:00:00Z'::TIMESTAMP) AS time,
+      '1970-01-01T00:00:00Z') AS time,
     room,
     selector_max(temp, time)['value'] AS 'max temp',
     selector_min(temp, time)['value'] AS 'min temp',

--- a/content/influxdb/cloud-serverless/reference/sql/_index.md
+++ b/content/influxdb/cloud-serverless/reference/sql/_index.md
@@ -634,7 +634,7 @@ WHERE time >= timestamp '2019-09-10T00:00:00Z' AND time <= timestamp '2019-09-19
 #### Examples
 
 ```sql
-SELECT DATE_BIN(INTERVAL '1 hour', time, '2019-09-18T00:00:00Z'::timestamp) AS "_time",
+SELECT DATE_BIN(INTERVAL '1 hour', time, '2019-09-18T00:00:00Z') AS "_time",
 SUM(water_level)
 FROM "h2o_feet"
 GROUP BY "_time"

--- a/content/influxdb/cloud-serverless/reference/sql/where.md
+++ b/content/influxdb/cloud-serverless/reference/sql/where.md
@@ -88,7 +88,7 @@ and a `level description` field value that equals `below 3 feet`.
 SELECT *
 FROM h2o_feet
 WHERE "location" = 'santa_monica'
-AND "time" >= '2019-08-19T12:00:00Z'::timestamp AND "time" <= '2019-08-19T13:00:00Z'::timestamp
+AND "time" >= '2019-08-19T12:00:00Z' AND "time" <= '2019-08-19T13:00:00Z'
 ```
 
 {{< expand-wrapper >}}

--- a/content/influxdb/clustered/reference/client-libraries/flight/python-flight.md
+++ b/content/influxdb/clustered/reference/client-libraries/flight/python-flight.md
@@ -21,7 +21,7 @@ list_code_example: |
   sql="""
     SELECT DATE_BIN(INTERVAL '2 hours',
         time,
-        '1970-01-01T00:00:00Z'::TIMESTAMP) AS time,
+        '1970-01-01T00:00:00Z') AS time,
       room,
       selector_max(temp, time)['value'] AS 'max temp',
       selector_min(temp, time)['value'] AS 'min temp',

--- a/content/influxdb/clustered/reference/sql/_index.md
+++ b/content/influxdb/clustered/reference/sql/_index.md
@@ -637,7 +637,7 @@ WHERE time >= timestamp '2019-09-10T00:00:00Z' AND time <= timestamp '2019-09-19
 #### Examples
 
 ```sql
-SELECT DATE_BIN(INTERVAL '1 hour', time, '2019-09-18T00:00:00Z'::timestamp) AS "_time",
+SELECT DATE_BIN(INTERVAL '1 hour', time, '2019-09-18T00:00:00Z') AS "_time",
 SUM(water_level)
 FROM "h2o_feet"
 GROUP BY "_time"

--- a/content/influxdb/clustered/reference/sql/where.md
+++ b/content/influxdb/clustered/reference/sql/where.md
@@ -89,7 +89,7 @@ and a `level description` field value that equals `below 3 feet`.
 SELECT *
 FROM h2o_feet 
 WHERE "location" = 'santa_monica'
-AND "time" >= '2019-08-19T12:00:00Z'::timestamp AND "time" <= '2019-08-19T13:00:00Z'::timestamp 
+AND "time" >= '2019-08-19T12:00:00Z' AND "time" <= '2019-08-19T13:00:00Z'
 ```
 
 {{< expand-wrapper >}}


### PR DESCRIPTION
@sanderson This removes anywhere that we had `::timestamp` where the value will already be coerced to a timestamp. This is important because the `::timestamp` cast currently (and may always) removes the timezone information from the timestamp. PR'd into the v3/timezone-support branch.


_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
