### PR TITLE
fix(v3): Replace "Clustered" references in monolith...

### DIFF
--- a/content/influxdb3/core/query-data/_index.md
+++ b/content/influxdb3/core/query-data/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Query data in {{< product-name >}}
 description: >
-  Learn to query data stored in InfluxDB using SQL and InfluxQL.
+  Learn to query data in {{% product-name %}} using SQL and InfluxQL.
 menu:
   influxdb3_core:
     name: Query data

--- a/content/influxdb3/core/query-data/execute-queries/_index.md
+++ b/content/influxdb3/core/query-data/execute-queries/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Execute queries
 description: >
-  Use tools and libraries to query data stored in {{< product-name >}}.
+  Use tools and libraries to query data from {{< product-name >}}.
 weight: 101
 menu:
   influxdb3_core:

--- a/content/influxdb3/core/query-data/influxql/_index.md
+++ b/content/influxdb3/core/query-data/influxql/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Query data with InfluxQL
 description: >
-  Learn to use InfluxQL to query data stored in {{< product-name >}}.
+  Learn to use InfluxQL to query data in {{< product-name >}}.
 menu:
   influxdb3_core:
     name: Query with InfluxQL

--- a/content/influxdb3/core/query-data/sql/_index.md
+++ b/content/influxdb3/core/query-data/sql/_index.md
@@ -2,7 +2,7 @@
 title: Query data with SQL
 seotitle: Query data with SQL
 description: >
-  Learn to query data stored in {{< product-name >}} using SQL.
+  Learn to query data in {{< product-name >}} using SQL.
 menu:
   influxdb3_core:
     name: Query with SQL

--- a/content/influxdb3/core/visualize-data/_index.md
+++ b/content/influxdb3/core/visualize-data/_index.md
@@ -2,14 +2,14 @@
 title: Visualize data
 description: >
   Use visualization tools like Grafana, Superset, and others to visualize time
-  series data stored in InfluxDB 3 Core.
+  series data queried from {{< product-name >}}.
 menu: influxdb3_core
 weight: 10
 related:
-  - /influxdb3/clustered/query-data/
+  - /influxdb3/core/query-data/
 ---
 
 Use visualization tools like Grafana, Superset, and others to visualize time
-series data stored in {{< product-name >}}.
+series data queried from {{< product-name >}}.
 
 {{< children >}}

