### PR TITLE
Adding a port exposure note to Core get started page 

### DIFF
--- a/content/influxdb3/core/install.md
+++ b/content/influxdb3/core/install.md
@@ -156,6 +156,7 @@ docker pull \
 quay.io/influxdb/influxdb3-core:latest
 ```
 > [!Note]
-> The {{% product-name %}} Docker image exposes port `8181`, the default for the `influxdb3` server HTTP port.
+> The {{% product-name %}} Docker image exposes port `8181`, the `influxdb` server default for HTTP connections.
+> To map the exposed port to a different port when running a container, see the Docker guide for [Publishing and exposing ports](https://docs.docker.com/get-started/docker-concepts/running-containers/publishing-ports/).
 
 {{< page-nav next="/influxdb3/core/get-started/" nextText="Get started with InfluxDB 3 Core" >}}

--- a/content/influxdb3/core/install.md
+++ b/content/influxdb3/core/install.md
@@ -155,5 +155,7 @@ docker pull \
 --platform linux/arm64 \
 quay.io/influxdb/influxdb3-core:latest
 ```
+> [!Note]
+> The {{% product-name %}} Docker image exposes port `8181`, the default for the `influxdb3` server HTTP port.
 
 {{< page-nav next="/influxdb3/core/get-started/" nextText="Get started with InfluxDB 3 Core" >}}

--- a/content/influxdb3/core/install.md
+++ b/content/influxdb3/core/install.md
@@ -156,7 +156,7 @@ docker pull \
 quay.io/influxdb/influxdb3-core:latest
 ```
 > [!Note]
-> The {{% product-name %}} Docker image exposes port `8181`, the `influxdb` server default for HTTP connections.
+> The {{% product-name %}} Docker image exposes port `8181`, the `influxdb3` server default for HTTP connections.
 > To map the exposed port to a different port when running a container, see the Docker guide for [Publishing and exposing ports](https://docs.docker.com/get-started/docker-concepts/running-containers/publishing-ports/).
 
 {{< page-nav next="/influxdb3/core/get-started/" nextText="Get started with InfluxDB 3 Core" >}}

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -164,6 +164,9 @@ To run the [Docker image](/influxdb3/core/install/#docker-image) and persist dat
 - `-v /path/on/host:/path/in/container`: Mounts a directory from your filesystem to the container
 - `--object-store file --data-dir /path/in/container`: Uses the mount for server storage
 
+> [!Note]
+> The InfluxDB 3 Core Docker image **can expose port 8181**.
+
 ```bash
 # FILESYSTEM USING DOCKER
 # Create a mount

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -165,11 +165,7 @@ To run the [Docker image](/influxdb3/core/install/#docker-image) and persist dat
 - `--object-store file --data-dir /path/in/container`: Uses the mount for server storage
 
 > [!Note]
-<<<<<<< HEAD
-> The InfluxDB 3 Core Docker image can expose port 8181.
-=======
 > The {{% product-name %}} Docker image exposes port `8181`, the default for the `influxdb3` server HTTP port.
->>>>>>> refs/remotes/origin/docs/v3/docker-port-update-5826
 
 ```bash
 # FILESYSTEM USING DOCKER

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -165,6 +165,7 @@ To run the [Docker image](/influxdb3/core/install/#docker-image) and persist dat
 - `--object-store file --data-dir /path/in/container`: Uses the mount for server storage
 
 > [!Note]
+> 
 > The {{% product-name %}} Docker image exposes port `8181`, the default for the `influxdb3` server HTTP port.
 
 ```bash

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -166,7 +166,7 @@ To run the [Docker image](/influxdb3/core/install/#docker-image) and persist dat
 
 > [!Note]
 > 
-> The {{% product-name %}} Docker image exposes port `8181`, the `influxdb` server default for HTTP connections.
+> The {{% product-name %}} Docker image exposes port `8181`, the `influxdb3` server default for HTTP connections.
 > To map the exposed port to a different port when running a container, see the Docker guide for [Publishing and exposing ports](https://docs.docker.com/get-started/docker-concepts/running-containers/publishing-ports/).
 
 ```bash

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -165,7 +165,7 @@ To run the [Docker image](/influxdb3/core/install/#docker-image) and persist dat
 - `--object-store file --data-dir /path/in/container`: Uses the mount for server storage
 
 > [!Note]
-> The InfluxDB 3 Core Docker image **can expose port 8181**.
+> The InfluxDB 3 Core Docker image can expose port 8181.
 
 ```bash
 # FILESYSTEM USING DOCKER

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -166,7 +166,8 @@ To run the [Docker image](/influxdb3/core/install/#docker-image) and persist dat
 
 > [!Note]
 > 
-> The {{% product-name %}} Docker image exposes port `8181`, the default for the `influxdb3` server HTTP port.
+> The {{% product-name %}} Docker image exposes port `8181`, the `influxdb` server default for HTTP connections.
+> To map the exposed port to a different port when running a container, see the Docker guide for [Publishing and exposing ports](https://docs.docker.com/get-started/docker-concepts/running-containers/publishing-ports/).
 
 ```bash
 # FILESYSTEM USING DOCKER


### PR DESCRIPTION
Closes ##5862

_Describe your proposed changes here._

To add a note to Core get started page. We want to notify users that port 8181 can be exposed when using Docker. 
