### PR TITLE
hotfix: clarify that influxdb_v2 tokens for telegraf can't be empty strings

### DIFF
--- a/content/shared/influxdb3-write-guides/use-telegraf/_index.md
+++ b/content/shared/influxdb3-write-guides/use-telegraf/_index.md
@@ -51,7 +51,7 @@ Replace the following:
 
   > [!Note]
   > While in alpha, {{< product-name >}} does not require an authorization token.
-  > For the `token` option, provide an empty or arbitrary token string.
+  > For the `token` option, provide an arbitrary, non-empty token string.
 
 _See how to [Configure Telegraf to write to {{% product-name %}}](/influxdb3/version/write-data/use-telegraf/configure/)._
 

--- a/content/shared/influxdb3-write-guides/use-telegraf/configure.md
+++ b/content/shared/influxdb3-write-guides/use-telegraf/configure.md
@@ -70,7 +70,7 @@ Replace the following:
 
   > [!Note]
   > While in alpha, {{< product-name >}} does not require an authorization token.
-  > For the `token` option, provide an empty or arbitrary token string.
+  > For the `token` option, provide an arbitrary, non-empty token string.
 
 The InfluxDB output plugin configuration contains the following options:
 
@@ -89,7 +89,7 @@ Your {{% product-name %}} authorization token.
 
 > [!Note]
 > While in alpha, {{< product-name >}} does not require an authorization token.
-> For the `token` option, provide an empty or arbitrary token string.
+> For the `token` option, provide an arbitrary, non-empty token string.
 
 > [!Tip]
 >

--- a/content/shared/influxdb3-write-guides/use-telegraf/csv.md
+++ b/content/shared/influxdb3-write-guides/use-telegraf/csv.md
@@ -100,7 +100,7 @@ Replace the following:
 
   > [!Note]
   > While in alpha, {{< product-name >}} does not require an authorization token.
-  > For the `token` option, provide an empty or arbitrary token string.
+  > For the `token` option, provide an arbitrary, non-empty token string.
 
   > [!Tip]
   >

--- a/content/shared/influxdb3-write-guides/use-telegraf/dual-write.md
+++ b/content/shared/influxdb3-write-guides/use-telegraf/dual-write.md
@@ -16,7 +16,7 @@ The following example configures Telegraf for dual writing to {{% product-name %
 
     > [!Note]
     > While in alpha, {{< product-name >}} does not require an authorization token.
-    > For the `token` option, provide an empty or arbitrary token string.
+    > For the `token` option, provide an arbitrary, non-empty token string.
 
 
 ## Sample configuration


### PR DESCRIPTION
- [x] Rebased/mergeable
