### PR TITLE
Add new influxdb3 show system commands

### DIFF
--- a/content/influxdb3/core/reference/cli/influxdb3/show/system/_index.md
+++ b/content/influxdb3/core/reference/cli/influxdb3/show/system/_index.md
@@ -1,0 +1,16 @@
+---
+title: influxdb3 show system
+description: >
+  The `influxdb3 show system` command displays data from {{< product-name >}}
+  system tables.
+menu:
+  influxdb3_core:
+    parent: influxdb3 show
+    name: influxdb3 show system
+weight: 400
+source: /shared/influxdb3-cli/show/system/_index.md
+---
+
+<!--
+The content for this page is at content/shared/influxdb3-cli/show/system/_index.md
+-->

--- a/content/influxdb3/core/reference/cli/influxdb3/show/system/summary.md
+++ b/content/influxdb3/core/reference/cli/influxdb3/show/system/summary.md
@@ -1,0 +1,16 @@
+---
+title: influxdb3 show system summary
+description: >
+  The `influxdb3 show system summary` command returns a summary various types of
+  system table data.
+menu:
+  influxdb3_core:
+    parent: influxdb3 show system
+    name: influxdb3 show system summary
+weight: 401
+source: /shared/influxdb3-cli/show/system/summary.md
+---
+
+<!--
+The content for this page is at content/shared/influxdb3-cli/show/system/summary.md
+-->

--- a/content/influxdb3/core/reference/cli/influxdb3/show/system/table-list.md
+++ b/content/influxdb3/core/reference/cli/influxdb3/show/system/table-list.md
@@ -1,0 +1,15 @@
+---
+title: influxdb3 show system table-list
+description: >
+  The `influxdb3 show system table-list` command lists available system tables.
+menu:
+  influxdb3_core:
+    parent: influxdb3 show system
+    name: influxdb3 show system table-list
+weight: 401
+source: /shared/influxdb3-cli/show/system/table-list.md
+---
+
+<!--
+The content for this page is at content/shared/influxdb3-cli/show/system/table-list.md
+-->

--- a/content/influxdb3/core/reference/cli/influxdb3/show/system/table.md
+++ b/content/influxdb3/core/reference/cli/influxdb3/show/system/table.md
@@ -1,0 +1,15 @@
+---
+title: influxdb3 show system table
+description: >
+  The `influxdb3 show system table` command queries data from a system table.
+menu:
+  influxdb3_core:
+    parent: influxdb3 show system
+    name: influxdb3 show system table
+weight: 401
+source: /shared/influxdb3-cli/show/system/table.md
+---
+
+<!--
+The content for this page is at content/shared/influxdb3-cli/show/system/table.md
+-->

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/show/system/_index.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/show/system/_index.md
@@ -1,0 +1,16 @@
+---
+title: influxdb3 show system
+description: >
+  The `influxdb3 show system` command displays data from {{< product-name >}}
+  system tables.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 show
+    name: influxdb3 show system
+weight: 400
+source: /shared/influxdb3-cli/show/system/_index.md
+---
+
+<!--
+The content for this page is at content/shared/influxdb3-cli/show/system/_index.md
+-->

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/show/system/summary.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/show/system/summary.md
@@ -1,0 +1,16 @@
+---
+title: influxdb3 show system summary
+description: >
+  The `influxdb3 show system summary` command returns a summary various types of
+  system table data.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 show system
+    name: influxdb3 show system summary
+weight: 401
+source: /shared/influxdb3-cli/show/system/summary.md
+---
+
+<!--
+The content for this page is at content/shared/influxdb3-cli/show/system/summary.md
+-->

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/show/system/table-list.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/show/system/table-list.md
@@ -1,0 +1,15 @@
+---
+title: influxdb3 show system table-list
+description: >
+  The `influxdb3 show system table-list` command lists available system tables.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 show system
+    name: influxdb3 show system table-list
+weight: 401
+source: /shared/influxdb3-cli/show/system/table-list.md
+---
+
+<!--
+The content for this page is at content/shared/influxdb3-cli/show/system/table-list.md
+-->

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/show/system/table.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/show/system/table.md
@@ -1,0 +1,15 @@
+---
+title: influxdb3 show system table
+description: >
+  The `influxdb3 show system table` command queries data from a system table.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 show system
+    name: influxdb3 show system table
+weight: 401
+source: /shared/influxdb3-cli/show/system/table.md
+---
+
+<!--
+The content for this page is at content/shared/influxdb3-cli/show/system/table.md
+-->

