### PR TITLE
feat(dedicated): Add Cloud Dedicated user groups

### DIFF
--- a/content/influxdb/cloud-dedicated/admin/users/_index.md
+++ b/content/influxdb/cloud-dedicated/admin/users/_index.md
@@ -1,0 +1,99 @@
+---
+title: Manage users
+seotitle: Manage users and permissions in InfluxDB Cloud Dedicated
+description: >
+  Manage users and access to resources in your InfluxDB Cloud Dedicated cluster.
+  Assign user groups for role-based access control and security.
+menu:
+  influxdb_cloud_dedicated:
+    parent: Administer InfluxDB Cloud
+weight: 101
+influxdb/cloud-dedicated/tags: [user groups]
+related:
+  - /influxdb/cloud-dedicated/reference/internals/security/
+  - /influxdb/cloud-dedicated/admin/tokens/ 
+---
+
+Manage users and access to resources in your {{% product-name %}} cluster.
+
+By assigning users to different groups based on the level of access they need,
+you can minimize unnecessary access and reduce the risk of inadvertent
+actions.
+User groups associate access privileges with user attributes--an important part of the
+Attribute-Based Access Control (ABAC) security model which grants access based on
+user attributes, resource types, and environment context.
+
+- [Available user groups](#available-user-groups)
+- [Manage users](#manage-users)
+- [Assign a user to a different group](#assign-a-user-to-a-different-group)
+- [Invite a user to your account](#invite-a-user-to-your-account)
+
+### Available user groups
+
+In {{% product-name %}}, users have "management" roles, such as creating and 
+deleting databases, viewing resource information, and provisioning
+[database tokens](/influxdb/cloud-dedicated/admin/tokens/database/) for reading and writing data. 
+
+A user can belong to the following groups, each with predefined privileges:
+
+<!-- Question: what are the "certain resources" below? -->
+
+- **Admin**: Read and write permissions on all resources.
+- **Member**: Read permission on certain resources and create permission for
+  database tokens; members can't delete or create databases or management tokens.
+- **Auditor**: Read permission on all resources; auditors can't modify resources.
+
+{{% note %}}
+#### Existing users are Admin by default
+
+With the release of user groups for {{% product-name %}}, all existing users
+in your account are initially assigned to the Admin group, retaining full
+access to resources in your cluster.
+{{% /note %}}
+
+### Manage users
+
+InfluxData uses Auth0 to create user accounts and assign users to groups
+in {{% product-name %}}.
+
+### Assign a user to a different group
+
+To assign existing users in your account to different
+groups, [contact InfluxData support](https://support.influxdata.com/s/login/)
+and provide the list of users and the desired [user groups](#available-user-groups)
+for each.
+
+### Invite a user to your account
+
+For new users that you want to add to your account, the InfluxData Support Team
+configures invitations with the attributes and groups that you specify. 
+
+<!-- Question: cluster admins shouldn't use `influctl user invite` https://github.com/influxdata/docs-v2/blob/dddf699722bc9e2ba33c4ea9f34673454f3164a5/content/influxdb/cloud-dedicated/reference/cli/influxctl/user/invite.md
+How should we communicate this? -->
+
+1. [Contact InfluxData support](https://support.influxdata.com/s/login/)
+   to invite a user to your account.
+   In your request, provide the user details, including email address, desired
+   [user groups](#available-user-groups), and other attributes for the user.
+2. InfluxData support creates the user account and emails the user an invitation
+   that includes following:
+
+   - An **Auth0 login** to authenticate access to the cluster
+   - The {{% product-name %}} **account ID**
+   - The {{% product-name %}} **cluster ID**
+   - The {{% product-name %}} **cluster URL**
+   - A password reset email for setting the login password
+
+3. The user accepts the invitation to your account
+
+With a valid password, the user can access cluster resources by interacting with the
+[`influxctl`](/influxdb/cloud-dedicated/reference/influxctl/) command line tool.
+The assigned user groups determine the user's access to resources.
+
+{{% note %}}
+#### Use database tokens to authorize data reads and writes
+
+In {{% product-name %}}, user groups control access for managing cluster resources.
+[Database tokens](/influxdb/cloud-dedicated/admin/tokens/database/) control access
+for reading and writing data in cluster databases.
+{{% /note %}}

--- a/content/influxdb/cloud-dedicated/reference/internals/security.md
+++ b/content/influxdb/cloud-dedicated/reference/internals/security.md
@@ -238,13 +238,15 @@ separates workload cluster management authorizations (using _management tokens_)
 from database read and write authorizations (using _database tokens_).
 
 - [User provisioning](#user-provisioning)
+- [User groups](#user-groups)
 - [Management tokens](#management-tokens)
 - [Database tokens](#database-tokens)
 
 #### User provisioning
 
-InfluxData uses [Auth0](https://auth0.com/) to create user accounts and assign
-permission sets to user accounts on {{% product-name %}}.
+InfluxData uses [Auth0](https://auth0.com/) to create user accounts and 
+assign user attributes, including [user groups](#user-groups), on {{% product-name %}}.
+
 After a user account is created, InfluxData provides the user with the following:
 
 - An **Auth0 login** to authenticate access to the cluster
@@ -260,12 +262,48 @@ exchanged with `influxctl`.
 After a successful Auth0 authentication, {{% product-name %}} provides the
 user's `influxctl` session with a short-lived
 [management token](#management-tokens) for access to the Granite service.
-The user interacts with the `influxctl` command line tool to manage the workload
-cluster, including creating [database tokens](#database-tokens) for database
-read and write access and [creating long-lived management tokens](/influxdb/cloud-dedicated/admin/management-tokens/)
-for use with the [Management API](/influxdb/cloud-dedicated/api/management/).
+The user interacts with the `influxctl` command line tool to view or manage
+cluster resources.
+The [user groups](#user-groups) assigned to the user determine the level of
+access to resources.
+
+#### User groups
+
+User groups associate access privileges with user attributes--an important part of the
+Attribute-Based Access Control (ABAC) security model, which grants access based on
+user attributes, resource types, and environment context.
+
+In {{% product-name %}}, a user can belong to any of the following user groups,
+each with predefined privileges:
+
+- [Admin user group]
+- [Member user group]
+- [Auditor user group]
+
+##### Admin user group
+
+Admins are {{% product-name %}} users who have read and write permissions on
+all resources (for all clusters) in the account.
+Only Admins can create [management tokens](#management-tokens).
+
+##### Members (role: member)
+
+<!-- Define "certain resources" below: -->
+
+Members are {{% product-name %}} users who have read permission on certain
+resources and create permission for [database tokens](#database-tokens).
+Members can't delete or create databases or management tokens.
+
+##### Auditor (role: auditor)
+
+Auditors are {{% product-name %}} users who have read permission on all resources
+(for all clusters) in the account; auditors can't modify account resources.
 
 #### Management tokens
+
+[Admins](#admin-group) can create long-lived
+[management tokens](/influxdb/cloud-dedicated/admin/management-tokens/)
+for use with the [Management API](/influxdb/cloud-dedicated/api/management/).
 
 Management tokens authenticate user accounts to the Granite service and provide
 authorizations for workload cluster management activities, including:
@@ -308,6 +346,12 @@ cases--for example, using the [Management API for
 {{% product-name %}}](/influxdb/cloud-dedicated/api/management/) to rotate
 database tokens or create tables.
 
+Manually created management tokens:
+
+- have an optional expiration and don't require human interaction with the OAuth provider
+- are for automation use cases
+- shouldn't be used to circumvent the OAuth provider
+
 To authenticate a Management API request, the user passes the manually created
 token in the HTTP `Authorization` header:
 
@@ -315,17 +359,15 @@ token in the HTTP `Authorization` header:
 Authorization MANAGEMENT_TOKEN
 ```
 
-A manually created management token has an optional expiration and
-doesn't require human interaction with the OAuth provider.
-
-Manually created management tokens are meant for automation use cases
-and shouldn't be used to circumvent the OAuth provider.
-
 #### Database tokens
 
-Database tokens provide authorization for users and client applications to read and write data and metadata in an {{% product-name %}} database.
+[Admins](#admin-group) and [Members](#member-group), can create
+[database tokens](#database-tokens) for database read and write access.
+Database tokens provide authorization for users and client applications to read
+and write data and metadata in an {{% product-name %}} database.
 All data write and query API requests require a valid database token with sufficient permissions.
-_**Note:** an all-access management token can't read or write to a database because it's not a database token._
+_**Note:** an all-access [management token](#management-tokens) can't read or
+write to a database because it's not a database token._
 
 Database tokens consist of the following:
 


### PR DESCRIPTION
**Don't merge until the feature is ready to announce** (on notice from @dsprogis and @bpalani)

Closes influxdata/dar/issues/450

- Introduces user groups for Dedicated
- Group descriptions
- Steps to invite new users and assign groups
- Steps to reassign existing users to different groups
- Describe user groups in /reference/internals/security/

The changes are deployed to Docs staging:
- https://test2.docs.influxdata.com/influxdb/cloud-dedicated/admin/users/
- https://test2.docs.influxdata.com/influxdb/cloud-dedicated/reference/internals/security/#user-provisioning

@dsprogis, @will-influxdata, or @eatondustin1, please advise on the following questions: 

- [For members, what are the "certain resources"?](https://github.com/influxdata/docs-v2/compare/DAR-450-add-user-groups-for-dedicated?expand=1#diff-c6363b619b88f938207510ed4f6a877c612ead3a428627e79017f83a6f007645R39)
- [Should cluster admins avoid using `influxctl user invite`?](https://github.com/influxdata/docs-v2/compare/DAR-450-add-user-groups-for-dedicated?expand=1#diff-c6363b619b88f938207510ed4f6a877c612ead3a428627e79017f83a6f007645R71)
