### PR TITLE
chore: clarify s3 default region

### DIFF
--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -110,7 +110,7 @@ influxdb3 serve --writer-id=local01 --object-store=file --data-dir ~/.influxdb3
 ```
 
 ```bash
-# S3
+# S3 (defaults to us-east-1 for region)
 influxdb3 serve --writer-id=local01 --object-store=s3 --bucket=[BUCKET] --aws-access-key=[AWS ACCESS KEY] --aws-secret-access-key=[AWS SECRET ACCESS KEY]
 ```
 

--- a/content/shared/v3-enterprise-get-started/_index.md
+++ b/content/shared/v3-enterprise-get-started/_index.md
@@ -108,7 +108,7 @@ influxdb3 serve --writer-id=local01 --object-store=file --data-dir ~/.influxdb3
 ```
 
 ```bash
-# S3
+# S3 (defaults to us-east-1 for region)
 influxdb3 serve --writer-id=local01 --object-store=s3 --bucket=[BUCKET] --aws-access-key=[AWS ACCESS KEY] --aws-secret-access-key=[AWS SECRET ACCESS KEY]
 ```
 


### PR DESCRIPTION
Clarifies that S3 defaults to `us-east-1` region