--- a/content/shared/influxdb3-cli/show/_index.md
+++ b/content/shared/influxdb3-cli/show/_index.md
@@ -11,10 +11,11 @@ influxdb3 show <SUBCOMMAND>
 
 ## Subcommands
 
-| Subcommand                                                                 | Description                                    |
-| :------------------------------------------------------------------------- | :--------------------------------------------- |
+| Subcommand                                                              | Description                                    |
+| :---------------------------------------------------------------------- | :--------------------------------------------- |
 | [databases](/influxdb3/version/reference/cli/influxdb3/show/databases/) | List database                                  |
-| help                                                                       | Print command help or the help of a subcommand |
+| [system](/influxdb3/version/reference/cli/influxdb3/show/system/)       | Display system table data                      |
+| help                                                                    | Print command help or the help of a subcommand |
 
 ## Options
 

--- a/content/shared/influxdb3-cli/show/system/_index.md
+++ b/content/shared/influxdb3-cli/show/system/_index.md
@@ -1,14 +1,27 @@
 
-The `influxdb3 show databases` command lists databases in your
-{{< product-name >}} server.
+The `influxdb3 show system` command displays data from {{< product-name >}}
+system tables.
 
 ## Usage
 
 <!--pytest.mark.skip-->
 
 ```bash
-influxdb3 show databases [OPTIONS]
+ influxdb3 show system [OPTIONS] --database <DATABASE_NAME> <SUBCOMMAND>
 ```
+
+##### Aliases
+
+`system`, `s`
+
+## Subcommands
+
+| Subcommand                                                                    | Description                                    |
+| :---------------------------------------------------------------------------- | :--------------------------------------------- |
+| [summary](/influxdb3/version/reference/cli/influxdb3/show/system/summary)        | Summarize system table data                    |
+| [table](/influxdb3/version/reference/cli/influxdb3/show/system/table/)           | Retrieve entries from a specific system table  |
+| [table-list](/influxdb3/version/reference/cli/influxdb3/show/system/table-list/) | List available system tables                   |
+| help                                                                          | Print command help or the help of a subcommand |
 
 ## Options
 
@@ -17,8 +30,6 @@ influxdb3 show databases [OPTIONS]
 | `-H`   | `--host`         | Host URL of the running {{< product-name >}} server (default is `http://127.0.0.1:8181`) |
 | `-d`   | `--database`     | _({{< req >}})_ Name of the database to operate on                                       |
 |        | `--token`        | Authentication token                                                                     |
-|        | `--show-deleted` | Include databases marked as deleted in the output                                        |
-|        | `--format`       | Output format (`pretty` _(default)_, `json`, `jsonl`, `csv`, or `parquet`)               |
 | `-h`   | `--help`         | Print help information                                                                   |
 
 ### Option environment variables
@@ -30,33 +41,3 @@ You can use the following environment variables to set command options:
 | `INFLUXDB3_HOST_URL`      | `--host`     |
 | `INFLUXDB3_DATABASE_NAME` | `--database` |
 | `INFLUXDB3_AUTH_TOKEN`    | `--token`    |
