### PR TITLE
chore: Add product-key shortcode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -546,6 +546,25 @@ Insert warning markdown content here.
 {{% /warn %}}
 ```
 
+### Product data
+
+Display the full product name and version name for the current page--for example:
+
+- InfluxDB 3 Core
+- InfluxDB 3 Cloud Dedicated
+
+```md
+{{% product-name %}}
+```
+
+Display the short version name (part of the key used in `products.yml`) from the current page URL--for example: 
+
+- `/influxdb3/core` returns `core`
+
+```md
+{{% product-key %}}
+```
+
 ### Enterprise Content
 
 For sections content that relate specifically to InfluxDB Enterprise, use the `{{% enterprise %}}` shortcode.

--- a/content/shared/v3-core-plugins/_index.md
+++ b/content/shared/v3-core-plugins/_index.md
@@ -255,7 +255,7 @@ influxdb3 install package <PACKAGE_NAME>
    --name CONTAINER_NAME \
    -v /path/to/.influxdb3/data:/data \
    -v /path/to/.influxdb3/plugins:/plugins \
-   quay.io/influxdb/influxdb3-core:latest \
+   quay.io/influxdb/influxdb3-{{< product-key >}}:latest \
    serve --node-id=node0 \
    --object-store=file \
    --data-dir=/data \

--- a/layouts/shortcodes/product-key.html
+++ b/layouts/shortcodes/product-key.html
@@ -1,0 +1,3 @@
+{{- $productPathData := findRE "[^/]+.*?" .Page.RelPermalink -}}
+{{- $currentProduct := index $productPathData 1 -}}
+{{ $currentProduct }}


### PR DESCRIPTION
- Returns the first item from <productdata>.versions in products.yml.
- Currently, long and short forms are the same.
- Borrows the term 'edition' from the influxdb3 install scripts--seemed apt and I don't know how we might extend long or short forms.
