### PR TITLE
docs: note that `option location` does not change the timezone used in `_time`

### DIFF
--- a/content/flux/v0/spec/options.md
+++ b/content/flux/v0/spec/options.md
@@ -62,7 +62,7 @@ option location = timezone.fixed(offset: -5h)
 option location = timezone.location(name: "America/Denver")
 ```
 
->  [!Note]
+> [!Note]
 > The `location` option only affects boundaries used for windowing, specifically around time shifts
 > like daylight savings. It does not change timestamps in the `_time` column, which are always UTC.
 

--- a/content/flux/v0/spec/options.md
+++ b/content/flux/v0/spec/options.md
@@ -62,4 +62,9 @@ option location = timezone.fixed(offset: -5h)
 option location = timezone.location(name: "America/Denver")
 ```
 
+{{% note %}}
+The `location` option affect the boundaries used for windowing, although the times may change, the timezone used in the `_time` results column will always be UTC.
+{{% /note %}}
+
+
 {{< page-nav prev="/flux/v0/spec/variables/" next="/flux/v0/spec/types/" >}}

--- a/content/flux/v0/spec/options.md
+++ b/content/flux/v0/spec/options.md
@@ -62,9 +62,9 @@ option location = timezone.fixed(offset: -5h)
 option location = timezone.location(name: "America/Denver")
 ```
 
-{{% note %}}
-The `location` option affect the boundaries used for windowing, although the times may change, the timezone used in the `_time` results column will always be UTC.
-{{% /note %}}
+>  [!Note]
+> The `location` option only affects boundaries used for windowing, specifically around time shifts
+> like daylight savings. It does not change timestamps in the `_time` column, which are always UTC.
 
 
 {{< page-nav prev="/flux/v0/spec/variables/" next="/flux/v0/spec/types/" >}}

--- a/content/flux/v0/stdlib/timezone/fixed.md
+++ b/content/flux/v0/stdlib/timezone/fixed.md
@@ -77,3 +77,7 @@ option location = timezone.fixed(offset: -8h)
 
 ```
 
+{{% note %}}
+The `location` option affect the boundaries used for windowing, although the times may change, the timezone used in the `_time` results column will always be UTC.
+{{% /note %}}
+

--- a/content/flux/v0/stdlib/timezone/fixed.md
+++ b/content/flux/v0/stdlib/timezone/fixed.md
@@ -77,7 +77,7 @@ option location = timezone.fixed(offset: -8h)
 
 ```
 
-{{% note %}}
-The `location` option affect the boundaries used for windowing, although the times may change, the timezone used in the `_time` results column will always be UTC.
-{{% /note %}}
+>  [!Note]
+> The `location` option only affects boundaries used for windowing, specifically around time shifts
+> like daylight savings. It does not change timestamps in the `_time` column, which are always UTC.
 

--- a/content/flux/v0/stdlib/timezone/fixed.md
+++ b/content/flux/v0/stdlib/timezone/fixed.md
@@ -77,7 +77,7 @@ option location = timezone.fixed(offset: -8h)
 
 ```
 
->  [!Note]
+> [!Note]
 > The `location` option only affects boundaries used for windowing, specifically around time shifts
 > like daylight savings. It does not change timestamps in the `_time` column, which are always UTC.
 

--- a/content/flux/v0/stdlib/timezone/location.md
+++ b/content/flux/v0/stdlib/timezone/location.md
@@ -75,6 +75,6 @@ option location = timezone.location(name: "America/Los_Angeles")
 
 ```
 
->  [!Note]
+> [!Note]
 > The `location` option only affects boundaries used for windowing, specifically around time shifts
 > like daylight savings. It does not change timestamps in the `_time` column, which are always UTC.

--- a/content/flux/v0/stdlib/timezone/location.md
+++ b/content/flux/v0/stdlib/timezone/location.md
@@ -75,6 +75,6 @@ option location = timezone.location(name: "America/Los_Angeles")
 
 ```
 
-{{% note %}}
-The `location` option affect the boundaries used for windowing, although the times may change, the timezone used in the `_time` results column will always be UTC.
-{{% /note %}}
+>  [!Note]
+> The `location` option only affects boundaries used for windowing, specifically around time shifts
+> like daylight savings. It does not change timestamps in the `_time` column, which are always UTC.

--- a/content/flux/v0/stdlib/timezone/location.md
+++ b/content/flux/v0/stdlib/timezone/location.md
@@ -75,3 +75,6 @@ option location = timezone.location(name: "America/Los_Angeles")
 
 ```
 
+{{% note %}}
+The `location` option affect the boundaries used for windowing, although the times may change, the timezone used in the `_time` results column will always be UTC.
+{{% /note %}}


### PR DESCRIPTION
This periodically causes some confusion as users are surprised to find that queries using `option location` still return results in UTC (albeit with times shifted)

Add a note to the `options` page and under the examples in `timezone.location()` and `timezone.fixed()` to clarify the behaviour of using this option.


_Describe your proposed changes here._

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