-
-## Examples
-
-- [List all databases](#list-all-databases)
-- [List all databases, including deleted databases](#list-all-databases-including-deleted-databases)
-- [List databases in JSON-formatted output](#list-databases-in-json-formatted-output)
-
-### List all databases
-
-<!--pytest.mark.skip-->
-
-```bash
-influxdb3 show databases
-```
-
-### List all databases, including deleted databases
-
-<!--pytest.mark.skip-->
-
-```bash
-influxdb3 show databases --show-deleted
-```
-
-### List databases in JSON-formatted output
-
-<!--pytest.mark.skip-->
-
-```bash
-influxdb3 show databases --format json
-```

--- a/content/shared/influxdb3-cli/show/system/summary.md
+++ b/content/shared/influxdb3-cli/show/system/summary.md
@@ -1,0 +1,48 @@
+
+The `influxdb3 show system summary` command returns a summary various types of
+system table data.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 show system --database <DATABASE_NAME> summary [OPTIONS]
+```
+
+## Options
+
+| Option |            | Description                                                                                    |
+| :----- | :--------- | :--------------------------------------------------------------------------------------------- |
+| `-l`   | `--limit`  | Maximum number of entries from each table to display (default is `10`, `0` indicates no limit) |
+|        | `--format` | Output format (`pretty` _(default)_, `json`, `jsonl`, `csv`, or `parquet)                      |
+| `-h`   | `--help`   | Print help information                                                                         |
+
+## Examples
+
+- [Summarize system table data](#summarize-system-table-data)
+- [Summarize system table data in JSON-formatted output](#summarize-system-table-data-in-json-formatted-output)
+
+In the examples below, replace
+{{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}} with
+the name of the database to operate on.
+
+{{% code-placeholders "DATABASE_NAME" %}}
+
+### Summarize system table data
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 show system --database DATABASE_NAME summary
+```
+
+### Summarize system table data in JSON-formatted output
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 show system --database DATABASE_NAME summary --format json
+```
+
+{{% /code-placeholders %}}

--- a/content/shared/influxdb3-cli/show/system/summary.md
+++ b/content/shared/influxdb3-cli/show/system/summary.md
@@ -15,7 +15,7 @@ influxdb3 show system --database <DATABASE_NAME> summary [OPTIONS]
 | Option |            | Description                                                                                    |
 | :----- | :--------- | :--------------------------------------------------------------------------------------------- |
 | `-l`   | `--limit`  | Maximum number of entries from each table to display (default is `10`, `0` indicates no limit) |
-|        | `--format` | Output format (`pretty` _(default)_, `json`, `jsonl`, `csv`, or `parquet)                      |
+|        | `--format` | Output format (`pretty` _(default)_, `json`, `jsonl`, `csv`, or `parquet`)                      |
 | `-h`   | `--help`   | Print help information                                                                         |
 
 ## Examples

--- a/content/shared/influxdb3-cli/show/system/summary.md
+++ b/content/shared/influxdb3-cli/show/system/summary.md
@@ -1,5 +1,5 @@
 
-The `influxdb3 show system summary` command returns a summary various types of
+The `influxdb3 show system summary` command returns a summary of various types of
 system table data.
 
 ## Usage

--- a/content/shared/influxdb3-cli/show/system/table-list.md
+++ b/content/shared/influxdb3-cli/show/system/table-list.md
@@ -13,7 +13,7 @@ influxdb3 show system --database <DATABASE_NAME> table-list [OPTIONS]
 
 | Option |            | Description                                                                                    |
 | :----- | :--------- | :--------------------------------------------------------------------------------------------- |
-|        | `--format` | Output format (`pretty` _(default)_, `json`, `jsonl`, `csv`, or `parquet)                      |
+|        | `--format` | Output format (`pretty` _(default)_, `json`, `jsonl`, `csv`, or `parquet`)                      |
 | `-h`   | `--help`   | Print help information                                                                         |
 
 ## Examples

--- a/content/shared/influxdb3-cli/show/system/table-list.md
+++ b/content/shared/influxdb3-cli/show/system/table-list.md
@@ -1,0 +1,46 @@
+
+The `influxdb3 show system table-list` command lists available system tables.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 show system --database <DATABASE_NAME> table-list [OPTIONS]
+```
+
+## Options
+
+| Option |            | Description                                                                                    |
+| :----- | :--------- | :--------------------------------------------------------------------------------------------- |
+|        | `--format` | Output format (`pretty` _(default)_, `json`, `jsonl`, `csv`, or `parquet)                      |
+| `-h`   | `--help`   | Print help information                                                                         |
+
+## Examples
+
+- [List system tables](#list-system-tables)
+- [List system tables in JSON-formatted output](#list-system-tables-in-json-formatted-output)
+
+In the examples below, replace
+{{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}} with
+the name of the database to operate on.
+
+{{% code-placeholders "DATABASE_NAME" %}}
+
+### List system tables
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 show system --database DATABASE_NAME summary
+```
+
+### List system tables in JSON-formatted output
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 show system --database DATABASE_NAME summary --format json
+```
+
+{{% /code-placeholders %}}

--- a/content/shared/influxdb3-cli/show/system/table.md
+++ b/content/shared/influxdb3-cli/show/system/table.md
@@ -20,7 +20,7 @@ influxdb3 show system --database <DATABASE_NAME> table [OPTIONS] <SYSTEM_TABLE>
 | `-l`   | `--limit`    | Maximum number of tables entries to display (default is `10`, `0` indicates no limit) |
 | `-o`   | `--order-by` | Order by the specified columns                                                        |
 | `-s`   | `--select`   | Select specific columns from the system table                                         |
-|        | `--format`   | Output format (`pretty` _(default)_, `json`, `jsonl`, `csv`, or `parquet)             |
+|        | `--format`   | Output format (`pretty` _(default)_, `json`, `jsonl`, `csv`, or `parquet`)             |
 | `-h`   | `--help`     | Print help information                                                                |
 
 ## Examples
@@ -41,6 +41,7 @@ the name of the database to operate on.
 <!--pytest.mark.skip-->
 
 ```bash
+# Query the parquet_files system table
 influxdb3 show system --database DATABASE_NAME table parquet_files
 ```
 
@@ -49,6 +50,7 @@ influxdb3 show system --database DATABASE_NAME table parquet_files
 <!--pytest.mark.skip-->
 
 ```bash
+# Select specific columns from the parquet_files system table
 influxdb3 show system \
   --database DATABASE_NAME \
   table \

--- a/content/shared/influxdb3-cli/show/system/table.md
+++ b/content/shared/influxdb3-cli/show/system/table.md
@@ -1,0 +1,83 @@
+
+The `influxdb3 show system table` command queries data from a system table.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 show system --database <DATABASE_NAME> table [OPTIONS] <SYSTEM_TABLE>
+```
+
+## Arguments
+
+- **SYSTEM_TABLE**: the system table to query
+
+## Options
+
+| Option |              | Description                                                                           |
+| :----- | :----------- | :------------------------------------------------------------------------------------ |
+| `-l`   | `--limit`    | Maximum number of tables entries to display (default is `10`, `0` indicates no limit) |
+| `-o`   | `--order-by` | Order by the specified columns                                                        |
+| `-s`   | `--select`   | Select specific columns from the system table                                         |
+|        | `--format`   | Output format (`pretty` _(default)_, `json`, `jsonl`, `csv`, or `parquet)             |
+| `-h`   | `--help`     | Print help information                                                                |
+
+## Examples
+
+- [Query a system table](#query-a-system-table)
+- [Query specific columns from a system table](#query-specific-columns-from-a-system-table)
+- [Query a system table and order by a specific column](#query-a-system-table-and-order-by-a-specific-column)
+- [Query a system table and return JSON-formatted output](#query-a-system-table-and-return-json-formatted-output)
+
+In the examples below, replace
+{{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}} with
+the name of the database to operate on.
+
+{{% code-placeholders "DATABASE_NAME" %}}
+
+### Query a system table
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 show system --database DATABASE_NAME table parquet_files
+```
+
+### Query specific columns from a system table
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 show system \
+  --database DATABASE_NAME \
+  table \
+  --select table_name,size_bytes,row_count \
+  parquet_files
+```
+
+### Query a system table and order by a specific column
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 show system \
+  --database DATABASE_NAME \
+  table \
+  --order-by size_bytes,row_count \
+  parquet_files
+```
+
+### Query a system table and return JSON-formatted output
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 show system \
+  --database DATABASE_NAME \
+  table \
+  --format json \
+  parquet_files
+```
+
+{{% /code-placeholders %}}


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb/pull/25912

Adds new `influxdb3 show system` commands and subcommands to InfluxDB 3 Core and Enterprise documentation.

- [x] Rebased/mergeable
