### PR TITLE
Adding  no_sync documentation to get-started page of Core and Enterprise 

### DIFF
--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -327,15 +327,20 @@ For more information, see [diskless architecture](#diskless-architecture).
 > Because InfluxDB sends a write response after the WAL file has been flushed to the configured object store (default is every second), individual write requests might not complete quickly, but you can make many concurrent requests to achieve higher total throughput.
 > Future enhancements will include an API parameter that lets requests return without waiting for the WAL flush.
 
+##### No sync write option
 
-##### no_sync Write Option
-
-InfluxDB provides a no_sync write option to allow faster response of write request by skipping the wait for WAL presistence. When `no_sync=true`, InfluxDB writes data to WAL but immediately acknowledges the write request without waiting for persistence. 
+InfluxDB provides a `no_sync` write option to allow faster response of write request by skipping the wait for WAL presistence. When `no_sync=true`, InfluxDB writes data to WAL but immediately acknowledges the write request without waiting for persistence. 
 
 - Default behavior(`no_sync=false`): Ensures data is persisted before acknowledging writes. Thus, reducing the risk of data loss. 
 - With `no_sync=true`: Improves write performance but increases the risk of data loss in case of crashes before WAL persistence. 
 
-#### Create a database or table
+If you are using the CLI, here is an example of how to enable the `no_sync` option:
+
+```sh
+influx write --bucket=mydb --org=my_org --token=my-token --no-sync
+```
+
+#### Create a database or Table
 
 To create a database without writing data, use the `create` subcommand--for example:
 

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -351,7 +351,7 @@ If you are using the CLI, here is an example of how to enable the `no_sync` opti
 influxdb3 write --bucket=mydb --org=my_org --token=my-token --no-sync
 ```
 
-#### Create a database or Table
+#### Create a database or table
 
 To create a database without writing data, use the `create` subcommand--for example:
 

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -333,7 +333,7 @@ InfluxDB provides a `no_sync` write option that allows the write request to resp
 
 Using `no_sync=true` is best when prioritizing high-throughput writes over absolute durability. 
 
-- Default behavior(`no_sync=false`): Waits for data to be written to disk before acknowledging writes. This reduces the risk of data loss but increases latency for writes.
+- Default behavior (`no_sync=false`): Waits for data to be written to disk before acknowledging writes. This reduces the risk of data loss but increases latency for writes.
 - With `no_sync=true`: Reduces write latency but increases the risk of data loss in case of crashes before WAL persistence. 
 
 ###### Immediate write using the HTTP API

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -340,7 +340,7 @@ The `no_sync` write option reduces latency by acknowledging write requests befor
 Using `no_sync=true` is best when prioritizing high-throughput writes over absolute durability. 
 
 - Default behavior (`no_sync=false`): Waits for data to be written to the Object store before acknowledging the write. Reduces the risk of data loss, but increases the latency of the response.
-- With `no_sync=true`: Reduces write latency but increases the risk of data loss in case of crashes before WAL persistence. 
+- With `no_sync=true`: Reduces write latency, but increases the risk of data loss in case of a crash before WAL persistence. 
 
 ###### Immediate write using the HTTP API
 

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -335,7 +335,10 @@ Using `no_sync=true` is best when prioritizing high-throughput writes over absol
 - Default behavior(`no_sync=false`): Waits for data to be written to disk before acknowledging writes. This reduces the risk of data loss but increases latency for writes.
 - With `no_sync=true`: Reduces write latency but increases the risk of data loss in case of crashes before WAL persistence. 
 
-If you are using the HTTP API, here is an example of how to enable the `no_sync` option:
+###### Immediate write using the HTTP API
+
+The `no_sync` parameter controls when writes are acknowledged--for example:
+
 
 ```sh
 curl -v "http://localhost:8181/api/v3/write_lp?db=sensors&precision=auto&no_sync=true" \

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -335,7 +335,7 @@ For more information, see [diskless architecture](#diskless-architecture).
 
 ##### No sync write option
 
-InfluxDB provides a `no_sync` write option that allows the write request to respond faster by skipping the wait for WAL persistence. When `no_sync=true`, InfluxDB writes data to the WAL and then immediately acknowledges the write request without waiting for persistence to the Object store.
+The `no_sync` write option reduces latency by acknowledging write requests before WAL persistence completes. When set to `true`, InfluxDB validates the data, writes the data to the WAL, and then immediately confirms the write, without waiting for persistence to the Object store.
 
 Using `no_sync=true` is best when prioritizing high-throughput writes over absolute durability. 
 

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -334,11 +334,20 @@ InfluxDB provides a `no_sync` write option to allow faster response of write req
 - Default behavior(`no_sync=false`): Ensures data is persisted before acknowledging writes. Thus, reducing the risk of data loss. 
 - With `no_sync=true`: Improves write performance but increases the risk of data loss in case of crashes before WAL persistence. 
 
+If you are using the HTTP API, here is an example of how to enable the `no_sync` option:
+
+```sh
+curl -v "http://localhost:8181/api/v3/write_lp?db=sensors&precision=auto&no_sync=true" \
+  --data-raw "home,room=Sunroom temp=96
+home,room=Sunroom temp=hi"
+```
+
 If you are using the CLI, here is an example of how to enable the `no_sync` option:
 
 ```sh
-influx write --bucket=mydb --org=my_org --token=my-token --no-sync
+influxdb3 write --bucket=mydb --org=my_org --token=my-token --no-sync
 ```
+Using `no_sync=true` is best when prioritizing high-throughput writes over absolute durability. 
 
 #### Create a database or Table
 

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -332,7 +332,7 @@ InfluxDB provides a `no_sync` write option that allows the write request to resp
 
 Using `no_sync=true` is best when prioritizing high-throughput writes over absolute durability. 
 
-- Default behavior(`no_sync=false`): Ensures data is persisted before acknowledging writes. Thus, reducing the risk of data loss. 
+- Default behavior(`no_sync=false`): Waits for data to be written to disk before acknowledging writes. This reduces the risk of data loss but increases latency for writes.
 - With `no_sync=true`: Improves write performance but increases the risk of data loss in case of crashes before WAL persistence. 
 
 If you are using the HTTP API, here is an example of how to enable the `no_sync` option:

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -350,7 +350,6 @@ If you are using the CLI, here is an example of how to enable the `no_sync` opti
 ```sh
 influxdb3 write --bucket=mydb --org=my_org --token=my-token --no-sync
 ```
-Using `no_sync=true` is best when prioritizing high-throughput writes over absolute durability. 
 
 #### Create a database or Table
 

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -329,8 +329,9 @@ For more information, see [diskless architecture](#diskless-architecture).
 > [!Note]
 > ##### Write requests return after WAL flush
 >
-> By default, when you write data, InfluxDB sends a write response after the WAL file has been flushed to the Object store (default is every second). Write requests might not complete quickly, but you can make many concurrent requests to achieve higher total throughput.
-For faster write responses, you can use the [`no_sync` option](#no-sync-write-option) to skip the wait for WAL persistence.
+> By default, InfluxDB acknowledges writes after flushing the WAL file to the Object store (occurring every second). For high throughput, you can send multiple concurrent write requests.
+>
+> To reduce the latency of writes, use the [`no_sync` write option](#no-sync-write-option), which acknowledges writes _before_ WAL persistence completes.
 
 ##### No sync write option
 

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -325,7 +325,6 @@ For more information, see [diskless architecture](#diskless-architecture).
 > ##### Write requests return after WAL flush
 >
 > Because InfluxDB sends a write response after the WAL file has been flushed to the configured object store (default is every second), individual write requests might not complete quickly, but you can make many concurrent requests to achieve higher total throughput.
-> Future enhancements will include an API parameter that lets requests return without waiting for the WAL flush.
 
 ##### No sync write option
 

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -323,6 +323,13 @@ For more information, see [diskless architecture](#diskless-architecture).
 > Because InfluxDB sends a write response after the WAL file has been flushed to the configured object store (default is every second), individual write requests might not complete quickly, but you can make many concurrent requests to achieve higher total throughput.
 > Future enhancements will include an API parameter that lets requests return without waiting for the WAL flush.
 
+##### no_sync Write Option
+
+InfluxDB provides a no_sync write option to allow faster response of write request by skipping the wait for WAL presistence. When `no_sync=true`, InfluxDB writes data to WAL but immediately acknowledges the write request without waiting for persistence. 
+
+- Default behavior(`no_sync=false`): Ensures data is persisted before acknowledging writes. Thus, reducing the risk of data loss. 
+- With `no_sync=true`: Improves write performance but increases the risk of data loss in case of crashes before WAL persistence. 
+
 #### Create a database or Table
 
 To create a database without writing data, use the `create` subcommand--for example:

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -346,7 +346,9 @@ curl "http://localhost:8181/api/v3/write_lp?db=sensors&precision=auto&no_sync=tr
   --data-raw "home,room=Sunroom temp=96"
 ```
 
-If you are using the CLI, here is an example of how to enable the `no_sync` option:
+###### Immediate write using the influxdb3 CLI
+
+The `no_sync` CLI option controls when writes are acknowledged--for example:
 
 ```sh
 influxdb3 write --bucket=mydb --org=my_org --token=my-token --no-sync

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -339,7 +339,7 @@ The `no_sync` write option reduces latency by acknowledging write requests befor
 
 Using `no_sync=true` is best when prioritizing high-throughput writes over absolute durability. 
 
-- Default behavior (`no_sync=false`): Waits for data to be written to disk before acknowledging writes. This reduces the risk of data loss but increases latency for writes.
+- Default behavior (`no_sync=false`): Waits for data to be written to the Object store before acknowledging the write. Reduces the risk of data loss, but increases the latency of the response.
 - With `no_sync=true`: Reduces write latency but increases the risk of data loss in case of crashes before WAL persistence. 
 
 ###### Immediate write using the HTTP API

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -342,7 +342,7 @@ The `no_sync` parameter controls when writes are acknowledged--for example:
 
 
 ```sh
-curl -v "http://localhost:8181/api/v3/write_lp?db=sensors&precision=auto&no_sync=true" \
+curl "http://localhost:8181/api/v3/write_lp?db=sensors&precision=auto&no_sync=true" \
   --data-raw "home,room=Sunroom temp=96"
 ```
 

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -333,7 +333,7 @@ InfluxDB provides a `no_sync` write option that allows the write request to resp
 Using `no_sync=true` is best when prioritizing high-throughput writes over absolute durability. 
 
 - Default behavior(`no_sync=false`): Waits for data to be written to disk before acknowledging writes. This reduces the risk of data loss but increases latency for writes.
-- With `no_sync=true`: Improves write performance but increases the risk of data loss in case of crashes before WAL persistence. 
+- With `no_sync=true`: Reduces write latency but increases the risk of data loss in case of crashes before WAL persistence. 
 
 If you are using the HTTP API, here is an example of how to enable the `no_sync` option:
 

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -324,7 +324,8 @@ For more information, see [diskless architecture](#diskless-architecture).
 > [!Note]
 > ##### Write requests return after WAL flush
 >
-> Because InfluxDB sends a write response after the WAL file has been flushed to the configured object store (default is every second), individual write requests might not complete quickly, but you can make many concurrent requests to achieve higher total throughput. Future enhancements will include an API parameter that lets requests return without waiting for the WAL flush.
+> By default, when you write data, InfluxDB sends a write response after the WAL file has been flushed to the Object store (default is every second). Write requests might not complete quickly, but you can make many concurrent requests to achieve higher total throughput.
+For faster write responses, you can use the [`no_sync` option](#no-sync-write-option) to skip the wait for WAL persistence.
 
 ##### No sync write option
 

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -338,8 +338,7 @@ If you are using the HTTP API, here is an example of how to enable the `no_sync`
 
 ```sh
 curl -v "http://localhost:8181/api/v3/write_lp?db=sensors&precision=auto&no_sync=true" \
-  --data-raw "home,room=Sunroom temp=96
-home,room=Sunroom temp=hi"
+  --data-raw "home,room=Sunroom temp=96"
 ```
 
 If you are using the CLI, here is an example of how to enable the `no_sync` option:

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -329,7 +329,7 @@ For faster write responses, you can use the [`no_sync` option](#no-sync-write-op
 
 ##### No sync write option
 
-InfluxDB provides a `no_sync` write option that allows the write request to respond faster by skipping the wait for WAL presistence. When `no_sync=true`, InfluxDB writes data to the WAL and then immediately acknowledges the write request without waiting for persistence to the Object store.
+InfluxDB provides a `no_sync` write option that allows the write request to respond faster by skipping the wait for WAL persistence. When `no_sync=true`, InfluxDB writes data to the WAL and then immediately acknowledges the write request without waiting for persistence to the Object store.
 
 Using `no_sync=true` is best when prioritizing high-throughput writes over absolute durability. 
 

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -328,7 +328,9 @@ For more information, see [diskless architecture](#diskless-architecture).
 
 ##### No sync write option
 
-InfluxDB provides a `no_sync` write option to allow faster response of write request by skipping the wait for WAL presistence. When `no_sync=true`, InfluxDB writes data to WAL but immediately acknowledges the write request without waiting for persistence. 
+InfluxDB provides a `no_sync` write option that allows the write request to respond faster by skipping the wait for WAL presistence. When `no_sync=true`, InfluxDB writes data to the WAL and then immediately acknowledges the write request without waiting for persistence to the Object store.
+
+Using `no_sync=true` is best when prioritizing high-throughput writes over absolute durability. 
 
 - Default behavior(`no_sync=false`): Ensures data is persisted before acknowledging writes. Thus, reducing the risk of data loss. 
 - With `no_sync=true`: Improves write performance but increases the risk of data loss in case of crashes before WAL persistence. 

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -324,7 +324,7 @@ For more information, see [diskless architecture](#diskless-architecture).
 > [!Note]
 > ##### Write requests return after WAL flush
 >
-> Because InfluxDB sends a write response after the WAL file has been flushed to the configured object store (default is every second), individual write requests might not complete quickly, but you can make many concurrent requests to achieve higher total throughput.
+> Because InfluxDB sends a write response after the WAL file has been flushed to the configured object store (default is every second), individual write requests might not complete quickly, but you can make many concurrent requests to achieve higher total throughput. Future enhancements will include an API parameter that lets requests return without waiting for the WAL flush.
 
 ##### No sync write option
 


### PR DESCRIPTION
Closes #5826 
Closes #5825  

_Describe your proposed changes here._

Adding no_sync documentation to Core and Enterprise 
