### PR TITLE
Note removal of Flux MQTT package support OSS 2.7+

### DIFF
--- a/data/flux_stdlib_frontmatter.yml
+++ b/data/flux_stdlib_frontmatter.yml
@@ -923,14 +923,15 @@
   prepend:
     block: warn
     content: |
-      #### Not supported in InfluxDB OSS
+      #### Only supported in InfluxDB Cloud (TSM)
 
-      The `experimental/mqtt` package is not supported in InfluxDB, but is
-      supported in InfluxDB Cloud (TSM). The package is still available to
-      import in OSS, but functions will not successfully publish to an MQTT broker.
+      The `experimental/mqtt` package only supported in InfluxDB Cloud (TSM).
+      It is still available to import in InfluxDB OSS and Enterprise, but
+      functions will not successfully publish to an MQTT broker.
   exclude_from:
-    oss: *
     nightly: true
+    oss: ^*
+    enterprise: ^*
 
 /flux/v0/stdlib/experimental/mqtt/to.md: |
   aliases:
@@ -939,27 +940,29 @@
   prepend:
     block: warn
     content: |
-      #### Not supported in InfluxDB OSS
+      #### Only supported in InfluxDB Cloud (TSM)
 
-      The `experimental/mqtt` package is not supported in InfluxDB, but is
-      supported in InfluxDB Cloud (TSM). The package is still available to
-      import in OSS, but functions will not successfully publish to an MQTT broker.
+      The `experimental/mqtt` package only supported in InfluxDB Cloud (TSM).
+      It is still available to import in InfluxDB OSS and Enterprise, but
+      functions will not successfully publish to an MQTT broker.
   exclude_from:
-    oss: *
     nightly: true
+    oss: ^*
+    enterprise: ^*
 
 /flux/v0/stdlib/experimental/mqtt/publish.md: |
   prepend:
     block: warn
     content: |
-      #### Not supported in InfluxDB OSS
+      #### Only supported in InfluxDB Cloud (TSM)
 
-      The `experimental/mqtt` package is not supported in InfluxDB, but is
-      supported in InfluxDB Cloud (TSM). The package is still available to
-      import in OSS, but functions will not successfully publish to an MQTT broker.
+      The `experimental/mqtt` package only supported in InfluxDB Cloud (TSM).
+      It is still available to import in InfluxDB OSS and Enterprise, but
+      functions will not successfully publish to an MQTT broker.
   exclude_from:
-    oss: *
     nightly: true
+    oss: ^*
+    enterprise: ^*
 
 /flux/v0/stdlib/experimental/oee/_index.md: |
   aliases:

--- a/data/flux_stdlib_frontmatter.yml
+++ b/data/flux_stdlib_frontmatter.yml
@@ -923,13 +923,13 @@
   prepend:
     block: warn
     content: |
-      #### Not supported in InfluxDB OSS 2.7+
+      #### Not supported in InfluxDB OSS
 
-      The `experimental/mqtt` package is not supported in InfluxDB 2.7+, but
-      is supported in InfluxDB Cloud (TSM). The package is still available to
+      The `experimental/mqtt` package is not supported in InfluxDB, but is
+      supported in InfluxDB Cloud (TSM). The package is still available to
       import in OSS, but functions will not successfully publish to an MQTT broker.
   exclude_from:
-    oss: ^2\.([7-9]|1[0-9])
+    oss: *
     nightly: true
 
 /flux/v0/stdlib/experimental/mqtt/to.md: |
@@ -939,26 +939,26 @@
   prepend:
     block: warn
     content: |
-      #### Not supported in InfluxDB OSS 2.7+
+      #### Not supported in InfluxDB OSS
 
-      The `experimental/mqtt` package is not supported in InfluxDB 2.7+, but
-      is supported in InfluxDB Cloud (TSM). The package is still available to
+      The `experimental/mqtt` package is not supported in InfluxDB, but is
+      supported in InfluxDB Cloud (TSM). The package is still available to
       import in OSS, but functions will not successfully publish to an MQTT broker.
   exclude_from:
-    oss: ^2\.([7-9]|1[0-9])
+    oss: *
     nightly: true
 
 /flux/v0/stdlib/experimental/mqtt/publish.md: |
   prepend:
     block: warn
     content: |
