### PR TITLE
Add new influxdb3 write and query input methods

### DIFF
--- a/content/shared/influxdb3-cli/query.md
+++ b/content/shared/influxdb3-cli/query.md
@@ -32,7 +32,7 @@ influxdb3 query [OPTIONS] --database <DATABASE_NAME> [QUERY]...
 | `-l`   | `--language` | Query language of the query string (`sql` _(default)_ or `influxql`)                     |
 |        | `--format`   | Output format (`pretty` _(default)_, `json`, `jsonl`, `csv`, `parquet`)                  |
 | `-o`   | `--output`   | Output query results to the specified file                                               |
-| `-f`   | `--file`     | A file that contains the query to execute                                                     |
+| `-f`   | `--file`     | A file that contains the query to execute                                                |
 | `-h`   | `--help`     | Print help information                                                                   |
 
 ### Option environment variables

--- a/content/shared/influxdb3-cli/query.md
+++ b/content/shared/influxdb3-cli/query.md
@@ -16,7 +16,11 @@ influxdb3 query [OPTIONS] --database <DATABASE_NAME> [QUERY]...
 
 ## Arguments
 
-- **QUERY**: The query string to execute.
+- **QUERY**: The query to execute. Provide the query in one of the following ways:
+
+  - a string on the command line
+  - a path to a file that contains the query using the `--file` option
+  - from stdin
 
 ## Options
 
@@ -26,8 +30,9 @@ influxdb3 query [OPTIONS] --database <DATABASE_NAME> [QUERY]...
 | `-d`   | `--database` | _({{< req >}})_ Name of the database to operate on                                       |
 |        | `--token`    | Authentication token                                                                     |
 | `-l`   | `--language` | Query language of the query string (`sql` _(default)_ or `influxql`)                     |
-|        | `--format`   | Output format (`pretty` _(default)_, `json`, `jsonl`, `csv`, `parquet`)             |
+|        | `--format`   | Output format (`pretty` _(default)_, `json`, `jsonl`, `csv`, `parquet`)                  |
 | `-o`   | `--output`   | Output query results to the specified file                                               |
+| `-f`   | `--file`     | File containing the query to execute                                                     |
 | `-h`   | `--help`     | Print help information                                                                   |
 
 ### Option environment variables
