### PR TITLE
docs: update all references to influxdb3-go client library to influxd…

### DIFF
--- a/content/influxdb/cloud-dedicated/get-started/query.md
+++ b/content/influxdb/cloud-dedicated/get-started/query.md
@@ -593,7 +593,7 @@ _If your project's virtual environment is already running, skip to step 3._
       "time"
       "text/tabwriter"
 
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+      "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
     )
 
     func Query() error {
@@ -659,7 +659,7 @@ _If your project's virtual environment is already running, skip to step 3._
         - `io`
         - `os`
         - `text/tabwriter`
-        - `github.com/InfluxCommunity/influxdb3-go/influxdb3/v1`
+        - `github.com/InfluxCommunity/influxdb3-go/v2/influxdb3`
 
     2.  Defines a `Query()` function that does the following:
 

--- a/content/influxdb/cloud-dedicated/get-started/write.md
+++ b/content/influxdb/cloud-dedicated/get-started/write.md
@@ -835,7 +835,7 @@ To write data to {{% product-name %}} using Go, use the InfluxDB v3
       "fmt"
       "log"
 
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+      "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
     )
 
     // Write line protocol data to InfluxDB

--- a/content/influxdb/cloud-dedicated/query-data/execute-queries/client-libraries/go.md
+++ b/content/influxdb/cloud-dedicated/query-data/execute-queries/client-libraries/go.md
@@ -21,7 +21,7 @@ list_code_example: |
     ```go
     import (
       "context"
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+      "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
     )
 
     func Query() error {
@@ -94,7 +94,7 @@ to install a recent version of the Go programming language for your system.
 In your terminal, enter the following command to download and install the client library:
 
 ```sh
-go get github.com/InfluxCommunity/influxdb3-go
+go get github.com/InfluxCommunity/influxdb3-go/v2
 ```
 
 - [`influxdb3-go`](https://github.com/InfluxCommunity/influxdb3-go) {{< req text="\* " color="magenta" >}}: Provides the `influxdb3` package and also installs the [Apache `arrow` module](https://arrow.apache.org/docs/python/index.html) for working with Arrow data returned from queries.
@@ -139,7 +139,7 @@ import (
     "text/tabwriter"
     "time"
 
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func Query() error {
@@ -234,7 +234,7 @@ import (
     "text/tabwriter"
     "time"
 
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func InfluxQL() error {

--- a/content/influxdb/cloud-dedicated/query-data/influxql/parameterized-queries.md
+++ b/content/influxdb/cloud-dedicated/query-data/influxql/parameterized-queries.md
@@ -257,7 +257,7 @@ import (
     "os"
     "text/tabwriter"
     "time"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func Query(query string, parameters influxdb3.QueryParameters,

--- a/content/influxdb/cloud-dedicated/query-data/sql/parameterized-queries.md
+++ b/content/influxdb/cloud-dedicated/query-data/sql/parameterized-queries.md
@@ -254,7 +254,7 @@ import (
     "os"
     "text/tabwriter"
     "time"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func Query(query string, parameters influxdb3.QueryParameters) error {

--- a/content/influxdb/cloud-dedicated/reference/client-libraries/v3/go.md
+++ b/content/influxdb/cloud-dedicated/reference/client-libraries/v3/go.md
@@ -20,7 +20,7 @@ to write and query data stored in an {{% product-name %}} database.
 ## Installation
 
 ```sh
