### PR TITLE
fix(v2): API nav items and v1 compat

### DIFF
--- a/content/influxdb/cloud/api-guide/influxdb-1x/_index.md
+++ b/content/influxdb/cloud/api-guide/influxdb-1x/_index.md
@@ -6,11 +6,13 @@ description: >
 menu:
   influxdb_cloud:
     name: v1 compatibility
-    parent: InfluxDB v2 API
+    parent: Develop with the API
 weight: 104
 influxdb/cloud/tags: [influxql, query, write]
 related:
   - /influxdb/cloud/query-data/influxql
+alias:
+  - /influxdb/cloud/reference/api/influxdb-1x/
 ---
 
 {{< duplicate-oss >}}

--- a/content/influxdb/cloud/api-guide/influxdb-1x/dbrp.md
+++ b/content/influxdb/cloud/api-guide/influxdb-1x/dbrp.md
@@ -13,6 +13,8 @@ related:
   - /influxdb/cloud/reference/api/influxdb-1x/write
   - /influxdb/cloud/api/#tag/DBRPs, InfluxDB v2 API /dbrps endpoint
   - /influxdb/cloud/query-data/influxql/
+alias:
+  - /influxdb/cloud/reference/api/influxdb-1x/dbrp/
 ---
 
 {{% duplicate-oss %}}

--- a/content/influxdb/cloud/api-guide/influxdb-1x/query.md
+++ b/content/influxdb/cloud/api-guide/influxdb-1x/query.md
@@ -15,6 +15,8 @@ list_code_example: |
   </pre>
 related:
   - /influxdb/cloud/query-data/influxql
+alias:
+  - /influxdb/cloud/reference/api/influxdb-1x/query/
 ---
 
 {{% duplicate-oss %}}

--- a/content/influxdb/cloud/api-guide/influxdb-1x/write.md
+++ b/content/influxdb/cloud/api-guide/influxdb-1x/write.md
@@ -16,6 +16,8 @@ list_code_example: |
   </pre>
 related:
   - /influxdb/cloud/reference/syntax/line-protocol
+alias:
+  - /influxdb/cloud/reference/api/influxdb-1x/write/
 ---
 
 {{% duplicate-oss %}}

--- a/content/influxdb/cloud/reference/api/_index.md
+++ b/content/influxdb/cloud/reference/api/_index.md
@@ -1,11 +1,13 @@
 ---
-title: InfluxDB v2 API
+title: InfluxDB HTTP API
 description: >
-  The InfluxDB v2 API provides a programmatic interface for interactions with InfluxDB.
+  The InfluxDB HTTP API provides a programmatic interface for interactions with InfluxDB, such as writing and querying data,
+  and managing resources within an InfluxDB instance.
   Access the InfluxDB API using the `/api/v2/` endpoint.
 menu:
   influxdb_cloud:
     parent: Reference
+    name: InfluxDB HTTP API
 weight: 3
 influxdb/cloud/tags: [api]
 ---

--- a/content/influxdb/v2/api-guide/influxdb-1x/_index.md
+++ b/content/influxdb/v2/api-guide/influxdb-1x/_index.md
@@ -6,12 +6,14 @@ description: >
 menu:
   influxdb_v2:
     name: v1 compatibility
-    parent: InfluxDB v2 API
+    parent: Develop with the API
 weight: 104
 influxdb/v2/tags: [influxql, query, write]
 related:
   - /influxdb/v2/query-data/influxql
   - /influxdb/v2/install/upgrade/v1-to-v2/
+alias:
+  - /influxdb/v2/reference/api/influxdb-1x/
 ---
 
 The InfluxDB v2 API includes InfluxDB 1.x compatibility endpoints that work with
@@ -37,7 +39,7 @@ Use the `Authorization` header with the `Token` scheme to provide your token to 
 
 #### Syntax
 