@@ -55,14 +60,44 @@ with the name of the database to query.
 
 ### Query data using SQL
 
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[string](#)
+[file](#)
+[stdin](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
 <!--pytest.mark.skip-->
 
 ```bash
 influxdb3 query --database DATABASE_NAME 'SELECT * FROM home'
 ```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 query --database DATABASE_NAME --file ./query.sql
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+cat ./query.sql | influxdb3 query --database DATABASE_NAME
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
 
 ### Query data using InfluxQL
 
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[string](#)
+[file](#)
+[stdin](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
 <!--pytest.mark.skip-->
 
 ```bash
@@ -71,9 +106,37 @@ influxdb3 query \
   --database DATABASE_NAME \
   'SELECT * FROM home'
 ```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 query \
+  --language influxql \
+  --database DATABASE_NAME \
+  --file ./query.influxql
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+cat ./query.influxql | influxdb3 query \
+  --language influxql \
+  --database DATABASE_NAME
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
 
 ### Query data and return JSON-formatted results
 
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[string](#)
+[file](#)
+[stdin](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
 <!--pytest.mark.skip-->
 
 ```bash
@@ -82,9 +145,37 @@ influxdb3 query \
   --database DATABASE_NAME \
   'SELECT * FROM home'
 ```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 query \
+  --format json \
+  --database DATABASE_NAME \
+  --file ./query.sql
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+cat ./query.sql | influxdb3 query \
+  --format json \
+  --database DATABASE_NAME
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
 
 ### Query data and write results to a file
 
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[string](#)
+[file](#)
+[stdin](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
 <!--pytest.mark.skip-->
 
 ```bash
@@ -93,5 +184,26 @@ influxdb3 query \
   --database DATABASE_NAME \
   'SELECT * FROM home'
 ```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 query \
+  --output /path/to/results.txt \
+  --database DATABASE_NAME \
+  --file ./query.sql
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+cat ./query.sql | influxdb3 query \
+  --output /path/to/results.txt \
+  --database DATABASE_NAME
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
 
 {{% /code-placeholders %}}

--- a/content/shared/influxdb3-cli/query.md
+++ b/content/shared/influxdb3-cli/query.md
@@ -18,7 +18,7 @@ influxdb3 query [OPTIONS] --database <DATABASE_NAME> [QUERY]...
 
 - **QUERY**: The query to execute. Provide the query in one of the following ways:
 
-  - a string on the command line
+  - a string
   - a path to a file that contains the query using the `--file` option
   - from stdin
 
@@ -32,7 +32,7 @@ influxdb3 query [OPTIONS] --database <DATABASE_NAME> [QUERY]...
 | `-l`   | `--language` | Query language of the query string (`sql` _(default)_ or `influxql`)                     |
 |        | `--format`   | Output format (`pretty` _(default)_, `json`, `jsonl`, `csv`, `parquet`)                  |
 | `-o`   | `--output`   | Output query results to the specified file                                               |
-| `-f`   | `--file`     | File containing the query to execute                                                     |
+| `-f`   | `--file`     | A file that contains the query to execute                                                     |
 | `-h`   | `--help`     | Print help information                                                                   |
 
 ### Option environment variables

--- a/content/shared/influxdb3-cli/write.md
+++ b/content/shared/influxdb3-cli/write.md
@@ -6,12 +6,21 @@ The `influxdb3 write` command writes data to your {{< product-name >}} server.
 <!--pytest.mark.skip-->
 
 ```bash
-influxdb3 write [OPTIONS] --database <DATABASE_NAME> --file <FILE_PATH>
+influxdb3 write [OPTIONS] --database <DATABASE_NAME> [LINE_PROTOCOL]...
 ```
 
 ##### Aliases
 
 `write`, `w`
+
+## Arguments
+
+- **LINE_PROTOCOL**: The line protocol to write to {{< product-name >}}.
+  Provide the line protocol in one of the following ways:
+
+  - a string on the command line
+  - a path to a file that contains the line protocol using the `--file` option
+  - from stdin
 
 ## Options
 
@@ -20,7 +29,7 @@ influxdb3 write [OPTIONS] --database <DATABASE_NAME> --file <FILE_PATH>
 | `-H`   | `--host`           | Host URL of the running {{< product-name >}} server (default is `http://127.0.0.1:8181`) |
 | `-d`   | `--database`       | _({{< req >}})_ Name of the database to operate on                                       |
 |        | `--token`          | Authentication token                                                                     |
-| `-f`   | `--file`           | _({{< req >}})_ Line protocol file to use to write data                                  |
+| `-f`   | `--file`           | Line protocol file to use to write data                                                  |
 |        | `--accept-partial` | Accept partial writes                                                                    |
 | `-h`   | `--help`           | Print help information                                                                   |
 
@@ -47,21 +56,77 @@ with the name of the database to query.
 
 ### Write line protocol to your InfluxDB 3 server
 
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[string](#)
+[file](#)
+[stdin](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+{{% influxdb/custom-timestamps %}}
 <!--pytest.mark.skip-->
 
 ```bash
-influxdb3 write --database DATABASE_NAME --file /path/to/data.lp
+influxdb3 write --database DATABASE_NAME \
+  'home,room=Living\ Room temp=21.1,hum=35.9,co=0i 1641024000'
 ```
+{{% /influxdb/custom-timestamps %}}
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 write --database DATABASE_NAME --file ./data.lp
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+cat ./data.lp | influxdb3 write --database DATABASE_NAME
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
 
 ### Write line protocol and accept partial writes
 
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[string](#)
+[file](#)
+[stdin](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+{{% influxdb/custom-timestamps %}}
 <!--pytest.mark.skip-->
 
 ```bash
 influxdb3 write \
   --accept-partial \
   --database DATABASE_NAME \
-  --file /path/to/data.lp
+  'home,room=Living\ Room temp=21.1,hum=35.9,co=0i 1641024000'
 ```
+{{% /influxdb/custom-timestamps %}}
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 write \
+  --accept-partial \
+  --database DATABASE_NAME \
+  --file ./data.lp
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+cat ./data.lp | influxdb3 write \
+  --accept-partial \
+  --database DATABASE_NAME \
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
 
 {{% /code-placeholders %}}

--- a/content/shared/influxdb3-cli/write.md
+++ b/content/shared/influxdb3-cli/write.md
@@ -18,7 +18,7 @@ influxdb3 write [OPTIONS] --database <DATABASE_NAME> [LINE_PROTOCOL]...
 - **LINE_PROTOCOL**: The line protocol to write to {{< product-name >}}.
   Provide the line protocol in one of the following ways:
 
-  - a string on the command line
+  - a string
   - a path to a file that contains the line protocol using the `--file` option
   - from stdin
 
@@ -29,7 +29,7 @@ influxdb3 write [OPTIONS] --database <DATABASE_NAME> [LINE_PROTOCOL]...
 | `-H`   | `--host`           | Host URL of the running {{< product-name >}} server (default is `http://127.0.0.1:8181`) |
 | `-d`   | `--database`       | _({{< req >}})_ Name of the database to operate on                                       |
 |        | `--token`          | Authentication token                                                                     |
-| `-f`   | `--file`           | Line protocol file to use to write data                                                  |
+| `-f`   | `--file`           | A file that contains line protocol to write                                                 |
 |        | `--accept-partial` | Accept partial writes                                                                    |
 | `-h`   | `--help`           | Print help information                                                                   |
 

--- a/content/shared/influxdb3-cli/write.md
+++ b/content/shared/influxdb3-cli/write.md
@@ -29,7 +29,7 @@ influxdb3 write [OPTIONS] --database <DATABASE_NAME> [LINE_PROTOCOL]...
 | `-H`   | `--host`           | Host URL of the running {{< product-name >}} server (default is `http://127.0.0.1:8181`) |
 | `-d`   | `--database`       | _({{< req >}})_ Name of the database to operate on                                       |
 |        | `--token`          | Authentication token                                                                     |
-| `-f`   | `--file`           | A file that contains line protocol to write                                                 |
+| `-f`   | `--file`           | A file that contains line protocol to write                                              |
 |        | `--accept-partial` | Accept partial writes                                                                    |
 | `-h`   | `--help`           | Print help information                                                                   |
 

--- a/content/shared/influxdb3-query-guides/execute-queries/influxdb3-cli.md
+++ b/content/shared/influxdb3-query-guides/execute-queries/influxdb3-cli.md
@@ -23,7 +23,12 @@ Provide the following with your command:
   - `sql` _(default)_
   - `influxql`
 
-- **Query**: SQL or InfluxQL query string to execute.
+- **Query**: SQL or InfluxQL query to execute. Provide the query in one of the 
+  following ways:
+  
+  - a string on the command line
+  - a path to a file that contains the query using the `--file` option
+  - from stdin
 
 {{% code-placeholders "(DATABASE|AUTH)_(TOKEN|NAME)" %}}
 
@@ -35,21 +40,87 @@ Provide the following with your command:
 
 {{% tab-content %}}
 
-```sh
+<!--------------------------------- BEGIN SQL --------------------------------->
+
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[string](#)
+[file](#)
+[stdin](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
 influxdb3 query \
   --database DATABASE_NAME \
   "SELECT * FROM home"
 ```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 query \
+  --database DATABASE_NAME \
+  --file ./query.sql
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+cat ./query.sql | influxdb3 query --database DATABASE_NAME
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+
+<!---------------------------------- END SQL ---------------------------------->
+
 {{% /tab-content %}}
 
 {{% tab-content %}}
 
-```sh
+<!------------------------------- BEGIN INFLUXQL ------------------------------>
+
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[string](#)
+[file](#)
+[stdin](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
 influxdb3 query \
-  --database DATABASE_NAME \
   --language influxql \
+  --database DATABASE_NAME \
   "SELECT * FROM home"
 ```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 query \
+  --language influxql \
+  --database DATABASE_NAME \
+  --file ./query.influxql
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!--pytest.mark.skip-->
+
+```bash
+cat ./query.influxql | influxdb3 query \
+  --language influxql \
+  --database DATABASE_NAME
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+
+<!-------------------------------- END INFLUXQL ------------------------------->
 
 {{% /tab-content %}}
 {{< /tabs-wrapper >}}

--- a/content/shared/influxdb3-query-guides/execute-queries/influxdb3-cli.md
+++ b/content/shared/influxdb3-query-guides/execute-queries/influxdb3-cli.md
@@ -26,8 +26,8 @@ Provide the following with your command:
 - **Query**: SQL or InfluxQL query to execute. Provide the query in one of the 
   following ways:
   
-  - a string on the command line
-  - a path to a file that contains the query using the `--file` option
+  - a string
+  - the `--file` option and the path to a file that contains the query
   - from stdin
 
 {{% code-placeholders "(DATABASE|AUTH)_(TOKEN|NAME)" %}}


### PR DESCRIPTION
The `influxdb3 write` and `influxdb3 query` commands now support input as a string, file, or from stdin.

- [x] Rebased/mergeable
