### PR TITLE
fix: Clustered may use any PostgreSQL 13 or 14

### DIFF
--- a/content/influxdb/clustered/install/set-up-cluster/prerequisites.md
+++ b/content/influxdb/clustered/install/set-up-cluster/prerequisites.md
@@ -373,7 +373,7 @@ PostgreSQL-compatible database.
 
 ### PostgreSQL-compatible database requirements
 
-- PostgreSQL versions **13.8–14.6**.
+- PostgreSQL version **13 or 14**.
 - **Minimum of 4 GB of memory** or equivalent provider-specific units.
 - To avoid conflicts and prevent issues caused by shared usage with other
   applications, ensure that your PostgreSQL-compatible instance is dedicated


### PR DESCRIPTION
PostgreSQL minor version releases do not add features, only fix bugs, so there's no need to limit to versions up to 14.6.
- https://www.postgresql.org/docs/13/release.html
- https://www.postgresql.org/docs/14/release.html

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
