### PR TITLE
fix(oss): Update TLS example using openssl and including Subject Alte…

### DIFF
--- a/content/influxdb/v2/admin/security/enable-tls.md
+++ b/content/influxdb/v2/admin/security/enable-tls.md
@@ -258,7 +258,16 @@ Restart Telegraf using the updated configuration file.
 
 ## Troubleshoot TLS
 
-### 1. Check InfluxDB logs
+Identify and resolve issues after activating TLS.
+
+- [Check InfluxDB logs](#check-influxdb-logs)
+- [Verify certificate and key files](#verify-certificate-and-key-files)
+- [Test with OpenSSL](#test-with-openssl)
+- [Check file permissions](#check-file-permissions)
+- [Verify TLS configuration](#verify-tls-configuration)
+- [Update OpenSSL and InfluxDB](#update-openssl-and-influxdb)
+
+### Check InfluxDB logs
 
 Review the InfluxDB logs for any error messages or warnings about the issue.
 
@@ -269,7 +278,7 @@ msg="http: TLS handshake error from [::1]:50476:
 remote error: tls: illegal parameter" log_id=0rqN8H_0000 service=http
 ```
 
-### 2. Verify certificate and key Files
+### Verify certificate and key Files
 
 To ensure that the certificate and key files are correct and match each other,
 enter the following command in your terminal:
@@ -279,7 +288,16 @@ openssl x509 -noout -modulus -in /etc/ssl/influxdb-selfsigned.crt | openssl md5
 openssl rsa -noout -modulus -in /etc/ssl/influxdb-selfsigned.key | openssl md5
 ```
 
-### 3. Check file permissions
+### Test with OpenSSL
+
+Use OpenSSL to test the server's certificate and key--for example, enter the
+following command in your terminal:
+
+```bash
+openssl s_client -connect localhost:8086 -CAfile /etc/ssl/influxdb-selfsigned.crt
+```
+
+### Check file permissions
 
 Ensure that the InfluxDB process has read access to the certificate and key
 files--for example, enter the following command to set file permissions:
@@ -289,22 +307,13 @@ sudo chmod 644 /etc/ssl/influxdb-selfsigned.crt
 sudo chmod 600 /etc/ssl/influxdb-selfsigned.key
 ```
 
-### 4. Verify TLS configuration
+### Verify TLS configuration
 
 Ensure that the TLS configuration in InfluxDB is correct.
 Check the paths to the certificate and key files in the InfluxDB configuration
 or command line flags.
 
-### 5. Test with OpenSSL
-
-Use OpenSSL to test the server's certificate and key--for example, enter the
-following command in your terminal:
-
-```bash
-openssl s_client -connect localhost:8086 -CAfile /etc/ssl/influxdb-selfsigned.crt
-```
-
-### 6. Update OpenSSL and InfluxDB
+### Update OpenSSL and InfluxDB
 
 Ensure that you are using the latest versions of OpenSSL and InfluxDB, as
 updates may include fixes for TLS-related issues.

--- a/test/scripts/prepare-content.sh
+++ b/test/scripts/prepare-content.sh
@@ -35,7 +35,7 @@ function substitute_placeholders {
           yesterday_timestamp=$(date -u -d "$yesterday_datetime" +%s)
 
           # Replace the extracted timestamp with `yesterday_timestamp`
-          sed -i "s|$specific_timestamp|$yesterday_timestamp|g;" $file  
+          sed -i "s|$specific_timestamp|$yesterday_timestamp|g;" $file
         fi
       done
 
@@ -66,8 +66,8 @@ function substitute_placeholders {
       # Shell-specific replacements.
       ## In JSON Heredoc
       sed -i 's|"orgID": "ORG_ID"|"orgID": "$INFLUX_ORG"|g;
-      s|"name": "BUCKET_NAME"|"name": "$INFLUX_DATABASE"|g;' \
-      $file
+      s|"name": "BUCKET_NAME"|"name": "$INFLUX_DATABASE"|g;
+      ' $file
 
       # Replace remaining placeholders with variables.
       # If the placeholder is inside of a Python os.getenv() function, don't replace it.
@@ -89,39 +89,41 @@ function substitute_placeholders {
       /os.getenv("ORG_ID")/! s/ORG_ID/$INFLUX_ORG/g;
       /os.getenv("PASSWORD")/! s/PASSWORD/$INFLUX_PASSWORD/g;
       /os.getenv("ORG_ID")/! s/ORG_ID/$INFLUX_ORG/g;
-      /os.getenv("RETENTION_POLICY")/! s/RETENTION_POLICY_NAME\|RETENTION_POLICY/$INFLUX_RETENTION_POLICY/g;
+      /os.getenv("RETENTION_POLICY")/! s/RETENTION_POLICY_NAME/$INFLUX_RETENTION_POLICY/g;
+      /os.getenv("RETENTION_POLICY")/! s/RETENTION_POLICY/$INFLUX_RETENTION_POLICY/g;
       /os.getenv("USERNAME")/! s/USERNAME/$INFLUX_USERNAME/g;
       s/exampleuser@influxdata.com/$INFLUX_EMAIL_ADDRESS/g;
       s/CONFIG_NAME/CONFIG_$(shuf -i 0-100 -n1)/g;
       s/TEST_RUN/TEST_RUN_$(date +%s)/g;
-      s|@path/to/line-protocol.txt|data/home-sensor-data.lp/g;
-      s|/path/to/custom/assets-dir|/app/custom-assets|g;' \
-      $file
+      s|NUMBER_OF_DAYS|365|g;
+      s|@path/to/line-protocol.txt|data/home-sensor-data.lp|g;
+      s|/path/to/custom/assets-dir|/app/custom-assets|g;
+      ' $file
 
       # v2-specific replacements.
       sed -i 's|https:\/\/us-west-2-1.aws.cloud2.influxdata.com|$INFLUX_HOST|g;
       s|influxdb2-{{< latest-patch >}}|influxdb2-${influxdb_latest_patches_v2}|g;
       s|{{< latest-patch cli=true >}}|${influxdb_latest_cli_v2}|g;
       s|influxdb2-{{% latest-patch %}}|influxdb2-${influxdb_latest_patches_v2}|g;
-      s|{{% latest-patch cli=true %}}|${influxdb_latest_cli_v2}|g;' \
-      $file
+      s|{{% latest-patch cli=true %}}|${influxdb_latest_cli_v2}|g;
+      ' $file
 
       # Telegraf-specific replacements
       sed -i 's|telegraf-{{< latest-patch >}}|telegraf-${telegraf_latest_patches_v1}|g;
       s|telegraf-{{% latest-patch %}}|telegraf-${telegraf_latest_patches_v1}|g;
       s/--input-filter <INPUT_PLUGIN_NAME>\[:<INPUT_PLUGIN_NAME>\]/--input-filter cpu:influxdb/g;
-      s/--output-filter <OUTPUT_PLUGIN_NAME>\[:<OUTPUT_PLUGIN_NAME>\]/--output-filter influxdb_v2:file/g;' \
-      $file
+      s/--output-filter <OUTPUT_PLUGIN_NAME>\[:<OUTPUT_PLUGIN_NAME>\]/--output-filter influxdb_v2:file/g;
+      ' $file
 
       # Skip package manager commands.
       sed -i 's|sudo dpkg.*$||g;
-      s|sudo yum.*$||g;' \
-      $file
+      s|sudo yum.*$||g;
+      ' $file
 
       # Environment-specific replacements.
       # You can't use sudo with Docker.
-      sed -i 's|sudo ||g;' \
-      $file
+      sed -i 's|sudo ||g;
+      ' $file
     fi
   done
 }


### PR DESCRIPTION
…rnative Name (SAN)

Closes #5608 
- Example uses Subject Alternative Name extension required by modern clients.
- Updated example is more verbose, but should work cross-platform.
- Added troubleshooting steps.
- Passes tests.
- Reformatted to headings and remove list nesting.