-```sh
+```http
 Authorization: Token INFLUX_API_TOKEN
 ```
 
@@ -49,6 +51,9 @@ Authorization: Token INFLUX_API_TOKEN
 [Node.js](#nodejs)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
+
+<!--pytest.mark.skip-->
+
 ```sh
 {{% get-shared-text "api/v1-compat/auth/oss/token-auth.sh" %}}
 ```
@@ -77,21 +82,21 @@ Username and password schemes require the following credentials:
 
 {{% note %}}
 #### Password or Token
-If you have [set a password](/influxdb/v2/upgrade/v1-to-v2/manual-upgrade/#1x-compatible-authorizations) for the 1.x-compatible username, provide the 1.x-compatible password.
+
+If you have [set a password](/influxdb/v2/install/upgrade/v1-to-v2/manual-upgrade/#1x-compatible-authorizations) for the 1.x-compatible username, provide the 1.x-compatible password.
 If you haven't set a password for the 1.x-compatible username, provide the InfluxDB [authentication token](/influxdb/v2/admin/tokens/) as the password.
 {{% /note %}}
 
-For information about creating and managing 1.x-compatible authorizations, see:
-
-- [`influx v1 auth` command](/influxdb/v2/reference/cli/influx/v1/auth/)
-- [Manually upgrade – 1.x-compatible authorizations](/influxdb/v2/upgrade/v1-to-v2/manual-upgrade/#1x-compatible-authorizations)
+For more information, see how to create and manage
+[1.x-compatible authorizations](/influxdb/v2/install/upgrade/v1-to-v2/manual-upgrade/#1x-compatible-authorizations)
+when manually upgrading from InfluxDB v1 to v2.
 
 {{% /oss-only %}}
 
 {{% cloud-only %}}
 
 - **username**: InfluxDB Cloud username
-  (Use the email address you signed up with as your username, _e.g._ `exampleuser@influxdata.com`.)
+  (Use the email address you signed up with as your username--for example, `exampleuser@influxdata.com`.)
 - **password**: InfluxDB Cloud [API token](/influxdb/cloud/admin/tokens/)
 
 {{% /cloud-only %}}
@@ -107,7 +112,7 @@ password credentials to InfluxDB.
 
 {{% oss-only %}}
 
-```sh
+```http
 Authorization: Basic INFLUX_USERNAME:INFLUX_PASSWORD_OR_TOKEN
 ```
 
@@ -116,13 +121,15 @@ Authorization: Basic INFLUX_USERNAME:INFLUX_PASSWORD_OR_TOKEN
 
 {{% cloud-only %}}
 
-```sh
+```http
 Authorization: Basic exampleuser@influxdata.com:INFLUX_API_TOKEN
 ```
 
 {{% /cloud-only %}}
 
 ##### Example
+
+{{% code-placeholders "INFLUX_(USERNAME|PASSWORD_OR_TOKEN|API_TOKEN)|exampleuser@influxdata.com" %}}
 
 {{% oss-only %}}
 
@@ -132,6 +139,9 @@ Authorization: Basic exampleuser@influxdata.com:INFLUX_API_TOKEN
 [Node.js](#nodejs)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
+
+<!--pytest.mark.skip-->
+
 ```sh
 {{% get-shared-text "api/v1-compat/auth/oss/basic-auth.sh" %}}
 ```
@@ -154,6 +164,9 @@ Authorization: Basic exampleuser@influxdata.com:INFLUX_API_TOKEN
 [Node.js](#nodejs)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
+
+<!--pytest.mark.skip-->
+
 ```sh
 {{% get-shared-text "api/v1-compat/auth/cloud/basic-auth.sh" %}}
 ```
@@ -167,8 +180,8 @@ Authorization: Basic exampleuser@influxdata.com:INFLUX_API_TOKEN
 {{< /code-tabs-wrapper >}}
 
 Replace the following:
-- *`exampleuser@influxdata.com`*: the email address that you signed up with
-- *`INFLUX_API_TOKEN`*: your [InfluxDB API token](/influxdb/cloud/reference/glossary/#token)
+- {{% code-placeholder-key %}}`exampleuser@influxdata.com`{{% /code-placeholder-key %}}: the email address that you signed up with
+- {{% code-placeholder-key %}}`INFLUX_API_TOKEN`{{% /code-placeholder-key %}}: your [InfluxDB API token](/influxdb/cloud/reference/glossary/#token)
 
 {{% /cloud-only %}}
 
@@ -186,7 +199,7 @@ Use InfluxDB 1.x API parameters to provide credentials through the query string.
 
 {{% oss-only %}}
 
-```sh
+```http
  /query/?u=INFLUX_USERNAME&p=INFLUX_PASSWORD_OR_TOKEN
  /write/?u=INFLUX_USERNAME&p=INFLUX_PASSWORD_OR_TOKEN
  ```
