### PR TITLE
v2: Small additions to the enable-tls guide

### DIFF
--- a/content/influxdb/v2/admin/security/enable-tls.md
+++ b/content/influxdb/v2/admin/security/enable-tls.md
@@ -116,6 +116,7 @@ cat > san.cnf <<EOF
    [alt_names]
    DNS.1 = example.com
    DNS.2 = www.example.com
+   IP.1 = 10.1.2.3
 EOF
 
 # Generate a private key and certificate signing request (CSR)

--- a/content/influxdb/v2/admin/security/enable-tls.md
+++ b/content/influxdb/v2/admin/security/enable-tls.md
@@ -151,11 +151,12 @@ The user running InfluxDB must have read permissions on the TLS certificate file
 Ultimately, make sure all users running InfluxDB have read permissions for the TLS certificate.
 {{% /note %}}
 
-In your terminal, run `chmod` to set permissions on your installed certificate files--for example:
-The following example shows how to set read permissions on the self-signed
+In your terminal, run `chown` to set the owner and `chmod` to set permissions on your installed certificate files--for example:
+The following example shows how to transfer the ownership to the user and group `influxdb` and to set read permissions on the self-signed
 certificate and key files generated in [the preceding step](#1-download-or-generate-certificate-files):
 
 ```bash
+sudo chown influxdb: /etc/ssl/influxdb-selfsigned.crt /etc/ssl/influxdb-selfsigned.key
 sudo chmod 644 /etc/ssl/influxdb-selfsigned.crt
 sudo chmod 600 /etc/ssl/influxdb-selfsigned.key
 ```

--- a/content/influxdb/v2/admin/security/enable-tls.md
+++ b/content/influxdb/v2/admin/security/enable-tls.md
@@ -151,7 +151,8 @@ The user running InfluxDB must have read permissions on the TLS certificate file
 Ultimately, make sure all users running InfluxDB have read permissions for the TLS certificate.
 {{% /note %}}
 
-In your terminal, run `chown` to set the owner and `chmod` to set permissions on your installed certificate files--for example:
+In your terminal, run `chown` to set the owner and `chmod` to set permissions on your installed certificate files.
+
 The following example shows how to transfer the ownership to the user and group `influxdb` and to set read permissions on the self-signed
 certificate and key files generated in [the preceding step](#1-download-or-generate-certificate-files):
 

--- a/content/influxdb/v2/admin/security/enable-tls.md
+++ b/content/influxdb/v2/admin/security/enable-tls.md
@@ -153,7 +153,7 @@ Ultimately, make sure all users running InfluxDB have read permissions for the T
 
 In your terminal, run `chown` to set the owner and `chmod` to set permissions on your installed certificate files.
 
-The following example shows how to transfer the ownership to the user and group `influxdb` and to set read permissions on the self-signed
+The following example shows how to transfer the ownership to the user and group `influxdb` and set read permissions on the self-signed
 certificate and key files generated in [the preceding step](#1-download-or-generate-certificate-files):
 
 ```bash


### PR DESCRIPTION
This includes two small additions to the very good guide written in #5616.

1) enable-tls add IP in san.cnf

When accessing the InfluxDB server via IP, the IP should be included in the subjectAltName.
If the IP is not present, errors like this will appear in the logs every 10 seconds (these specific errors arose from the scraper created by the onboarding/quick-start, which causes also these ones related issues https://github.com/influxdata/ui/issues/6956 and https://github.com/influxdata/influxdb/issues/24882):

```
Sep 25 14:00:02 host influxd-systemd-start.sh[11782]: ts=2024-09-25T12:00:02.055617Z lvl=error msg="Unable to gather" log_id=0rr6jG30000 service=scraper scraper-name="new target" error="Get \"https://10.1.2.3:8086/metrics\": tls: failed to verify certificate: x509: cannot validate certificate for 10.1.2.3 because it doesn't contain any IP SANs"
Sep 25 14:00:02 host influxd-systemd-start.sh[11782]: ts=2024-09-25T12:00:02.055397Z lvl=info msg="http: TLS handshake error from 10.1.2.3:46380: remote error: tls: bad certificate" log_id=0rr6jG30000 service=http
```

2) enable-tls add chown of .crt and .key to influxdb user

In the guide, there is a chmod command for setting the permissions, but the openssl command usually already sets them right. Instead, what is usually needed (at least on Debian) is to make these files accessible to the influxdb user and group.