-      #### Not supported in InfluxDB OSS 2.7+
+      #### Not supported in InfluxDB OSS
 
-      The `experimental/mqtt` package is not supported in InfluxDB 2.7+, but
-      is supported in InfluxDB Cloud (TSM). The package is still available to
+      The `experimental/mqtt` package is not supported in InfluxDB, but is
+      supported in InfluxDB Cloud (TSM). The package is still available to
       import in OSS, but functions will not successfully publish to an MQTT broker.
   exclude_from:
-    oss: ^2\.([7-9]|1[0-9])
+    oss: *
     nightly: true
 
 /flux/v0/stdlib/experimental/oee/_index.md: |

--- a/data/flux_stdlib_frontmatter.yml
+++ b/data/flux_stdlib_frontmatter.yml
@@ -931,6 +931,7 @@
       publish to an MQTT broker.
   exclude_from:
     oss: ^2\.[7-9]
+    nightly: true
 
 /flux/v0/stdlib/experimental/mqtt/to.md: |
   aliases:
@@ -947,6 +948,7 @@
       publish to an MQTT broker.
   exclude_from:
     oss: ^2\.[7-9]
+    nightly: true
 
 /flux/v0/stdlib/experimental/mqtt/publish.md: |
   prepend:
@@ -960,6 +962,7 @@
       publish to an MQTT broker.
   exclude_from:
     oss: ^2\.[7-9]
+    nightly: true
 
 /flux/v0/stdlib/experimental/oee/_index.md: |
   aliases:

--- a/data/flux_stdlib_frontmatter.yml
+++ b/data/flux_stdlib_frontmatter.yml
@@ -920,11 +920,40 @@
   aliases:
     - /influxdb/v2/reference/flux/stdlib/experimental/mqtt/
     - /influxdb/cloud/reference/flux/stdlib/experimental/mqtt/
+  prepend:
+    block: warn
+    content: |
+      #### Not supported in InfluxDB OSS 2.7+
+
+      The `experimental.mqtt` package is not supported in InfluxDB 2.7+, but
+      it is supported in InfluxDB Cloud (TSM). You can still import and use
+      the package in InfluxDB 2.7+, but functions will not successfully
+      publish to an MQTT broker.
 
 /flux/v0/stdlib/experimental/mqtt/to.md: |
   aliases:
     - /influxdb/v2/reference/flux/stdlib/experimental/mqtt/to/
     - /influxdb/cloud/reference/flux/stdlib/experimental/mqtt/to/
+  prepend:
+    block: warn
+    content: |
+      #### Not supported in InfluxDB OSS 2.7+
+
+      The `experimental.mqtt` package is not supported in InfluxDB 2.7+, but
+      it is supported in InfluxDB Cloud (TSM). You can still import and use
+      the package in InfluxDB 2.7+, but functions will not successfully
+      publish to an MQTT broker.
+
+/flux/v0/stdlib/experimental/mqtt/publish.md: |
+  prepend:
+    block: warn
+    content: |
+      #### Not supported in InfluxDB OSS 2.7+
+
+      The `experimental.mqtt` package is not supported in InfluxDB 2.7+, but
+      it is supported in InfluxDB Cloud (TSM). You can still import and use
+      the package in InfluxDB 2.7+, but functions will not successfully
+      publish to an MQTT broker.
 
 /flux/v0/stdlib/experimental/oee/_index.md: |
   aliases:

--- a/data/flux_stdlib_frontmatter.yml
+++ b/data/flux_stdlib_frontmatter.yml
@@ -927,7 +927,7 @@
 
       The `experimental/mqtt` package is not supported in InfluxDB 2.7+, but
       is supported in InfluxDB Cloud (TSM). The package is still available to
-      import, but functions will not successfully publish to an MQTT broker.
+      import in OSS, but functions will not successfully publish to an MQTT broker.
   exclude_from:
     oss: ^2\.([7-9]|1[0-9])
     nightly: true
@@ -943,7 +943,7 @@
 
       The `experimental/mqtt` package is not supported in InfluxDB 2.7+, but
       is supported in InfluxDB Cloud (TSM). The package is still available to