@@ -195,7 +208,7 @@ Use InfluxDB 1.x API parameters to provide credentials through the query string.
 
 {{% cloud-only %}}
 
-```sh
+```http
 /query/?u=INFLUX_USERNAME&p=INFLUX_API_TOKEN
 /write/?u=INFLUX_USERNAME&p=INFLUX_API_TOKEN
 ```
@@ -211,6 +224,9 @@ Use InfluxDB 1.x API parameters to provide credentials through the query string.
 [Node.js](#nodejs)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
+
+<!--pytest.mark.skip-->
+
 ```sh
 {{< get-shared-text "api/v1-compat/auth/oss/querystring-auth.sh" >}}
 ```
@@ -223,8 +239,8 @@ Use InfluxDB 1.x API parameters to provide credentials through the query string.
 {{< /code-tabs-wrapper >}}
 
 Replace the following:
-- *`INFLUX_USERNAME`*: [InfluxDB 1.x username](#manage-credentials)
-- *`INFLUX_PASSWORD_OR_TOKEN`*: [InfluxDB 1.x password or InfluxDB API token](#manage-credentials)
+- {{% code-placeholder-key %}}`INFLUX_USERNAME`{{% /code-placeholder-key %}}: [InfluxDB 1.x username](#manage-credentials)
+- {{% code-placeholder-key %}}`INFLUX_PASSWORD_OR_TOKEN`{{% /code-placeholder-key %}}: [InfluxDB 1.x password or InfluxDB API token](#manage-credentials)
 
 {{% /oss-only %}}
 
@@ -236,6 +252,9 @@ Replace the following:
 [Node.js](#nodejs)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
+
+<!--pytest.mark.skip-->
+
 ```sh
 {{% get-shared-text "api/v1-compat/auth/cloud/basic-auth.sh" %}}
 ```
@@ -248,9 +267,11 @@ Replace the following:
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
 
+{{% /code-placeholders %}}
+
 Replace the following:
-- *`exampleuser@influxdata.com`*: the email address that you signed up with
-- *`INFLUX_API_TOKEN`*: your [InfluxDB API token](/influxdb/cloud/reference/glossary/#token)
+- {{% code-placeholder-key %}}`exampleuser@influxdata.com`{{% /code-placeholder-key %}}: the email address that you signed up with
+- {{% code-placeholder-key %}}`INFLUX_API_TOKEN`{{% /code-placeholder-key %}}: your [InfluxDB API token](/influxdb/cloud/reference/glossary/#token)
 
 {{% /cloud-only %}}
 
@@ -258,7 +279,7 @@ Replace the following:
 
 The compatibility API supports InfluxQL, with the following caveats:
 
-- The `INTO` clause (e.g. `SELECT ... INTO ...`) is not supported.
+- The `INTO` clause (for example, `SELECT ... INTO ...`) is not supported.
 - With the exception of [`DELETE`](/influxdb/v1/query_language/manage-database/#delete-series-with-delete) and
   [`DROP MEASUREMENT`](/influxdb/v1/query_language/manage-database/#delete-measurements-with-drop-measurement) queries, which are still allowed,
   InfluxQL database management commands are not supported.

--- a/content/influxdb/v2/api-guide/influxdb-1x/dbrp.md
+++ b/content/influxdb/v2/api-guide/influxdb-1x/dbrp.md
@@ -13,6 +13,8 @@ related:
   - /influxdb/v2/reference/api/influxdb-1x/write
   - /influxdb/v2/api/#tag/DBRPs, InfluxDB v2 API /dbrps endpoint
   - /influxdb/v2/query-data/influxql/
+alias:
+  - /influxdb/v2/reference/api/influxdb-1x/dbrp/
 ---
 
 The InfluxDB 1.x data model includes [databases](/influxdb/v1/concepts/glossary/#database)
@@ -82,9 +84,10 @@ the DBRP mapping service checks for a bucket mapped to the database and retentio
 
 - If a mapped bucket is found, data is written to the bucket.
 - If an unmapped bucket with a name matching:
-    - **database/retention policy** exists, a DBRP mapping is added to the bucket,
+
+    - `database/retention policy` exists, a DBRP mapping is added to the bucket,
       and data is written to the bucket.
-    - **database** exists (without a specified retention policy), the default
+    - `database` exists (without a specified retention policy), the default
       database retention policy is used, a DBRP mapping is added to the bucket,
       and data is written to the bucket.
 

--- a/content/influxdb/v2/api-guide/influxdb-1x/query.md
+++ b/content/influxdb/v2/api-guide/influxdb-1x/query.md
@@ -15,6 +15,8 @@ list_code_example: |
   </pre>
 related:
   - /influxdb/v2/query-data/influxql
+alias:
+  - /influxdb/v2/reference/api/influxdb-1x/query/
 ---
 
 The `/query` 1.x compatibility endpoint queries InfluxDB {{< current-version >}} using **InfluxQL**.
@@ -92,6 +94,8 @@ The following precisions are available:
 - [Return query results with millisecond Unix timestamps](#return-query-results-with-millisecond-unix-timestamps)
 - [Execute InfluxQL queries from a file](#execute-influxql-queries-from-a-file)
 
+{{% code-placeholders "API_TOKEN" %}}
+
 ##### Query using basic authentication
 
 {{% oss-only %}}
@@ -102,6 +106,9 @@ The following precisions are available:
 [Node.js](#nodejs)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
+
+<!--pytest.mark.skip-->
+
 ```sh
 {{% get-shared-text "api/v1-compat/auth/oss/basic-auth.sh" %}}
 ```
@@ -123,6 +130,9 @@ The following precisions are available:
 [Node.js](#nodejs)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
+
+<!--pytest.mark.skip-->
+
 ```sh
 {{% get-shared-text "api/v1-compat/auth/cloud/basic-auth.sh" %}}
 ```
@@ -138,18 +148,34 @@ The following precisions are available:
 {{% /cloud-only %}}
 
 ##### Query a non-default retention policy
+
+<!--test:setup
+
+```sh
+service influxdb start && \
+influx setup \
+  --username USERNAME \
+  --token API_TOKEN \
+  --org ORG_NAME \
+  --bucket BUCKET_NAME \
+  --force || true
+```
+
+-->
+
 ```sh
 curl --get http://localhost:8086/query \
