### PR TITLE
SQL window functions

### DIFF
--- a/assets/styles/layouts/_article.scss
+++ b/assets/styles/layouts/_article.scss
@@ -244,6 +244,7 @@
     &.blue {color: $b-dodger;}
     &.green {color: $gr-viridian;}
     &.magenta {color: $p-comet;}
+    &.pink {color: $br-new-magenta;}
   }
 
   h2,

--- a/assets/styles/layouts/article/_html-diagrams.scss
+++ b/assets/styles/layouts/article/_html-diagrams.scss
@@ -904,6 +904,244 @@ table tr.point{
   }
 }
 
+//////////////////////// SQL WINDOW FRAME UNITS EXAMPLES ///////////////////////
+
+table.window-frame-units {
+  &.groups {
+    .group {
+      position: relative;
+      outline-style: solid;
+      outline-width: 3px;
+      outline-offset: -5px;
+      border-radius: 10px;
+
+      &::before {
+        content: "Row Group";
+        display: block;
+        padding: .25rem .5rem;
+        position: absolute;
+        top: 3px;
+        left: 3px;
+        border-radius: 4px;
+        color: #fff;
+        font-size: .8rem;
+        font-weight: bold;
+        text-transform: uppercase;
+        letter-spacing: .02em;
+        box-shadow: 4px 4px 4px $article-bg;
+      }
+
+      td:nth-child(2), td:nth-child(3) {
+        font-weight: bold;
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 5px;        
+      }
+
+      &:nth-of-type(1) {     
+        &::before {background: $br-new-magenta;}   
+        outline-color: $br-new-magenta;
+        td:nth-child(2), td:nth-child(3) {
+          text-decoration-color: $br-new-magenta;
+        }
+      }
+      &:nth-of-type(2) {
+        &::before {background: $br-new-purple;}  
+        outline-color: $br-new-purple;
+        td:nth-child(2), td:nth-child(3) {
+          text-decoration-color: $br-new-purple;
+        }
+      }
+      &:nth-of-type(3) {
+        &::before {background: $b-dodger;}  
+        outline-color: $b-dodger;
+        td:nth-child(2), td:nth-child(3) {
+          text-decoration-color: $b-dodger;
+        }
+      }
+      &:nth-of-type(4) {
+        &::before {background: $b-sapphire;}  
+        outline-color: $b-sapphire;
+        td:nth-child(2), td:nth-child(3) {
+          text-decoration-color: $b-sapphire;
+        }
+      }
+    }
+  }
+
+  &.groups-with-frame {
+    .frame, tr.current-row {
+      position: relative;
+      outline-style: solid;
+      outline-width: 3px;
+      outline-offset: -5px;
+      border-radius: 10px;
+
+      &::after {
+        display: block;
+        padding: .25rem .5rem;
+        position: absolute;
+        top: 3px;
+        left: 3px;
+        border-radius: 4px;
+        color: #fff;
+        font-size: .8rem;
+        font-weight: bold;
+        text-transform: uppercase;
+        letter-spacing: .02em;
+        box-shadow: 4px 4px 4px $article-bg;
+      }
+
+      tr:nth-child(n + 1):nth-child(-n + 3) {
+        td {text-decoration-color: $br-new-magenta;}
+      }
+      tr:nth-child(n + 4):nth-child(-n + 6) {
+        td {text-decoration-color: $br-magenta;}
+      }
+      tr:nth-child(n + 7):nth-child(-n + 8) {
+        td {text-decoration-color: $b-dodger;}
+      }
+
+      td:nth-child(n + 2):nth-child(-n + 3) {
+        font-weight: bold;
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 5px;
+      }
+    }
+    tr.current-row {
+      outline-color: $br-new-magenta;
+      &::after {
+        content: "Current Row";
+        background: $br-new-magenta;
+      }
+      td {text-decoration-color: $b-dodger !important;}
+    }
+
+    .frame {
+      outline-color: $br-new-purple;
+      &::after {
+        content: "Frame";
+        background: $br-new-purple;
+      }
+    }
+    .group {
+      position: relative;
+      outline-color: $b-sapphire;
+      td:nth-child(2), td:nth-child(3) {
+        font-weight: bold;
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 5px;
+        text-decoration-color: $b-sapphire;
+      }
+    }
+  }
+
+  &.range-interval {
+    .frame, tr.current-row {
+      position: relative;
+      outline-style: solid;
+      outline-width: 3px;
+      outline-offset: -5px;
+      border-radius: 10px;
+      
+      td:first-child {
+        font-weight: bold;
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 5px;
+        text-decoration-color: $br-new-purple;
+      }
+      &::after {
+        display: block;
+        padding: .25rem .5rem;
+        position: absolute;
+        top: 3px;
+        right: 3px;
+        border-radius: 4px;
+        color: #fff;
+        font-size: .8rem;
+        font-weight: bold;
+        text-transform: uppercase;
+        letter-spacing: .02em;
+        box-shadow: -4px 4px 4px $article-bg;
+      }
+    }
+    tr.current-row {
+      outline-color: $br-new-magenta;
+      td:first-child {text-decoration-color: $br-new-magenta;}
+      &::after {
+        content: "Current Row";
+        background: $br-new-magenta;
+        box-shadow: -4px 4px 4px $article-table-row-alt;
+      }
+    }
+
+    .frame {
+      outline-color: $br-new-purple;
+      &::after {
+        content: "Frame";
+        background: $br-new-purple;
+      }
+    }
+  }
+
+  &.range-numeric, &.rows {
+    .frame, tr.current-row {
+      position: relative;
+      outline-style: solid;
+      outline-width: 3px;
+      outline-offset: -5px;
+      border-radius: 10px;
+      
+      &::after {
+        display: block;
+        padding: .25rem .5rem;
+        position: absolute;
+        top: 3px;
+        left: 3px;
+        border-radius: 4px;
+        color: #fff;
+        font-size: .8rem;
+        font-weight: bold;
+        text-transform: uppercase;
+        letter-spacing: .02em;
+        box-shadow: 4px 4px 4px $article-bg;
+      }
+    }
+    tr.current-row {
+      outline-color: $br-new-magenta;
+      &::after {
+        content: "Current Row";
+        background: $br-new-magenta;
+      }
+    }
+
+    .frame {
+      outline-color: $br-new-purple;
+      &::after {
+        content: "Frame";
+        background: $br-new-purple;
+      }
+    }
+  }
+  &.range-numeric {
+    .frame {
+      td:nth-child(3) {
+        font-weight: bold;
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 5px;
+        text-decoration-color: $br-new-purple;
+      }
+      tr.current-row {
+        td:nth-child(3) {text-decoration-color: $br-new-magenta;}
+      }
+    }
+  }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////// MEDIA QUERIES ////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////

--- a/content/influxdb3/cloud-dedicated/reference/sql/functions/window.md
+++ b/content/influxdb3/cloud-dedicated/reference/sql/functions/window.md
@@ -82,7 +82,10 @@ current row.
 ### ORDER BY clause
 
 The `ORDER BY` clause inside of the `OVER` clause controls the order that the
-window function processors rows in each partition.
+window function processes rows in each partition.
+When a window clause contains an `ORDER BY` clause, the window frame boundaries
+may be explicit or implicit, limiting a window frame size in both directions
+relative to the current row.
 
 > [!Note]
 > The `ORDER BY` clause in an `OVER` clause is separate from the `ORDER BY`
@@ -91,14 +94,49 @@ window function processors rows in each partition.
 
 ### Frame clause
 
-The frame clause can be one of the following:
+The frame clause defines window frame boundaries relative to the current row and
+can be one of the following:
 
 ```sql
 { RANGE | ROWS | GROUPS } frame_start
 { RANGE | ROWS | GROUPS } BETWEEN frame_start AND frame_end
 ```
 
-and **frame_start** and **frame_end** can be one of
+#### Frame units
+
+##### RANGE
+
+Defines frame boundaries using rows with distinct values for columns specified 
+in the [`ORDER BY` clause](#order-by-clause) within a value range relative to
+the current row value.
+
+> [!Important]
+> When using `RANGE` frame units, you must include an `ORDER BY` clause with
+> _exactly one column_.
+
+The offset is the difference the between the current row value and surrounding
+row values. `RANGE` supports the following offset types:
+
+- Numeric
+- String
+- Interval
+
+##### ROWS
+
+Defines frame boundaries using row positions relative to the current row.
+The offset is the difference in row position from the current row.
+
+##### GROUPS
+
+Defines frame boundaries using row groups.
+Rows with the same values for the columns in the [`ORDER BY` clause](#order-by-clause)
+comprise a row group. The offset is the difference in row group position
+relative to the the current row group.
+When using `GROUPS` frame units, you must include an `ORDER BY` clause.
+
+#### Frame boundaries
+
+**frame_start** and **frame_end** can be one of the following:
 
 ```sql
 UNBOUNDED PRECEDING
@@ -108,18 +146,23 @@ offset FOLLOWING
 UNBOUNDED FOLLOWING
 ```
 
+##### UNBOUNDED PRECEDING
+
+
+##### offset PRECEDING
+
 where **offset** is an non-negative integer.
 
-`RANGE` and `GROUPS` modes require an `ORDER BY` clause (with `RANGE` the `ORDER BY` must
-specify exactly one column).
+##### CURRENT ROW
 
-#### Framing modes
 
-##### RANGE
 
-##### ROWS
+##### offset FOLLOWING
 
-##### GROUPs
+where **offset** is an non-negative integer.
+
+##### UNBOUNDED FOLLOWING
+
 
 
 

--- a/content/influxdb3/cloud-dedicated/reference/sql/functions/window.md
+++ b/content/influxdb3/cloud-dedicated/reference/sql/functions/window.md
@@ -1,0 +1,342 @@
+---
+title: SQL window functions
+list_title: Window functions
+description: >
+  ....
+menu:
+  influxdb3_cloud_dedicated:
+    name: Window
+    parent: sql-functions
+weight: 309
+related:
+  - /influxdb3/cloud-dedicated/query-data/sql/aggregate-select/
+
+# source: /content/shared/sql-reference/functions/aggregate.md
+---
+
+A _window function_ performs an operation across a set of rows related to the
+current row. This is similar to the type of operations
+[aggregate functions](/influxdb3/cloud-dedicated/reference/sql/functions/aggregate/)
+perform. However, window functions do not return a single output row per group
+like non-window aggregate functions do. Instead, rows retain their separate
+identities.
+
+For example, the following query uses the {{< influxdb3/home-sample-link >}}
+and returns each temperature reading with the average temperature per room over
+the queried time range:
+
+```sql
+SELECT
+  time,
+  room,
+  temp,
+  avg(temp) OVER (PARTITION BY room) AS avg_room_temp
+FROM
+  home
+WHERE
+  time >= '2022-01-01T08:00:00Z'
+  AND time <= '2022-01-01T12:00:00Z'
+ORDER BY
+  room,
+  time
+```
+
+| time                | room        | temp | avg_room_temp |
+| :------------------ | :---------- | ---: | ------------: |
+| 2022-01-01T08:00:00 | Kitchen     | 21.0 |         22.32 |
+| 2022-01-01T09:00:00 | Kitchen     | 23.0 |         22.32 |
+| 2022-01-01T10:00:00 | Kitchen     | 22.7 |         22.32 |
+| 2022-01-01T11:00:00 | Kitchen     | 22.4 |         22.32 |
+| 2022-01-01T12:00:00 | Kitchen     | 22.5 |         22.32 |
+| 2022-01-01T08:00:00 | Living Room | 21.1 |         21.74 |
+| 2022-01-01T09:00:00 | Living Room | 21.4 |         21.74 |
+| 2022-01-01T10:00:00 | Living Room | 21.8 |         21.74 |
+| 2022-01-01T11:00:00 | Living Room | 22.2 |         21.74 |
+| 2022-01-01T12:00:00 | Living Room | 22.2 |         21.74 |
+
+## Window function syntax
+
+```sql
+function([expr])
+  OVER(
+    [PARTITION BY expr[, …]]
+    [ORDER BY expr [ ASC | DESC ][, …]]
+    [ frame_clause ]
+    )
+```
+
+### OVER clause
+
+Window functions use an `OVER` clause directly following the window function's
+name and arguments. The `OVER` clause syntactically distinguishes a window
+function from a normal function or non-window aggregate function and determines
+how rows are split up for the window operation.
+
+### PARTITION BY clause
+
+The `PARTITION BY` clause in the `OVER` clause divides the rows into groups, or
+partitions, that share the same values of the `PARTITION BY` expressions.
+The window function operates on all the rows in the same partition as the
+current row.
+
+### ORDER BY clause
+
+The `ORDER BY` clause inside of the `OVER` clause controls the order that the
+window function processors rows in each partition.
+
+> [!Note]
+> The `ORDER BY` clause in an `OVER` clause is separate from the `ORDER BY`
+> clause of the query and only determines the order that rows in each partition
+> are processed in.
+
+### Frame clause
+
+The frame clause can be one of the following:
+
+```sql
+{ RANGE | ROWS | GROUPS } frame_start
+{ RANGE | ROWS | GROUPS } BETWEEN frame_start AND frame_end
+```
+
+and **frame_start** and **frame_end** can be one of
+
+```sql
+UNBOUNDED PRECEDING
+offset PRECEDING
+CURRENT ROW
+offset FOLLOWING
+UNBOUNDED FOLLOWING
+```
+
+where **offset** is an non-negative integer.
+
+`RANGE` and `GROUPS` modes require an `ORDER BY` clause (with `RANGE` the `ORDER BY` must
+specify exactly one column).
+
+#### Framing modes
+
+##### RANGE
+
+##### ROWS
+
+##### GROUPs
+
+
+
+```sql
+SELECT depname, empno, salary,
+  rank() OVER (PARTITION BY depname ORDER BY salary DESC)
+FROM empsalary;
+
++-----------+-------+--------+--------+
+| depname   | empno | salary | rank   |
++-----------+-------+--------+--------+
+| personnel | 2     | 3900   | 1      |
+| develop   | 8     | 6000   | 1      |
+| develop   | 10    | 5200   | 2      |
+| develop   | 11    | 5200   | 2      |
+| develop   | 9     | 4500   | 4      |
+| develop   | 7     | 4200   | 5      |
+| sales     | 1     | 5000   | 1      |
+| sales     | 4     | 4800   | 2      |
+| personnel | 5     | 3500   | 2      |
+| sales     | 3     | 4800   | 2      |
++-----------+-------+--------+--------+
+```
+
+There is another important concept associated with window functions: for each
+row, there is a set of rows within its partition called its window frame. Some
+window functions act only on the rows of the window frame, rather than of the
+whole partition. Here is an example of using window frames in queries:
+
+```sql
+SELECT depname, empno, salary,
+    avg(salary) OVER(ORDER BY salary ASC ROWS BETWEEN 1 PRECEDING AND 1
+FOLLOWING) AS avg,
+    min(salary) OVER(ORDER BY empno ASC ROWS BETWEEN UNBOUNDED PRECEDING AND
+CURRENT ROW) AS cum_min
+FROM empsalary
+ORDER BY empno ASC;
+
++-----------+-------+--------+--------------------+---------+
+| depname   | empno | salary | avg                | cum_min |
++-----------+-------+--------+--------------------+---------+
+| sales     | 1     | 5000   | 5000.0             | 5000    |
+| personnel | 2     | 3900   | 3866.6666666666665 | 3900    |
+| sales     | 3     | 4800   | 4700.0             | 3900    |
+| sales     | 4     | 4800   | 4866.666666666667  | 3900    |
+| personnel | 5     | 3500   | 3700.0             | 3500    |
+| develop   | 7     | 4200   | 4200.0             | 3500    |
+| develop   | 8     | 6000   | 5600.0             | 3500    |
+| develop   | 9     | 4500   | 4500.0             | 3500    |
+| develop   | 10    | 5200   | 5133.333333333333  | 3500    |
+| develop   | 11    | 5200   | 5466.666666666667  | 3500    |
++-----------+-------+--------+--------------------+---------+
+```
+
+When a query involves multiple window functions, it is possible to write out
+each one with a separate OVER clause, but this is duplicative and error-prone if
+the same windowing behavior is wanted for several functions. Instead, each
+windowing behavior can be named in a WINDOW clause and then referenced in OVER.
+For example:
+
+```sql
+SELECT sum(salary) OVER w, avg(salary) OVER w
+FROM empsalary
+WINDOW w AS (PARTITION BY depname ORDER BY salary DESC);
+```
+
+## Aggregate functions
+
+All [aggregate functions](/influxdb3/cloud-dedicated/reference/sql/functions/aggregate/)
+can be used as window functions.
+
+## Ranking Functions
+
+- [cume_dist](#cume_dist)
+- [dense_rank](#dense_rank)
+- [ntile](#ntile)
+- [percent_rank](#percent_rank)
+- [rank](#rank)
+- [row_number](#row_number)
+
+### `cume_dist`
+
+Relative rank of the current row: (number of rows preceding or peer with current
+row) / (total rows).
+
+```sql
+cume_dist()
+```
+
+### `dense_rank`
+
+Returns the rank of the current row without gaps. This function ranks rows in a
+dense manner, meaning consecutive ranks are assigned even for identical values.
+
+```sql
+dense_rank()
+```
+
+### `ntile`
+
+Integer ranging from 1 to the argument value, dividing the partition as equally
+as possible.
+
+```sql
+ntile(expression)
+```
+
+#### Arguments
+
+- **expression**: An integer describing the number groups the partition should
+  be split into.
+
+### `percent_rank`
+
+Returns the percentage rank of the current row within its partition. The value
+ranges from 0 to 1 and is computed as `(rank - 1) / (total_rows - 1)`.
+
+```sql
+percent_rank()
+```
+
+### `rank`
+
+Returns the rank of the current row within its partition, allowing gaps between
+ranks. This function provides a ranking similar to `row_number`, but skips ranks
+for identical values.
+
+```sql
+rank()
+```
+
+### `row_number`
+
+Number of the current row within its partition, counting from 1.
+
+```sql
+row_number()
+```
+
+## Analytical Functions
+
+- [first_value](#first_value)
+- [lag](#lag)
+- [last_value](#last_value)
+- [lead](#lead)
+- [nth_value](#nth_value)
+
+### `first_value`
+
+Returns value evaluated at the row that is the first row of the window frame.
+
+```sql
+first_value(expression)
+```
+
+#### Arguments
+
+- **expression**: Expression to operate on.
+
+### `lag`
+
+Returns value evaluated at the row that is offset rows before the current row
+within the partition; if there is no such row, instead return default (which
+must be of the same type as value).
+
+```sql
+lag(expression, offset, default)
+```
+
+#### Arguments
+
+- **expression**: Expression to operate on.
+- **offset**: Integer. Specifies how many rows back the value of expression
+  should be retrieved. Defaults to 1.
+- **default**: The default value if the offset is not within the partition. Must
+  be of the same type as expression.
+
+### `last_value`
+
+Returns value evaluated at the row that is the last row of the window frame.
+
+```sql
+last_value(expression)
+```
+
+#### Arguments
+
+- **expression**: Expression to operate on.
+
+### `lead`
+
+Returns value evaluated at the row that is offset rows after the current row
+within the partition; if there is no such row, instead return default (which
+must be of the same type as value).
+
+```sql
+lead(expression, offset, default)
+```
+
+#### Arguments
+
+- **expression**: Expression to operate on.
+- **offset**: Integer. Specifies how many rows forward the value of expression
+  should be retrieved. Defaults to 1.
+- **default**: The default value if the offset is not within the partition. Must
+  be of the same type as expression.
+
+### `nth_value`
+
+Returns value evaluated at the row that is the nth row of the window frame
+(counting from 1); null if no such row.
+
+```sql
+nth_value(expression, n)
+```
+
+#### Arguments
+
+- **expression**: The name the column of which nth value to retrieve.
+- **n**: Integer. Specifies the n in nth.

--- a/content/influxdb3/cloud-serverless/reference/sql/functions/window.md
+++ b/content/influxdb3/cloud-serverless/reference/sql/functions/window.md
@@ -5,7 +5,7 @@ description: >
   SQL window functions perform an operation across a set of rows related to the
   current row.
 menu:
-  influxdb3_cloud_dedicated:
+  influxdb3_cloud_serverless:
     name: Window
     parent: sql-functions
 weight: 309

--- a/content/influxdb3/clustered/reference/sql/functions/window.md
+++ b/content/influxdb3/clustered/reference/sql/functions/window.md
@@ -5,7 +5,7 @@ description: >
   SQL window functions perform an operation across a set of rows related to the
   current row.
 menu:
-  influxdb3_cloud_dedicated:
+  influxdb3_clustered:
     name: Window
     parent: sql-functions
 weight: 309

--- a/content/influxdb3/core/reference/sql/functions/window.md
+++ b/content/influxdb3/core/reference/sql/functions/window.md
@@ -5,7 +5,7 @@ description: >
   SQL window functions perform an operation across a set of rows related to the
   current row.
 menu:
-  influxdb3_cloud_dedicated:
+  influxdb3_core:
     name: Window
     parent: sql-functions
 weight: 309

--- a/content/influxdb3/enterprise/reference/sql/functions/window.md
+++ b/content/influxdb3/enterprise/reference/sql/functions/window.md
@@ -5,7 +5,7 @@ description: >
   SQL window functions perform an operation across a set of rows related to the
   current row.
 menu:
-  influxdb3_cloud_dedicated:
+  influxdb3_enterprise:
     name: Window
     parent: sql-functions
 weight: 309

--- a/content/shared/sql-reference/_index.md
+++ b/content/shared/sql-reference/_index.md
@@ -582,6 +582,58 @@ FROM "h2o_feet"
 GROUP BY "location"
 ```
 
+### Window aggregate functions
+
+Window functions let you calculate running totals, moving averages, or other
+aggregate-like results without collapsing rows into groups
+(unlike non-window aggregate functions).
+
+Window aggregate functions include **all [aggregate functions](#aggregate-functions/)**
+and the [ranking functions](#ranking-functions).
+The SQL `OVER` clause syntactically distinguishes a window  
+function from a non-window or aggregate function and defines how to group and
+order rows for the window operation.
+
+#### Examples:
+
+{{% influxdb/custom-timestamps %}}
+
+```sql
+SELECT
+  time,
+  room,
+  temp,
+  avg(temp) OVER (PARTITION BY room) AS avg_room_temp
+FROM
+  home
+WHERE
+  time >= '2022-01-01T08:00:00Z'
+  AND time <= '2022-01-01T09:00:00Z'
+ORDER BY
+  room,
+  time
+```
+
+| time                | room        | temp | avg_room_temp |
+| :------------------ | :---------- | ---: | ------------: |
+| 2022-01-01T08:00:00 | Kitchen     | 21.0 |          22.0 |
+| 2022-01-01T09:00:00 | Kitchen     | 23.0 |          22.0 |
+| 2022-01-01T08:00:00 | Living Room | 21.1 |         21.25 |
+| 2022-01-01T09:00:00 | Living Room | 21.4 |         21.25 |
+
+{{% /influxdb/custom-timestamps %}}
+
+#### Ranking Functions
+
+| Function | Description                                                |
+| :------- | :--------------------------------------------------------- |
+| CUME_DIST() | Returns the cumulative distribution of a value within a group of values |
+| DENSE_RANK() | Returns a rank for each row without gaps in the numbering |
+| NTILE() | Distributes the rows in an ordered partition into the specified number of groups |
+| PERCENT_RANK() | Returns the percentage rank of the current row within its partition |
+| RANK() | Returns the rank of the current row in its partition, allowing gaps between ranks |
+| ROW_NUMBER() | Returns the position of the current row in its partition |
+
 ### Selector functions
 
 Selector functions are unique to InfluxDB. They behave like aggregate functions in that they take a row of data and compute it down to a single value.  However, selectors are unique in that they return a **time value** in addition to the computed value. In short, selectors return an aggregated value along with a timestamp. 

--- a/content/shared/sql-reference/functions/window.md
+++ b/content/shared/sql-reference/functions/window.md
@@ -1,0 +1,986 @@
+
+A _window function_ performs an operation across a set of rows related to the
+current row. This is similar to the type of operations
+[aggregate functions](/influxdb3/cloud-dedicated/reference/sql/functions/aggregate/)
+perform. However, window functions do not return a single output row per group
+like non-window aggregate functions do. Instead, rows retain their separate
+identities.
+
+For example, the following query uses the {{< influxdb3/home-sample-link >}}
+and returns each temperature reading with the average temperature per room over
+the queried time range:
+
+{{% influxdb/custom-timestamps %}}
+
+```sql
+SELECT
+  time,
+  room,
+  temp,
+  avg(temp) OVER (PARTITION BY room) AS avg_room_temp
+FROM
+  home
+WHERE
+  time >= '2022-01-01T08:00:00Z'
+  AND time <= '2022-01-01T09:00:00Z'
+ORDER BY
+  room,
+  time
+```
+
+| time                | room        | temp | avg_room_temp |
+| :------------------ | :---------- | ---: | ------------: |
+| 2022-01-01T08:00:00 | Kitchen     | 21.0 |          22.0 |
+| 2022-01-01T09:00:00 | Kitchen     | 23.0 |          22.0 |
+| 2022-01-01T08:00:00 | Living Room | 21.1 |         21.25 |
+| 2022-01-01T09:00:00 | Living Room | 21.4 |         21.25 |
+
+{{% /influxdb/custom-timestamps %}}
+
+- [Window frames](#window-frames)
+- [Window function syntax](#window-function-syntax)
+  - [OVER clause](#over-clause)
+  - [PARTITION BY clause](#partition-by-clause)
+  - [ORDER BY clause](#order-by-clause)
+  - [Frame clause](#frame-clause)
+    - [Frame units](#frame-units)
+    - [Frame boundaries](#frame-boundaries)
+  - [WINDOW clause](#window-clause)
+- [Aggregate functions](#aggregate-functions)
+- [Ranking Functions](#ranking-functions)
+  - [cume_dist](#cume_dist)
+  - [dense_rank](#dense_rank)
+  - [ntile](#ntile)
+  - [percent_rank](#percent_rank)
+  - [rank](#rank)
+  - [row_number](#row_number)
+- [Analytical Functions](#analytical-functions)
+  - [first_value](#first_value)
+  - [lag](#lag)
+  - [last_value](#last_value)
+  - [lead](#lead)
+  - [nth_value](#nth_value)
+
+## Window frames
+
+As window functions operate on a row, there is a set of rows in the row's
+partition that the window function uses to perform the operation. This set of
+rows is called the _window frame_. Window frame boundaries can be defined using
+`RANGE`, `ROW`, or `GROUPS` frame units, each relative to the current row--for
+exmaple:
+
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[RANGE](#)
+[ROWS](#)
+[GROUPS](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+```sql
+SELECT
+  time,
+  temp,
+  avg(temp) OVER (
+    ORDER BY time
+    RANGE INTERVAL '3 hours' PRECEDING
+  ) AS 3h_moving_avg
+FROM home
+WHERE room = 'Kitchen'
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+```sql
+SELECT
+  time,
+  temp,
+  avg(temp) OVER (
+    ROWS 3 PRECEDING
+  ) AS moving_avg
+FROM home
+WHERE room = 'Kitchen'
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+```sql
+SELECT
+  time,
+  room,
+  temp,
+  avg(temp) OVER (
+    ORDER BY room
+    GROUPS 1 PRECEDING
+  ) AS moving_avg
+FROM home
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+
+_For more information about how window frames work, see the [frame clause](#frame-clause)._
+
+If window frames are not defined, window functions use all rows in the current
+partition to perform their operation.
+
+## Window function syntax
+
+```sql
+function([expr])
+  OVER(
+    [PARTITION BY expr[, …]]
+    [ORDER BY expr [ ASC | DESC ][, …]]
+    [ frame_clause ]
+    )
+```
+
+### OVER clause
+
+Window functions use an `OVER` clause directly following the window function's
+name and arguments. The `OVER` clause syntactically distinguishes a window
+function from a normal function or non-window aggregate function and determines
+how rows are split up for the window operation.
+
+### PARTITION BY clause
+
+The `PARTITION BY` clause in the `OVER` clause divides the rows into groups, or
+partitions, that share the same values of the `PARTITION BY` expressions.
+The window function operates on all the rows in the same partition as the
+current row.
+
+### ORDER BY clause
+
+The `ORDER BY` clause inside of the `OVER` clause controls the order that the
+window function processes rows in each partition.
+When a window clause contains an `ORDER BY` clause, the window frame boundaries
+may be explicit or implicit, limiting a window frame size in both directions
+relative to the current row.
+
+> [!Note]
+> The `ORDER BY` clause in an `OVER` clause is separate from the `ORDER BY`
+> clause of the query and only determines the order that rows in each partition
+> are processed in.
+
+### Frame clause
+
+The frame clause defines window frame boundaries and can be one of the following:
+
+```sql
+{ RANGE | ROWS | GROUPS } frame_start
+{ RANGE | ROWS | GROUPS } BETWEEN frame_start AND frame_end
+```
+
+- [Frame units](#frame-units)
+  - [RANGE](#range)
+  - [ROWS](#rows)
+  - [GROUPS](#groups)
+- [Frame boundaries](#frame-boundaries)
+  - [UNBOUNDED PRECEDING](#unbounded-preceding)
+  - [offset PRECEDING](#offset-preceding)
+  - [CURRENT ROW](#current-row)
+  - [offset FOLLOWING](#offset-following)
+  - [UNBOUNDED FOLLOWING](#unbounded-following)
+
+#### Frame units
+
+When defining window frames, you can use one of the following frame units:
+
+- [RANGE](#range)
+- [ROWS](#rows)
+- [GROUPS](#groups)
+
+##### RANGE
+
+Defines frame boundaries using rows with values for columns specified 
+in the [`ORDER BY` clause](#order-by-clause) within a value range relative to
+the current row value.
+
+> [!Important]
+> When using `RANGE` frame units, you must include an `ORDER BY` clause with
+> _exactly one column_.
+
+The offset is the difference the between the current row value and surrounding
+row values. `RANGE` supports the following offset types:
+
+- Numeric _(non-negative)_
+- Numeric string _(non-negative)_
+- Interval
+
+{{< expand-wrapper >}}
+{{% expand "See how `RANGE` frame units work with numeric offsets" %}}
+
+To use a numeric offset with the `RANGE` frame unit, you must sort partitions
+by a numeric-typed column.
+
+```sql
+... OVER (
+  ORDER BY wind_direction
+  RANGE BETWEEN 45 PRECEDING AND 45 FOLLOWING
+)
+```
+
+The window frame includes rows with sort column values between 45 below and 
+45 above the current row's value:
+
+{{< sql/window-frame-units "range numeric" >}}
+
+{{% /expand %}}
+
+{{% expand "See how `RANGE` frame units work with interval offsets" %}}
+
+To use an interval offset with the `RANGE` frame unit, you must sort partitions
+by `time` or a timestamp-typed column.
+
+```sql
+... OVER (
+  ORDER BY time
+  RANGE BETWEEN
+    INTERVAL '3 hours' PRECEDING
+    AND INTERVAL '1 hour' FOLLOWING
+)
+```
+
+The window frame includes rows with timestamps between three hours before and
+one hour after the current row's timestamp:
+
+{{% influxdb/custom-timestamps %}}
+
+{{< sql/window-frame-units "range interval" >}}
+
+{{% /influxdb/custom-timestamps %}}
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+##### ROWS
+
+Defines frame boundaries using row positions relative to the current row.
+The offset is the difference in row position from the current row.
+`ROWS` supports the following offset types:
+
+- Numeric _(non-negative)_
+- Numeric string _(non-negative)_
+
+{{< expand-wrapper >}}
+{{% expand "See how `ROWS` frame units work" %}}
+
+When using the `ROWS` frame unit, row positions relative to the current row
+determine frame boundaries--for example:
+
+```sql
+... OVER (
+  ROWS BETWEEN 2 PRECEDING AND 1 FOLLOWING
+)
+```
+
+The window frame includes the two rows before and the one row after the current row:
+
+{{< sql/window-frame-units "rows" >}}
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+##### GROUPS
+
+Defines frame boundaries using row groups.
+Rows with the same values for the columns in the [`ORDER BY` clause](#order-by-clause)
+comprise a row group.
+
+> [!Important]
+> When using `GROUPS` frame units, you must include an `ORDER BY` clause.
+
+The offset is the difference in row group position relative to the the current row group.
+`GROUPS` supports the following offset types:
+
+- Numeric _(non-negative)_
+- Numeric string _(non-negative)_
+
+{{< expand-wrapper >}}
+{{% expand "See how `GROUPS` frame units work" %}}
+
+When using the `GROUPS` frame unit, unique combinations column values specified
+in the `ORDER BY` clause determine each row group. For example, if you sort
+partitions by `country` and `city`:
+
+```sql
+... OVER (
+  ORDER BY country, city
+  GROUPS ...
+)
+```
+
+The query defines row groups in the following way:
+
+{{< sql/window-frame-units "groups" >}}
+
+You can then use group offsets to determine frame boundaries:
+
+```sql
+... OVER (
+  ORDER BY country, city
+  GROUPS 2 PRECEDING
+)
+```
+
+The window function uses all rows in the two row groups before the current
+row group and the current row group to perform the operation:
+
+{{< sql/window-frame-units "groups with frame" >}}
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+#### Frame boundaries
+
+Frame boundaries (**frame_start** and **frame_end**) define the boundaries of
+each frame the window function operates on. Use the following to define
+frame boundaries:
+
+```sql
+UNBOUNDED PRECEDING
+offset PRECEDING
+CURRENT ROW
+offset FOLLOWING
+UNBOUNDED FOLLOWING
+```
+
+##### UNBOUNDED PRECEDING
+
+Use the beginning of the partition to the current row as the frame boundary.
+
+##### offset PRECEDING
+
+Use a specified offset of [frame units](#frame-units) _before_ the current row
+as a frame boundary.
+
+##### CURRENT ROW
+
+Use the current row as a frame boundary.
+
+##### offset FOLLOWING
+
+Use a specified offset of [frame units](#frame-units) _after_ the current row
+as a frame boundary.
+
+##### UNBOUNDED FOLLOWING
+
+Use the current row to the end of the current partition the frame boundary.
+
+### WINDOW clause
+
+When a query has multiple window functions that use the same window, rather than
+writing each with a separate `OVER` clause (which is duplicative and error-prone),
+use the `WINDOW` clause to define the window and then reference the window alias
+in each `OVER` clause--for example:
+
+```sql
+SELECT
+  sum(net_gain) OVER w,
+  avg(net_net) OVER w
+FROM
+  finance
+WINDOW w AS ( PARTITION BY ticker ORDER BY time DESC);
+```
+
+---
+
+## Aggregate functions
+
+All [aggregate functions](/influxdb3/cloud-dedicated/reference/sql/functions/aggregate/)
+can be used as window functions.
+
+## Ranking Functions
+
+- [cume_dist](#cume_dist)
+- [dense_rank](#dense_rank)
+- [ntile](#ntile)
+- [percent_rank](#percent_rank)
+- [rank](#rank)
+- [row_number](#row_number)
+
+### cume_dist
+
+Returns the cumulative distribution of a value within a group of values.
+The returned value is greater than 0 and less than or equal to 1 and represents
+the relative rank of the value in the set of values.
+The [`ORDER BY` clause](#order-by-clause) in the `OVER` clause determines
+ranking order.
+
+```sql
+cume_dist()
+```
+
+> [!Important]
+> `cume_dist` needs an [`ORDER BY` clause](#order-by-clause) in the `OVER` clause
+> to correctly calculate the cumulative distribution of the current row value.
+
+{{< expand-wrapper >}}
+{{% expand "View `cume_dist` query example" %}}
+
+The following example uses the {{< influxdb3/home-sample-link >}}.
+
+{{% influxdb/custom-timestamps %}}
+
+```sql
+SELECT
+  time,
+  room,
+  temp,
+  cume_dist() OVER (
+    PARTITION BY room
+    ORDER BY temp 
+  ) AS cume_dist
+FROM home
+WHERE
+  time >= '2022-01-01T08:00:00Z'
+  AND time < '2022-01-01T12:00:00Z'
+```
+
+| time                | room        | temp | cume_dist |
+| :------------------ | :---------- | ---: | --------: |
+| 2022-01-01T08:00:00 | Living Room | 21.1 |      0.25 |
+| 2022-01-01T09:00:00 | Living Room | 21.4 |       0.5 |
+| 2022-01-01T10:00:00 | Living Room | 21.8 |      0.75 |
+| 2022-01-01T11:00:00 | Living Room | 22.2 |       1.0 |
+| 2022-01-01T08:00:00 | Kitchen     | 21.0 |      0.25 |
+| 2022-01-01T11:00:00 | Kitchen     | 22.4 |       0.5 |
+| 2022-01-01T10:00:00 | Kitchen     | 22.7 |      0.75 |
+| 2022-01-01T09:00:00 | Kitchen     | 23.0 |       1.0 |
+
+{{% /influxdb/custom-timestamps %}}
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+### dense_rank
+
+Returns the rank of the current row without gaps. This function ranks rows in a
+dense manner, meaning consecutive ranks are assigned even for identical values.
+The [`ORDER BY` clause](#order-by-clause) in the `OVER` clause determines
+ranking order.
+
+```sql
+dense_rank()
+```
+
+{{< expand-wrapper >}}
+{{% expand "View `dense_rank` query example" %}}
+
+The following example uses the {{< influxdb3/home-sample-link >}}.
+
+{{% influxdb/custom-timestamps %}}
+
+```sql
+SELECT
+  time,
+  room,
+  temp,
+  dense_rank() OVER (
+    PARTITION BY room
+    ORDER BY temp 
+  ) AS dense_rank
+FROM home
+WHERE
+  time >= '2022-01-01T08:00:00Z'
+  AND time < '2022-01-01T12:00:00Z'
+```
+
+| time                | room        | temp | dense_rank |
+| :------------------ | :---------- | ---: | ---------: |
+| 2022-01-01T08:00:00 | Kitchen     | 21.0 |          1 |
+| 2022-01-01T11:00:00 | Kitchen     | 22.4 |          2 |
+| 2022-01-01T10:00:00 | Kitchen     | 22.7 |          3 |
+| 2022-01-01T09:00:00 | Kitchen     | 23.0 |          4 |
+| 2022-01-01T08:00:00 | Living Room | 21.1 |          1 |
+| 2022-01-01T09:00:00 | Living Room | 21.4 |          2 |
+| 2022-01-01T10:00:00 | Living Room | 21.8 |          3 |
+| 2022-01-01T11:00:00 | Living Room | 22.2 |          4 |
+
+{{% /influxdb/custom-timestamps %}}
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+### ntile
+
+Distributes the rows in an ordered partition into a specified number of groups.
+Each group is numbered, starting at one. For each row, `ntile` returns the
+group number to which the row belongs.
+Group numbers range from 1 to the `expression` value, dividing the partition as
+equally as possible.
+The [`ORDER BY` clause](#order-by-clause) in the `OVER` clause determines
+ranking order.
+
+```sql
+ntile(expression)
+```
+
+##### Arguments
+
+- **expression**: An integer describing the number groups to split the partition
+  into.
+
+{{< expand-wrapper >}}
+{{% expand "View `ntile` query example" %}}
+
+The following example uses the {{< influxdb3/home-sample-link >}}.
+
+{{% influxdb/custom-timestamps %}}
+
+```sql
+SELECT
+  time,
+  temp,
+  ntile(4) OVER (
+    ORDER BY time 
+  ) AS ntile
+FROM home
+WHERE
+  room = 'Kitchen'
+  AND time >= '2022-01-01T08:00:00Z'
+  AND time < '2022-01-01T15:00:00Z'
+```
+
+| time                | temp | ntile |
+| :------------------ | ---: | ----: |
+| 2022-01-01T08:00:00 | 21.0 |     1 |
+| 2022-01-01T09:00:00 | 23.0 |     1 |
+| 2022-01-01T10:00:00 | 22.7 |     2 |
+| 2022-01-01T11:00:00 | 22.4 |     2 |
+| 2022-01-01T12:00:00 | 22.5 |     3 |
+| 2022-01-01T13:00:00 | 22.8 |     3 |
+| 2022-01-01T14:00:00 | 22.8 |     4 |
+
+{{% /influxdb/custom-timestamps %}}
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+### percent_rank
+
+Returns the percentage rank of the current row within its partition.
+The returned value is between `0` and `1` and is computed as
+`(rank - 1) / (total_rows - 1)`.
+The [`ORDER BY` clause](#order-by-clause) in the `OVER` clause determines
+ranking order.
+
+```sql
+percent_rank()
+```
+
+{{< expand-wrapper >}}
+{{% expand "View `percent_rank` query example" %}}
+
+The following example uses the {{< influxdb3/home-sample-link >}}.
+
+{{% influxdb/custom-timestamps %}}
+
+```sql
+SELECT
+  time,
+  room,
+  temp,
+  percent_rank() OVER (
+    PARTITION BY room
+    ORDER BY temp 
+  ) AS percent_rank
+FROM home
+WHERE
+  time >= '2022-01-01T08:00:00Z'
+  AND time < '2022-01-01T11:00:00Z'
+```
+
+| time                | room        | temp | percent_rank |
+| :------------------ | :---------- | ---: | -----------: |
+| 2022-01-01T08:00:00 | Kitchen     | 21.0 |          0.0 |
+| 2022-01-01T10:00:00 | Kitchen     | 22.7 |          0.5 |
+| 2022-01-01T09:00:00 | Kitchen     | 23.0 |          1.0 |
+| 2022-01-01T08:00:00 | Living Room | 21.1 |          0.0 |
+| 2022-01-01T09:00:00 | Living Room | 21.4 |          0.5 |
+| 2022-01-01T10:00:00 | Living Room | 21.8 |          1.0 |
+
+{{% /influxdb/custom-timestamps %}}
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+### rank
+
+Returns the rank of the current row in its partition, allowing gaps between
+ranks. This function provides a ranking similar to [`row_number`](#row_number),
+but skips ranks for identical values.
+The [`ORDER BY` clause](#order-by-clause) in the `OVER` clause determines
+ranking order.
+
+```sql
+rank()
+```
+
+{{< expand-wrapper >}}
+{{% expand "View `rank` query example" %}}
+
+The following example uses the {{< influxdb3/home-sample-link >}}.
+
+{{% influxdb/custom-timestamps %}}
+
+```sql
+SELECT
+  time,
+  room,
+  temp,
+  rank() OVER (
+    PARTITION BY room
+    ORDER BY temp 
+  ) AS rank
+FROM home
+WHERE
+  time >= '2022-01-01T08:00:00Z'
+  AND time < '2022-01-01T11:00:00Z'
+```
+
+| time                | room        | temp | rank |
+| :------------------ | :---------- | ---: | ---: |
+| 2022-01-01T08:00:00 | Living Room | 21.1 |    1 |
+| 2022-01-01T09:00:00 | Living Room | 21.4 |    2 |
+| 2022-01-01T10:00:00 | Living Room | 21.8 |    3 |
+| 2022-01-01T08:00:00 | Kitchen     | 21.0 |    1 |
+| 2022-01-01T10:00:00 | Kitchen     | 22.7 |    2 |
+| 2022-01-01T09:00:00 | Kitchen     | 23.0 |    3 |
+
+{{% /influxdb/custom-timestamps %}}
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+### row_number
+
+Returns the position of the current row in its partition, counting from 1.
+The [`ORDER BY` clause](#order-by-clause) in the `OVER` clause determines
+row order.
+
+```sql
+row_number()
+```
+
+{{< expand-wrapper >}}
+{{% expand "View `row_number` query example" %}}
+
+The following example uses the {{< influxdb3/home-sample-link >}}.
+
+{{% influxdb/custom-timestamps %}}
+
+```sql
+SELECT
+  time,
+  room,
+  temp,
+  row_number() OVER (
+    PARTITION BY room
+    ORDER BY temp 
+  ) AS row_number
+FROM home
+WHERE
+  time >= '2022-01-01T08:00:00Z'
+  AND time < '2022-01-01T11:00:00Z'
+```
+
+| time                | room        | temp | row_number |
+| :------------------ | :---------- | ---: | ---------: |
+| 2022-01-01T08:00:00 | Living Room | 21.1 |          1 |
+| 2022-01-01T09:00:00 | Living Room | 21.4 |          2 |
+| 2022-01-01T10:00:00 | Living Room | 21.8 |          3 |
+| 2022-01-01T08:00:00 | Kitchen     | 21.0 |          1 |
+| 2022-01-01T10:00:00 | Kitchen     | 22.7 |          2 |
+| 2022-01-01T09:00:00 | Kitchen     | 23.0 |          3 |
+
+{{% /influxdb/custom-timestamps %}}
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+## Analytical Functions
+
+- [first_value](#first_value)
+- [lag](#lag)
+- [last_value](#last_value)
+- [lead](#lead)
+- [nth_value](#nth_value)
+
+### first_value
+
+Returns the value from the first row of the window frame.
+
+```sql
+first_value(expression)
+```
+
+##### Arguments
+
+- **expression**: Expression to operate on. Can be a constant, column, or
+  function, and any combination of arithmetic operators.
+
+##### Related functions
+
+[last_value](#last_value)
+
+{{< expand-wrapper >}}
+{{% expand "View `first_value` query example" %}}
+
+The following example uses the {{< influxdb3/home-sample-link >}}.
+
+{{% influxdb/custom-timestamps %}}
+
+```sql
+SELECT
+  time,
+  room,
+  temp,
+  first_value(temp) OVER (
+    PARTITION BY room
+    ORDER BY time 
+  ) AS first_value
+FROM home
+WHERE  
+  time >= '2022-01-01T08:00:00Z'
+  AND time < '2022-01-01T11:00:00Z'
+ORDER BY room, time
+```
+
+| time                | room        | temp | first_value |
+| :------------------ | :---------- | ---: | ----------: |
+| 2022-01-01T08:00:00 | Kitchen     | 21.0 |        21.0 |
+| 2022-01-01T09:00:00 | Kitchen     | 23.0 |        21.0 |
+| 2022-01-01T10:00:00 | Kitchen     | 22.7 |        21.0 |
+| 2022-01-01T08:00:00 | Living Room | 21.1 |        21.1 |
+| 2022-01-01T09:00:00 | Living Room | 21.4 |        21.1 |
+| 2022-01-01T10:00:00 | Living Room | 21.8 |        21.1 |
+
+{{% /influxdb/custom-timestamps %}}
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+### lag
+
+Returns the value from the row that is at the specified offset before the
+current row in the partition. If the offset row is outside of the partition,
+the function returns the specified default.
+
+```sql
+lag(expression, offset, default)
+```
+
+##### Arguments
+
+- **expression**: Expression to operate on.
+  Can be a constant, column, or function, and any combination of arithmetic or 
+  string operators.
+- **offset**: How many rows _before_ the current row to retrieve the value of
+  _expression_ from. Default is `1`.
+- **default**: The default value to return if the offset is in the partition.
+  Must be of the same type as _expression_.
+
+##### Related functions
+
+[lead](#lead)
+
+{{< expand-wrapper >}}
+{{% expand "View `lag` query example" %}}
+
+The following example uses the {{< influxdb3/home-sample-link >}}.
+
+{{% influxdb/custom-timestamps %}}
+
+```sql
+SELECT
+  time,
+  room,
+  temp,
+  lag(temp, 1, 0) OVER (
+    PARTITION BY room
+    ORDER BY time
+  ) AS previous_value
+FROM home
+WHERE
+  time >= '2022-01-01T08:00:00Z'
+  AND time < '2022-01-01T11:00:00Z'
+ORDER BY room, time
+```
+
+| time                | room        | temp | previous_value |
+|:--------------------|:------------|-----:|---------------:|
+| 2022-01-01T08:00:00 | Kitchen     | 21.0 | 0.0            |
+| 2022-01-01T09:00:00 | Kitchen     | 23.0 | 21.0           |
+| 2022-01-01T10:00:00 | Kitchen     | 22.7 | 23.0           |
+| 2022-01-01T08:00:00 | Living Room | 21.1 | 0.0            |
+| 2022-01-01T09:00:00 | Living Room | 21.4 | 21.1           |
+| 2022-01-01T10:00:00 | Living Room | 21.8 | 21.4           |
+
+{{% /influxdb/custom-timestamps %}}
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+### last_value
+
+Returns the value from the last row of the window frame.
+
+```sql
+last_value(expression)
+```
+
+##### Arguments
+
+- **expression**: Expression to operate on. Can be a constant, column, or
+  function, and any combination of arithmetic operators.
+
+##### Related functions
+
+[first_value](#first_value)
+
+{{< expand-wrapper >}}
+{{% expand "View `last_value` query example" %}}
+
+The following example uses the {{< influxdb3/home-sample-link >}}.
+
+{{% influxdb/custom-timestamps %}}
+
+```sql
+SELECT
+  time,
+  room,
+  temp,
+  last_value(temp) OVER (
+    PARTITION BY room
+    ORDER BY time
+    ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+  ) AS last_value
+FROM home
+WHERE  
+  time >= '2022-01-01T08:00:00Z'
+  AND time < '2022-01-01T11:00:00Z'
+ORDER BY room, time
+```
+
+| time                | room        | temp | last_value |
+| :------------------ | :---------- | ---: | ---------: |
+| 2022-01-01T08:00:00 | Kitchen     | 21.0 | 22.7       |
+| 2022-01-01T09:00:00 | Kitchen     | 23.0 | 22.7       |
+| 2022-01-01T10:00:00 | Kitchen     | 22.7 | 22.7       |
+| 2022-01-01T08:00:00 | Living Room | 21.1 | 21.8       |
+| 2022-01-01T09:00:00 | Living Room | 21.4 | 21.8       |
+| 2022-01-01T10:00:00 | Living Room | 21.8 | 21.8       |
+
+{{% /influxdb/custom-timestamps %}}
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+### lead
+
+Returns the value from the row that is at the specified offset after the
+current row in the partition. If the offset row is outside of the partition,
+the function returns the specified default.
+
+```sql
+lead(expression, offset, default)
+```
+
+##### Arguments
+
+- **expression**: Expression to operate on.
+  Can be a constant, column, or function, and any combination of arithmetic or 
+  string operators.
+- **offset**: How many rows _before_ the current row to retrieve the value of
+  _expression_ from. Default is `1`.
+- **default**: The default value to return if the offset is in the partition.
+  Must be of the same type as _expression_.
+
+##### Related functions
+
+[lag](#lag)
+
+{{< expand-wrapper >}}
+{{% expand "View `lead` query example" %}}
+
+The following example uses the {{< influxdb3/home-sample-link >}}.
+
+{{% influxdb/custom-timestamps %}}
+
+```sql
+SELECT
+  time,
+  room,
+  temp,
+  lead(temp, 1, 0) OVER (
+    PARTITION BY room
+    ORDER BY time
+  ) AS next_value
+FROM home
+WHERE
+  time >= '2022-01-01T08:00:00Z'
+  AND time < '2022-01-01T11:00:00Z'
+ORDER BY room, time
+```
+
+| time                | room        | temp | next_value |
+| :------------------ | :---------- | ---: | ---------: |
+| 2022-01-01T08:00:00 | Kitchen     | 21.0 |       23.0 |
+| 2022-01-01T09:00:00 | Kitchen     | 23.0 |       22.7 |
+| 2022-01-01T10:00:00 | Kitchen     | 22.7 |        0.0 |
+| 2022-01-01T08:00:00 | Living Room | 21.1 |       21.4 |
+| 2022-01-01T09:00:00 | Living Room | 21.4 |       21.8 |
+| 2022-01-01T10:00:00 | Living Room | 21.8 |        0.0 |
+
+{{% /influxdb/custom-timestamps %}}
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+### nth_value
+
+Returns the value from the row that is the nth row of the window frame
+(counting from 1). If the nth row doesn't exist, the function returns _null_.
+
+```sql
+nth_value(expression, n)
+```
+
+##### Arguments
+
+- **expression**: The expression to operator on.
+  Can be a constant, column, or function, and any combination of arithmetic or 
+  string operators.
+- **n**: Specifies the row number in the current frame and partition to reference.
+
+{{< expand-wrapper >}}
+{{% expand "View `lead` query example" %}}
+
+The following example uses the {{< influxdb3/home-sample-link >}}.
+
+{{% influxdb/custom-timestamps %}}
+
+```sql
+SELECT
+  time,
+  room,
+  temp,
+  nth_value(temp, 2) OVER (
+    PARTITION BY room
+  ) AS "2nd_temp"
+FROM home
+WHERE  
+  time >= '2025-02-10T08:00:00Z'
+  AND time < '2025-02-10T11:00:00Z'
+```
+
+| time                | room        | temp | 2nd_temp |
+| :------------------ | :---------- | ---: | -------: |
+| 2025-02-10T08:00:00 | Kitchen     | 21.0 |     22.7 |
+| 2025-02-10T10:00:00 | Kitchen     | 22.7 |     22.7 |
+| 2025-02-10T09:00:00 | Kitchen     | 23.0 |     22.7 |
+| 2025-02-10T08:00:00 | Living Room | 21.1 |     21.8 |
+| 2025-02-10T10:00:00 | Living Room | 21.8 |     21.8 |
+| 2025-02-10T09:00:00 | Living Room | 21.4 |     21.8 |
+
+{{% /influxdb/custom-timestamps %}}
+
+{{% /expand %}}
+{{< /expand-wrapper >}}

--- a/layouts/shortcodes/influxdb3/home-sample-link.html
+++ b/layouts/shortcodes/influxdb3/home-sample-link.html
@@ -1,0 +1,8 @@
+{{- $productPathData := split .Page.RelPermalink "/" -}}
+{{- $product := index $productPathData 2 -}}
+{{- $isDistributed := in (slice "cloud-dedicated" "cloud-serverless" "clustered") $product -}}
+{{- if $isDistributed -}}
+<a href="/influxdb3/{{ $product }}//reference/sample-data/#get-started-home-sensor-data">Get started home sensor sample data</a>
+{{- else -}}
+<a href="/influxdb3/{{ $product }}//reference/sample-data/#home-sensor-data">Home sensor sample data</a>
+{{- end -}}

--- a/layouts/shortcodes/influxdb3/home-sample-link.html
+++ b/layouts/shortcodes/influxdb3/home-sample-link.html
@@ -2,7 +2,7 @@
 {{- $product := index $productPathData 2 -}}
 {{- $isDistributed := in (slice "cloud-dedicated" "cloud-serverless" "clustered") $product -}}
 {{- if $isDistributed -}}
-<a href="/influxdb3/{{ $product }}//reference/sample-data/#get-started-home-sensor-data">Get started home sensor sample data</a>
+<a href="/influxdb3/{{ $product }}/reference/sample-data/#get-started-home-sensor-data">Get started home sensor sample data</a>
 {{- else -}}
-<a href="/influxdb3/{{ $product }}//reference/sample-data/#home-sensor-data">Home sensor sample data</a>
+<a href="/influxdb3/{{ $product }}/reference/sample-data/#home-sensor-data">Home sensor sample data</a>
 {{- end -}}

--- a/layouts/shortcodes/sql/window-frame-units..html
+++ b/layouts/shortcodes/sql/window-frame-units..html
@@ -1,0 +1,335 @@
+{{ $unit := .Get 0 | default "groups" }}
+
+{{ if eq $unit "groups" }}
+<table class="window-frame-units groups">
+  <thead>
+      <tr>
+          <th style="text-align: left">time</th>
+          <th style="text-align: left">country</th>
+          <th style="text-align: left">city</th>
+          <th style="text-align: right">wind_direction</th>
+      </tr>
+  </thead>
+  <tbody class="group">
+      <tr>
+          <td style="text-align: left">2025-02-17T00:00:00</td>
+          <td style="text-align: left">France</td>
+          <td style="text-align: left">Strasbourg</td>
+          <td style="text-align: right">181</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T01:00:00</td>
+          <td style="text-align: left">France</td>
+          <td style="text-align: left">Strasbourg</td>
+          <td style="text-align: right">228</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T02:00:00</td>
+          <td style="text-align: left">France</td>
+          <td style="text-align: left">Strasbourg</td>
+          <td style="text-align: right">289</td>
+      </tr>
+  </tbody>
+  <tbody class="group">
+      <tr>
+          <td style="text-align: left">2025-02-17T00:00:00</td>
+          <td style="text-align: left">France</td>
+          <td style="text-align: left">Toulouse</td>
+          <td style="text-align: right">24</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T01:00:00</td>
+          <td style="text-align: left">France</td>
+          <td style="text-align: left">Toulouse</td>
+          <td style="text-align: right">210</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T02:00:00</td>
+          <td style="text-align: left">France</td>
+          <td style="text-align: left">Toulouse</td>
+          <td style="text-align: right">206</td>
+      </tr>
+    </tbody>
+    <tbody class="group">
+      <tr>
+          <td style="text-align: left">2025-02-17T00:00:00</td>
+          <td style="text-align: left">Italy</td>
+          <td style="text-align: left">Bari</td>
+          <td style="text-align: right">2</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T01:00:00</td>
+          <td style="text-align: left">Italy</td>
+          <td style="text-align: left">Bari</td>
+          <td style="text-align: right">57</td>
+      </tr>
+    </tbody>
+    <tbody class="group">
+      <tr>
+          <td style="text-align: left">2025-02-17T00:00:00</td>
+          <td style="text-align: left">Italy</td>
+          <td style="text-align: left">Bologna</td>
+          <td style="text-align: right">351</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T01:00:00</td>
+          <td style="text-align: left">Italy</td>
+          <td style="text-align: left">Bologna</td>
+          <td style="text-align: right">232</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T02:00:00</td>
+          <td style="text-align: left">Italy</td>
+          <td style="text-align: left">Bologna</td>
+          <td style="text-align: right">29</td>
+      </tr>
+  </tbody>
+</table>
+
+{{ else if eq $unit "groups with frame" }}
+<table class="window-frame-units groups-with-frame">
+  <thead>
+      <tr>
+          <th style="text-align: left">time</th>
+          <th style="text-align: left">country</th>
+          <th style="text-align: left">city</th>
+          <th style="text-align: right">wind_direction</th>
+      </tr>
+  </thead>
+  <tbody class="frame">
+      <tr>
+          <td style="text-align: left">2025-02-17T00:00:00</td>
+          <td style="text-align: left">France</td>
+          <td style="text-align: left">Strasbourg</td>
+          <td style="text-align: right">181</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T01:00:00</td>
+          <td style="text-align: left">France</td>
+          <td style="text-align: left">Strasbourg</td>
+          <td style="text-align: right">228</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T02:00:00</td>
+          <td style="text-align: left">France</td>
+          <td style="text-align: left">Strasbourg</td>
+          <td style="text-align: right">289</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T00:00:00</td>
+          <td style="text-align: left">France</td>
+          <td style="text-align: left">Toulouse</td>
+          <td style="text-align: right">24</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T01:00:00</td>
+          <td style="text-align: left">France</td>
+          <td style="text-align: left">Toulouse</td>
+          <td style="text-align: right">210</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T02:00:00</td>
+          <td style="text-align: left">France</td>
+          <td style="text-align: left">Toulouse</td>
+          <td style="text-align: right">206</td>
+      </tr>
+      <tr class="current-row">
+          <td style="text-align: left">2025-02-17T00:00:00</td>
+          <td style="text-align: left">Italy</td>
+          <td style="text-align: left">Bari</td>
+          <td style="text-align: right">2</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T01:00:00</td>
+          <td style="text-align: left">Italy</td>
+          <td style="text-align: left">Bari</td>
+          <td style="text-align: right">57</td>
+      </tr>
+    </tbody>
+    <tbody class="group">
+      <tr>
+          <td style="text-align: left">2025-02-17T00:00:00</td>
+          <td style="text-align: left">Italy</td>
+          <td style="text-align: left">Bologna</td>
+          <td style="text-align: right">351</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T01:00:00</td>
+          <td style="text-align: left">Italy</td>
+          <td style="text-align: left">Bologna</td>
+          <td style="text-align: right">232</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T02:00:00</td>
+          <td style="text-align: left">Italy</td>
+          <td style="text-align: left">Bologna</td>
+          <td style="text-align: right">29</td>
+      </tr>
+  </tbody>
+</table>
+
+{{ else if (eq $unit "range interval") }}
+
+<table class="window-frame-units range-interval">
+  <thead>
+      <tr>
+          <th style="text-align: left">time</th>
+          <th style="text-align: left">room</th>
+          <th style="text-align: right">temp</th>
+      </tr>
+  </thead>
+  <tbody>
+      <tr>
+          <td style="text-align: left">2022-01-01T08:00:00</td>
+          <td style="text-align: left">Kitchen</td>
+          <td style="text-align: right">21.0</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2022-01-01T09:00:00</td>
+          <td style="text-align: left">Kitchen</td>
+          <td style="text-align: right">23.0</td>
+      </tr>
+  </tbody>
+  <tbody class="frame">
+      <tr>
+          <td style="text-align: left">2022-01-01T10:00:00</td>
+          <td style="text-align: left">Kitchen</td>
+          <td style="text-align: right">22.7</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2022-01-01T11:00:00</td>
+          <td style="text-align: left">Kitchen</td>
+          <td style="text-align: right">22.4</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2022-01-01T12:00:00</td>
+          <td style="text-align: left">Kitchen</td>
+          <td style="text-align: right">22.5</td>
+      </tr>
+      <tr class="current-row">
+          <td style="text-align: left">2022-01-01T13:00:00</td>
+          <td style="text-align: left">Kitchen</td>
+          <td style="text-align: right">22.8</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2022-01-01T14:00:00</td>
+          <td style="text-align: left">Kitchen</td>
+          <td style="text-align: right">22.8</td>
+      </tr>
+  </tbody>
+  <tbody>
+      <tr>
+          <td style="text-align: left">2022-01-01T15:00:00</td>
+          <td style="text-align: left">Kitchen</td>
+          <td style="text-align: right">22.7</td>
+      </tr>
+  </tbody>
+</table>
+
+{{ else if (eq $unit "range numeric") }}
+
+<table class="window-frame-units range-numeric">
+  <thead>
+      <tr>
+          <th style="text-align: left">time</th>
+          <th style="text-align: left">city</th>
+          <th style="text-align: right">wind_direction</th>
+      </tr>
+  </thead>
+  <tbody>
+      <tr>
+          <td style="text-align: left">2025-02-17T13:00:00</td>
+          <td style="text-align: left">Rome</td>
+          <td style="text-align: right">33</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T08:00:00</td>
+          <td style="text-align: left">Rome</td>
+          <td style="text-align: right">34</td>
+      </tr>
+  </tbody>
+  <tbody class="frame">
+      <tr>
+          <td style="text-align: left">2025-02-17T23:00:00</td>
+          <td style="text-align: left">Rome</td>
+          <td style="text-align: right">49</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T17:00:00</td>
+          <td style="text-align: left">Rome</td>
+          <td style="text-align: right">86</td>
+      </tr>
+      <tr class="current-row">
+          <td style="text-align: left">2025-02-17T11:00:00</td>
+          <td style="text-align: left">Rome</td>
+          <td style="text-align: right">93</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T12:00:00</td>
+          <td style="text-align: left">Rome</td>
+          <td style="text-align: right">115</td>
+      </tr>
+  </tbody>
+  <tbody>
+      <tr>
+          <td style="text-align: left">2025-02-17T10:00:00</td>
+          <td style="text-align: left">Rome</td>
+          <td style="text-align: right">156</td>
+      </tr>
+  </tbody>
+</table>
+
+{{ else if (eq $unit "rows") }}
+
+<table class="window-frame-units rows">
+  <thead>
+      <tr>
+          <th style="text-align: left">time</th>
+          <th style="text-align: left">city</th>
+          <th style="text-align: right">wind_direction</th>
+      </tr>
+  </thead>
+  <tbody>
+      <tr>
+          <td style="text-align: left">2025-02-17T08:00:00</td>
+          <td style="text-align: left">Rome</td>
+          <td style="text-align: right">34</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T10:00:00</td>
+          <td style="text-align: left">Rome</td>
+          <td style="text-align: right">156</td>
+      </tr>      
+  </tbody>
+  <tbody class="frame">
+      <tr>
+          <td style="text-align: left">2025-02-17T11:00:00</td>
+          <td style="text-align: left">Rome</td>
+          <td style="text-align: right">93</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T12:00:00</td>
+          <td style="text-align: left">Rome</td>
+          <td style="text-align: right">115</td>
+      </tr>
+      <tr class="current-row">
+          <td style="text-align: left">2025-02-17T13:00:00</td>
+          <td style="text-align: left">Rome</td>
+          <td style="text-align: right">33</td>
+      </tr>
+      <tr>
+          <td style="text-align: left">2025-02-17T17:00:00</td>
+          <td style="text-align: left">Rome</td>
+          <td style="text-align: right">86</td>
+      </tr>
+  </tbody>
+  <tbody>    
+      <tr>
+          <td style="text-align: left">2025-02-17T23:00:00</td>
+          <td style="text-align: left">Rome</td>
+          <td style="text-align: right">49</td>
+      </tr>
+  </tbody>
+</table>
+
+{{ end }}


### PR DESCRIPTION
Closes #5851

- Adds SQL window functions and supporting `OVER` clause documentation
- Adds a new shortcode for linking to the home sensor sample data since it's named differently between distributed and monolith
- Adds a shortcode and styles for displaying HTML diagrams for window frame unit types. For example:

<img width="436" alt="image" src="https://github.com/user-attachments/assets/0d388dbb-6fe4-4444-980a-98c0f0878a65" />

- [x] Rebased/mergeable