-      import, but functions will not successfully publish to an MQTT broker.
+      import in OSS, but functions will not successfully publish to an MQTT broker.
   exclude_from:
     oss: ^2\.([7-9]|1[0-9])
     nightly: true
@@ -956,7 +956,7 @@
 
       The `experimental/mqtt` package is not supported in InfluxDB 2.7+, but
       is supported in InfluxDB Cloud (TSM). The package is still available to
-      import, but functions will not successfully publish to an MQTT broker.
+      import in OSS, but functions will not successfully publish to an MQTT broker.
   exclude_from:
     oss: ^2\.([7-9]|1[0-9])
     nightly: true

--- a/data/flux_stdlib_frontmatter.yml
+++ b/data/flux_stdlib_frontmatter.yml
@@ -929,6 +929,8 @@
       it is supported in InfluxDB Cloud (TSM). You can still import and use
       the package in InfluxDB 2.7+, but functions will not successfully
       publish to an MQTT broker.
+  exclude_from:
+    oss: ^2\.[7-9]
 
 /flux/v0/stdlib/experimental/mqtt/to.md: |
   aliases:
@@ -943,6 +945,8 @@
       it is supported in InfluxDB Cloud (TSM). You can still import and use
       the package in InfluxDB 2.7+, but functions will not successfully
       publish to an MQTT broker.
+  exclude_from:
+    oss: ^2\.[7-9]
 
 /flux/v0/stdlib/experimental/mqtt/publish.md: |
   prepend:
@@ -954,6 +958,8 @@
       it is supported in InfluxDB Cloud (TSM). You can still import and use
       the package in InfluxDB 2.7+, but functions will not successfully
       publish to an MQTT broker.
+  exclude_from:
+    oss: ^2\.[7-9]
 
 /flux/v0/stdlib/experimental/oee/_index.md: |
   aliases:

--- a/data/flux_stdlib_frontmatter.yml
+++ b/data/flux_stdlib_frontmatter.yml
@@ -925,12 +925,11 @@
     content: |
       #### Not supported in InfluxDB OSS 2.7+
 
-      The `experimental.mqtt` package is not supported in InfluxDB 2.7+, but
-      it is supported in InfluxDB Cloud (TSM). You can still import and use
-      the package in InfluxDB 2.7+, but functions will not successfully
-      publish to an MQTT broker.
+      The `experimental/mqtt` package is not supported in InfluxDB 2.7+, but
+      is supported in InfluxDB Cloud (TSM). The package is still available to
+      import, but functions will not successfully publish to an MQTT broker.
   exclude_from:
-    oss: ^2\.[7-9]
+    oss: ^2\.([7-9]|1[0-9])
     nightly: true
 
 /flux/v0/stdlib/experimental/mqtt/to.md: |
@@ -942,12 +941,11 @@
     content: |
       #### Not supported in InfluxDB OSS 2.7+
 
-      The `experimental.mqtt` package is not supported in InfluxDB 2.7+, but
-      it is supported in InfluxDB Cloud (TSM). You can still import and use
-      the package in InfluxDB 2.7+, but functions will not successfully
-      publish to an MQTT broker.
+      The `experimental/mqtt` package is not supported in InfluxDB 2.7+, but
+      is supported in InfluxDB Cloud (TSM). The package is still available to
+      import, but functions will not successfully publish to an MQTT broker.
   exclude_from:
-    oss: ^2\.[7-9]
+    oss: ^2\.([7-9]|1[0-9])
     nightly: true
 
 /flux/v0/stdlib/experimental/mqtt/publish.md: |
@@ -956,12 +954,11 @@
     content: |
       #### Not supported in InfluxDB OSS 2.7+
 
-      The `experimental.mqtt` package is not supported in InfluxDB 2.7+, but
-      it is supported in InfluxDB Cloud (TSM). You can still import and use
-      the package in InfluxDB 2.7+, but functions will not successfully
-      publish to an MQTT broker.
+      The `experimental/mqtt` package is not supported in InfluxDB 2.7+, but
+      is supported in InfluxDB Cloud (TSM). The package is still available to
+      import, but functions will not successfully publish to an MQTT broker.
   exclude_from:
-    oss: ^2\.[7-9]
+    oss: ^2\.([7-9]|1[0-9])
     nightly: true
 
 /flux/v0/stdlib/experimental/oee/_index.md: |

--- a/layouts/partials/footer/modals/flux-influxdb-versions.html
+++ b/layouts/partials/footer/modals/flux-influxdb-versions.html
@@ -19,7 +19,6 @@
 {{ $sameAsLatest := eq $introduced $fluxLatest }}
 {{ $excludePatternOSS := $.Page.Params.exclude_from.oss | default " " }}
 {{ $excludePatternEnterprise := $.Page.Params.exclude_from.enterprise | default " " }}
-{{ $excludeFromNightly := $.Page.Params.exclude_from.nightly | default false }}
 
 <div class="modal-content" id="flux-influxdb-versions">
   <div class="flex-wrapper">
@@ -46,12 +45,12 @@
         {{ $versionSemVer := split $value "." }}
         {{ $supported := cond (ge (index $versionSemVer 0) (index $introducedSemVer 0)) (cond (ge (index $versionSemVer 1) (index $introducedSemVer 1)) (cond (ge (index $versionSemVer 2) (index $introducedSemVer 2)) true false) false) false }}
         {{ $deprecated := and (isset $.Page.Params "deprecated") (cond (ge (index $versionSemVer 0) (index $deprecatedSemVer 0)) (cond (ge (index $versionSemVer 1) (index $deprecatedSemVer 1)) (cond (ge (index $versionSemVer 2) (index $deprecatedSemVer 2)) true false) false) false) }}
-        {{ $excluded := gt (len (findRE (string $excludePatternOSS) $key)) 0 }}
+        {{ $nightlyExcluded := and (eq $key "nightly") $.Page.Params.exclude_from.nightly }}
+        {{ $excluded := or (gt (len (findRE (string $excludePatternOSS) $key)) 0) $nightlyExcluded }}
         <div class="version-row">
           <div class="version-col"><p>InfluxDB {{ $key }}</p></div>
           <div class="version-col"><p>
-            {{ if adm (eq . "nightly") $excludeFromNightly }}
-            {{ else if $excluded }}
+            {{ if $excluded }}
             {{ else if $deprecated }}<span class="deprecated"></span>      
             {{ else if $supported }}<span class="cf-icon Checkmark_New{{ if $sameAsLatest }} pending{{ end }} supported"></span>
             {{ end }}

--- a/layouts/partials/footer/modals/flux-influxdb-versions.html
+++ b/layouts/partials/footer/modals/flux-influxdb-versions.html
@@ -19,6 +19,7 @@
 {{ $sameAsLatest := eq $introduced $fluxLatest }}
 {{ $excludePatternOSS := $.Page.Params.exclude_from.oss | default " " }}
 {{ $excludePatternEnterprise := $.Page.Params.exclude_from.enterprise | default " " }}
+{{ $excludeFromNightly := $.Page.Params.exclude_from.nightly | default false }}
 
 <div class="modal-content" id="flux-influxdb-versions">
   <div class="flex-wrapper">
@@ -49,7 +50,8 @@
         <div class="version-row">
           <div class="version-col"><p>InfluxDB {{ $key }}</p></div>
           <div class="version-col"><p>
-            {{ if $excluded }}
+            {{ if adm (eq . "nightly") $excludeFromNightly }}
+            {{ else if $excluded }}
             {{ else if $deprecated }}<span class="deprecated"></span>      
             {{ else if $supported }}<span class="cf-icon Checkmark_New{{ if $sameAsLatest }} pending{{ end }} supported"></span>
             {{ end }}


### PR DESCRIPTION
Closes influxdata/DAR#437

Adds a warning to the top of the `experimental/mqtt` package and function pages:

<img width="916" alt="image" src="https://github.com/user-attachments/assets/94511d90-9fb3-4034-ae75-730858422fd2">

Removes support from InfluxDB OSS 2.7+ and nightly in the InfluxDB version support modal:

<img width="623" alt="image" src="https://github.com/user-attachments/assets/d59feac1-daff-46a1-a7f6-4220891999b0">

- [x] Rebased/mergeable