-  --header "Authorization: Token INFLUX_API_TOKEN" \
+  --header "Authorization: Token API_TOKEN" \
   --data-urlencode "db=mydb" \
   --data-urlencode "rp=customrp" \
   --data-urlencode "q=SELECT used_percent FROM mem WHERE host=host1"
 ```
 
 ##### Execute multiple queries
+
 ```sh
 curl --get http://localhost:8086/query \
-  --header "Authorization: Token INFLUX_API_TOKEN" \
+  --header "Authorization: Token API_TOKEN" \
   --data-urlencode "db=mydb" \
   --data-urlencode "q=SELECT * FROM mem WHERE host=host1;SELECT mean(used_percent) FROM mem WHERE host=host1 GROUP BY time(10m)"
 ```
@@ -157,7 +183,7 @@ curl --get http://localhost:8086/query \
 ##### Return query results with millisecond Unix timestamps
 ```sh
 curl --get http://localhost:8086/query \
-  --header "Authorization: Token INFLUX_API_TOKEN" \
+  --header "Authorization: Token API_TOKEN" \
   --data-urlencode "db=mydb" \
   --data-urlencode "rp=myrp" \
   --data-urlencode "q=SELECT used_percent FROM mem WHERE host=host1" \
@@ -167,11 +193,14 @@ curl --get http://localhost:8086/query \
 ##### Execute InfluxQL queries from a file
 ```sh
 curl --get http://localhost:8086/query \
-  --header "Authorization: Token INFLUX_API_TOKEN" \
+  --header "Authorization: Token API_TOKEN" \
   --data-urlencode "db=mydb" \
   --data-urlencode "q@path/to/influxql.txt" \
   --data-urlencode "async=true"
 ```
 
