### PR TITLE
fix(dedicated): Update links to database token management API reference

### DIFF
--- a/content/influxdb/cloud-dedicated/admin/tokens/database/create.md
+++ b/content/influxdb/cloud-dedicated/admin/tokens/database/create.md
@@ -50,7 +50,7 @@ related:
 ---
 
 Use the [`influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/)
-or the [Management HTTP API](influxdb/cloud-dedicated/api/management/) to create a [database token](/influxdb/cloud-dedicated/admin/tokens/database/) with permissions for reading and writing data in your {{< product-name omit=" Clustered" >}} cluster.
+or the [Management HTTP API](influxdb/cloud-dedicated/reference/api/management/) to create a [database token](/influxdb/cloud-dedicated/admin/tokens/database/) with permissions for reading and writing data in your {{< product-name omit=" Clustered" >}} cluster.
 
 {{< tabs-wrapper >}}
 {{% tabs %}}

--- a/content/influxdb/cloud-dedicated/admin/tokens/database/create.md
+++ b/content/influxdb/cloud-dedicated/admin/tokens/database/create.md
@@ -50,7 +50,7 @@ related:
 ---
 
 Use the [`influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/)
-or the [Management HTTP API](influxdb/cloud-dedicated/reference/api/management/) to create a [database token](/influxdb/cloud-dedicated/admin/tokens/database/) with permissions for reading and writing data in your {{< product-name omit=" Clustered" >}} cluster.
+or the [Management HTTP API](/influxdb/cloud-dedicated/api/management/) to create a [database token](/influxdb/cloud-dedicated/admin/tokens/database/) with permissions for reading and writing data in your {{< product-name omit=" Clustered" >}} cluster.
 
 {{< tabs-wrapper >}}
 {{% tabs %}}

--- a/content/influxdb/cloud-dedicated/admin/tokens/database/delete.md
+++ b/content/influxdb/cloud-dedicated/admin/tokens/database/delete.md
@@ -32,7 +32,7 @@ related:
 ---
 
 Use the [`influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/)
-or the [Management HTTP API](influxdb/cloud-dedicated/reference/api/management/)
+or the [Management HTTP API](/influxdb/cloud-dedicated/api/management/)
 to delete a database token from your {{< product-name omit=" Clustered" >}} cluster.
 
 {{< tabs-wrapper >}}

--- a/content/influxdb/cloud-dedicated/admin/tokens/database/delete.md
+++ b/content/influxdb/cloud-dedicated/admin/tokens/database/delete.md
@@ -32,7 +32,7 @@ related:
 ---
 
 Use the [`influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/)
-or the [Management HTTP API](influxdb/cloud-dedicated/api/management/)
+or the [Management HTTP API](influxdb/cloud-dedicated/reference/api/management/)
 to delete a database token from your {{< product-name omit=" Clustered" >}} cluster.
 
 {{< tabs-wrapper >}}

--- a/content/influxdb/cloud-dedicated/admin/tokens/database/list.md
+++ b/content/influxdb/cloud-dedicated/admin/tokens/database/list.md
@@ -36,7 +36,7 @@ related:
 ---
 
 Use the [`influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/)
-or the [Management HTTP API](influxdb/cloud-dedicated/api/management/)
+or the [Management HTTP API](influxdb/cloud-dedicated/reference/api/management/)
 to list database tokens in your {{< product-name omit=" Clustered" >}} cluster.
 
 [List database tokens](#list-database-tokens)

--- a/content/influxdb/cloud-dedicated/admin/tokens/database/list.md
+++ b/content/influxdb/cloud-dedicated/admin/tokens/database/list.md
@@ -36,7 +36,7 @@ related:
 ---
 
 Use the [`influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/)
-or the [Management HTTP API](influxdb/cloud-dedicated/reference/api/management/)
+or the [Management HTTP API](/influxdb/cloud-dedicated/api/management/)
 to list database tokens in your {{< product-name omit=" Clustered" >}} cluster.
 
 [List database tokens](#list-database-tokens)

--- a/content/influxdb/cloud-dedicated/admin/tokens/database/update.md
+++ b/content/influxdb/cloud-dedicated/admin/tokens/database/update.md
@@ -53,7 +53,7 @@ related:
 ---
 
 Use the [`influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/)
-or the [Management HTTP API](influxdb/cloud-dedicated/reference/api/management/)
+or the [Management HTTP API](/influxdb/cloud-dedicated/api/management/)
 to update a database token's permissions {{< product-name omit=" Clustered" >}} cluster.
 
 {{< tabs-wrapper >}}

--- a/content/influxdb/cloud-dedicated/admin/tokens/database/update.md
+++ b/content/influxdb/cloud-dedicated/admin/tokens/database/update.md
@@ -53,7 +53,7 @@ related:
 ---
 
 Use the [`influxctl` CLI](/influxdb/cloud-dedicated/reference/cli/influxctl/)
-or the [Management HTTP API](influxdb/cloud-dedicated/api/management/)
+or the [Management HTTP API](influxdb/cloud-dedicated/reference/api/management/)
 to update a database token's permissions {{< product-name omit=" Clustered" >}} cluster.
 
 {{< tabs-wrapper >}}


### PR DESCRIPTION
It looks like the API references got shuffled around at some point - I clicked the thing and it 404'd me.

---

* fix(dedicated): Update links to database token management API reference (c6086a6fc)

      Links what have been broke, have done unbroke.