-go get github.com/InfluxCommunity/influxdb3-go
+go get github.com/InfluxCommunity/influxdb3-go/v2
 ```
 
 ## Importing the package
@@ -31,7 +31,7 @@ Import the package:
 
 ```go
 import (
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 ```
 
@@ -75,7 +75,7 @@ Initializes and returns a `influxdb3.Client` instance with the following:
 package main
 
 import (
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func main() {

--- a/content/influxdb/cloud-dedicated/write-data/line-protocol/client-libraries.md
+++ b/content/influxdb/cloud-dedicated/write-data/line-protocol/client-libraries.md
@@ -119,7 +119,7 @@ The following steps set up a Go project using the
    which provides the InfluxDB `influxdb3` Go client library module.
 
    ```sh
-   go get github.com/InfluxCommunity/influxdb3-go
+   go get github.com/InfluxCommunity/influxdb3-go/v2
    ```
 
 <!-- END GO SETUP PROJECT -->
@@ -228,7 +228,7 @@ points.
     "os"
     "fmt"
     "time"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
     "github.com/influxdata/line-protocol/v2/lineprotocol"
    )
 

--- a/content/influxdb/cloud-serverless/get-started/query.md
+++ b/content/influxdb/cloud-serverless/get-started/query.md
@@ -538,7 +538,7 @@ _If your project's virtual environment is already running, skip to step 3._
       "time"
       "text/tabwriter"
 
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+      "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
     )
 
     func Query() error {
@@ -604,7 +604,7 @@ _If your project's virtual environment is already running, skip to step 3._
         - `io`
         - `os`
         - `text/tabwriter`
-        - `github.com/InfluxCommunity/influxdb3-go/influxdb3/v1`
+        - `github.com/InfluxCommunity/influxdb3-go/v2/influxdb3`
 
     2.  Defines a `Query()` function that does the following:
 

--- a/content/influxdb/cloud-serverless/get-started/write.md
+++ b/content/influxdb/cloud-serverless/get-started/write.md
@@ -804,7 +804,7 @@ InfluxDB v3 [influxdb3-go client library package](https://github.com/InfluxCommu
       "fmt"
       "log"
 
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+      "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
     )
 
     // Write line protocol data to InfluxDB

--- a/content/influxdb/cloud-serverless/query-data/execute-queries/client-libraries/go.md
+++ b/content/influxdb/cloud-serverless/query-data/execute-queries/client-libraries/go.md
@@ -21,7 +21,7 @@ list_code_example: |
     ```go
     import (
       "context"
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+      "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
     )
 
     func Query() error {
@@ -94,7 +94,7 @@ to install a recent version of the Go programming language for your system.
 In your terminal, enter the following command to download and install the client library:
 
 ```sh
-go get github.com/InfluxCommunity/influxdb3-go
+go get github.com/InfluxCommunity/influxdb3-go/v2
 ```
 
 - [`influxdb3-go`](https://github.com/InfluxCommunity/influxdb3-go) {{< req text="\* " color="magenta" >}}: Provides the `influxdb3` package and also installs the [Apache `arrow` module](https://arrow.apache.org/docs/python/index.html) for working with Arrow data returned from queries.
@@ -138,7 +138,7 @@ import (
     "text/tabwriter"
     "time"
 
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func Query() error {
@@ -233,7 +233,7 @@ import (
     "text/tabwriter"
     "time"
 
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func InfluxQL() error {

--- a/content/influxdb/cloud-serverless/query-data/influxql/parameterized-queries.md
+++ b/content/influxdb/cloud-serverless/query-data/influxql/parameterized-queries.md
@@ -257,7 +257,7 @@ import (
     "os"
     "text/tabwriter"
     "time"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func Query(query string, parameters influxdb3.QueryParameters,

--- a/content/influxdb/cloud-serverless/query-data/sql/parameterized-queries.md
+++ b/content/influxdb/cloud-serverless/query-data/sql/parameterized-queries.md
@@ -254,7 +254,7 @@ import (
     "os"
     "text/tabwriter"
     "time"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func Query(query string, parameters influxdb3.QueryParameters) error {

--- a/content/influxdb/cloud-serverless/reference/client-libraries/v3/go.md
+++ b/content/influxdb/cloud-serverless/reference/client-libraries/v3/go.md
@@ -20,7 +20,7 @@ to write and query data stored in an {{% product-name %}} bucket.
 ## Installation
 
 ```sh
-go get github.com/InfluxCommunity/influxdb3-go
+go get github.com/InfluxCommunity/influxdb3-go/v2
 ```
 
 ## Importing the package
@@ -31,7 +31,7 @@ Import the package:
 
 ```go
 import (
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 ```
 
@@ -75,7 +75,7 @@ Initializes and returns a `influxdb3.Client` instance with the following:
 package main
 
 import (
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func Query() error {

--- a/content/influxdb/cloud-serverless/write-data/line-protocol/client-libraries.md
+++ b/content/influxdb/cloud-serverless/write-data/line-protocol/client-libraries.md
@@ -120,7 +120,7 @@ The following steps set up a Go project using the
    which provides the InfluxDB `influxdb3` Go client library module.
 
    ```sh
-   go get github.com/InfluxCommunity/influxdb3-go
+   go get github.com/InfluxCommunity/influxdb3-go/v2
    ```
 
 <!-- END GO SETUP PROJECT -->
@@ -229,7 +229,7 @@ points.
     "os"
     "fmt"
     "time"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
     "github.com/influxdata/line-protocol/v2/lineprotocol"
    )
 

--- a/content/influxdb/clustered/get-started/query.md
+++ b/content/influxdb/clustered/get-started/query.md
@@ -585,7 +585,7 @@ _If your project's virtual environment is already running, skip to step 3._
       "time"
       "text/tabwriter"
 
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+      "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
     )
 
     func Query() error {
@@ -651,7 +651,7 @@ _If your project's virtual environment is already running, skip to step 3._
         - `io`
         - `os`
         - `text/tabwriter`
-        - `github.com/InfluxCommunity/influxdb3-go/influxdb3/v1`
+        - `github.com/InfluxCommunity/influxdb3-go/v2/influxdb3`
 
     2.  Defines a `Query()` function that does the following:
 

--- a/content/influxdb/clustered/get-started/write.md
+++ b/content/influxdb/clustered/get-started/write.md
@@ -840,7 +840,7 @@ To write data to {{% product-name %}} using Go, use the InfluxDB v3
       "fmt"
       "log"
 
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+      "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
     )
 
     // Write line protocol data to InfluxDB

--- a/content/influxdb/clustered/query-data/execute-queries/client-libraries/go.md
+++ b/content/influxdb/clustered/query-data/execute-queries/client-libraries/go.md
@@ -21,7 +21,7 @@ list_code_example: |
     ```go
     import (
       "context"
-      "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+      "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
     )
 
     func Query() error {
@@ -94,7 +94,7 @@ to install a recent version of the Go programming language for your system.
 In your terminal, enter the following command to download and install the client library:
 
 ```sh
-go get github.com/InfluxCommunity/influxdb3-go
+go get github.com/InfluxCommunity/influxdb3-go/v2
 ```
 
 - [`influxdb3-go`](https://github.com/InfluxCommunity/influxdb3-go) {{< req text="\* " color="magenta" >}}: Provides the `influxdb3` package and also installs the [Apache `arrow` module](https://arrow.apache.org/docs/python/index.html) for working with Arrow data returned from queries.
@@ -137,7 +137,7 @@ import (
     "text/tabwriter"
     "time"
 
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func Query() error {
@@ -232,7 +232,7 @@ import (
     "text/tabwriter"
     "time"
 
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func InfluxQL() error {

--- a/content/influxdb/clustered/query-data/influxql/parameterized-queries.md
+++ b/content/influxdb/clustered/query-data/influxql/parameterized-queries.md
@@ -257,7 +257,7 @@ import (
     "os"
     "text/tabwriter"
     "time"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func Query(query string, parameters influxdb3.QueryParameters,

--- a/content/influxdb/clustered/query-data/sql/parameterized-queries.md
+++ b/content/influxdb/clustered/query-data/sql/parameterized-queries.md
@@ -254,7 +254,7 @@ import (
     "os"
     "text/tabwriter"
     "time"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func Query(query string, parameters influxdb3.QueryParameters) error {

--- a/content/influxdb/clustered/reference/client-libraries/v3/go.md
+++ b/content/influxdb/clustered/reference/client-libraries/v3/go.md
@@ -20,7 +20,7 @@ to write and query data stored in an {{% product-name %}} database.
 ## Installation
 
 ```sh
-go get github.com/InfluxCommunity/influxdb3-go
+go get github.com/InfluxCommunity/influxdb3-go/v2
 ```
 
 ## Importing the package
@@ -31,7 +31,7 @@ Import the package:
 
 ```go
 import (
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 ```
 
@@ -75,7 +75,7 @@ Initializes and returns a `influxdb3.Client` instance with the following:
 package main
 
 import (
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func main() {

--- a/content/influxdb/clustered/write-data/line-protocol/client-libraries.md
+++ b/content/influxdb/clustered/write-data/line-protocol/client-libraries.md
@@ -120,7 +120,7 @@ The following steps set up a Go project using the
    which provides the InfluxDB `influxdb3` Go client library module.
 
    ```sh
-   go get github.com/InfluxCommunity/influxdb3-go
+   go get github.com/InfluxCommunity/influxdb3-go/v2
    ```
 
 <!-- END GO SETUP PROJECT -->
@@ -229,7 +229,7 @@ points.
     "os"
     "fmt"
     "time"
-    "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+    "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
     "github.com/influxdata/line-protocol/v2/lineprotocol"
    )
 


### PR DESCRIPTION
The client library Influxdb3-go was released with a major version upgrade last night.  The latest release is now version 2.

These changes update code and command references in the documentation reflecting this release. 

_Describe your proposed changes here._

- [X] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [X] Rebased/mergeable
