### PR TITLE
influxctl 2.9.9 release notes and changes

### DIFF
--- a/content/influxdb3/cloud-dedicated/reference/cli/influxctl/management/list.md
+++ b/content/influxdb3/cloud-dedicated/reference/cli/influxctl/management/list.md
@@ -39,10 +39,11 @@ influxctl management list [--format=table|json]
 
 ## Flags
 
-| Flag |            | Description                                   |
-| :--- | :--------- | :-------------------------------------------- |
-|      | `--format` | Output format (`table` _(default)_ or `json`) |
-| `-h` | `--help`   | Output command help                           |
+| Flag |            | Description                                                                                                   |
+| :--- | :--------- | :------------------------------------------------------------------------------------------------------------ |
+|      | `--format` | Output format (`table` _(default)_ or `json`)                                                                 |
+|      | `--sort`   | Sort output by a specific column (`created` _(default)_, `id`, `description`, `prefix`, `expires`, `revoked`) |
+| `-h` | `--help`   | Output command help                                                                                           |
 
 {{% caption %}}
 _Also see [`influxctl` global flags](/influxdb3/cloud-dedicated/reference/cli/influxctl/#global-flags)._

--- a/content/influxdb3/cloud-dedicated/reference/cli/influxctl/token/list.md
+++ b/content/influxdb3/cloud-dedicated/reference/cli/influxctl/token/list.md
@@ -24,10 +24,11 @@ influxctl token list [--format=table|json]
 
 ## Flags
 
-| Flag |            | Description                                   |
-| :--- | :--------- | :-------------------------------------------- |
-|      | `--format` | Output format (`table` _(default)_ or `json`) |
-| `-h` | `--help`   | Output command help                           |
+| Flag |            | Description                                                                                                   |
+| :--- | :--------- | :------------------------------------------------------------------------------------------------------------ |
+|      | `--format` | Output format (`table` _(default)_ or `json`)                                                                 |
+|      | `--sort`   | Sort output by a specific column (`created` _(default)_, `id`, `description`, `prefix`, `expires`, `revoked`) |
+| `-h` | `--help`   | Output command help                                                                                           |
 
 {{% caption %}}
 _Also see [`influxctl` global flags](/influxdb3/cloud-dedicated/reference/cli/influxctl/#global-flags)._

--- a/content/influxdb3/cloud-dedicated/reference/release-notes/influxctl.md
+++ b/content/influxdb3/cloud-dedicated/reference/release-notes/influxctl.md
@@ -11,6 +11,34 @@ menu:
 weight: 202
 ---
 
+## v2.9.9 {date="2025-01-24"}
+
+### Features
+
+- Sort [`influxctl token list`](/influxdb3/cloud-dedicated/reference/cli/influxctl/token/list/)
+and [`influxctl management list`](/influxdb3/cloud-dedicated/reference/cli/influxctl/management/list/) output.
+
+### Bug fixes
+
+- Remove `UpdateAccount` and `UpdateCluster`.
+- Remove "incorrect version" warning for gRPC unimplemented error code.
+- Correctly parse multi-line queries from stdin.
+
+### Dependency updates
+
+- Update `github.com/fatih/color` from 1.17.0 to 1.18.0.
+- Update `github.com/go-git/go-git/v5` from 5.12.0 to 5.13.1.
+- Update `github.com/jedib0t/go-pretty/v6` from 6.6.0 to 6.6.5.
+- Update `github.com/stretchr/testify` from 1.9.0 to 1.10.0.
+- Update `golang.org/x/crypto` from 0.27.0 to 0.31.0.
+- Update `golang.org/x/mod` from 0.21.0 to 0.22.0.
+- Update `golang.org/x/oauth2` from 0.23.0 to 0.25.0.
+- Update `google.golang.org/grpc` from 1.67.1 to 1.69.4.
+- Update `google.golang.org/protobuf` from 1.35.1 to 1.36.3.
+- Update Go to v1.23.5.
+
+---
+
 ## v2.9.8 {date="2024-10-15"}
 
 ### Bug Fixes

--- a/content/influxdb3/clustered/reference/cli/influxctl/management/list.md
+++ b/content/influxdb3/clustered/reference/cli/influxctl/management/list.md
@@ -39,10 +39,11 @@ influxctl management list [--format=table|json]
 
 ## Flags
 
-| Flag |            | Description                                   |
-| :--- | :--------- | :-------------------------------------------- |
-|      | `--format` | Output format (`table` _(default)_ or `json`) |
-| `-h` | `--help`   | Output command help                           |
+| Flag |            | Description                                                                                                   |
+| :--- | :--------- | :------------------------------------------------------------------------------------------------------------ |
+|      | `--format` | Output format (`table` _(default)_ or `json`)                                                                 |
+|      | `--sort`   | Sort output by a specific column (`created` _(default)_, `id`, `description`, `prefix`, `expires`, `revoked`) |
+| `-h` | `--help`   | Output command help                                                                                           |
 
 {{% caption %}}
 _Also see [`influxctl` global flags](/influxdb3/clustered/reference/cli/influxctl/#global-flags)._

--- a/content/influxdb3/clustered/reference/cli/influxctl/token/list.md
+++ b/content/influxdb3/clustered/reference/cli/influxctl/token/list.md
@@ -23,10 +23,11 @@ influxctl token list [--format=table|json]
 
 ## Flags
 
-| Flag |            | Description                                   |
-| :--- | :--------- | :-------------------------------------------- |
-|      | `--format` | Output format (`table` _(default)_ or `json`) |
-| `-h` | `--help`   | Output command help                           |
+| Flag |            | Description                                                                                                   |
+| :--- | :--------- | :------------------------------------------------------------------------------------------------------------ |
+|      | `--format` | Output format (`table` _(default)_ or `json`)                                                                 |
+|      | `--sort`   | Sort output by a specific column (`created` _(default)_, `id`, `description`, `prefix`, `expires`, `revoked`) |
+| `-h` | `--help`   | Output command help                                                                                           |
 
 {{% caption %}}
 _Also see [`influxctl` global flags](/influxdb3/clustered/reference/cli/influxctl/#global-flags)._

--- a/content/influxdb3/clustered/reference/release-notes/influxctl.md
+++ b/content/influxdb3/clustered/reference/release-notes/influxctl.md
@@ -12,6 +12,34 @@ weight: 202
 canonical: /influxdb3/cloud-dedicated/reference/release-notes/influxctl/
 ---
 
+## v2.9.9 {date="2025-01-24"}
+
+### Features
+
+- Sort [`influxctl token list`](/influxdb3/clustered/reference/cli/influxctl/token/list/)
+and [`influxctl management list`](/influxdb3/clustered/reference/cli/influxctl/management/list/) output.
+
+### Bug fixes
+
+- Remove `UpdateAccount` and `UpdateCluster`.
+- Remove "incorrect version" warning for gRPC unimplemented error code.
+- Correctly parse multi-line queries from stdin.
+
+### Dependency updates
+
+- Update `github.com/fatih/color` from 1.17.0 to 1.18.0.
+- Update `github.com/go-git/go-git/v5` from 5.12.0 to 5.13.1.
+- Update `github.com/jedib0t/go-pretty/v6` from 6.6.0 to 6.6.5.
+- Update `github.com/stretchr/testify` from 1.9.0 to 1.10.0.
+- Update `golang.org/x/crypto` from 0.27.0 to 0.31.0.
+- Update `golang.org/x/mod` from 0.21.0 to 0.22.0.
+- Update `golang.org/x/oauth2` from 0.23.0 to 0.25.0.
+- Update `google.golang.org/grpc` from 1.67.1 to 1.69.4.
+- Update `google.golang.org/protobuf` from 1.35.1 to 1.36.3.
+- Update Go to v1.23.5.
+
+---
+
 ## v2.9.8 {date="2024-10-15"}
 
 ### Bug Fixes


### PR DESCRIPTION
- Adds influxctl 2.9.9 release notes to Dedicated and Clustered
- Adds the `--sort` flag to the `influxctl management list` and `influxctl token list` commands

---

- [x] Rebased/mergeable
