### PR TITLE
chore: fix typo in Clustered bypass identity provider section

### DIFF
--- a/content/influxdb3/clustered/admin/bypass-identity-provider.md
+++ b/content/influxdb3/clustered/admin/bypass-identity-provider.md
@@ -69,7 +69,7 @@ The only way to revoke the token is to do the following:
     kubectl delete secret rsa-keys admin-token --namespace INFLUXDB_NAMESPACE
     ```
 
-2.  Rerun the `key-gen` and `create-amin-token` jobs:
+2.  Rerun the `key-gen` and `create-admin-token` jobs:
 
     1.  List the jobs in your InfluxDB namespace to find the key-gen job pod:
 


### PR DESCRIPTION
This fixes a typo in the "Bypass your identity provider" section of the InfluxDB 3 Clustered docs.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
