### PR TITLE
docs: add other required fields to user setup for clustered

### DIFF
--- a/content/influxdb/clustered/admin/users/add.md
+++ b/content/influxdb/clustered/admin/users/add.md
@@ -119,7 +119,12 @@ spec:
         jwksEndpoint: |-
           https://AUTH0_HOST/.well-known/openid-configuration
         users:
-          - AUTH0_USER_ID
+          # All fields are required but `firstName`, `lastName`, and `email` can be
+          # arbitrary values. However, `id` must match the user ID provided by Auth0.
+          - id: AUTH0_USER_ID
+            firstName: Marty
+            lastName: McFly
+            email: mcfly@influxdata.com
 ```
 
 {{% /code-placeholders %}}
@@ -152,7 +157,12 @@ spec:
         jwksEndpoint: |-
           https://login.microsoftonline.com/AZURE_TENANT_ID/discovery/v2.0/keys
         users:
-          - AZURE_USER_ID
+          # All fields are required but `firstName`, `lastName`, and `email` can be
+          # arbitrary values. However, `id` must match the user ID provided by Azure.
+          - id: AZURE_USER_ID
+            firstName: Marty
+            lastName: McFly
+            email: mcfly@influxdata.com
 ```
 
 {{% /code-placeholders %}}
@@ -249,7 +259,12 @@ admin:
     https://AUTH0_HOST/.well-known/openid-configuration
   # The list of users to grant access to Clustered via influxctl
   users:
-    - AUTH0_USER_ID
+    # All fields are required but `firstName`, `lastName`, and `email` can be
+    # arbitrary values. However, `id` must match the user ID provided by Auth0.
+    - id: AUTH0_USER_ID
+      firstName: Marty
+      lastName: McFly
+      email: mcfly@influxdata.com
 ```
 
 {{% /code-placeholders %}}
@@ -280,7 +295,12 @@ admin:
     https://login.microsoftonline.com/AZURE_TENANT_ID/discovery/v2.0/keys
   # The list of users to grant access to Clustered via influxctl
   users:
-    - AZURE_USER_ID
+    # All fields are required but `firstName`, `lastName`, and `email` can be
+    # arbitrary values. However, `id` must match the user ID provided by Azure.
+    - id: AZURE_USER_ID
+      firstName: Marty
+      lastName: McFly
+      email: mcfly@influxdata.com
 ```
 
 {{% /code-placeholders %}}

--- a/content/influxdb/clustered/install/configure-cluster/directly.md
+++ b/content/influxdb/clustered/install/configure-cluster/directly.md
@@ -747,7 +747,12 @@ spec:
         jwksEndpoint: |-
           https://AUTH0_HOST/.well-known/openid-configuration
         users:
-          - AUTH0_USER_ID
+          # All fields are required but `firstName`, `lastName`, and `email` can be
+          # arbitrary values. However, `id` must match the user ID provided by Auth0.
+          - id: AUTH0_USER_ID
+            firstName: Marty
+            lastName: McFly
+            email: mcfly@influxdata.com
 ```
 
 {{% /code-placeholders %}}
@@ -782,7 +787,12 @@ spec:
         jwksEndpoint: |-
           https://login.microsoftonline.com/AZURE_TENANT_ID/discovery/v2.0/keys
         users:
-          - AZURE_USER_ID
+          # All fields are required but `firstName`, `lastName`, and `email` can be
+          # arbitrary values. However, `id` must match the user ID provided by Azure.
+          - id: AZURE_USER_ID
+            firstName: Marty
+            lastName: McFly
+            email: mcfly@influxdata.com
 ```
 
 {{% /code-placeholders %}}

--- a/content/influxdb/clustered/install/configure-cluster/use-helm.md
+++ b/content/influxdb/clustered/install/configure-cluster/use-helm.md
@@ -764,7 +764,12 @@ admin:
     https://AUTH0_HOST/.well-known/openid-configuration
   # The list of users to grant access to Clustered via influxctl
   users:
-    - AUTH0_USER_ID
+    # All fields are required but `firstName`, `lastName`, and `email` can be
+    # arbitrary values. However, `id` must match the user ID provided by Auth0.
+    - id: AUTH0_USER_ID
+      firstName: Marty
+      lastName: McFly
+      email: mcfly@influxdata.com
 ```
 
 {{% /code-placeholders %}}
@@ -797,7 +802,12 @@ admin:
     https://login.microsoftonline.com/AZURE_TENANT_ID/discovery/v2.0/keys
   # The list of users to grant access to Clustered via influxctl
   users:
-    - AZURE_USER_ID
+    # All fields are required but `firstName`, `lastName`, and `email` can be
+    # arbitrary values. However, `id` must match the user ID provided by Azure.
+    - id: AZURE_USER_ID
+      firstName: Marty
+      lastName: McFly
+      email: mcfly@influxdata.com
 ```
 
 {{% /code-placeholders %}}


### PR DESCRIPTION
Hey team! A customer attempted to use azure docs during clustered set up and ran into an issue with the current code example for setting azure users in the `appInstance`. I've added the rest of the fields as required (similar to keycloak).

I see there is [this PR](https://github.com/influxdata/docs-v2/pull/5636) out for reorganizing the clustered docs, so maybe it can be done there to avoid conflicts? Let me know the best way forward, thanks!

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
