### PR TITLE
Jts/influxdb3 plugins doc

### DIFF
--- a/content/influxdb3/core/query-data/sql/parameterized-queries.md
+++ b/content/influxdb3/core/query-data/sql/parameterized-queries.md
@@ -32,11 +32,10 @@ list_code_example: |
   // Call the client's function to query InfluxDB with parameters.
   iterator, err := client.QueryWithParameters(context.Background(), query, parameters)
   ```
-# Leaving in draft until tested
-draft: true
 source: /shared/influxdb3-query-guides/sql/parameterized-queries.md
 ---
 
 <!--
-The content for this page is at content/shared/influxdb3-query-guides/sql/parameterized-queries.md
+The content for this page is at
+//SOURCE content/shared/influxdb3-query-guides/sql/parameterized-queries.md
 -->

--- a/content/influxdb3/enterprise/query-data/sql/parameterized-queries.md
+++ b/content/influxdb3/enterprise/query-data/sql/parameterized-queries.md
@@ -32,11 +32,10 @@ list_code_example: |
   // Call the client's function to query InfluxDB with parameters.
   iterator, err := client.QueryWithParameters(context.Background(), query, parameters)
   ```
-# Leaving in draft until tested
-draft: true
 source: /shared/influxdb3-query-guides/sql/parameterized-queries.md
 ---
 
 <!--
-The content for this page is at content/shared/influxdb3-query-guides/sql/parameterized-queries.md
+The content for this page is at
+//SOURCE content/shared/influxdb3-query-guides/sql/parameterized-queries.md
 -->


### PR DESCRIPTION
https://github.com/influxdata/docs-v2/commit/fd8d29d1c2d5684e05672d9214446d3a573ad5aa:
- Update the Processing engine guide and examples for using the latest `influxdb3 install` command.
- Provides more Docker-specific examples.
- Removes `draft` from Parameterized queries guides.
- Cleanup.

Other:
- Update from `master`, resolve conflicts
