### PR TITLE
docs: add release notes for 20250212 clustered release

### DIFF
--- a/content/influxdb3/clustered/reference/release-notes/clustered.md
+++ b/content/influxdb3/clustered/reference/release-notes/clustered.md
@@ -26,6 +26,35 @@ identified below with the <span class="cf-icon Shield pink"></span> icon.
 
 ---
 
+## 20250212-1570743 {date="2025-02-12"}
+
+### Quickstart
+
+```yaml
+spec:
+  package:
+    image: us-docker.pkg.dev/influxdb2-artifacts/clustered/influxdb:20250212-1570743
+```
+
+### Bug Fixes
+
+This release fixes a bug in the 20241217-1494922 release where the default 
+Prometheus CPU limit was set to an integer instead of a string.
+
+### Changes
+
+#### Deployment
+
+- The Prometheus `retention` period has been exposed, allowing users 
+  to set a custom retention period for Prometheus metrics.
+
+#### Database Engine
+
+- Datafusion upgrades
+- Added the ability to restore a cluster's data from a Data Snapshot.
+
+---
+
 ## 20241217-1494922 {date="2024-12-17"}
 
 ### Quickstart

--- a/content/influxdb3/clustered/reference/release-notes/clustered.md
+++ b/content/influxdb3/clustered/reference/release-notes/clustered.md
@@ -45,13 +45,13 @@ Prometheus CPU limit was set to an integer instead of a string.
 
 #### Deployment
 
-- The Prometheus `retention` period has been exposed, allowing users 
-  to set a custom retention period for Prometheus metrics.
+- Expose the Prometheus `retention` period to let users set a custom
+  retention period for Prometheus metrics.
 
 #### Database Engine
 
-- Datafusion upgrades
-- Added the ability to restore a cluster's data from a Data Snapshot.
+- Upgrade DataFusion
+- Add the ability to restore a cluster from a Catalog snapshot.
 
 ---
 


### PR DESCRIPTION
Adds release notes for 2025-02-12 clustered release

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