--- a/content/influxdb3/core/visualize-data/grafana.md
+++ b/content/influxdb3/core/visualize-data/grafana.md
@@ -3,7 +3,7 @@ title: Use Grafana to visualize data
 list_title: Grafana
 description: >
   Install and run [Grafana](https://grafana.com/) to query and visualize data
-  stored in InfluxDB 3 Core.
+  from {{< product-name >}}.
 weight: 101
 menu:
   influxdb3_core:

--- a/content/influxdb3/core/visualize-data/superset.md
+++ b/content/influxdb3/core/visualize-data/superset.md
@@ -3,7 +3,7 @@ title: Use Superset to visualize data
 list_title: Superset
 description: >
   Install and run [Apache Superset](https://superset.apache.org/)
-  to query and visualize data stored in InfluxDB 3 Core.
+  to query and visualize data stored from {{< product-name >}}.
 weight: 101
 menu:
   influxdb3_core:

--- a/content/influxdb3/core/visualize-data/tableau.md
+++ b/content/influxdb3/core/visualize-data/tableau.md
@@ -3,7 +3,7 @@ title: Use Tableau to visualize data
 list_title: Tableau
 description: >
   Install and use [Tableau](https://www.tableau.com/) to query and visualize
-  data stored in InfluxDB 3 Core.
+  data from {{< product-name >}}.
 weight: 101
 menu:
   influxdb3_core:

--- a/content/influxdb3/core/write-data/client-libraries.md
+++ b/content/influxdb3/core/write-data/client-libraries.md
@@ -1,8 +1,7 @@
 ---
 title: Use InfluxDB client libraries to write data
 description: >
-  Use InfluxDB API clients to write points as line protocol data to InfluxDB
-  Clustered.
+  Use InfluxDB API clients to write points as line protocol data to {{% product-name %}}.
 menu:
   influxdb3_core:
     name: Use client libraries

--- a/content/influxdb3/core/write-data/influxdb3-cli.md
+++ b/content/influxdb3/core/write-data/influxdb3-cli.md
@@ -2,7 +2,7 @@
 title: Use the influxdb3 CLI to write data
 description: >
   Use the [`influxdb3` CLI](/influxdb3/core/reference/cli/influxdb3/)
-  to write line protocol data to InfluxDB Clustered.
+  to write line protocol data to {{% product-name %}}.
 menu:
   influxdb3_core:
     name: Use the influxdb3 CLI

--- a/content/influxdb3/enterprise/query-data/_index.md
+++ b/content/influxdb3/enterprise/query-data/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Query data in {{< product-name >}}
 description: >
-  Learn to query data stored in InfluxDB using SQL and InfluxQL.
+  Learn to query data in {{< product-name >}} using SQL and InfluxQL.
 menu:
   influxdb3_enterprise:
     name: Query data

--- a/content/influxdb3/enterprise/query-data/execute-queries/_index.md
+++ b/content/influxdb3/enterprise/query-data/execute-queries/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Execute queries
 description: >
-  Use tools and libraries to query data stored in {{< product-name >}}.
+  Use tools and libraries to query data from {{< product-name >}}.
 weight: 101
 menu:
   influxdb3_enterprise:

--- a/content/influxdb3/enterprise/query-data/influxql/_index.md
+++ b/content/influxdb3/enterprise/query-data/influxql/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Query data with InfluxQL
 description: >
-  Learn to use InfluxQL to query data stored in {{< product-name >}}.
+  Learn to use InfluxQL to query data in {{< product-name >}}.
 menu:
   influxdb3_enterprise:
     name: Query with InfluxQL

--- a/content/influxdb3/enterprise/query-data/sql/_index.md
+++ b/content/influxdb3/enterprise/query-data/sql/_index.md
@@ -2,7 +2,7 @@
 title: Query data with SQL
 seotitle: Query data with SQL
 description: >
-  Learn to query data stored in {{< product-name >}} using SQL.
+  Learn to query data in {{< product-name >}} using SQL.
 menu:
   influxdb3_enterprise:
     name: Query with SQL

--- a/content/influxdb3/enterprise/visualize-data/_index.md
+++ b/content/influxdb3/enterprise/visualize-data/_index.md
@@ -2,7 +2,7 @@
 title: Visualize data
 description: >
   Use visualization tools like Grafana, Superset, and others to visualize time
-  series data stored in InfluxDB 3 Core.
+  series data queried from {{< product-name >}}.
 menu: influxdb3_enterprise
 weight: 10
 related:
@@ -10,6 +10,6 @@ related:
 ---
 
 Use visualization tools like Grafana, Superset, and others to visualize time
-series data stored in {{< product-name >}}.
+series data queried from {{< product-name >}}.
 
 {{< children >}}

--- a/content/influxdb3/enterprise/visualize-data/grafana.md
+++ b/content/influxdb3/enterprise/visualize-data/grafana.md
@@ -3,7 +3,7 @@ title: Use Grafana to visualize data
 list_title: Grafana
 description: >
   Install and run [Grafana](https://grafana.com/) to query and visualize data
-  stored in InfluxDB 3 Enterprise.
+  from {{< product-name >}}.
 weight: 101
 menu:
   influxdb3_enterprise:

--- a/content/influxdb3/enterprise/visualize-data/superset.md
+++ b/content/influxdb3/enterprise/visualize-data/superset.md
@@ -3,7 +3,7 @@ title: Use Superset to visualize data
 list_title: Superset
 description: >
   Install and run [Apache Superset](https://superset.apache.org/)
-  to query and visualize data stored in InfluxDB 3 Enterprise.
+  to query and visualize data from {{< product-name >}}.
 weight: 101
 menu:
   influxdb3_enterprise:

--- a/content/influxdb3/enterprise/visualize-data/tableau.md
+++ b/content/influxdb3/enterprise/visualize-data/tableau.md
@@ -3,7 +3,7 @@ title: Use Tableau to visualize data
 list_title: Tableau
 description: >
   Install and use [Tableau](https://www.tableau.com/) to query and visualize
-  data stored in InfluxDB 3 Enterprise.
+  data from {{< product-name >}}.
 weight: 101
 menu:
   influxdb3_enterprise:

--- a/content/influxdb3/enterprise/write-data/client-libraries.md
+++ b/content/influxdb3/enterprise/write-data/client-libraries.md
@@ -1,8 +1,7 @@
 ---
 title: Use InfluxDB client libraries to write data
 description: >
-  Use InfluxDB API clients to write points as line protocol data to InfluxDB
-  Clustered.
+  Use InfluxDB API clients to write points as line protocol data to {{% product-name %}}.
 menu:
   influxdb3_enterprise:
     name: Use client libraries

--- a/content/influxdb3/enterprise/write-data/influxdb3-cli.md
+++ b/content/influxdb3/enterprise/write-data/influxdb3-cli.md
@@ -2,7 +2,7 @@
 title: Use the influxdb3 CLI to write data
 description: >
   Use the [`influxdb3` CLI](/influxdb3/enterprise/reference/cli/influxdb3/)
-  to write line protocol data to InfluxDB Clustered.
+  to write line protocol data to {{% product-name %}}.
 menu:
   influxdb3_enterprise:
     name: Use the influxdb3 CLI

--- a/content/shared/influxdb3-query-guides/_index.md
+++ b/content/shared/influxdb3-query-guides/_index.md
@@ -1,4 +1,4 @@
 
-Learn to query data stored in {{< product-name >}}.
+Learn to query data in {{< product-name >}}.
 
 {{< children >}}

--- a/content/shared/influxdb3-query-guides/execute-queries/_index.md
+++ b/content/shared/influxdb3-query-guides/execute-queries/_index.md
@@ -1,4 +1,4 @@
-Use tools and libraries to query data stored in an {{< product-name >}} database.
+Use tools and libraries to query data from an {{< product-name >}} database.
 
 InfluxDB client libraries and Flight clients can use the Flight+gRPC protocol to
 query with SQL or InfluxQL and retrieve data in the

--- a/content/shared/influxdb3-query-guides/influxql/_index.md
+++ b/content/shared/influxdb3-query-guides/influxql/_index.md
@@ -1,5 +1,5 @@
 
-Learn to use InfluxQL to query data stored in {{< product-name >}}.
+Learn to query data in {{< product-name >}} using InfluxQL.
 
 {{< children type="anchored-list" >}}
 

--- a/content/shared/influxdb3-query-guides/sql/_index.md
+++ b/content/shared/influxdb3-query-guides/sql/_index.md
@@ -1,5 +1,5 @@
 
-Learn to query data stored in {{< product-name >}} using SQL.
+Learn to query data in {{< product-name >}} using SQL.
 
 {{< children type="anchored-list" >}}
 

--- a/content/shared/influxdb3-visualize/grafana.md
+++ b/content/shared/influxdb3-visualize/grafana.md
@@ -1,4 +1,4 @@
-Use [Grafana](https://grafana.com/) to query and visualize data stored in
+Use [Grafana](https://grafana.com/) to query and visualize data from 
 {{% product-name %}}.
 
 > [Grafana] enables you to query, visualize, alert on, and explore your metrics,
@@ -24,7 +24,7 @@ If using **Grafana Cloud**, login to your Grafana Cloud instance.
 ## InfluxDB data source
 
 The InfluxDB data source plugin is included in the Grafana core distribution.
-Use the plugin to query and visualize data stored in {{< product-name >}} with
+Use the plugin to query and visualize data from {{< product-name >}} with
 both SQL and InfluxQL.
 
 > [!Note]

--- a/content/shared/influxdb3-visualize/tableau.md
+++ b/content/shared/influxdb3-visualize/tableau.md
@@ -1,6 +1,6 @@
 
 Use [Tableau](https://www.tableau.com/) to query and visualize time series data
-stored in {{< product-name >}}. Tableau supports multiple SQL dialects.
+from {{< product-name >}}. Tableau supports multiple SQL dialects.
 
 > Tableau is a visual analytics platform transforming the way we use data to
 > solve problems—empowering people and organizations to make the most of their data.

--- a/content/shared/influxdb3-write-guides/use-telegraf/dual-write.md
+++ b/content/shared/influxdb3-write-guides/use-telegraf/dual-write.md
@@ -10,7 +10,7 @@ The following example configures Telegraf for dual writing to {{% product-name %
   - The [InfluxDB v2 output plugin](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/influxdb_v2)
     twice--the first pointing to {{< product-name >}} and the other to an
     InfluxDB v2 OSS instance.
-  - Two different tokens--one for InfluxDB v2 OSS and one for Clustered.
+  - Two different tokens--one for InfluxDB v2 OSS and one for {{< product-name >}}.
     Configure both tokens as environment variables and use string interpolation
     in your Telegraf configuration file to reference each environment variable.
 


### PR DESCRIPTION
- Replace names with product-name shortcode
- Be more precise with grammar for the Object storage model (where data isn't exactly stored _in_ InfluxDB 3)

Closes #5874
