### PR TITLE
Release Kapacitor v1.7.6, New Kafka Handler params

### DIFF
--- a/content/kapacitor/v1/reference/about_the_project/release-notes.md
+++ b/content/kapacitor/v1/reference/about_the_project/release-notes.md
@@ -9,6 +9,23 @@ aliases:
   - /kapacitor/v1/about_the_project/releasenotes-changelog/
 ---
 
+## v1.7.6 {date="2024-10-28"}
+
+### Features
+
+- Kafka Handler set and send SASL extensions.
+- Kafka Handler SASL OAUTH token refreshing.
+
+### Bug Fixes
+
+- Using UTC timezone for alert levels.
+
+### Dependency updates
+
+- Upgrade Go to 1.22.7.
+
+---
+
 ## v1.7.5 {date="2024-06-12"}
 
 ### Dependency updates

--- a/content/kapacitor/v1/reference/event_handlers/kafka.md
+++ b/content/kapacitor/v1/reference/event_handlers/kafka.md
@@ -37,6 +37,7 @@ Below is an example configuration:
   # Optional SASL configuration
   sasl-username = "xxxxx"
   sasl-password = "xxxxxxxx"
+  sasl-extensions = {}
   sasl-mechanism = ""
   sasl-version = ""
   # Use if sasl-mechanism is GSSAPI. GSSAPI is for organizations using Kerberos.
@@ -46,7 +47,16 @@ Below is an example configuration:
   sasl-gssapi-kerberos-config-path = "/"
   sasl-gssapi-key-tab-path = ""
   sasl-gssapi-realm = "realm"
-  # Use if sasl-mechanism is `OAUTHBEARER` (experimental).
+  # Options if sasl-mechanism is OAUTHBEARER
+  sasl-oauth-service = "auth0"
+  sasl-oauth-client-id = "xxxxxxx"
+  sasl-oauth-client-secret = "xxxxxxxx"
+  sasl-oauth-token-url = "dedicated-auth0-token-url"
+  sasl-oauth-token-expiry-margin = "10s"
+  sasl-oauth-scopes = ""
+  sasl-oauth-tenant-id = ""
+  [kafka.sasl-oauth-parameters]
+     audience = "development"
   sasl-access-token = ""
 
 ```
@@ -102,8 +112,11 @@ Username to use for SASL authentication.
 #### sasl-password
 Password to use for SASL authentication.
 
+### sasl-extensions
+Arbitrary key value string pairs to pass as a TOML table
+
 #### sasl-mechanism
-SASL mechanism type. Options include `GSSAPI`, `OAUTHBEARER`, `PLAIN`.
+SASL mechanism type. Options include `GSSAPI`, `OAUTHBEARER`, `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`.
 
 #### sasl-version
 SASL protocol version.
@@ -126,8 +139,37 @@ Path to the Kerberos key tab.
 ####  sasl-gssapi-realm
 Default Kerberos realm.
 
+### Options if sasl-mechanism is OAUTHBEARER
+#### sasl-oauth-service
+The service name to use when authenticating with SASL/OAUTH.
+One of:
+ - `""` (empty) or `custom`
+ - `auth0`
+ - `azuread`
+
+#### sasl-oauth-client-id
+The client ID to use when authenticating with SASL/OAUTH.
+
+#### sasl-oauth-client-secret 
+The client secret to use when authenticating with SASL/OAUTH.
+
+#### sasl-oauth-token-url
+The token URL to use when sasl-oauth-service is `custom` or `auth0`. Leave empty otherwise.
+  
+#### sasl-oauth-token-expiry-margin
+The expiry margin for the token.
+  
+#### sasl-oauth-scopes  
+Optional scopes to use when authenticating with SASL/OAUTH.
+  
+#### sasl-oauth-tenant-id
+Tenant ID for the AzureAD service.
+  
+#### [kafka.sasl-oauth-parameters]
+The optional key/value params for SASL/OAUTH. e.g. audience for AUTH0
+  
 #### sasl-access-token
-Used if the SASL mechanism is `OAUTHBEARER` (experimental).
+Static OAUTH token. Use this instead of other OAUTH params.
 
 ## Options
 The following Kafka event handler options can be set in a

--- a/content/kapacitor/v1/reference/event_handlers/kafka.md
+++ b/content/kapacitor/v1/reference/event_handlers/kafka.md
@@ -157,7 +157,7 @@ The client secret to use when authenticating with SASL/OAUTH.
 The token URL to use when sasl-oauth-service is `custom` or `auth0`. Leave empty otherwise.
   
 #### sasl-oauth-token-expiry-margin
-The expiry margin for the token.
+The margin for the token's expiration time.
   
 #### sasl-oauth-scopes  
 Optional scopes to use when authenticating with SASL/OAUTH.

--- a/content/kapacitor/v1/reference/event_handlers/kafka.md
+++ b/content/kapacitor/v1/reference/event_handlers/kafka.md
@@ -116,7 +116,12 @@ Password to use for SASL authentication.
 Arbitrary key value string pairs to pass as a TOML table
 
 #### sasl-mechanism
-SASL mechanism type. Options include `GSSAPI`, `OAUTHBEARER`, `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`.
+SASL mechanism type. Options are:
+- `GSSAPI`
+- `OAUTHBEARER`
+- `PLAIN`
+- `SCRAM-SHA-256`
+- `SCRAM-SHA-512`
 
 #### sasl-version
 SASL protocol version.

--- a/data/products.yml
+++ b/data/products.yml
@@ -97,7 +97,7 @@ kapacitor:
   versions: [v1]
   latest: v1.7
   latest_patches:
-    v1: 1.7.5
+    v1: 1.7.6
 
 enterprise_influxdb:
   name: "InfluxDB Enterprise"


### PR DESCRIPTION
1. Release Kapacitor v1.7.6 - https://github.com/influxdata/kapacitor/releases/tag/v1.7.6
1. [Kapacitor PR #2834](https://github.com/influxdata/kapacitor/pull/2834) also adds new configuration params for Kafka output. This PR is extending docs for it.