### PR TITLE
fix: updating writer-id to node-id

### DIFF
--- a/content/influxdb3/core/reference/cli/influxdb3/serve.md
+++ b/content/influxdb3/core/reference/cli/influxdb3/serve.md
@@ -18,7 +18,7 @@ The `influxdb3 serve` command starts the {{< product-name >}} server.
 <!--pytest.mark.skip-->
 
 ```bash
-influxdb3 serve [OPTIONS] --writer-id <HOST_IDENTIFIER_PREFIX>
+influxdb3 serve [OPTIONS] --node-id <HOST_IDENTIFIER_PREFIX>
 ```
 
 ## Options
@@ -81,7 +81,7 @@ influxdb3 serve [OPTIONS] --writer-id <HOST_IDENTIFIER_PREFIX>
 |                  | `--snapshotted-wal-files-to-keep`                    | _See [configuration options](/influxdb3/core/reference/config-options/#snapshotted-wal-files-to-keep)_                    |
 |                  | `--query-log-size`                                   | _See [configuration options](/influxdb3/core/reference/config-options/#query-log-size)_                                   |
 |                  | `--buffer-mem-limit-mb`                              | _See [configuration options](/influxdb3/core/reference/config-options/#buffer-mem-limit-mb)_                              |
-| {{< req "\*" >}} | `--writer-id`                                        | _See [configuration options](/influxdb3/core/reference/config-options/#writer-id)_                                        |
+| {{< req "\*" >}} | `--node-id`                                          | _See [configuration options](/influxdb3/core/reference/config-options/#node-id)_                                          |
 |                  | `--parquet-mem-cache-size-mb`                        | _See [configuration options](/influxdb3/core/reference/config-options/#parquet-mem-cache-size-mb)_                        |
 |                  | `--parquet-mem-cache-prune-percentage`               | _See [configuration options](/influxdb3/core/reference/config-options/#parquet-mem-cache-prune-percentage)_               |
 |                  | `--parquet-mem-cache-prune-interval`                 | _See [configuration options](/influxdb3/core/reference/config-options/#parquet-mem-cache-prune-interval)_                 |
@@ -121,7 +121,7 @@ with a unique identifier for your {{< product-name >}} server.
 influxdb3 serve \
   --object-store file \
   --data-dir ~/.influxdb3 \
-  --writer-id MY_HOST_ID
+  --node-id MY_HOST_ID
 ```
 
 ### Run the InfluxDB 3 server with extra verbose logging
@@ -133,7 +133,7 @@ influxdb3 serve \
   --verbose \
   --object-store file \
   --data-dir ~/.influxdb3 \
-  --writer-id MY_HOST_ID
+  --node-id MY_HOST_ID
 ```
 
 ### Run InfluxDB 3 with debug logging using LOG_FILTER
@@ -144,7 +144,7 @@ influxdb3 serve \
 LOG_FILTER=debug influxdb3 serve \
   --object-store file \
   --data-dir ~/.influxdb3 \
-  --writer-id MY_HOST_ID
+  --node-id MY_HOST_ID
 ```
 
 {{% /code-placeholders %}}

--- a/content/influxdb3/core/reference/config-options.md
+++ b/content/influxdb3/core/reference/config-options.md
@@ -27,7 +27,7 @@ environment variables.
 influxdb3 serve \
   --object-store file \
   --data-dir ~/.influxdb3 \
-  --writer-id my-host \
+  --node-id my-host \
   --log-filter info \
   --max-http-request-size 20971520 \
   --aws-allow-http
@@ -53,7 +53,7 @@ influxdb3 serve
 - [General](#general)
   - [object-store](#object-store)
   - [data-dir](#data-dir)
-  - [writer-id](#writer-id)
+  - [node-id](#node-id)
 - [AWS](#aws)
   - [aws-access-key-id](#aws-access-key-id)
   - [aws-secret-access-key](#aws-secret-access-key)
@@ -136,7 +136,7 @@ influxdb3 serve
 - [object-store](#object-store)
 - [bucket](#bucket)
 - [data-dir](#data-dir)
-- [writer-id](#writer-id)
+- [node-id](#node-id)
 
 #### object-store
 
@@ -166,15 +166,15 @@ Defines the location {{< product-name >}} uses to store files locally.
 
 ---
 
-#### writer-id
+#### node-id
 
-Specifies the writer identifier used as a prefix in all object store file paths.
+Specifies the node identifier used as a prefix in all object store file paths.
 This should be unique for any hosts sharing the same object store
 configuration--for example, the same bucket.
 
-| influxdb3 serve option | Environment variable                 |
-| :--------------------- | :----------------------------------- |
-| `--writer-id`          | `INFLUXDB3_WRITER_IDENTIFIER_PREFIX` |
+| influxdb3 serve option | Environment variable               |
+| :--------------------- | :--------------------------------- |
+| `--node-id`            | `INFLUXDB3_NODE_IDENTIFIER_PREFIX` |
 
 ---
 

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/serve.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/serve.md
@@ -16,7 +16,7 @@ The `influxdb3 serve` command starts the {{< product-name >}} server.
 <!--pytest.mark.skip-->
 
 ```bash
-influxdb3 serve [OPTIONS] --writer-id <HOST_IDENTIFIER_PREFIX>
+influxdb3 serve [OPTIONS] --node-id <HOST_IDENTIFIER_PREFIX>
 ```
 
 ## Options
@@ -78,12 +78,12 @@ influxdb3 serve [OPTIONS] --writer-id <HOST_IDENTIFIER_PREFIX>
 |                  | `--wal-max-write-buffer-size`                        | _See [configuration options](/influxdb3/enterprise/reference/config-options/#wal-max-write-buffer-size)_                        |
 |                  | `--query-log-size`                                   | _See [configuration options](/influxdb3/enterprise/reference/config-options/#query-log-size)_                                   |
 |                  | `--buffer-mem-limit-mb`                              | _See [configuration options](/influxdb3/enterprise/reference/config-options/#buffer-mem-limit-mb)_                              |
-| {{< req "\*" >}} | `--writer-id`                                        | _See [configuration options](/influxdb3/enterprise/reference/config-options/#writer-id)_                                        |
+| {{< req "\*" >}} | `--node-id`                                          | _See [configuration options](/influxdb3/enterprise/reference/config-options/#node-id)_                                          |
 |                  | `--mode`                                             | _See [configuration options](/influxdb3/enterprise/reference/config-options/#mode)_                                             |
-|                  | `--read-from-writer-ids`                             | _See [configuration options](/influxdb3/enterprise/reference/config-options/#read-from-writer-ids)_                             |
+|                  | `--read-from-node-ids`                               | _See [configuration options](/influxdb3/enterprise/reference/config-options/#read-from-node-ids)_                               |
 |                  | `--replication-interval`                             | _See [configuration options](/influxdb3/enterprise/reference/config-options/#replication-interval)_                             |
 |                  | `--compactor-id`                                     | _See [configuration options](/influxdb3/enterprise/reference/config-options/#compactor-id)_                                     |
-|                  | `--compact-from-writer-ids`                          | _See [configuration options](/influxdb3/enterprise/reference/config-options/#compact-from-writer-ids)_                          |
+|                  | `--compact-from-node-ids`                            | _See [configuration options](/influxdb3/enterprise/reference/config-options/#compact-from-node-ids)_                            |
 |                  | `--run-compactions`                                  | _See [configuration options](/influxdb3/enterprise/reference/config-options/#run-compactions)_                                  |
 |                  | `--compaction-row-limit`                             | _See [configuration options](/influxdb3/enterprise/reference/config-options/#compaction-row-limit)_                             |
 |                  | `--compaction-max-num-files-per-plan`                | _See [configuration options](/influxdb3/enterprise/reference/config-options/#compaction-max-num-files-per-plan)_                |
@@ -128,7 +128,7 @@ with a unique identifier for your {{< product-name >}} server.
 influxdb3 serve \
   --object-store file \
   --data-dir ~/.influxdb3 \
-  --writer-id MY_HOST_NAME
+  --node-id MY_HOST_NAME
 ```
 
 ### Run the InfluxDB 3 server with extra verbose logging
@@ -140,7 +140,7 @@ influxdb3 serve \
   --verbose \
   --object-store file \
   --data-dir ~/.influxdb3 \
-  --writer-id MY_HOST_NAME
+  --node-id MY_HOST_NAME
 ```
 
 ### Run InfluxDB 3 with debug logging using LOG_FILTER
@@ -151,7 +151,7 @@ influxdb3 serve \
 LOG_FILTER=debug influxdb3 serve \
   --object-store file \
   --data-dir ~/.influxdb3 \
-  --writer-id MY_HOST_NAME
+  --node-id MY_HOST_NAME
 ```
 
 {{% /code-placeholders %}}

--- a/content/influxdb3/enterprise/reference/config-options.md
+++ b/content/influxdb3/enterprise/reference/config-options.md
@@ -27,7 +27,7 @@ environment variables.
 influxdb3 serve \
   --object-store file \
   --data-dir ~/.influxdb3 \
-  --writer-id my-host \
+  --node-id my-host \
   --log-filter info \
   --max-http-request-size 20971520 \
   --aws-allow-http
@@ -53,7 +53,7 @@ influxdb3 serve
 - [General](#general)
   - [object-store](#object-store)
   - [data-dir](#data-dir)
-  - [writer-id](#writer-id)
+  - [node-id](#node-id)
   - [mode](#mode)
 - [AWS](#aws)
   - [aws-access-key-id](#aws-access-key-id)
@@ -118,11 +118,11 @@ influxdb3 serve
   - [wal-max-write-buffer-size](#wal-max-write-buffer-size)
   - [snapshotted-wal-files-to-keep](#snapshotted-wal-files-to-keep)
 - [Replication](#replication)
-  - [read-from-writer-ids](#read-from-writer-ids)
+  - [read-from-node-ids](#read-from-node-ids)
   - [replication-interval](#replication-interval)
 - [Compaction](#compaction)
   - [compactor-id](#compactor-id)
-  - [compact-from-writer-ids](#compact-from-writer-ids)
+  - [compact-from-node-ids](#compact-from-node-ids)
   - [run-compactions](#run-compactions)
   - [compaction-row-limit](#compaction-row-limit)
   - [compaction-max-num-files-per-plan](#compaction-max-num-files-per-plan)
@@ -147,7 +147,7 @@ influxdb3 serve
 - [object-store](#object-store)
 - [bucket](#bucket)
 - [data-dir](#data-dir)
-- [writer-id](#writer-id)
+- [node-id](#node-id)
 - [mode](#mode)
 
 #### object-store
@@ -178,15 +178,15 @@ Defines the location {{< product-name >}} uses to store files locally.
 
 ---
 
-#### writer-id
+#### node-id
 
-Specifies the writer identifier used as a prefix in all object store file paths.
+Specifies the node identifier used as a prefix in all object store file paths.
 This should be unique for any hosts sharing the same object store
 configuration--for example, the same bucket.
 
-| influxdb3 serve option | Environment variable                 |
-| :--------------------- | :----------------------------------- |
-| `--writer-id`          | `INFLUXDB3_WRITER_IDENTIFIER_PREFIX` |
+| influxdb3 serve option | Environment variable               |
+| :--------------------- | :--------------------------------- |
+| `--node-id`            | `INFLUXDB3_NODE_IDENTIFIER_PREFIX` |
 
 ---
 
@@ -902,24 +902,24 @@ they are deleted when the number of snapshotted WAL files exceeds this number.
 
 ### Replication
 
-- [read-from-writer-ids](#read-from-writer-ids)
+- [read-from-node-ids](#read-from-node-ids)
 - [replication-interval](#replication-interval)
 
-#### read-from-writer-ids
+#### read-from-node-ids
 
-Specifies a comma-separated list of writer identifier prefixes (`writer-id`s) to
+Specifies a comma-separated list of writer identifier prefixes (`node-id`s) to
 read WAL files from. [env: =]
 
 | influxdb3 serve option | Environment variable            |
 | :--------------------- | :------------------------------ |
-| `--read-from-writer-ids`           | `INFLUXDB3_ENTERPRISE_READ_FROM_WRITER_IDS` |
+| `--read-from-node-ids`           | `INFLUXDB3_ENTERPRISE_READ_FROM_WRITER_IDS` |
 
 ---
 
 #### replication-interval
 
 Defines the interval at which each replica specified in the
-`read-from-writer-ids` option is replicated.
+`read-from-node-ids` option is replicated.
 
 **Default:** `250ms`
 
@@ -932,7 +932,7 @@ Defines the interval at which each replica specified in the
 ### Compaction
 
 - [compactor-id](#compactor-id)
-- [compact-from-writer-ids](#compact-from-writer-ids)
+- [compact-from-node-ids](#compact-from-node-ids)
 - [run-compactions](#run-compactions)
 - [compaction-row-limit](#compaction-row-limit)
 - [compaction-max-num-files-per-plan](#compaction-max-num-files-per-plan)
@@ -952,14 +952,14 @@ write buffer and any replicas it manages.
 
 ---
 
-#### compact-from-writer-ids
+#### compact-from-node-ids
 
 Defines a comma-separated list of writer identifier prefixes from which data is
 compacted.
 
 | influxdb3 serve option      | Environment variable                           |
 | :-------------------------- | :--------------------------------------------- |
-| `--compact-from-writer-ids` | `INFLUXDB3_ENTERPRISE_COMPACT_FROM_WRITER_IDS` |
+| `--compact-from-node-ids` | `INFLUXDB3_ENTERPRISE_COMPACT_FROM_WRITER_IDS` |
 
 ---
 

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -139,21 +139,21 @@ To start your InfluxDB instance, use the `influxdb3 serve` command
 and provide the following:
 
 - `--object-store`: Specifies the type of Object store to use. InfluxDB supports the following: local file system (`file`), `memory`, S3 (and compatible services like Ceph or Minio) (`s3`), Google Cloud Storage (`google`), and Azure Blob Storage (`azure`).
-- `--writer-id`: A string identifier that determines the server's storage path within the configured storage location
+- `--node-id`: A string identifier that determines the server's storage path within the configured storage location
 
 The following examples show how to start InfluxDB 3 with different object store configurations:
 
 ```bash
 # MEMORY
 # Stores data in RAM; doesn't persist data
-influxdb3 serve --writer-id=local01 --object-store=memory
+influxdb3 serve --node-id=local01 --object-store=memory
 ```
 
 ```bash
 # FILESYSTEM
 # Provide the filesystem directory
 influxdb3 serve \
-  --writer-id=local01 \
+  --node-id=local01 \
   --object-store=file \
   --data-dir ~/.influxdb3
 ```
@@ -170,7 +170,7 @@ To run the [Docker image](/influxdb3/core/install/#docker-image) and persist dat
 docker run -it \
  -v /path/on/host:/path/in/container \
  quay.io/influxdb/influxdb3-core:latest serve \
- --writer-id my_host \
+ --node-id my_host \
  --object-store file \
  --data-dir /path/in/container
 ```
@@ -178,13 +178,13 @@ docker run -it \
 ```bash
 # S3 (defaults to us-east-1 for region)
 # Specify the Object store type and associated options
-influxdb3 serve --writer-id=local01 --object-store=s3 --bucket=[BUCKET] --aws-access-key=[AWS ACCESS KEY] --aws-secret-access-key=[AWS SECRET ACCESS KEY]
+influxdb3 serve --node-id=local01 --object-store=s3 --bucket=[BUCKET] --aws-access-key=[AWS ACCESS KEY] --aws-secret-access-key=[AWS SECRET ACCESS KEY]
 ```
 
 ```bash
 # Minio/Open Source Object Store (Uses the AWS S3 API, with additional parameters)
 # Specify the Object store type and associated options
-influxdb3 serve --writer-id=local01 --object-store=s3 --bucket=[BUCKET] --aws-access-key=[AWS ACCESS KEY] --aws-secret-access-key=[AWS SECRET ACCESS KEY] --aws-endpoint=[ENDPOINT] --aws-allow-http
+influxdb3 serve --node-id=local01 --object-store=s3 --bucket=[BUCKET] --aws-access-key=[AWS ACCESS KEY] --aws-secret-access-key=[AWS SECRET ACCESS KEY] --aws-endpoint=[ENDPOINT] --aws-allow-http
 ```
 
 _For more information about server options, run `influxdb3 serve --help`._

--- a/content/shared/v3-enterprise-get-started/_index.md
+++ b/content/shared/v3-enterprise-get-started/_index.md
@@ -130,21 +130,21 @@ To start your InfluxDB instance, use the `influxdb3 serve` command
 and provide the following:
 
 - `--object-store`: Specifies the type of Object store to use. InfluxDB supports the following: local file system (`file`), `memory`, S3 (and compatible services like Ceph or Minio) (`s3`), Google Cloud Storage (`google`), and Azure Blob Storage (`azure`).
-- `--writer-id`: A string identifier that determines the server's storage path within the configured storage location, and, in a multi-node setup, is used to reference the node
+- `--node-id`: A string identifier that determines the server's storage path within the configured storage location, and, in a multi-node setup, is used to reference the node
 
 The following examples show how to start InfluxDB 3 with different object store configurations:
 
 ```bash
 # MEMORY
 # Stores data in RAM; doesn't persist data
-influxdb3 serve --writer-id=local01 --object-store=memory
+influxdb3 serve --node-id=local01 --object-store=memory
 ```
 
 ```bash
 # FILESYSTEM
 # Provide the filesystem directory
 influxdb3 serve \
-  --writer-id=local01 \
+  --node-id=local01 \
   --object-store=file \
   --data-dir ~/.influxdb3
 ```
@@ -161,7 +161,7 @@ To run the [Docker image](/influxdb3/enterprise/install/#docker-image) and persi
 docker run -it \
  -v /path/on/host:/path/in/container \
  quay.io/influxdb/influxdb3-enterprise:latest serve \
- --writer-id my_host \
+ --node-id my_host \
  --object-store file \
  --data-dir /path/in/container
 ```
@@ -169,13 +169,13 @@ docker run -it \
 ```bash
 # S3 (defaults to us-east-1 for region)
 # Specify the Object store type and associated options
-influxdb3 serve --writer-id=local01 --object-store=s3 --bucket=[BUCKET] --aws-access-key=[AWS ACCESS KEY] --aws-secret-access-key=[AWS SECRET ACCESS KEY]
+influxdb3 serve --node-id=local01 --object-store=s3 --bucket=[BUCKET] --aws-access-key=[AWS ACCESS KEY] --aws-secret-access-key=[AWS SECRET ACCESS KEY]
 ```
 
 ```bash
 # Minio/Open Source Object Store (Uses the AWS S3 API, with additional parameters)
 # Specify the Object store type and associated options
-influxdb3 serve --writer-id=local01 --object-store=s3 --bucket=[BUCKET] --aws-access-key=[AWS ACCESS KEY] --aws-secret-access-key=[AWS SECRET ACCESS KEY] --aws-endpoint=[ENDPOINT] --aws-allow-http
+influxdb3 serve --node-id=local01 --object-store=s3 --bucket=[BUCKET] --aws-access-key=[AWS ACCESS KEY] --aws-secret-access-key=[AWS SECRET ACCESS KEY] --aws-endpoint=[ENDPOINT] --aws-allow-http
 ```
 
 _For more information about server options, run `influxdb3 serve --help`._
@@ -783,7 +783,7 @@ The following examples show how to configure and start two nodes
 for a basic HA setup.
 The example commands pass the following options:
 
-- `--read-from-writer-ids`: makes the node a _read replica_, which checks the Object store for data arriving from other nodes
+- `--read-from-node-ids`: makes the node a _read replica_, which checks the Object store for data arriving from other nodes
 - `--compactor-id`: activates the Compactor for a node. Only one node can run compaction
 - `--run-compactions`: ensures the Compactor runs the compaction process
 
@@ -791,22 +791,22 @@ The example commands pass the following options:
 ## NODE 1
 
 # Example variables
-# writer-id: 'host01'
+# node-id: 'host01'
 # bucket: 'influxdb-3-enterprise-storage'
 # compactor-id: 'c01'
 
 
-influxdb3 serve --writer-id=host01 --read-from-writer-ids=host02 --compactor-id=c01 --run-compactions --object-store=s3 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8181 --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY> 
+influxdb3 serve --node-id=host01 --read-from-node-ids=host02 --compactor-id=c01 --run-compactions --object-store=s3 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8181 --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY> 
 ```
 
 ```
 ## NODE 2
 
 # Example variables
-# writer-id: 'host02'
+# node-id: 'host02'
 # bucket: 'influxdb-3-enterprise-storage'
 
-influxdb3 serve --writer-id=host02 --read-from-writer-ids=host01 --object-store=s3 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8282
+influxdb3 serve --node-id=host02 --read-from-node-ids=host01 --object-store=s3 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8282
 --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY> 
 ```
 
@@ -814,7 +814,7 @@ After the nodes have started, querying either node returns data for both nodes, 
 To add nodes to this setup, start more read replicas:
 
 ```bash
-influxdb3 serve --read-from-writer-ids=host01,host02 [...OPTIONS]
+influxdb3 serve --read-from-node-ids=host01,host02 [...OPTIONS]
 ```
 
 > [!Note]
@@ -822,12 +822,12 @@ influxdb3 serve --read-from-writer-ids=host01,host02 [...OPTIONS]
 > 
 > ```bash
 > # In terminal 1
-> influxdb3 serve --writer-id=host01 --http-bind=http://127.0.0.1:8181 [...OPTIONS]
+> influxdb3 serve --node-id=host01 --http-bind=http://127.0.0.1:8181 [...OPTIONS]
 > ```
 >
 > ```bash
 > # In terminal 2
-> influxdb3 serve --writer-id=host01 --http-bind=http://127.0.0.1:8181 [...OPTIONS]
+> influxdb3 serve --node-id=host01 --http-bind=http://127.0.0.1:8181 [...OPTIONS]
 
 ### High availability with a dedicated Compactor
 
@@ -845,20 +845,20 @@ The following examples show how to set up HA with a dedicated Compactor node:
    ## NODE 1 — Writer/Reader Node #1
 
    # Example variables
-   # writer-id: 'host01'
+   # node-id: 'host01'
    # bucket: 'influxdb-3-enterprise-storage'
 
-   influxdb3 serve --writer-id=host01 --compactor-id=c01 --read-from-writer-ids=host02 --object-store=s3 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8181 --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
+   influxdb3 serve --node-id=host01 --compactor-id=c01 --read-from-node-ids=host02 --object-store=s3 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8181 --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
    ```
 
    ```bash
    ## NODE 2 — Writer/Reader Node #2
 
    # Example variables
-   # writer-id: 'host02'
+   # node-id: 'host02'
    # bucket: 'influxdb-3-enterprise-storage'
 
-   influxdb3 serve --writer-id=host02 --compactor-id=c01 --read-from-writer-ids=host01 --object-store=s3 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8282 --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
+   influxdb3 serve --node-id=host02 --compactor-id=c01 --read-from-node-ids=host01 --object-store=s3 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8282 --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
    ```
 
 2. Start the dedicated compactor node, which uses the following options:
@@ -866,18 +866,18 @@ The following examples show how to set up HA with a dedicated Compactor node:
    - `--mode=compactor`: Ensures the node **only** runs compaction.
    - `--compaction-hosts`: Specifies a comma-delimited list of hosts to run compaction for.
   
-  _**Don't include the replicas (`--read-from-writer-ids`) parameter because this node doesn't replicate data._
+  _**Don't include the replicas (`--read-from-node-ids`) parameter because this node doesn't replicate data._
 
    ```bash
 
    ## NODE 3 — Compactor Node
 
    # Example variables
-   # writer-id: 'host03'
+   # node-id: 'host03'
    # bucket: 'influxdb-3-enterprise-storage'
    # compactor-id: 'c01'
 
-   influxdb3 serve --writer-id=host03 --mode=compactor --compactor-id=c01 --compaction-hosts=host01,host02 --run-compactions --object-store=s3 --bucket=influxdb-3-enterprise-storage --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
+   influxdb3 serve --node-id=host03 --mode=compactor --compactor-id=c01 --compaction-hosts=host01,host02 --run-compactions --object-store=s3 --bucket=influxdb-3-enterprise-storage --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
    ```
 
 ### High availability with read replicas and a dedicated Compactor
@@ -893,10 +893,10 @@ For a very robust and effective setup for managing time-series data, you can run
    ## NODE 1 — Writer Node #1
 
    # Example variables
-   # writer-id: 'host01'
+   # node-id: 'host01'
    # bucket: 'influxdb-3-enterprise-storage'
 
-   influxdb3 serve --writer-id=host01 --mode=read_write --object-store=s3 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8181 --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
+   influxdb3 serve --node-id=host01 --mode=read_write --object-store=s3 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8181 --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
 
    ```
 
@@ -904,10 +904,10 @@ For a very robust and effective setup for managing time-series data, you can run
    ## NODE 2 — Writer Node #2
 
    # Example variables
-   # writer-id: 'host02'
+   # node-id: 'host02'
    # bucket: 'influxdb-3-enterprise-storage'
 
-   Usage: $ influxdb3 serve --writer-id=host02 --mode=read_write --object-store=s3 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8282 --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
+   Usage: $ influxdb3 serve --node-id=host02 --mode=read_write --object-store=s3 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8282 --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
    ```
 
 2. Start the dedicated Compactor node (`--mode=compactor`) and ensure it runs compactions on the specified `compaction-hosts`.
@@ -916,36 +916,36 @@ For a very robust and effective setup for managing time-series data, you can run
    ## NODE 3 — Compactor Node
 
    # Example variables
-   # writer-id: 'host03'
+   # node-id: 'host03'
    # bucket: 'influxdb-3-enterprise-storage'
 
-   influxdb3 serve --writer-id=host03 --mode=compactor --compaction-hosts=host01,host02 --run-compactions --object-store=s3 --bucket=influxdb-3-enterprise-storage --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
+   influxdb3 serve --node-id=host03 --mode=compactor --compaction-hosts=host01,host02 --run-compactions --object-store=s3 --bucket=influxdb-3-enterprise-storage --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
    ```
 
 3. Finally, start the query nodes as _read-only_.
    Include the following options: 
    
    - `--mode=read`: Sets the node to _read-only_
-   - `--read-from-writer-ids=host01,host02`: A comma-demlimited list of host IDs to read data from
+   - `--read-from-node-ids=host01,host02`: A comma-demlimited list of host IDs to read data from
 
    ```bash
    ## NODE 4 — Read Node #1
 
    # Example variables
-   # writer-id: 'host04'
+   # node-id: 'host04'
    # bucket: 'influxdb-3-enterprise-storage'
 
-   influxdb3 serve --writer-id=host04 --mode=read --object-store=s3 --read-from-writer-ids=host01,host02 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8383 --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
+   influxdb3 serve --node-id=host04 --mode=read --object-store=s3 --read-from-node-ids=host01,host02 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8383 --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
    ```
 
    ```
    ## NODE 5 — Read Node #2
 
    # Example variables
-   # writer-id: 'host05'
+   # node-id: 'host05'
    # bucket: 'influxdb-3-enterprise-storage'
 
-   influxdb3 serve --writer-id=host05 --mode=read --object-store=s3 --read-from-writer-ids=host01,host02 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8484 --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
+   influxdb3 serve --node-id=host05 --mode=read --object-store=s3 --read-from-node-ids=host01,host02 --bucket=influxdb-3-enterprise-storage --http-bind=0.0.0.0:8484 --aws-access-key-id=<AWS_ACCESS_KEY_ID> --aws-secret-access-key=<AWS_SECRET_ACCESS_KEY>
    ```
 
 Congratulations, you have a robust setup to workload isolation using {{% product-name %}}.


### PR DESCRIPTION
Updates to tell users to use `--node-id` instead of `--writer-id` given newest changes.