### PR TITLE
Telegraf v1.32.0

### DIFF
--- a/content/telegraf/v1/_index.md
+++ b/content/telegraf/v1/_index.md
@@ -5,7 +5,7 @@ description: >
   time series platform, used to collect and report metrics. Telegraf supports four categories of plugins -- input, output, aggregator, and processor.
 menu:
   telegraf_v1:
-    name: Telegraf v1.31
+    name: Telegraf v1.32
 weight: 1
 related:
   - /resources/videos/intro-to-telegraf/

--- a/content/telegraf/v1/release-notes.md
+++ b/content/telegraf/v1/release-notes.md
@@ -23,7 +23,7 @@ menu:
   [#15751](https://github.com/influxdata/telegraf/pull/15751)).
   As a consequence, the redundant `logtarget` setting is deprecated. `stderr` is
   used if no `logfile` is provided, otherwise messages are logged to the given
-  file. For using the Windows `eventlog` set `logformat = "eventlog"`!
+  file. To use Windows `eventlog`, set `logformat = "eventlog"`.
 - This release contains a change in json_v2 parser config parsing -
   if the config is empty (not define any rules), initialization will fail
   (see PR [#15844](https://github.com/influxdata/telegraf/pull/15844)).

--- a/content/telegraf/v1/release-notes.md
+++ b/content/telegraf/v1/release-notes.md
@@ -21,7 +21,7 @@ menu:
   [#15677](https://github.com/influxdata/telegraf/pull/15677),
   [#15695](https://github.com/influxdata/telegraf/pull/15695) and
   [#15751](https://github.com/influxdata/telegraf/pull/15751)).
-  As a consequence the redunant `logtarget` setting is deprecated, `stderr` is
+  As a consequence, the redundant `logtarget` setting is deprecated. `stderr` is
   used if no `logfile` is provided, otherwise messages are logged to the given
   file. For using the Windows `eventlog` set `logformat = "eventlog"`!
 - This release contains a change in json_v2 parser config parsing -

--- a/content/telegraf/v1/release-notes.md
+++ b/content/telegraf/v1/release-notes.md
@@ -29,8 +29,7 @@ menu:
 - This release contains a feature for a disk-backed metric buffer under the
   `buffer_strategy` agent config (see
   PR [#15564](https://github.com/influxdata/telegraf/pull/15564)).
-  Please note, this feature is **experimental**, please give it a test and
-  report any issues you encounter.
+  _This feature is **experimental**. Please report any issues you encounter while using it._
 
 ### New Plugins
 

--- a/content/telegraf/v1/release-notes.md
+++ b/content/telegraf/v1/release-notes.md
@@ -24,8 +24,7 @@ menu:
   As a consequence, the redundant `logtarget` setting is deprecated. `stderr` is
   used if no `logfile` is provided, otherwise messages are logged to the given
   file. To use Windows `eventlog`, set `logformat = "eventlog"`.
-- This release contains a change in json_v2 parser config parsing -
-  if the config is empty (not define any rules), initialization will fail
+- This release contains a change in json_v2 parser config parsing: if the config is empty (doesn't define any rules), initialization will fail
   (see PR [#15844](https://github.com/influxdata/telegraf/pull/15844)).
 - This release contains a feature for a disk-backed metric buffer under the
   `buffer_strategy` agent config (see

--- a/content/telegraf/v1/release-notes.md
+++ b/content/telegraf/v1/release-notes.md
@@ -11,6 +11,116 @@ menu:
     weight: 60
 ---
 
+## v1.32.0 {date="2024-09-09"}
+
+### Important Changes
+
+- This release contains a logging overhaul as well as some new features for
+  logging (see PRs [#15556](https://github.com/influxdata/telegraf/pull/15556),
+  [#15629](https://github.com/influxdata/telegraf/pull/15629),
+  [#15677](https://github.com/influxdata/telegraf/pull/15677),
+  [#15695](https://github.com/influxdata/telegraf/pull/15695) and
+  [#15751](https://github.com/influxdata/telegraf/pull/15751)).
+  As a consequence the redunant `logtarget` setting is deprecated, `stderr` is
+  used if no `logfile` is provided, otherwise messages are logged to the given
+  file. For using the Windows `eventlog` set `logformat = "eventlog"`!
+- This release contains a change in json_v2 parser config parsing -
+  if the config is empty (not define any rules), initialization will fail
+  (see PR [#15844](https://github.com/influxdata/telegraf/pull/15844)).
+- This release contains a feature for a disk-backed metric buffer under the
+  `buffer_strategy` agent config (see
+  PR [#15564](https://github.com/influxdata/telegraf/pull/15564)).
+  Please note, this feature is **experimental**, please give it a test and
+  report any issues you encounter.
+
+### New Plugins
+
+- [#15700](https://github.com/influxdata/telegraf/pull/15700) `inputs.slurm` SLURM workload manager
+- [#15602](https://github.com/influxdata/telegraf/pull/15602) `outputs.parquet` Parquet file writer
+- [#15569](https://github.com/influxdata/telegraf/pull/15569) `outputs.remotefile` Output to remote location like S3
+
+### Features
+
+- [#15732](https://github.com/influxdata/telegraf/pull/15732) `agent` Add config check sub-command
+- [#15564](https://github.com/influxdata/telegraf/pull/15564) `agent` Add metric disk buffer
+- [#15645](https://github.com/influxdata/telegraf/pull/15645) `agent` Enable watching for new configuration files
+- [#15644](https://github.com/influxdata/telegraf/pull/15644) `agent` Watch for deleted files
+- [#15695](https://github.com/influxdata/telegraf/pull/15695) `logging` Add 'trace' log-level
+- [#15677](https://github.com/influxdata/telegraf/pull/15677) `logging` Allow to override log-level per plugin
+- [#15751](https://github.com/influxdata/telegraf/pull/15751) `logging` Implement structured logging
+- [#15640](https://github.com/influxdata/telegraf/pull/15640) `common.cookie` Allow usage of secrets in headers
+- [#15636](https://github.com/influxdata/telegraf/pull/15636) `common.shim` Enable metric tracking within external plugins
+- [#15570](https://github.com/influxdata/telegraf/pull/15570) `common.tls` Allow group aliases for cipher-suites
+- [#15628](https://github.com/influxdata/telegraf/pull/15628) `inputs.amd_rocm_smi` Parse newer ROCm versions
+- [#15519](https://github.com/influxdata/telegraf/pull/15519) `inputs.azure_monitor` Add client options parameter
+- [#15544](https://github.com/influxdata/telegraf/pull/15544) `inputs.elasticsearch` Add support for custom headers
+- [#15688](https://github.com/influxdata/telegraf/pull/15688) `inputs.elasticsearch` Gather enrich stats
+- [#15834](https://github.com/influxdata/telegraf/pull/15834) `inputs.execd` Allow to provide logging prefixes on stderr
+- [#15764](https://github.com/influxdata/telegraf/pull/15764) `inputs.http_listener_v2` Add unix socket mode
+- [#15495](https://github.com/influxdata/telegraf/pull/15495) `inputs.ipmi_sensor` Collect additional commands
+- [#15790](https://github.com/influxdata/telegraf/pull/15790) `inputs.kafka_consumer` Allow to select the metric time source
+- [#15648](https://github.com/influxdata/telegraf/pull/15648) `inputs.modbus` Allow reading single bits of input and holding registers
+- [#15528](https://github.com/influxdata/telegraf/pull/15528) `inputs.mqtt_consumer` Add variable length topic parsing
+- [#15486](https://github.com/influxdata/telegraf/pull/15486) `inputs.mqtt_consumer` Implement startup error behaviors
+- [#15749](https://github.com/influxdata/telegraf/pull/15749) `inputs.mysql` Add support for replica status
+- [#15521](https://github.com/influxdata/telegraf/pull/15521) `inputs.netflow` Add more fields for sFlow extended gateway packets
+- [#15396](https://github.com/influxdata/telegraf/pull/15396) `inputs.netflow` Add support for sFlow drop notification packets
+- [#15468](https://github.com/influxdata/telegraf/pull/15468) `inputs.openstack` Allow collection without admin privileges
+- [#15637](https://github.com/influxdata/telegraf/pull/15637) `inputs.opentelemetry` Add profiles support
+- [#15423](https://github.com/influxdata/telegraf/pull/15423) `inputs.procstat` Add ability to collect per-process socket statistics
+- [#15655](https://github.com/influxdata/telegraf/pull/15655) `inputs.s7comm` Implement startup-error behavior settings
+- [#15600](https://github.com/influxdata/telegraf/pull/15600) `inputs.sql` Add SAP HANA SQL driver
+- [#15424](https://github.com/influxdata/telegraf/pull/15424) `inputs.sqlserver` Introduce user specified ID parameter for ADD logins
+- [#15687](https://github.com/influxdata/telegraf/pull/15687) `inputs.statsd` Expose allowed_pending_messages as internal stat
+- [#15458](https://github.com/influxdata/telegraf/pull/15458) `inputs.systemd_units` Support user scoped units
+- [#15702](https://github.com/influxdata/telegraf/pull/15702) `outputs.datadog` Add support for submitting alongside dd-agent
+- [#15668](https://github.com/influxdata/telegraf/pull/15668) `outputs.dynatrace` Report metrics as a delta counter using regular expression
+- [#15471](https://github.com/influxdata/telegraf/pull/15471) `outputs.elasticsearch` Allow custom template index settings
+- [#15613](https://github.com/influxdata/telegraf/pull/15613) `outputs.elasticsearch` Support data streams
+- [#15722](https://github.com/influxdata/telegraf/pull/15722) `outputs.kafka` Add option to add metric name as record header
+- [#15689](https://github.com/influxdata/telegraf/pull/15689) `outputs.kafka` Add option to set producer message timestamp
+- [#15787](https://github.com/influxdata/telegraf/pull/15787) `outputs.syslog` Implement startup error behavior options
+- [#15697](https://github.com/influxdata/telegraf/pull/15697) `parsers.value` Add base64 datatype
+- [#15795](https://github.com/influxdata/telegraf/pull/15795) `processors.aws_ec2` Allow to use instance metadata
+
+### Bugfixes
+
+- [#15661](https://github.com/influxdata/telegraf/pull/15661) `agent` Fix buffer directory config and document
+- [#15788](https://github.com/influxdata/telegraf/pull/15788) `inputs.kinesis_consumer` Honor the configured endpoint
+- [#15791](https://github.com/influxdata/telegraf/pull/15791) `inputs.mysql` Enforce float for all known floating-point information
+- [#15743](https://github.com/influxdata/telegraf/pull/15743) `inputs.snmp` Avoid sending a nil to gosmi's GetEnumBitsFormatted
+- [#15815](https://github.com/influxdata/telegraf/pull/15815) `logger` Handle trace level for standard log
+- [#15781](https://github.com/influxdata/telegraf/pull/15781) `outputs.kinesis` Honor the configured endpoint
+- [#15615](https://github.com/influxdata/telegraf/pull/15615) `outputs.remotefile` Resolve linter not checking error
+- [#15740](https://github.com/influxdata/telegraf/pull/15740) `serializers.template` Unwrap metrics if required
+
+### Dependency Updates
+
+- [#15829](https://github.com/influxdata/telegraf/pull/15829) `deps` Bump github.com/BurntSushi/toml from 1.3.2 to 1.4.0
+- [#15775](https://github.com/influxdata/telegraf/pull/15775) `deps` Bump github.com/aws/aws-sdk-go-v2/feature/ec2/imds from 1.16.11 to 1.16.12
+- [#15733](https://github.com/influxdata/telegraf/pull/15733) `deps` Bump github.com/aws/aws-sdk-go-v2/service/cloudwatch from 1.38.7 to 1.40.3
+- [#15761](https://github.com/influxdata/telegraf/pull/15761) `deps` Bump github.com/aws/aws-sdk-go-v2/service/cloudwatch from 1.40.3 to 1.40.4
+- [#15827](https://github.com/influxdata/telegraf/pull/15827) `deps` Bump github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs from 1.37.3 to 1.38.0
+- [#15760](https://github.com/influxdata/telegraf/pull/15760) `deps` Bump github.com/aws/aws-sdk-go-v2/service/timestreamwrite from 1.25.5 to 1.27.4
+- [#15737](https://github.com/influxdata/telegraf/pull/15737) `deps` Bump github.com/eclipse/paho.mqtt.golang from 1.4.3 to 1.5.0
+- [#15734](https://github.com/influxdata/telegraf/pull/15734) `deps` Bump github.com/google/cel-go from 0.20.1 to 0.21.0
+- [#15777](https://github.com/influxdata/telegraf/pull/15777) `deps` Bump github.com/miekg/dns from 1.1.59 to 1.1.62
+- [#15828](https://github.com/influxdata/telegraf/pull/15828) `deps` Bump github.com/openconfig/goyang from 1.5.0 to 1.6.0
+- [#15735](https://github.com/influxdata/telegraf/pull/15735) `deps` Bump github.com/pion/dtls/v2 from 2.2.11 to 2.2.12
+- [#15779](https://github.com/influxdata/telegraf/pull/15779) `deps` Bump github.com/prometheus/client_golang from 1.19.1 to 1.20.2
+- [#15831](https://github.com/influxdata/telegraf/pull/15831) `deps` Bump github.com/prometheus/prometheus from 0.53.1 to 0.54.1
+- [#15736](https://github.com/influxdata/telegraf/pull/15736) `deps` Bump github.com/redis/go-redis/v9 from 9.5.1 to 9.6.1
+- [#15830](https://github.com/influxdata/telegraf/pull/15830) `deps` Bump github.com/seancfoley/ipaddress-go from 1.6.0 to 1.7.0
+- [#15842](https://github.com/influxdata/telegraf/pull/15842) `deps` Bump github.com/showwin/speedtest-go from 1.7.7 to 1.7.9
+- [#15778](https://github.com/influxdata/telegraf/pull/15778) `deps` Bump go.step.sm/crypto from 0.50.0 to 0.51.1
+- [#15776](https://github.com/influxdata/telegraf/pull/15776) `deps` Bump golang.org/x/net from 0.27.0 to 0.28.0
+- [#15757](https://github.com/influxdata/telegraf/pull/15757) `deps` Bump golang.org/x/sync from 0.7.0 to 0.8.0
+- [#15759](https://github.com/influxdata/telegraf/pull/15759) `deps` Bump gonum.org/v1/gonum from 0.15.0 to 0.15.1
+- [#15758](https://github.com/influxdata/telegraf/pull/15758) `deps` Bump modernc.org/sqlite from 1.30.0 to 1.32.0
+- [#15756](https://github.com/influxdata/telegraf/pull/15756) `deps` Bump super-linter/super-linter from 6.8.0 to 7.0.0
+- [#15826](https://github.com/influxdata/telegraf/pull/15826) `deps` Bump super-linter/super-linter from 7.0.0 to 7.1.0
+- [#15780](https://github.com/influxdata/telegraf/pull/15780) `deps` Bump tj-actions/changed-files from 44 to 45
+
 ## v1.31.3 {date="2024-08-12"}
 
 ### Bugfixes

--- a/content/telegraf/v1/release-notes.md
+++ b/content/telegraf/v1/release-notes.md
@@ -11,6 +11,104 @@ menu:
     weight: 60
 ---
 
+## v1.31.3 {date="2024-08-12"}
+
+### Bugfixes
+
+- [#15552](https://github.com/influxdata/telegraf/pull/15552) `inputs.chrony` Use DGRAM for the unix socket
+- [#15667](https://github.com/influxdata/telegraf/pull/15667) `inputs.diskio` Print warnings once, add details to messages
+- [#15670](https://github.com/influxdata/telegraf/pull/15670) `inputs.mqtt_consumer` Restore trace logging option
+- [#15696](https://github.com/influxdata/telegraf/pull/15696) `inputs.opcua` Reconnect if closed connection
+- [#15724](https://github.com/influxdata/telegraf/pull/15724) `inputs.smartctl` Use --scan-open instead of --scan to provide correct device type info
+- [#15649](https://github.com/influxdata/telegraf/pull/15649) `inputs.tail` Prevent deadlock when closing and max undelivered lines hit
+
+### Dependency Updates
+
+- [#15720](https://github.com/influxdata/telegraf/pull/15720) `deps` Bump Go from v1.22.5 to v1.22.6
+- [#15683](https://github.com/influxdata/telegraf/pull/15683) `deps` Bump cloud.google.com/go/bigquery from 1.61.0 to 1.62.0
+- [#15654](https://github.com/influxdata/telegraf/pull/15654) `deps` Bump cloud.google.com/go/monitoring from 1.19.0 to 1.20.2
+- [#15679](https://github.com/influxdata/telegraf/pull/15679) `deps` Bump cloud.google.com/go/monitoring from 1.20.2 to 1.20.3
+- [#15626](https://github.com/influxdata/telegraf/pull/15626) `deps` Bump github.com/antchfx/xmlquery from 1.4.0 to 1.4.1
+- [#15706](https://github.com/influxdata/telegraf/pull/15706) `deps` Bump github.com/apache/iotdb-client-go from 1.2.0-tsbs to 1.3.2
+- [#15651](https://github.com/influxdata/telegraf/pull/15651) `deps` Bump github.com/aws/aws-sdk-go-v2/credentials from 1.17.17 to 1.17.27
+- [#15703](https://github.com/influxdata/telegraf/pull/15703) `deps` Bump github.com/aws/aws-sdk-go-v2/service/kinesis from v1.27.4 to v1.29.3
+- [#15681](https://github.com/influxdata/telegraf/pull/15681) `deps` Bump github.com/docker/docker from 25.0.5-incompatible to 27.1.1-incompatible
+- [#15650](https://github.com/influxdata/telegraf/pull/15650) `deps` Bump github.com/gofrs/uuid/v5 from 5.0.0 to 5.2.0
+- [#15705](https://github.com/influxdata/telegraf/pull/15705) `deps` Bump github.com/gorilla/websocket from 1.5.1 to 1.5.3
+- [#15708](https://github.com/influxdata/telegraf/pull/15708) `deps` Bump github.com/multiplay/go-ts3 from 1.1.0 to 1.2.0
+- [#15707](https://github.com/influxdata/telegraf/pull/15707) `deps` Bump github.com/prometheus-community/pro-bing from 0.4.0 to 0.4.1
+- [#15709](https://github.com/influxdata/telegraf/pull/15709) `deps` Bump github.com/prometheus/prometheus from 0.48.1 to 0.53.1
+- [#15680](https://github.com/influxdata/telegraf/pull/15680) `deps` Bump github.com/vmware/govmomi from 0.37.2 to 0.39.0
+- [#15682](https://github.com/influxdata/telegraf/pull/15682) `deps` Bump go.mongodb.org/mongo-driver from 1.14.0 to 1.16.0
+- [#15652](https://github.com/influxdata/telegraf/pull/15652) `deps` Bump go.step.sm/crypto from 0.47.1 to 0.50.0
+- [#15653](https://github.com/influxdata/telegraf/pull/15653) `deps` Bump google.golang.org/grpc from 1.64.1 to 1.65.0
+- [#15704](https://github.com/influxdata/telegraf/pull/15704) `deps` Bump super-linter/super-linter from 6.7.0 to 6.8.0
+
+## v1.31.2 {date="2024-07-22"}
+
+### Bugfixes
+
+- [#15589](https://github.com/influxdata/telegraf/pull/15589) `common.socket` Switch to context to simplify closing
+- [#15601](https://github.com/influxdata/telegraf/pull/15601) `inputs.ping` Check addr length to avoid crash
+- [#15618](https://github.com/influxdata/telegraf/pull/15618) `inputs.snmp` Translate field correctly when not in table
+- [#15586](https://github.com/influxdata/telegraf/pull/15586) `parsers.xpath` Allow resolving extensions
+- [#15630](https://github.com/influxdata/telegraf/pull/15630) `tools.custom_builder` Handle multiple instances of the same plugin correctly
+
+### Dependency Updates
+
+- [#15582](https://github.com/influxdata/telegraf/pull/15582) `deps` Bump cloud.google.com/go/storage from 1.41.0 to 1.42.0
+- [#15623](https://github.com/influxdata/telegraf/pull/15623) `deps` Bump cloud.google.com/go/storage from 1.42.0 to 1.43.0
+- [#15607](https://github.com/influxdata/telegraf/pull/15607) `deps` Bump github.com/alitto/pond from 1.8.3 to 1.9.0
+- [#15625](https://github.com/influxdata/telegraf/pull/15625) `deps` Bump github.com/antchfx/xpath from 1.3.0 to 1.3.1
+- [#15622](https://github.com/influxdata/telegraf/pull/15622) `deps` Bump github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs from 1.34.3 to 1.37.3
+- [#15606](https://github.com/influxdata/telegraf/pull/15606) `deps` Bump github.com/hashicorp/consul/api from 1.26.1 to 1.29.1
+- [#15604](https://github.com/influxdata/telegraf/pull/15604) `deps` Bump github.com/jackc/pgx/v4 from 4.18.2 to 4.18.3
+- [#15581](https://github.com/influxdata/telegraf/pull/15581) `deps` Bump github.com/nats-io/nats-server/v2 from 2.10.16 to 2.10.17
+- [#15603](https://github.com/influxdata/telegraf/pull/15603) `deps` Bump github.com/openconfig/goyang from 1.0.0 to 1.5.0
+- [#15624](https://github.com/influxdata/telegraf/pull/15624) `deps` Bump github.com/sijms/go-ora/v2 from 2.8.4 to 2.8.19
+- [#15585](https://github.com/influxdata/telegraf/pull/15585) `deps` Bump github.com/testcontainers/testcontainers-go/modules/kafka from 0.30.0 to 0.31.0
+- [#15605](https://github.com/influxdata/telegraf/pull/15605) `deps` Bump github.com/tinylib/msgp from 1.1.9 to 1.2.0
+- [#15584](https://github.com/influxdata/telegraf/pull/15584) `deps` Bump github.com/urfave/cli/v2 from 2.27.1 to 2.27.2
+- [#15614](https://github.com/influxdata/telegraf/pull/15614) `deps` Bump google.golang.org/grpc from 1.64.0 to 1.64.1
+- [#15608](https://github.com/influxdata/telegraf/pull/15608) `deps` Bump super-linter/super-linter from 6.6.0 to 6.7.0
+
+For versions earlier than v1.13 and earlier see
+[CHANGELOG-1.13.md](CHANGELOG-1.13.md).
+
+## v1.31.1 {date="2024-07-01"}
+
+### Bugfixes
+
+- [#15488](https://github.com/influxdata/telegraf/pull/15488) `agent` Ignore startup-errors in test mode
+- [#15568](https://github.com/influxdata/telegraf/pull/15568) `inputs.chrony` Handle ServerStats4 response
+- [#15551](https://github.com/influxdata/telegraf/pull/15551) `inputs.chrony` Support local (reference) sources
+- [#15565](https://github.com/influxdata/telegraf/pull/15565) `inputs.gnmi` Handle YANG namespaces in paths correctly
+- [#15496](https://github.com/influxdata/telegraf/pull/15496) `inputs.http_response` Fix for IPv4 and IPv6 addresses when interface is set
+- [#15493](https://github.com/influxdata/telegraf/pull/15493) `inputs.mysql` Handle custom TLS configs correctly
+- [#15514](https://github.com/influxdata/telegraf/pull/15514) `logging` Add back constants for backward compatibility
+- [#15531](https://github.com/influxdata/telegraf/pull/15531) `secretstores.oauth2` Ensure endpoint params is not nil
+
+### Dependency Updates
+
+- [#15483](https://github.com/influxdata/telegraf/pull/15483) `deps` Bump cloud.google.com/go/monitoring from 1.18.1 to 1.19.0
+- [#15559](https://github.com/influxdata/telegraf/pull/15559) `deps` Bump github.com/Azure/azure-kusto-go from 0.15.2 to 0.15.3
+- [#15489](https://github.com/influxdata/telegraf/pull/15489) `deps` Bump github.com/Azure/azure-sdk-for-go/sdk/azidentity from 1.5.1 to 1.6.0
+- [#15560](https://github.com/influxdata/telegraf/pull/15560) `deps` Bump github.com/Azure/go-autorest/autorest/azure/auth from 0.5.12 to 0.5.13
+- [#15480](https://github.com/influxdata/telegraf/pull/15480) `deps` Bump github.com/IBM/sarama from 1.43.1 to 1.43.2
+- [#15526](https://github.com/influxdata/telegraf/pull/15526) `deps` Bump github.com/aws/aws-sdk-go-v2/service/cloudwatch from 1.37.0 to 1.38.7
+- [#15527](https://github.com/influxdata/telegraf/pull/15527) `deps` Bump github.com/aws/aws-sdk-go-v2/service/dynamodb from 1.30.2 to 1.32.9
+- [#15558](https://github.com/influxdata/telegraf/pull/15558) `deps` Bump github.com/aws/aws-sdk-go-v2/service/dynamodb from 1.32.9 to 1.33.2
+- [#15448](https://github.com/influxdata/telegraf/pull/15448) `deps` Bump github.com/aws/aws-sdk-go-v2/service/ec2 from 1.161.1 to 1.162.1
+- [#15557](https://github.com/influxdata/telegraf/pull/15557) `deps` Bump github.com/go-ldap/ldap/v3 from 3.4.6 to 3.4.8
+- [#15523](https://github.com/influxdata/telegraf/pull/15523) `deps` Bump github.com/linkedin/goavro/v2 from 2.12.0 to 2.13.0
+- [#15484](https://github.com/influxdata/telegraf/pull/15484) `deps` Bump github.com/microsoft/go-mssqldb from 1.7.0 to 1.7.2
+- [#15561](https://github.com/influxdata/telegraf/pull/15561) `deps` Bump github.com/nats-io/nats-server/v2 from 2.10.14 to 2.10.16
+- [#15524](https://github.com/influxdata/telegraf/pull/15524) `deps` Bump github.com/prometheus/common from 0.53.0 to 0.54.0
+- [#15481](https://github.com/influxdata/telegraf/pull/15481) `deps` Bump github.com/prometheus/procfs from 0.15.0 to 0.15.1
+- [#15482](https://github.com/influxdata/telegraf/pull/15482) `deps` Bump github.com/rabbitmq/amqp091-go from 1.9.0 to 1.10.0
+- [#15525](https://github.com/influxdata/telegraf/pull/15525) `deps` Bump go.step.sm/crypto from 0.44.1 to 0.47.1
+- [#15479](https://github.com/influxdata/telegraf/pull/15479) `deps` Bump super-linter/super-linter from 6.5.1 to 6.6.0
+
 ## v1.31.0 {date="2024-06-10"}
 
 ### Important Changes

--- a/data/products.yml
+++ b/data/products.yml
@@ -75,9 +75,9 @@ telegraf:
   menu_category: other
   list_order: 6
   versions: [v1]
-  latest: v1.31
+  latest: v1.32
   latest_patches:
-    v1: 1.31.3
+    v1: 1.32.0
 
 chronograf:
   name: Chronograf

--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -1689,7 +1689,7 @@ input:
     tags: [linux, macos, windows, messaging]
 
   - name: Radius
-    id: Radius
+    id: radius
     description: |
       Collects authentication response time metrics from Radius.
     introduced: 1.26.0
@@ -2668,13 +2668,6 @@ output:
     introduced: 1.19.0
     tags: [web, servers]
 
-  - name: XML
-    id: xml
-    description: |
-      The XML parser plugin parses an XML string into metric fields using XPath expressions.
-    introduced: 1.18.0
-    tags: []
-
   - name: Yandex Cloud Monitoring
     id: yandex_cloud_monitoring
     description: |
@@ -2785,7 +2778,7 @@ aggregator:
 
 processor:
   - name: AWS EC2 Metadata
-    id: aws/ec2
+    id: aws_ec2
     description: |
       The AWS EC2 Metadata processor plugin appends metadata gathered from [AWS IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) to metrics associated with EC2 instances.
     introduced: 1.18.0

--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -2575,9 +2575,7 @@ output:
   - name: Parquet
     id: parquet
     description: |
-      This plugin writes metrics to parquet files. By default, the parquet
-      output groups metrics by metric name and write those metrics all to the
-      same file. If a metric schema does not match then metrics are dropped.
+      This plugin writes metrics to parquet files. By default, it groups metrics by name, and then writes each group to a separate file. If a metric schema doesn't match, the metrics are dropped.
     introduced: 1.32.0
     tags: [linux, macos, windows, data-stores]
 

--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -1035,7 +1035,7 @@ input:
     introduced: 1.10.0
     tags: [linux, macos, windows, build-deploy, containers]
 
-  - name: ldap
+  - name: LDAP
     id: ldap
     description: |
       This plugin gathers metrics from LDAP servers' monitoring (cn=Monitor) backend.
@@ -1737,6 +1737,14 @@ input:
     introduced: 0.1.1
     tags: [linux, macos, windows, data-stores]
 
+  - name: Redis sentinel
+    id: redis_sentinel
+    description: |
+      A plugin for Redis Sentinel to monitor multiple Sentinel instances that
+      are monitoring multiple Redis servers and replicas.
+    introduced: 1.22.0
+    tags: [linux, macos, windows]
+
   - name: RethinkDB
     id: rethinkdb
     description: |
@@ -1797,7 +1805,7 @@ input:
       This plugin gathers information from Siemens PLC (Programmatic Logic Controller).
     introduced: 1.28.0
     link: https://github.com/nicolasme/s7comm/blob/main/README.md
-    tags: [serial, iot]
+    tags: [linux, macos, windows, iot]
 
   - name: Slab
     id: slab
@@ -1806,6 +1814,14 @@ input:
     introduced: 1.23.0
     link: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/slab/README.md
     tags: [linux, system]
+
+  - name: SLURM
+    id: slurm
+    description: |
+      This plugin gather diag, jobs, nodes, partitions and reservation metrics
+      by leveraging SLURM's REST API as provided by the slurmrestd daemon
+    introduced: 1.32.0
+    tags: [linux, macos, windows]
 
   - name: S.M.A.R.T.
     id: smart
@@ -2431,6 +2447,14 @@ output:
     introduced: 0.13.1
     tags: [linux, macos, windows, applications]
 
+  - name: IoTDB
+    id: iotdb
+    description: |
+      This output plugin saves Telegraf metrics to an Apache IoTDB backend,
+      supporting session connection and data insertion.
+    introduced: 1.24.0
+    tags: [linux, macos, windows, data-stores]
+
   - name: Librato
     id: librato
     description: |
@@ -2548,6 +2572,15 @@ output:
     introduced: 0.1.9
     tags: [linux, macos, windows, data-stores]
 
+  - name: Parquet
+    id: parquet
+    description: |
+      This plugin writes metrics to parquet files. By default, the parquet
+      output groups metrics by metric name and write those metrics all to the
+      same file. If a metric schema does not match then metrics are dropped.
+    introduced: 1.32.0
+    tags: [linux, macos, windows, data-stores]
+
   - name: Postgre SQL
     id: postgresql
     description: |
@@ -2563,12 +2596,21 @@ output:
     introduced: 0.2.1
     tags: [linux, macos, windows, applications]
 
-  - name: RedisTimeSeries
+  - name: Redis time series
     id: redistimeseries
     description: |
-      The RedisTimeSeries output plugin writes metrics to the RedisTimeSeries server.
+      The Redis time series output plugin writes metrics to the RedisTimeSeries server.
     introduced: 1.24.0
     tags: [linux, macos, windows, networking]
+
+  - name: Remote file
+    id: remotefile
+    description: |
+      This plugin writes telegraf metrics to files in remote locations using
+      the rclone library. Multiple backends such as Amazon S3 or SFTP are
+      supported.
+    introduced: 1.32.0
+    tags: [linux, macos, windows, data-stores]
 
   - name: Riemann
     id: riemann
@@ -2674,6 +2716,15 @@ output:
       The Yandex Cloud Monitoring output plugin sends custom metrics to Yandex Cloud Monitoring.
     introduced: 1.17.0
     tags: [linux, macos, windows]
+
+  - name: Zabbix
+    id: zabbix
+    description: |
+      This plugin send metrics to Zabbix via traps. It has been tested with
+      versions 3.0, 4.0 and 6.0. It should work with newer versions as long as
+      Zabbix does not change the protocol.
+    introduced: 1.30.0
+    tags: [linux, macos, windows, data-stores]
 
 #    %%%%    %%%%    %%%%   %%%%%   %%%%%%   %%%%    %%%%   %%%%%%   %%%%   %%%%%    %%%%    #
 #   %%  %%  %%      %%      %%  %%  %%      %%      %%  %%    %%    %%  %%  %%  %%  %%       #
@@ -2978,6 +3029,13 @@ processor:
     description: |
       Processor to scale values from a specified range into another range
     introduced: 1.27.0
+    tags: [linux, macos, windows]
+
+  - name: SNMP lookup
+    id: snmp_lookup
+    description: |
+      Processor to look-up extra tags using SNMP
+    introduced: 1.30.0
     tags: [linux, macos, windows]
 
   - name: Split


### PR DESCRIPTION
Closes #

This PR documents missing v1.31.x releases, adds Telegraf v1.32.0 and tags this release as the latest. It also fixes the `telegraf-plugins.yml` list of plugins by adding missing plugins and fix typos in plugin `id`s.

- [x] Rebased/mergeable