+{{% /code-placeholders %}}
+
 Replace the following:
-- *`INFLUX_API_TOKEN`*: InfluxDB API token
+
+- {{% code-placeholder-key %}}`API_TOKEN`{{% /code-placeholder-key %}}: your InfluxDB [API token](/influxdb/v2/admin/tokens/)

--- a/content/influxdb/v2/api-guide/influxdb-1x/write.md
+++ b/content/influxdb/v2/api-guide/influxdb-1x/write.md
@@ -16,6 +16,8 @@ list_code_example: |
   </pre>
 related:
   - /influxdb/v2/reference/syntax/line-protocol
+alias:
+  - /influxdb/v2/reference/api/influxdb-1x/write/
 ---
 
 The `/write` 1.x compatibility endpoint writes data to InfluxDB Cloud and InfluxDB OSS {{< current-version >}}
@@ -30,8 +32,8 @@ to the `/write` endpoint.
 {{% cloud-only %}}
 
 {{% note %}}
-If you have an existing bucket that doesn't follow the **database/retention-policy** naming convention,
-you **must** [manually create a database and retention policy mapping](/influxdb/v2/query-data/influxql/dbrp/#create-dbrp-mappings)
+If you have an existing bucket that doesn't follow the `database/retention-policy` naming convention,
+you _must_ [manually create a database and retention policy mapping](/influxdb/v2/query-data/influxql/dbrp/#create-dbrp-mappings)
 to write data to that bucket with the `/write` compatibility API.
 {{% /note %}}
 
@@ -42,9 +44,9 @@ to write data to that bucket with the `/write` compatibility API.
 {{% oss-only %}}
 
 Use one of the following authentication methods:
-* **token authentication**
-* **basic authentication with username and password**
-* **query string authentication with username and password**
+- **token authentication**
+- **basic authentication with username and password**
+- **query string authentication with username and password**
 
 _For more information, see [Authentication](/influxdb/v2/reference/api/influxdb-1x/#authentication)._
 
@@ -120,79 +122,112 @@ The following precisions are available:
 
 ##### Write data using basic authentication
 
-{{% oss-only %}}
+<!--test:setup
 
 ```sh
-curl --request POST http://localhost:8086/write?db=mydb \
-  --user "INFLUX_USERNAME:INFLUX_PASSWORD_OR_TOKEN" \
+service influxdb start && \
+influx setup \
+  --username USERNAME \
+  --token API_TOKEN \
+  --org ORG_NAME \
+  --bucket BUCKET_NAME \
+  --force || true
+```
+
+-->
+
+{{% oss-only %}}
+
+{{% code-placeholders "DATABASE_NAME|USERNAME|PASSWORD_OR_TOKEN|API_TOKEN|exampleuser@influxdata.com" %}}
+```sh
+curl --request POST http://localhost:8086/write?db=DATABASE_NAME \
+  --user "USERNAME:PASSWORD_OR_TOKEN" \
   --data-binary "measurement,host=host1 field1=2i,field2=2.0 1577836800000000000"
 ```
+{{% /code-placeholders %}}
 
 {{% /oss-only %}}
 
 {{% cloud-only %}}
-
+{{% code-placeholders "DATABASE_NAME|USERNAME|PASSWORD_OR_TOKEN|API_TOKEN|exampleuser@influxdata.com" %}}
 ```sh
-curl --request POST https://cloud2.influxdata.com/write?db=mydb \
-  --user "exampleuser@influxdata.com:INFLUX_API_TOKEN" \
+curl --request POST https://cloud2.influxdata.com/write?db=DATABASE_NAME \
+  --user "exampleuser@influxdata.com:API_TOKEN" \
   --data-binary "measurement,host=host1 field1=2i,field2=2.0 1577836800000000000"
 ```
+{{% /code-placeholders %}}
 
 {{% /cloud-only %}}
 
 ##### Write data using token authentication
+
+{{% code-placeholders "DATABASE_NAME|USERNAME|PASSWORD_OR_TOKEN|API_TOKEN|exampleuser@influxdata.com" %}}
 ```sh
-curl --request POST http://localhost:8086/write?db=mydb \
-  --header "Authorization: Token INFLUX_API_TOKEN" \
+curl --request POST http://localhost:8086/write?db=DATABASE_NAME \
+  --header "Authorization: Token API_TOKEN" \
   --data-binary "measurement,host=host1 field1=2i,field2=2.0 1577836800000000000"
 ```
+{{% /code-placeholders %}}
 
 ##### Write data to a non-default retention policy
 
+{{% code-placeholders "DATABASE_NAME|USERNAME|PASSWORD_OR_TOKEN|API_TOKEN|exampleuser@influxdata.com" %}}
 ```sh
-curl --request POST http://localhost:8086/write?db=mydb&rp=customrp \
-  --header "Authorization: Token INFLUX_API_TOKEN" \
+curl --request POST "http://localhost:8086/write?db=DATABASE_NAME&rp=RETENTION_POLICY" \
+  --header "Authorization: Token API_TOKEN" \
   --data-binary "measurement,host=host1 field1=2i,field2=2.0 1577836800000000000"
 ```
-
-
+{{% /code-placeholders %}}
 
 ##### Write multiple lines of line protocol
+
+{{% code-placeholders "DATABASE_NAME|USERNAME|PASSWORD_OR_TOKEN|API_TOKEN|exampleuser@influxdata.com" %}}
 ```sh
-curl --request POST http://localhost:8086/write?db=mydb \
-  --header "Authorization: Token INFLUX_API_TOKEN" \
+curl --request POST http://localhost:8086/write?db=DATABASE_NAME \
+  --header "Authorization: Token API_TOKEN" \
   --data-binary "measurement,host=host1 field1=2i,field2=2.0 1577836800000000000
 measurement,host=host2 field1=14i,field2=12.7 1577836800000000000
 measurement,host=host3 field1=5i,field2=6.8 1577836800000000000"
 ```
+{{% /code-placeholders %}}
 
 ##### Write data with millisecond Unix timestamps
+
+{{% code-placeholders "DATABASE_NAME|USERNAME|PASSWORD_OR_TOKEN|API_TOKEN|exampleuser@influxdata.com" %}}
 ```sh
-curl --request POST http://localhost:8086/write?db=mydb&precision=ms \
-  --header "Authorization: Token INFLUX_API_TOKEN" \
+curl --request POST "http://localhost:8086/write?db=DATABASE_NAME&precision=ms" \
+  --header "Authorization: Token API_TOKEN" \
   --data-binary "measurement,host=host1 field1=2i,field2=2.0 1577836800000"
 ```
+{{% /code-placeholders %}}
 
 ##### Use curl to write data from a file
+
+{{% code-placeholders "DATABASE_NAME|USERNAME|PASSWORD_OR_TOKEN|API_TOKEN|exampleuser@influxdata.com" %}}
 ```sh
-curl --request POST http://localhost:8086/write?db=mydb \
-  --header "Authorization: Token INFLUX_API_TOKEN" \
+curl --request POST http://localhost:8086/write?db=DATABASE_NAME \
+  --header "Authorization: Token API_TOKEN" \
   --data-binary @path/to/line-protocol.txt
 ```
+{{% /code-placeholders %}}
 
 {{% oss-only %}}
 
 Replace the following:
-- *`INFLUX_USERNAME`*: [InfluxDB 1.x username](/influxdb/v2/reference/api/influxdb-1x/#manage-credentials)
-- *`INFLUX_PASSWORD_OR_TOKEN`*: [InfluxDB 1.x password or InfluxDB API token](/influxdb/v2/reference/api/influxdb-1x/#manage-credentials)
-- *`INFLUX_API_TOKEN`*: your [InfluxDB API token](/influxdb/v2/reference/glossary/#token)
+
+- {{% code-placeholder-key %}}`DATABASE_NAME` and `RETENTION_POLICY`{{% /code-placeholder-key %}}: the [database and retention policy mapping (DBRP)](/influxdb/v2/reference/api/influxdb-1x/dbrp/) for the InfluxDB v2 bucket that you want to write to
+- {{% code-placeholder-key %}}`USERNAME`{{% /code-placeholder-key %}}: your [InfluxDB 1.x username](/influxdb/v2/reference/api/influxdb-1x/#manage-credentials)
+- {{% code-placeholder-key %}}`PASSWORD_OR_TOKEN`{{% /code-placeholder-key %}}: your [InfluxDB 1.x password or InfluxDB API token](/influxdb/v2/reference/api/influxdb-1x/#manage-credentials)
+- {{% code-placeholder-key %}}`API_TOKEN`{{% /code-placeholder-key %}}: your [InfluxDB API token](/influxdb/v2/admin/tokens/)
 
 {{% /oss-only %}}
 
 {{% cloud-only %}}
 
 Replace the following:
-- *`exampleuser@influxdata.com`*: the email address that you signed up with
-- *`INFLUX_API_TOKEN`*: your [InfluxDB API token](/influxdb/cloud/reference/glossary/#token)
+
+- {{% code-placeholder-key %}}`DATABASE_NAME` and `RETENTION_POLICY`{{% /code-placeholder-key %}}: the [database and retention policy mapping (DBRP)](/influxdb/v2/reference/api/influxdb-1x/dbrp/) for the InfluxDB v2 bucket that you want to write to
+- {{% code-placeholder-key %}}}`exampleuser@influxdata.com`{{% /code-placeholder-key %}}: the email address that you signed up with
+- {{% code-placeholder-key %}}`API_TOKEN`{{% /code-placeholder-key %}}: your [InfluxDB API token](/influxdb/v2/admin/tokens/)
 
 {{% /cloud-only %}}

--- a/content/influxdb/v2/reference/api/_index.md
+++ b/content/influxdb/v2/reference/api/_index.md
@@ -1,5 +1,5 @@
 ---
-title: InfluxDB v2 API
+title: InfluxDB HTTP API
 description: >
   The InfluxDB HTTP API provides a programmatic interface for interactions with InfluxDB, such as writing and querying data,
   and managing resources within an InfluxDB instance.
@@ -7,13 +7,14 @@ description: >
 menu:
   influxdb_v2:
     parent: Reference
+    name: InfluxDB HTTP API
 weight: 3
 influxdb/v2/tags: [api]
 aliases:
   - /influxdb/v2/concepts/api/
 ---
 
-The InfluxDB v2 API provides a programmatic interface for interactions such as writing and querying data, and managing resources in {{% product-name %}}.
+The InfluxDB HTTP API provides a programmatic interface for interactions such as writing and querying data, and managing resources in {{% product-name %}}.
 
 Access the InfluxDB HTTP API using the `/api/v2/` endpoint or InfluxDB v1 endpoints
 for {{% product-name %}}

--- a/hugo.toml
+++ b/hugo.toml
@@ -32,6 +32,8 @@ smartDashes = false
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
+    [markup.goldmark.extensions]
+      linkify = false
 
 [privacy]
   [privacy.googleAnalytics]

--- a/static/downloads/home-sensor-data.lp
+++ b/static/downloads/home-sensor-data.lp
@@ -1,0 +1,26 @@
+home,room=Living\ Room temp=21.1,hum=35.9,co=0i 1721548800
+home,room=Kitchen temp=21.0,hum=35.9,co=0i 1721548800
+home,room=Living\ Room temp=21.4,hum=35.9,co=0i 1721552400
+home,room=Kitchen temp=23.0,hum=36.2,co=0i 1721552400
+home,room=Living\ Room temp=21.8,hum=36.0,co=0i 1721556000
+home,room=Kitchen temp=22.7,hum=36.1,co=0i 1721556000
+home,room=Living\ Room temp=22.2,hum=36.0,co=0i 1721559600
+home,room=Kitchen temp=22.4,hum=36.0,co=0i 1721559600
+home,room=Living\ Room temp=22.2,hum=35.9,co=0i 1721563200
+home,room=Kitchen temp=22.5,hum=36.0,co=0i 1721563200
+home,room=Living\ Room temp=22.4,hum=36.0,co=0i 1721566800
+home,room=Kitchen temp=22.8,hum=36.5,co=1i 1721566800
+home,room=Living\ Room temp=22.3,hum=36.1,co=0i 1721570400
+home,room=Kitchen temp=22.8,hum=36.3,co=1i 1721570400
+home,room=Living\ Room temp=22.3,hum=36.1,co=1i 1721574000
+home,room=Kitchen temp=22.7,hum=36.2,co=3i 1721574000
+home,room=Living\ Room temp=22.4,hum=36.0,co=4i 1721577600
+home,room=Kitchen temp=22.4,hum=36.0,co=7i 1721577600
+home,room=Living\ Room temp=22.6,hum=35.9,co=5i 1721581200
+home,room=Kitchen temp=22.7,hum=36.0,co=9i 1721581200
+home,room=Living\ Room temp=22.8,hum=36.2,co=9i 1721584800
+home,room=Kitchen temp=23.3,hum=36.9,co=18i 1721584800
+home,room=Living\ Room temp=22.5,hum=36.3,co=14i 1721588400
+home,room=Kitchen temp=23.1,hum=36.6,co=22i 1721588400
+home,room=Living\ Room temp=22.2,hum=36.4,co=17i 1721592000
+home,room=Kitchen temp=22.7,hum=36.5,co=26i 1721592000

--- a/test/scripts/prepare-content.sh
+++ b/test/scripts/prepare-content.sh
@@ -74,6 +74,7 @@ function substitute_placeholders {
       # Note the specific use of double quotes for the os.getenv() arguments here. You'll need to use double quotes in your code samples for this to match.
       sed -i '/os.getenv("ACCOUNT_ID")/! s/ACCOUNT_ID/$ACCOUNT_ID/g;
       /os.getenv("API_TOKEN")/! s/API_TOKEN/$INFLUX_TOKEN/g;
+      /os.getenv("PASSWORD_OR_TOKEN")/! s/PASSWORD_OR_TOKEN/$INFLUX_TOKEN/g;
       /os.getenv("BUCKET_ID")/! s/--bucket-id BUCKET_ID/--bucket-id $INFLUX_BUCKET_ID/g;
       /os.getenv("BUCKET_NAME")/! s/BUCKET_NAME/$INFLUX_DATABASE/g;
       /os.getenv("CLUSTER_ID")/! s/CLUSTER_ID/$CLUSTER_ID/g;
@@ -90,8 +91,10 @@ function substitute_placeholders {
       /os.getenv("ORG_ID")/! s/ORG_ID/$INFLUX_ORG/g;
       /os.getenv("RETENTION_POLICY")/! s/RETENTION_POLICY_NAME\|RETENTION_POLICY/$INFLUX_RETENTION_POLICY/g;
       /os.getenv("USERNAME")/! s/USERNAME/$INFLUX_USERNAME/g;
+      s/exampleuser@influxdata.com/$INFLUX_EMAIL_ADDRESS/g;
       s/CONFIG_NAME/CONFIG_$(shuf -i 0-100 -n1)/g;
       s/TEST_RUN/TEST_RUN_$(date +%s)/g;
+      s|@path/to/line-protocol.txt|data/home-sensor-data.lp/g;
       s|/path/to/custom/assets-dir|/app/custom-assets|g;' \
       $file
 


### PR DESCRIPTION
- Fixes sidebar navigation for API pages, moving the v1-compatibility Hugo page into Develop with the API.
- Makes titles consistent for API reference docs.
- Disables **linkify** autolinking of URLs and email addresses to prevent linking example email addresses (I audited content to make sure we don't rely on the autolinking behavior; we use explicit HTML/MD syntax for links)
- Uses standard placeholders and adds test setup for v1-compat write and query.
- Clean up Markdown
- Adds home-sensor-data.lp to Downloads (thought it already existed)

### Before

<img width="356" alt="image" src="https://github.com/user-attachments/assets/d256e4bf-3e51-4aa7-b65f-00c5686cdff8">

### After

<img width="356" alt="image" src="https://github.com/user-attachments/assets/5b6a2f9c-42b9-4b05-8b89-2dca84571fec">

