### PR TITLE
fix: clarify behaviour of `influxdb.cardinality()`

### DIFF
--- a/content/flux/v0/stdlib/influxdata/influxdb/cardinality.md
+++ b/content/flux/v0/stdlib/influxdata/influxdb/cardinality.md
@@ -1,7 +1,7 @@
 ---
 title: influxdb.cardinality() function
 description: >
-  `influxdb.cardinality()` returns the series cardinality of data stored in InfluxDB.
+  `influxdb.cardinality()` returns the series cardinality of data retrieved from InfluxDB.
 menu:
   flux_v0_ref:
     name: influxdb.cardinality
@@ -28,8 +28,15 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 
 ------------------------------------------------------------------------------->
 
-`influxdb.cardinality()` returns the series cardinality of data stored in InfluxDB.
+`influxdb.cardinality()` returns the series cardinality of data retrieved from InfluxDB.
 
+
+{{% note %}}
+Although this function is similar to InfluxQL's [`SHOW SERIES CARDINALITY`](/influxdb/v1/query_language/spec/#show-series-cardinality),
+it works in a slightly different manner.
+
+`influxdb.cardinality()` is time bounded and reports the cardinality of the data that's passed into it rather than the cardinality of the bucket as a whole.
+{{% /note %}}
 
 
 ##### Function type signature
@@ -106,6 +113,12 @@ Latest time to include when calculating cardinality.
 The cardinality calculation excludes points that match the specified start time.
 Use a relative duration or absolute time. For example, `-1h` or `2019-08-28T22:00:00Z`.
 Durations are relative to `now()`. Default is `now()`.
+
+{{% note %}}
+The default value is `now()`, so any points that have been written into the future will
+not be counted unless a future `stop` date is provided.
+{{% /note %}}
+
 
 ### predicate
 

--- a/content/flux/v0/stdlib/influxdata/influxdb/cardinality.md
+++ b/content/flux/v0/stdlib/influxdata/influxdb/cardinality.md
@@ -35,7 +35,7 @@ Fluxdoc syntax: https://github.com/influxdata/flux/blob/master/docs/fluxdoc.md
 Although this function is similar to InfluxQL's [`SHOW SERIES CARDINALITY`](/influxdb/v1/query_language/spec/#show-series-cardinality),
 it works in a slightly different manner.
 
-`influxdb.cardinality()` is time bounded and reports the cardinality of the data that's passed into it rather than the cardinality of the bucket as a whole.
+`influxdb.cardinality()` is time bounded and reports the cardinality of data that matches the conditions passed into it rather than that of the bucket as a whole.
 {{% /note %}}
 
 

--- a/content/flux/v0/stdlib/influxdata/influxdb/cardinality.md
+++ b/content/flux/v0/stdlib/influxdata/influxdb/cardinality.md
@@ -139,9 +139,10 @@ Default is `(r) => true`.
 ```js
 import "influxdata/influxdb"
 
-influxdb.cardinality(bucket: "example-bucket", start: -1y)
+influxdb.cardinality(bucket: "example-bucket", start: 1)
 
 ```
+Note: if points have been written into the future, you will need to add an appropriate `stop` date
 
 
 ### Query series cardinality in a measurement//
@@ -151,7 +152,7 @@ import "influxdata/influxdb"
 
 influxdb.cardinality(
     bucket: "example-bucket",
-    start: -1y,
+    start: 1,
     predicate: (r) => r._measurement == "example-measurement",
 )
 
