### PR TITLE
Change comments in line protocol syntax to be self-descriptive `#`

### DIFF
--- a/content/influxdb/v2/reference/syntax/line-protocol.md
+++ b/content/influxdb/v2/reference/syntax/line-protocol.md
@@ -27,11 +27,11 @@ It is a text-based format that provides the measurement, tag set, field set, and
 - [Naming restrictions](#naming-restrictions)
 - [Duplicate points](#duplicate-points)
 
-```js
-// Syntax
+```python
+# Syntax
 <measurement>[,<tag_key>=<tag_value>[,<tag_key>=<tag_value>]] <field_key>=<field_value>[,<field_key>=<field_value>] [<timestamp>]
 
-// Example
+# Example
 myMeasurement,tag1=value1,tag2=value2 fieldKey="fieldValue" 1556813561098000000
 ```
 


### PR DESCRIPTION
I suppose, the current
```js
// Syntax
<measurement>[,<tag_key>=<tag_value>[,<tag_key>=<tag_value>]] <field_key>=<field_value>[,<field_key>=<field_value>] [<timestamp>]

// Example
myMeasurement,tag1=value1,tag2=value2 fieldKey="fieldValue" 1556813561098000000
```
can confuse new users by implying that `//` can be used to comment lines in the line protocol itself.

So, I propose to change this snippet to
```python
# Syntax
<measurement>[,<tag_key>=<tag_value>[,<tag_key>=<tag_value>]] <field_key>=<field_value>[,<field_key>=<field_value>] [<timestamp>]

# Example
myMeasurement,tag1=value1,tag2=value2 fieldKey="fieldValue" 1556813561098000000

```
and use some #-comment language descriptor in the Markdown code block (like Python).