### PR TITLE
docs(clients): new major version of Go v3 client

### DIFF
--- a/content/influxdb/cloud-dedicated/get-started/query.md
+++ b/content/influxdb/cloud-dedicated/get-started/query.md
@@ -593,8 +593,7 @@ _If your project's virtual environment is already running, skip to step 3._
       "time"
       "text/tabwriter"
 
-      "github.com/apache/arrow/go/v13/arrow"
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
     )
 
     func Query() error {
@@ -638,10 +637,9 @@ _If your project's virtual environment is already running, skip to step 3._
       // Iterate over rows and prints column values in table format.
       for iterator.Next() {
         row := iterator.Value()
-        // Use Go arrow and time packages to format unix timestamp
+        // Use Go time package to format unix timestamp
         // as a time with timezone layout (RFC3339).
-        time := (row["time"].(arrow.Timestamp)).
-          ToTime(arrow.TimeUnit(arrow.Nanosecond)).
+        time := (row["time"].(time.Time)).
           Format(time.RFC3339)
         fmt.Fprintf(w, "%s\t%s\t%d\t%.1f\t%.1f\n",
           time, row["room"], row["co"], row["hum"], row["temp"])
@@ -661,8 +659,7 @@ _If your project's virtual environment is already running, skip to step 3._
         - `io`
         - `os`
         - `text/tabwriter`
-        - `github.com/apache/arrow/go/v13/arrow`
-        - `github.com/InfluxCommunity/influxdb3-go/influxdb3`
+        - `github.com/InfluxCommunity/influxdb3-go/influxdb3/v1`
 
     2.  Defines a `Query()` function that does the following:
 

--- a/content/influxdb/cloud-dedicated/get-started/write.md
+++ b/content/influxdb/cloud-dedicated/get-started/write.md
@@ -835,7 +835,7 @@ To write data to {{% product-name %}} using Go, use the InfluxDB v3
       "fmt"
       "log"
 
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
     )
 
     // Write line protocol data to InfluxDB

--- a/content/influxdb/cloud-dedicated/query-data/execute-queries/client-libraries/go.md
+++ b/content/influxdb/cloud-dedicated/query-data/execute-queries/client-libraries/go.md
@@ -21,7 +21,7 @@ list_code_example: |
     ```go
     import (
       "context"
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
     )
 
     func Query() error {
@@ -139,8 +139,7 @@ import (
     "text/tabwriter"
     "time"
 
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
-    "github.com/apache/arrow/go/v13/arrow"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 
 func Query() error {
@@ -187,10 +186,9 @@ func Query() error {
     fmt.Fprintln(w, "Process each row as key-value pairs:")
     for iterator2.Next() {
         row := iterator2.Value()
-        // Use Go arrow and time packages to format unix timestamp
+        // Use Go time package to format unix timestamp
         // as a time with timezone layout (RFC3339)
-        time := (row["time"].(arrow.Timestamp)).
-            ToTime(arrow.TimeUnit(arrow.Nanosecond)).
+        time := (row["time"].(time.Time)).
             Format(time.RFC3339)
         fmt.Fprintf(w, "%s\t%s\t%d\t%.1f\t%.1f\n",
             time, row["room"], row["co"], row["hum"], row["temp"])
@@ -236,8 +234,7 @@ import (
     "text/tabwriter"
     "time"
 
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
-    "github.com/apache/arrow/go/v13/arrow"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 
 func InfluxQL() error {
@@ -289,10 +286,9 @@ func InfluxQL() error {
     fmt.Fprintln(w, "Process each row as key-value pairs:")
     for iterator2.Next() {
         row := iterator2.Value()
-        // Use Go arrow and time packages to format unix timestamp
+        // Use Go time package to format unix timestamp
         // as a time with timezone layout (RFC3339)
-        time := (row["time"].(arrow.Timestamp)).
-            ToTime(arrow.TimeUnit(arrow.Nanosecond)).
+        time := (row["time"].(time.Time)).
             Format(time.RFC3339)
         fmt.Fprintf(w, "%s\t%s\t%d\t%.1f\t%.1f\n",
             time, row["room"], row["co"], row["hum"], row["temp"])

--- a/content/influxdb/cloud-dedicated/query-data/influxql/parameterized-queries.md
+++ b/content/influxdb/cloud-dedicated/query-data/influxql/parameterized-queries.md
@@ -257,8 +257,7 @@ import (
     "os"
     "text/tabwriter"
     "time"
-    "github.com/apache/arrow/go/v14/arrow"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 
 func Query(query string, parameters influxdb3.QueryParameters,
@@ -301,10 +300,10 @@ func Query(query string, parameters influxdb3.QueryParameters,
     // Process each row as key-value pairs.
     for iterator.Next() {
         row := iterator.Value()
-        // Use Go arrow and time packages to format unix timestamp
+        // Use Go time package to format unix timestamp
         // as a time with timezone layout (RFC3339 format)
-        time := (row["time"].(arrow.Timestamp)).
-                ToTime(arrow.Nanosecond).Format(time.RFC3339)
+        time := (row["time"].(time.Time)).
+                Format(time.RFC3339)
 
         fmt.Fprintf(w, "%s\t%s\t%d\t%.1f\t%.1f\n",
             time, row["room"], row["co"], row["hum"], row["temp"])

--- a/content/influxdb/cloud-dedicated/query-data/sql/parameterized-queries.md
+++ b/content/influxdb/cloud-dedicated/query-data/sql/parameterized-queries.md
@@ -254,8 +254,7 @@ import (
     "os"
     "text/tabwriter"
     "time"
-    "github.com/apache/arrow/go/v14/arrow"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 
 func Query(query string, parameters influxdb3.QueryParameters) error {
@@ -297,10 +296,10 @@ func Query(query string, parameters influxdb3.QueryParameters) error {
     // Process each row as key-value pairs.
     for iterator.Next() {
         row := iterator.Value()
-        // Use Go arrow and time packages to format unix timestamp
+        // Use Go time package to format unix timestamp
         // as a time with timezone layout (RFC3339 format)
-        time := (row["time"].(arrow.Timestamp)).
-                ToTime(arrow.Nanosecond).Format(time.RFC3339)
+        time := (row["time"].(time.Time)).
+                Format(time.RFC3339)
 
         fmt.Fprintf(w, "%s\t%s\t%d\t%.1f\t%.1f\n",
             time, row["room"], row["co"], row["hum"], row["temp"])

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v3/go.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v3/go.md
@@ -31,7 +31,7 @@ Import the package:
 
 ```go
 import (
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 ```
 
@@ -75,7 +75,7 @@ Initializes and returns a `influxdb3.Client` instance with the following:
 package main
 
 import (
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 
 func main() {

--- a/content/influxdb/cloud-dedicated/write-data/line-protocol/client-libraries.md
+++ b/content/influxdb/cloud-dedicated/write-data/line-protocol/client-libraries.md
@@ -228,7 +228,7 @@ points.
     "os"
     "fmt"
     "time"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
     "github.com/influxdata/line-protocol/v2/lineprotocol"
    )
 

--- a/content/influxdb/cloud-serverless/get-started/query.md
+++ b/content/influxdb/cloud-serverless/get-started/query.md
@@ -538,8 +538,7 @@ _If your project's virtual environment is already running, skip to step 3._
       "time"
       "text/tabwriter"
 
-      "github.com/apache/arrow/go/v13/arrow"
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
     )
 
     func Query() error {
@@ -583,10 +582,9 @@ _If your project's virtual environment is already running, skip to step 3._
       // Iterate over rows and prints column values in table format.
       for iterator.Next() {
         row := iterator.Value()
-        // Use Go arrow and time packages to format unix timestamp
+        // Use Go time package to format unix timestamp
         // as a time with timezone layout (RFC3339).
-        time := (row["time"].(arrow.Timestamp)).
-          ToTime(arrow.TimeUnit(arrow.Nanosecond)).
+        time := (row["time"].(time.Time)).
           Format(time.RFC3339)
         fmt.Fprintf(w, "%s\t%s\t%d\t%.1f\t%.1f\n",
           time, row["room"], row["co"], row["hum"], row["temp"])
@@ -606,8 +604,7 @@ _If your project's virtual environment is already running, skip to step 3._
         - `io`
         - `os`
         - `text/tabwriter`
-        - `github.com/apache/arrow/go/v13/arrow`
-        - `github.com/InfluxCommunity/influxdb3-go/influxdb3`
+        - `github.com/InfluxCommunity/influxdb3-go/influxdb3/v1`
 
     2.  Defines a `Query()` function that does the following:
 

--- a/content/influxdb/cloud-serverless/get-started/write.md
+++ b/content/influxdb/cloud-serverless/get-started/write.md
@@ -804,7 +804,7 @@ InfluxDB v3 [influxdb3-go client library package](https://github.com/InfluxCommu
       "fmt"
       "log"
 
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
     )
 
     // Write line protocol data to InfluxDB

--- a/content/influxdb/cloud-serverless/query-data/execute-queries/client-libraries/go.md
+++ b/content/influxdb/cloud-serverless/query-data/execute-queries/client-libraries/go.md
@@ -21,7 +21,7 @@ list_code_example: |
     ```go
     import (
       "context"
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
     )
 
     func Query() error {
@@ -138,8 +138,7 @@ import (
     "text/tabwriter"
     "time"
 
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
-    "github.com/apache/arrow/go/v13/arrow"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 
 func Query() error {
@@ -186,10 +185,9 @@ func Query() error {
     fmt.Fprintln(w, "Process each row as key-value pairs:")
     for iterator2.Next() {
         row := iterator2.Value()
-        // Use Go arrow and time packages to format unix timestamp
+        // Use Go time package to format unix timestamp
         // as a time with timezone layout (RFC3339)
-        time := (row["time"].(arrow.Timestamp)).
-            ToTime(arrow.TimeUnit(arrow.Nanosecond)).
+        time := (row["time"].(time.Time)).
             Format(time.RFC3339)
         fmt.Fprintf(w, "%s\t%s\t%d\t%.1f\t%.1f\n",
             time, row["room"], row["co"], row["hum"], row["temp"])
@@ -235,8 +233,7 @@ import (
     "text/tabwriter"
     "time"
 
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
-    "github.com/apache/arrow/go/v13/arrow"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 
 func InfluxQL() error {
@@ -288,10 +285,9 @@ func InfluxQL() error {
     fmt.Fprintln(w, "Process each row as key-value pairs:")
     for iterator2.Next() {
         row := iterator2.Value()
-        // Use Go arrow and time packages to format unix timestamp
+        // Use Go time package to format unix timestamp
         // as a time with timezone layout (RFC3339)
-        time := (row["time"].(arrow.Timestamp)).
-            ToTime(arrow.TimeUnit(arrow.Nanosecond)).
+        time := (row["time"].(time.Time)).
             Format(time.RFC3339)
         fmt.Fprintf(w, "%s\t%s\t%d\t%.1f\t%.1f\n",
             time, row["room"], row["co"], row["hum"], row["temp"])

--- a/content/influxdb/cloud-serverless/query-data/influxql/parameterized-queries.md
+++ b/content/influxdb/cloud-serverless/query-data/influxql/parameterized-queries.md
@@ -257,8 +257,7 @@ import (
     "os"
     "text/tabwriter"
     "time"
-    "github.com/apache/arrow/go/v14/arrow"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 
 func Query(query string, parameters influxdb3.QueryParameters,
@@ -301,10 +300,10 @@ func Query(query string, parameters influxdb3.QueryParameters,
     // Process each row as key-value pairs.
     for iterator.Next() {
         row := iterator.Value()
-        // Use Go arrow and time packages to format unix timestamp
+        // Use Go time package to format unix timestamp
         // as a time with timezone layout (RFC3339 format)
-        time := (row["time"].(arrow.Timestamp)).
-                ToTime(arrow.Nanosecond).Format(time.RFC3339)
+        time := (row["time"].(time.Time)).
+                Format(time.RFC3339)
 
         fmt.Fprintf(w, "%s\t%s\t%d\t%.1f\t%.1f\n",
             time, row["room"], row["co"], row["hum"], row["temp"])

--- a/content/influxdb/cloud-serverless/query-data/sql/parameterized-queries.md
+++ b/content/influxdb/cloud-serverless/query-data/sql/parameterized-queries.md
@@ -254,8 +254,7 @@ import (
     "os"
     "text/tabwriter"
     "time"
-    "github.com/apache/arrow/go/v14/arrow"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 
 func Query(query string, parameters influxdb3.QueryParameters) error {
@@ -297,10 +296,10 @@ func Query(query string, parameters influxdb3.QueryParameters) error {
     // Process each row as key-value pairs.
     for iterator.Next() {
         row := iterator.Value()
-        // Use Go arrow and time packages to format unix timestamp
+        // Use Go time package to format unix timestamp
         // as a time with timezone layout (RFC3339 format)
-        time := (row["time"].(arrow.Timestamp)).
-                ToTime(arrow.Nanosecond).Format(time.RFC3339)
+        time := (row["time"].(time.Time)).
+                Format(time.RFC3339)
 
         fmt.Fprintf(w, "%s\t%s\t%d\t%.1f\t%.1f\n",
             time, row["room"], row["co"], row["hum"], row["temp"])

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v3/go.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v3/go.md
@@ -31,7 +31,7 @@ Import the package:
 
 ```go
 import (
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 ```
 
@@ -75,7 +75,7 @@ Initializes and returns a `influxdb3.Client` instance with the following:
 package main
 
 import (
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 
 func Query() error {

--- a/content/influxdb/cloud-serverless/write-data/line-protocol/client-libraries.md
+++ b/content/influxdb/cloud-serverless/write-data/line-protocol/client-libraries.md
@@ -229,7 +229,7 @@ points.
     "os"
     "fmt"
     "time"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
     "github.com/influxdata/line-protocol/v2/lineprotocol"
    )
 

--- a/content/influxdb/clustered/get-started/query.md
+++ b/content/influxdb/clustered/get-started/query.md
@@ -585,8 +585,7 @@ _If your project's virtual environment is already running, skip to step 3._
       "time"
       "text/tabwriter"
 
-      "github.com/apache/arrow/go/v13/arrow"
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
     )
 
     func Query() error {
@@ -630,10 +629,9 @@ _If your project's virtual environment is already running, skip to step 3._
       // Iterate over rows and prints column values in table format.
       for iterator.Next() {
         row := iterator.Value()
-        // Use Go arrow and time packages to format unix timestamp
+        // Use Go time package to format unix timestamp
         // as a time with timezone layout (RFC3339).
-        time := (row["time"].(arrow.Timestamp)).
-          ToTime(arrow.TimeUnit(arrow.Nanosecond)).
+        time := (row["time"].(time.Time)).
           Format(time.RFC3339)
         fmt.Fprintf(w, "%s\t%s\t%d\t%.1f\t%.1f\n",
           time, row["room"], row["co"], row["hum"], row["temp"])
@@ -653,8 +651,7 @@ _If your project's virtual environment is already running, skip to step 3._
         - `io`
         - `os`
         - `text/tabwriter`
-        - `github.com/apache/arrow/go/v13/arrow`
-        - `github.com/InfluxCommunity/influxdb3-go/influxdb3`
+        - `github.com/InfluxCommunity/influxdb3-go/influxdb3/v1`
 
     2.  Defines a `Query()` function that does the following:
 

--- a/content/influxdb/clustered/get-started/write.md
+++ b/content/influxdb/clustered/get-started/write.md
@@ -840,7 +840,7 @@ To write data to {{% product-name %}} using Go, use the InfluxDB v3
       "fmt"
       "log"
 
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
     )
 
     // Write line protocol data to InfluxDB

--- a/content/influxdb/clustered/query-data/execute-queries/client-libraries/go.md
+++ b/content/influxdb/clustered/query-data/execute-queries/client-libraries/go.md
@@ -21,7 +21,7 @@ list_code_example: |
     ```go
     import (
       "context"
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
     )
 
     func Query() error {
@@ -137,8 +137,7 @@ import (
     "text/tabwriter"
     "time"
 
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
-    "github.com/apache/arrow/go/v13/arrow"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 
 func Query() error {
@@ -185,10 +184,9 @@ func Query() error {
     fmt.Fprintln(w, "Process each row as key-value pairs:")
     for iterator2.Next() {
         row := iterator2.Value()
-        // Use Go arrow and time packages to format unix timestamp
+        // Use Go time package to format unix timestamp
         // as a time with timezone layout (RFC3339)
-        time := (row["time"].(arrow.Timestamp)).
-            ToTime(arrow.TimeUnit(arrow.Nanosecond)).
+        time := (row["time"].(time.Time)).
             Format(time.RFC3339)
         fmt.Fprintf(w, "%s\t%s\t%d\t%.1f\t%.1f\n",
             time, row["room"], row["co"], row["hum"], row["temp"])
@@ -234,8 +232,7 @@ import (
     "text/tabwriter"
     "time"
 
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
-    "github.com/apache/arrow/go/v13/arrow"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 
 func InfluxQL() error {
@@ -287,10 +284,9 @@ func InfluxQL() error {
     fmt.Fprintln(w, "Process each row as key-value pairs:")
     for iterator2.Next() {
         row := iterator2.Value()
-        // Use Go arrow and time packages to format unix timestamp
+        // Use Go time package to format unix timestamp
         // as a time with timezone layout (RFC3339)
-        time := (row["time"].(arrow.Timestamp)).
-            ToTime(arrow.TimeUnit(arrow.Nanosecond)).
+        time := (row["time"].(time.Time)).
             Format(time.RFC3339)
         fmt.Fprintf(w, "%s\t%s\t%d\t%.1f\t%.1f\n",
             time, row["room"], row["co"], row["hum"], row["temp"])

--- a/content/influxdb/clustered/query-data/influxql/parameterized-queries.md
+++ b/content/influxdb/clustered/query-data/influxql/parameterized-queries.md
@@ -257,8 +257,7 @@ import (
     "os"
     "text/tabwriter"
     "time"
-    "github.com/apache/arrow/go/v14/arrow"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 
 func Query(query string, parameters influxdb3.QueryParameters,
@@ -301,10 +300,10 @@ func Query(query string, parameters influxdb3.QueryParameters,
     // Process each row as key-value pairs.
     for iterator.Next() {
         row := iterator.Value()
-        // Use Go arrow and time packages to format unix timestamp
+        // Use Go time package to format unix timestamp
         // as a time with timezone layout (RFC3339 format)
-        time := (row["time"].(arrow.Timestamp)).
-                ToTime(arrow.Nanosecond).Format(time.RFC3339)
+        time := (row["time"].(time.Time)).
+                Format(time.RFC3339)
 
         fmt.Fprintf(w, "%s\t%s\t%d\t%.1f\t%.1f\n",
             time, row["room"], row["co"], row["hum"], row["temp"])

--- a/content/influxdb/clustered/query-data/sql/parameterized-queries.md
+++ b/content/influxdb/clustered/query-data/sql/parameterized-queries.md
@@ -254,8 +254,7 @@ import (
     "os"
     "text/tabwriter"
     "time"
-    "github.com/apache/arrow/go/v14/arrow"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 
 func Query(query string, parameters influxdb3.QueryParameters) error {
@@ -297,10 +296,10 @@ func Query(query string, parameters influxdb3.QueryParameters) error {
     // Process each row as key-value pairs.
     for iterator.Next() {
         row := iterator.Value()
-        // Use Go arrow and time packages to format unix timestamp
+        // Use Go time package to format unix timestamp
         // as a time with timezone layout (RFC3339 format)
-        time := (row["time"].(arrow.Timestamp)).
-                ToTime(arrow.Nanosecond).Format(time.RFC3339)
+        time := (row["time"].(time.Time)).
+                Format(time.RFC3339)
 
         fmt.Fprintf(w, "%s\t%s\t%d\t%.1f\t%.1f\n",
             time, row["room"], row["co"], row["hum"], row["temp"])

--- a/content/influxdb/clustered/reference/client-libraries/v3/go.md
+++ b/content/influxdb/clustered/reference/client-libraries/v3/go.md
@@ -31,7 +31,7 @@ Import the package:
 
 ```go
 import (
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 ```
 
@@ -75,7 +75,7 @@ Initializes and returns a `influxdb3.Client` instance with the following:
 package main
 
 import (
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
 )
 
 func main() {

--- a/content/influxdb/clustered/write-data/line-protocol/client-libraries.md
+++ b/content/influxdb/clustered/write-data/line-protocol/client-libraries.md
@@ -229,7 +229,7 @@ points.
     "os"
     "fmt"
     "time"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3"
+    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
     "github.com/influxdata/line-protocol/v2/lineprotocol"
    )
 


### PR DESCRIPTION
This PR changes code example for Go v3 client. The client has new major versions and examples adopts this version. For more info see https://github.com/InfluxCommunity/influxdb3-go/blob/main/CHANGELOG.md#100-2024-11-15

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