@@ -163,7 +164,7 @@ influxdb.cardinality(
 ```js
 import "influxdata/influxdb"
 
-influxdb.cardinality(bucket: "example-bucket", start: -1y, predicate: (r) => r.exampleTag == "foo")
+influxdb.cardinality(bucket: "example-bucket", start: 1, predicate: (r) => r.exampleTag == "foo")
 
 ```
 

--- a/content/flux/v0/stdlib/influxdata/influxdb/cardinality.md
+++ b/content/flux/v0/stdlib/influxdata/influxdb/cardinality.md
@@ -133,6 +133,7 @@ Default is `(r) => true`.
 - [Query series cardinality in a bucket](#query-series-cardinality-in-a-bucket)
 - [Query series cardinality in a measurement//](#query-series-cardinality-in-a-measurement)
 - [Query series cardinality for a specific tag](#query-series-cardinality-for-a-specific-tag)
+- [Query series cardinality of Data Written In the Last 4 Hours](#query-series-cardinality-of-data-written-in-the-last-4-hours)
 
 ### Query series cardinality in a bucket
 
@@ -165,6 +166,15 @@ influxdb.cardinality(
 import "influxdata/influxdb"
 
 influxdb.cardinality(bucket: "example-bucket", start: time(v: 1), predicate: (r) => r.exampleTag == "foo")
+
+```
+
+
+### Query Cardinality of Data Written In the Last 4 hours
+```js
+import "influxdata/influxdb"
+
+influxdb.cardinality(bucket: "example-bucket", start: -4h)
 
 ```
 

--- a/content/flux/v0/stdlib/influxdata/influxdb/cardinality.md
+++ b/content/flux/v0/stdlib/influxdata/influxdb/cardinality.md
@@ -139,7 +139,7 @@ Default is `(r) => true`.
 ```js
 import "influxdata/influxdb"
 
-influxdb.cardinality(bucket: "example-bucket", start: 1)
+influxdb.cardinality(bucket: "example-bucket", start: time(v: 1))
 
 ```
 Note: if points have been written into the future, you will need to add an appropriate `stop` date
@@ -152,7 +152,7 @@ import "influxdata/influxdb"
 
 influxdb.cardinality(
     bucket: "example-bucket",
-    start: 1,
+    start: time(v: 1),
     predicate: (r) => r._measurement == "example-measurement",
 )
 
@@ -164,7 +164,7 @@ influxdb.cardinality(
 ```js
 import "influxdata/influxdb"
 
-influxdb.cardinality(bucket: "example-bucket", start: 1, predicate: (r) => r.exampleTag == "foo")
+influxdb.cardinality(bucket: "example-bucket", start: time(v: 1), predicate: (r) => r.exampleTag == "foo")
 
 ```
 

--- a/content/influxdb/v2/reference/faq.md
+++ b/content/influxdb/v2/reference/faq.md
@@ -1088,7 +1088,7 @@ Each InfluxDB Cloud organization has a series cardinality limit to prevent
 runaway cardinality. For information about adjusting cardinality limits, see
 [How do I increase my organization’s rate limits and quotas?](#how-do-i-increase-my-organizations-rate-limits-and-quotas).
 
-{{% /oss-only %}}
+{{% /cloud-only %}}
 
 Use [`influxdb.cardinality()`](/flux/v0/stdlib/influxdata/influxdb/cardinality/) in Flux
 or [`SHOW SERIES CARDINALITY`](/influxdb/v1/query_language/spec/#show-series-cardinality)


### PR DESCRIPTION
The functionality of `influxdb.cardinality()` is not directly analogous to `SHOW SERIES CARDINALITY` because it's time bounded. 

Unlike the InfluxQL command, it reports the cardinality of a specific dataset, but is often the cause of confusion as a result of being interpreted as providing the cardinality of the bucket _as a whole_.

There are various caveats which need to be considered when using it to obtain the cardinality of the bucket as a whole

* `start` needs to be earlier than the earliest timestamp (some docs pages suggest `1` which is good)
* `stop` needs to be later than the latest timestamp (the default is `now()` which is problematic if users are writing into the future)
* There's a small nuance on replicated systems (such as Cloud2) - the reported value may depend on which replica has respond (results will be eventually consistent, but may not always directly match). Not sure we necessarily need to squeeze that in


Note: a corresponding change will need to be made in the Flux code comments, but I thought it best to work on wording here first.

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
