### PR TITLE
Fix typo in broken link

### DIFF
--- a/content/influxdb/v2/admin/security/enable-tls.md
+++ b/content/influxdb/v2/admin/security/enable-tls.md
@@ -55,7 +55,7 @@ You can generate a self-signed certificate on your own machine.
 
 ## Configure InfluxDB to use TLS
 
-1. [Download or generate certificate files](download-or-generate-certificate-files)
+1. [Download or generate certificate files](#download-or-generate-certificate-files)
 2. [Set certificate file permissions](#set-certificate-file-permissions)
 3. [Run `influxd` with TLS flags](#run-influxd-with-tls-flags)
 4. [Verify TLS connection](#verify-tls-connection)


### PR DESCRIPTION
Just adding a # that has been deleted by mistake in #5631 and that caused a broken link.
Also, running linkchecker on the website did reveal a few more broken links (but I did not fix them as I am not sure of the correct URL).