### PR TITLE
fix(v2): v1-compat 404 due to alias typo

### DIFF
--- a/content/influxdb/v2/api-guide/influxdb-1x/_index.md
+++ b/content/influxdb/v2/api-guide/influxdb-1x/_index.md
@@ -12,7 +12,7 @@ influxdb/v2/tags: [influxql, query, write]
 related:
   - /influxdb/v2/query-data/influxql
   - /influxdb/v2/install/upgrade/v1-to-v2/
-alias:
+aliases:
   - /influxdb/v2/reference/api/influxdb-1x/
 ---
 

--- a/content/influxdb/v2/reference/api/_index.md
+++ b/content/influxdb/v2/reference/api/_index.md
@@ -12,6 +12,9 @@ weight: 3
 influxdb/v2/tags: [api]
 aliases:
   - /influxdb/v2/concepts/api/
+related:
+  - /influxdb/v2/api-guide/api_intro/
+  - /influxdb/v2/api-guide/influxdb-1x/
 ---
 
 The InfluxDB HTTP API provides a programmatic interface for interactions such as writing and querying data, and managing resources in {{% product-name %}}.
@@ -38,6 +41,6 @@ and visit the `/docs` endpoint in a browser ([localhost:8086/docs](http://localh
 
 <a class="btn" href="/influxdb/v2/api/v1-compatibility/">InfluxDB v1 API for {{% product-name %}}</a>
 
-The InfluxDB HTTP API includes [InfluxDB v1 compatibility endpoints](/influxdb/v2/reference/api/influxdb-1x/)
+The InfluxDB HTTP API includes InfluxDB v1 compatibility endpoints
 that work with InfluxDB 1.x client libraries and third-party integrations like
 [Grafana](https://grafana.com) and others.


### PR DESCRIPTION
Closes #5607 

