### PR TITLE
fix(cloudv2): Doesn't support environment references in templates

### DIFF
--- a/Dockerfile.pytest
+++ b/Dockerfile.pytest
@@ -10,6 +10,15 @@ RUN echo '393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c influ
 
 RUN echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg] https://repos.influxdata.com/debian stable main' | tee /etc/apt/sources.list.d/influxdata.list
 
+# Vault is used for testing InfluxDB 2.0 Secrets
+# Fetch vault package information from HashiCorp repository
+ADD https://apt.releases.hashicorp.com/gpg /tmp/hashicorp.gpg
+RUN apt-get update && apt-get install -y lsb-release && \
+    cat /tmp/hashicorp.gpg | gpg --dearmor > /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
+    tee /etc/apt/sources.list.d/hashicorp.list
+
+
 # Install depedencies for clients and tests.
 # - InfluxData clients to use in tests.
 # - apt-utils for verification tools
@@ -32,6 +41,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
   python3-venv \
   rsync \
   telegraf \
+  vault \
   wget \
   yq
 
@@ -55,6 +65,7 @@ WORKDIR /app
 
 RUN mkdir -p /app/log && chmod +w /app/log
 RUN mkdir -p /app/assets && chmod +w /app/assets
+RUN mkdir -p /root/influxdb/templates && chmod +rw /root/influxdb/templates
 
 # Some Python test dependencies (pytest-dotenv and pytest-codeblocks) aren't
 # available as packages in apt-cache, so use pip to download dependencies in a # separate step and use Docker's caching.
@@ -78,6 +89,7 @@ RUN echo '#!/bin/bash' > /usr/local/bin/xdg-open \
     && chmod +x /usr/local/bin/xdg-open
 
 RUN service influxdb start
+RUN vault server -dev > ~/.vault-server-log 2>&1 &
 
 # Copy test scripts and make them executable.
 COPY --chmod=755 ./test/scripts/parse_yaml.sh /usr/local/bin/parse_yaml

--- a/api-docs/influxdb/cloud/v2/ref.yml
+++ b/api-docs/influxdb/cloud/v2/ref.yml
@@ -10564,13 +10564,12 @@ paths:
         template and generates the resource diff, but doesn’t make any
         changes to your instance.
 
+        **Important**: InfluxDB Cloud doesn't support all template features. We recommend using InfluxDB OSS v2 if you need full template support.
+
         #### Custom values for templates
 
-        - Some templates may contain [environment references](/influxdb/cloud/influxdb-templates/create/#include-user-definable-resource-names) for custom metadata.
-          To provide custom values for environment references, pass the _`envRefs`_
-          property in the request body.
-          For more information and examples, see how to
-          [define environment references](/influxdb/cloud/influxdb-templates/use/#define-environment-references).
+        - **Not supported**: InfluxDB Cloud doesn't
+        support environment reference substitution in templates. Variable names you define in templates aren't replaced by user-defined values.
 
         - Some templates may contain queries that use
           [secrets](/influxdb/cloud/security/secrets/).
@@ -10778,67 +10777,6 @@ paths:
                   "remotes": [
                     {
                       "url": "https://raw.githubusercontent.com/influxdata/community-templates/master/fortnite/fn-template.yml"
-                    }
-                  ]
-                }
-            EOF
-        - label: 'cURL: Apply template objects with environment references'
-          lang: Shell
-          source: |
-            curl --request POST "http://localhost:8086/api/v2/templates/apply" \
-              --header "Authorization: Token INFLUX_API_TOKEN" \
-              --data @- << EOF
-              { "orgID": "INFLUX_ORG_ID",
-                "envRefs": {
-                  "linux-cpu-label": "MY_CPU_LABEL",
-                  "docker-bucket": "MY_DOCKER_BUCKET",
-                  "docker-spec-1": "MY_DOCKER_SPEC"
-                },
-                "templates": [
-                  { "contents": [{
-                      "apiVersion": "influxdata.com/v2alpha1",
-                      "kind": "Label",
-                      "metadata": {
-                        "name": {
-                          "envRef": {
-                            "key": "linux-cpu-label"
-                          }
-                        }
-                      },
-                      "spec": {
-                        "color": "#326BBA",
-                        "name": "inputs.cpu"
-                      }
-                    }]
-                  },
-                  "templates": [
-                    { "contents": [{
-                        "apiVersion": "influxdata.com/v2alpha1",
-                        "kind": "Label",
-                        "metadata": {
-                          "name": {
-                            "envRef": {
-                              "key": "linux-cpu-label"
-                            }
-                          }
-                        },
-                        "spec": {
-                          "color": "#326BBA",
-                          "name": "inputs.cpu"
-                        }
-                      }]
-                    },
-                    { "contents": [{
-                        "apiVersion": "influxdata.com/v2alpha1",
-                        "kind": "Bucket",
-                        "metadata": {
-                          "name": {
-                            "envRef": {
-                              "key": "docker-bucket"
-                            }
-                          }
-                        }
-                      }]
                     }
                   ]
                 }
@@ -17707,26 +17645,10 @@ components:
               - type: number
               - type: boolean
           description: |
-            An object with key-value pairs that map to **environment references** in templates.
+            - **Not supported**: InfluxDB Cloud doesn't
+            support environment reference substitution in templates. Variable names you define in templates aren't replaced by user-defined values.
 
-            Environment references in templates are `envRef` objects with an `envRef.key`
-            property.
-            To substitute a custom environment reference value when applying templates,
-            pass `envRefs` with the `envRef.key` and the value.
-
-            When you apply a template, InfluxDB replaces `envRef` objects in the template
-            with the values that you provide in the `envRefs` parameter.
-            For more examples, see how to [define environment references](/influxdb/cloud/influxdb-templates/use/#define-environment-references).
-
-            The following template fields may use environment references:
-
-              - `metadata.name`
-              - `spec.endpointName`
-              - `spec.associations.name`
-
-            For more information about including environment references in template fields, see how to
-            [include user-definable resource names](/influxdb/cloud/influxdb-templates/create/#include-user-definable-resource-names).
-          type: object
+            **Important**: InfluxDB Cloud doesn't support all template features. We recommend using InfluxDB OSS v2 if you need full template support.
         orgID:
           description: |
             Organization ID.

--- a/content/influxdb/cloud/tools/influxdb-templates/create.md
+++ b/content/influxdb/cloud/tools/influxdb-templates/create.md
@@ -67,7 +67,7 @@ influx export all --org <INFLUX_ORG> --file <FILE_PATH> --token <INFLUX_TOKEN>
 # Example
 influx export all \
   --org $INFLUX_ORG \
-  --file /path/to/TEMPLATE_FILE.yml \
+  --file /path/to/templates/TEMPLATE_FILE.yml \
   --token $INFLUX_TOKEN
 ```
 
@@ -85,10 +85,10 @@ and
 (labelName == "Example1" or labelName == "Example2")
 ```
 
-```sh
+```bash
 influx export all \
   --org $INFLUX_ORG \
-  --file /path/to/TEMPLATE_FILE.yml \
+  --file /path/to/templates/TEMPLATE_FILE.yml \
   --token $INFLUX_TOKEN \
   --filter=resourceKind=Bucket \
   --filter=resourceKind=Dashboard \
@@ -128,7 +128,7 @@ influx export --file <FILE_PATH> --token <INFLUX_TOKEN> [resource-flags]
 ```bash
 # Example
 influx export \
-  --file /path/to/TEMPLATE_FILE.yml \
+  --file /path/to/templates/TEMPLATE_FILE.yml \
   --token $INFLUX_TOKEN \
   --buckets=00x000ooo0xx0xx,o0xx0xx00x000oo \
   --dashboards=00000xX0x0X00x000 \
@@ -165,119 +165,17 @@ influx export stack \
 # Example
 influx export stack \
   -t $INFLUX_TOKEN \
-  -f /path/to/TEMPLATE_FILE.yml \
+  -f /path/to/templates/TEMPLATE_FILE.yml \
   05dbb791a4324000
 ```
 
 ## Include user-definable resource names
-After exporting a template manifest, replace resource names with **environment references**
-to let users customize resource names when installing your template.
 
-1.  [Export a template](#export-a-template)
-2.  Select any of the following resource fields to update:
-
-    - `metadata.name`
-    - `associations[].name`
-    - `endpointName` _(unique to `NotificationRule` resources)_
-
-3.  Replace the resource field value with an `envRef` object with a `key` property
-    that reference the key of a key-value pair the user provides when installing the template.
-    During installation, the `envRef` object is replaced by the value of the
-    referenced key-value pair.
-    If the user does not provide the environment reference key-value pair, InfluxDB
-    uses the `key` string as the default value.
-
-    {{< code-tabs-wrapper >}}
-    {{% code-tabs %}}
-[YAML](#)
-[JSON](#)
-  {{% /code-tabs %}}
-  {{% code-tab-content %}}
-```yml
-apiVersion: influxdata.com/v2alpha1
-kind: Bucket
-metadata:
-  name:
-    envRef:
-      key: bucket-name-1
-```
-  {{% /code-tab-content %}}
-  {{% code-tab-content %}}
-```json
-{
-  "apiVersion": "influxdata.com/v2alpha1",
-  "kind": "Bucket",
-  "metadata": {
-    "name": {
-      "envRef": {
-        "key": "bucket-name-1"
-      }
-    }
-  }
-}
-```
-  {{% /code-tab-content %}}
-  {{< /code-tabs-wrapper >}}
-
-Using the example above, users are prompted to provide a value for `bucket-name-1`
-when [applying the template](/influxdb/cloud/tools/influxdb-templates/use/#apply-templates).
-Users can also include the `--env-ref` flag with the appropriate key-value pair
-when installing the template.
-
-<!-- //REVIEW I can't get this to work with environment reference substitution
-  -- Skipping the test for now, but we should review it and fix it.
-  -->
-<!--pytest.mark.skip-->
-<!--test:setup
-```sh
-jq -n '{
-  apiVersion: "influxdata.com/v2alpha1",
-  kind: "Bucket",
-  metadata: {
-    name: {
-      envRef: {
-        key: "bucket-name-1"
-      }
-    }
-  }
-}' >  /path/to/TEMPLATE_FILE.json
-chmod +rx /path/to/TEMPLATE_FILE.json
-# View formatted JSON
-jq '.' /path/to/TEMPLATE_FILE.json
-```
--->
-
-For example, to set a custom bucket name when applying a template with an environment reference:
-
-<!--pytest-codeblocks:cont-->
-```sh
-# The template, edited to include an environment reference:
-# apiVersion: influxdata.com/v2alpha1
-# kind: Bucket
-# metadata:
-#   name:
-#     envRef: bucket-name-1
-
-# Apply template, set bucket-name-1 to "myBucket", and skip verification 
-influx apply \
-  --file /path/to/TEMPLATE_FILE.json \
-  --env-ref bucket-name-1=myBucket \
-  --force yes
-  --org $INFLUX_ORG
-  --token $INFLUX_TOKEN
-```
-
-_If sharing your template, we recommend documenting what environment references
-exist in the template and what keys to use to replace them._
-
-{{% note %}}
-#### Resource fields that support environment references
-Only the following fields support environment references:
-
-- `metadata.name`
-- `spec.endpointName`
-- `spec.associations.name`
-{{% /note %}}
+> [!Warning]
+>
+> #### Environment reference substitution not supported
+>  
+> This feature is not supported by InfluxDB Cloud.
 
 ## Share your InfluxDB templates
 Share your InfluxDB templates with the entire InfluxData community.

--- a/content/influxdb/v2/admin/secrets/use-vault.md
+++ b/content/influxdb/v2/admin/secrets/use-vault.md
@@ -31,18 +31,18 @@ The following links provide information about running Vault in both development 
 - [Start a Vault dev server](https://learn.hashicorp.com/vault/getting-started/dev-server)
 - [Deploy Vault](https://learn.hashicorp.com/vault/getting-started/deploy)
 
-{{% note %}}
-InfluxDB supports the [Vault KV Secrets Engine Version 2 API](https://www.vaultproject.io/api/secret/kv/kv-v2.html) only.
-When you create a secrets engine, enable the `kv-v2` version by running:
-
-```js
-vault secrets enable kv-v2
-```
-{{% /note %}}
+> [!Note]
+> InfluxDB supports the [Vault KV Secrets Engine Version 2 API](https://www.vaultproject.io/api/secret/kv/kv-v2.html) only.
+> When you create a secrets engine, enable the `kv-v2` version by running:
+>
+> ```js
+> vault secrets enable kv-v2
+> ```
 
 For this example, install Vault on your local machine and start a Vault dev server.
 
-```sh
+<!--pytest.mark.skip-->
+```bash
 vault server -dev
 ```
 
@@ -70,12 +70,23 @@ _Your Vault server configuration may require other Vault settings._
 ## Start InfluxDB
 
 Start the [`influxd` service](/influxdb/v2/reference/cli/influxd/) with the `--secret-store`
-option set to `vault` any other necessary flags.
+option set to `vault` and any other necessary flags--for example, enter the following
+command:
 
+<!--pytest.mark.skip-->
+<!--test:setup
+```bash
+service influxdb stop \
+&& service influxdb start --secret-store vault \
+  --vault-addr=http://127.0.0.1:8200 \
+  --vault-token=$VAULT_TOKEN 
+```
+-->
+<!--pytest.mark.skip-->
 ```bash
 influxd --secret-store vault \
   --vault-addr=http://127.0.0.1:8200 \
-  --vault-token=s.0X0XxXXx0xXxXXxxxXxXxX0x
+  --vault-token=$VAULT_TOKEN
 ```
 
 `influxd` includes the following Vault configuration options.
@@ -97,4 +108,4 @@ For more information, see [InfluxDB configuration options](/influxdb/v2/referenc
 ## Manage secrets through the InfluxDB API
 
 Use the InfluxDB `/org/{orgID}/secrets` API endpoint to add tokens to Vault.
-For details, see [Manage secrets](/influxdb/v2/admin/secrets/manage-secrets/).
+For details, see [Secrets](/influxdb/v2/admin/secrets/).

--- a/content/influxdb/v2/tools/influxdb-templates/use.md
+++ b/content/influxdb/v2/tools/influxdb-templates/use.md
@@ -35,20 +35,18 @@ or download the template.
 
 {{< youtube 2JjW4Rym9XE >}}
 
-{{% note %}}
-When attempting to access the community templates via the URL, the templates use the following
-as the root of the URL:
-
-```sh
-https://raw.githubusercontent.com/influxdata/community-templates/master/
-```
-
-For example, the Docker community template can be accessed via:
-
-```sh
-https://raw.githubusercontent.com/influxdata/community-templates/master/docker/docker.yml
-```
-{{% /note %}}
+> [!Note]
+> The community templates are under the following root URL:
+>
+> ```text
+> https://raw.githubusercontent.com/influxdata/community-templates/master/
+> ```
+>
+> For example, to access the Docker community template, use the following URL:
+>
+> ```text
+> https://raw.githubusercontent.com/influxdata/community-templates/master/docker/docker.yml
+> ```
 
 <a class="btn" href="https://github.com/influxdata/community-templates/" target="\_blank">View InfluxDB Community Templates</a>
 
@@ -63,19 +61,41 @@ View a summary of a template stored in your local filesystem or from a URL.
 [From a URL](#)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
-```sh
+
+```text
 # Syntax
 influx template -f <FILE_PATH>
+```
 
+<!--test:setup
+```bash
+# Start InfluxDB service
+service influxdb start && \
+
+# Set up InfluxDB
+influx setup --username USERNAME --password PASSWORD --token API_TOKEN --org ORG_NAME \
+  --bucket BUCKET_NAME --force || true &&
+
+# Download a template for tests
+curl https://raw.githubusercontent.com/influxdata/community-templates/master/docker/docker.yml \
+  -o /path/to/templates/TEMPLATE_FILE.yml
+```
+-->
+<!--pytest-codeblocks:cont-->
+<!--pytest.mark.skip-->
+```bash
 # Example
-influx template -f /path/to/template.yml
+influx template -org ORG_NAME -f /path/to/templates/TEMPLATE_FILE.yml
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
-```sh
-# Syntax
-influx template -u <FILE_URL>
 
+```text
+# Syntax
+influx template -org <ORG_NAME> -u <FILE_URL>
+```
+<!--pytest.mark.skip-->
+```bash
 # Example
 influx template -u https://raw.githubusercontent.com/influxdata/community-templates/master/linux_system/linux_system.yml
 ```
@@ -93,19 +113,34 @@ Validate a template stored in your local filesystem or from a URL.
 [From a URL](#)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
-```sh
-# Syntax
-influx template validate -f <FILE_PATH>
 
+```text
+# Syntax
+influx template validate -org <ORG_NAME> -f <FILE_PATH>
+```
+
+<!--pytest.mark.skip-->
+<!--test:setup
+```bash
+# Download a template for tests
+curl https://raw.githubusercontent.com/influxdata/community-templates/master/docker/docker.yml \
+  -so /path/to/templates/TEMPLATE_FILE.yml
+```
+-->
+<!--pytest-codeblocks:cont-->
+```bash
 # Example
-influx template validate -f /path/to/template.yml
+influx template validate -org ORG_NAME -f /path/to/templates/TEMPLATE_FILE.yml
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
-```sh
+
+```text
 # Syntax
 influx template validate -u <FILE_URL>
+```
 
+```bash
 # Example
 influx template validate -u https://raw.githubusercontent.com/influxdata/community-templates/master/linux_system/linux_system.yml
 ```
@@ -115,6 +150,17 @@ influx template validate -u https://raw.githubusercontent.com/influxdata/communi
 ## Apply templates
 Use the [`influx apply` command](/influxdb/v2/reference/cli/influx/apply/) to install templates
 from your local filesystem or from URLs.
+The default output is a summary of the template in "pretty" format and a prompt
+to confirm applying the changes.
+
+```text
+# Syntax
+influx apply \
+ -o <INFLUX_ORG> \
+ -f <FILE_PATH> \
+ -u <URL> \
+ --secret=<SECRET_KEY>=<SECRET_VALUE>
+```
 
 - [Apply a template from a file](#apply-a-template-from-a-file)
 - [Apply all templates in a directory](#apply-all-templates-in-a-directory)
@@ -123,30 +169,48 @@ from your local filesystem or from URLs.
 - [Define environment references](#define-environment-references)
 - [Include a secret when installing a template](#include-a-secret-when-installing-a-template)
 
-{{% note %}}
-#### Apply templates to an existing stack
-To apply a template to an existing stack, include the stack ID when applying the template.
-Any time you apply a template without a stack ID, InfluxDB initializes a new stack
-and all new resources.
-For more information, see [InfluxDB stacks](/influxdb/v2/tools/influxdb-templates/stacks/).
-{{% /note %}}
+> [!Note]
+> #### Apply templates to an existing stack
+>
+> To apply a template to an existing stack, include the stack ID when applying the template.
+> Any time you apply a template without a stack ID, InfluxDB initializes a new stack
+> and all new resources.
+> For more information, see [InfluxDB stacks](/influxdb/v2/tools/influxdb-templates/stacks/).
+>
+> You can extract a stack ID from the output of `influx stacks` and pass it to `influx apply`:
+>
+> <!--pytest.mark.skip-->
+> ```bash
+> # Extract stack ID by name and apply a template to that stack
+> influx stacks | grep STACK_NAME | awk '{print $1}' | xargs -I{} influx apply -o ORG_NAME -f /path/to/TEMPLATE_FILE.yml --stack-id {}
+> ```
 
 ### Apply a template from a file
 To install templates stored on your local machine, use the `-f` or `--file` flag
 to provide the **file path** of the template manifest.
 
-```sh
-# Syntax
-influx apply -o <INFLUX_ORG> -f <FILE_PATH>
 
-# Examples
-# Apply a single template
-influx apply -o example-org -f /path/to/template.yml
-
+<!--pytest.mark.skip-->
+```bash
+# Example
 # Apply multiple templates
-influx apply -o example-org \
-  -f /path/to/this/template.yml \
-  -f /path/to/that/template.yml
+influx apply -o ORG_NAME \
+  -f /path/to/templates/TEMPLATE_FILE_1.yml \
+  -f /path/to/templates/TEMPLATE_FILE_2.yml
+```
+
+To skip the confirmation and apply the templates non-interactively, pass `--force yes`:
+
+```bash
+# Download templates for tests
+curl https://raw.githubusercontent.com/influxdata/community-templates/master/docker/docker.yml \
+  -so /path/to/templates/TEMPLATE_FILE_1.yml &&
+curl https://raw.githubusercontent.com/influxdata/community-templates/master/github/github.yml \
+  -so /path/to/templates/TEMPLATE_FILE_2.yml &&
+influx apply -o ORG_NAME \
+  -f /path/to/templates/TEMPLATE_FILE_1.yml \
+  -f /path/to/templates/TEMPLATE_FILE_2.yml \
+  --force yes
 ```
 
 ### Apply all templates in a directory
@@ -156,54 +220,75 @@ By default, this only applies templates stored in the specified directory.
 To apply all templates stored in the specified directory and its subdirectories,
 include the `-R`, `--recurse` flag.
 
-```sh
-# Syntax
-influx apply -o <INFLUX_ORG> -f <DIRECTORY_PATH>
+<!--test:next
+```bash
+influx stacks | grep 'docker-github' | awk '{print $1}' | xargs -I{} influx apply -o ORG_NAME -f /path/to/TEMPLATE_FILE.yml --stack-id {}
+```
+-->
 
+<!--pytest.mark.skip-->
+```bash
 # Examples
 # Apply all templates in a directory
-influx apply -o example-org -f /path/to/template/dir/
+influx apply -o ORG_NAME -f /path/to/templates/
 
 # Apply all templates in a directory and its subdirectories
-influx apply -o example-org -f /path/to/template/dir/ -R
+influx apply -o ORG_NAME -f /path/to/templates/ --recurse
 ```
 
 ### Apply a template from a URL
 To apply templates from a URL, use the `-u` or `--template-url` flag to provide the URL
 of the template manifest.
 
-```sh
-# Syntax
-influx apply -o <INFLUX_ORG> -u <FILE_URL>
+<!--test:next
+```bash
+influx apply -o ORG_NAME \
+  -u https://raw.githubusercontent.com/influxdata/community-templates/master/docker/docker.yml \
+  -u https://raw.githubusercontent.com/influxdata/community-templates/master/github/github.yml \
+  --force yes
+```
+-->
 
-# Examples
-# Apply a single template from a URL
-influx apply -o example-org -u https://example.com/templates/template.yml
-
+<!--pytest.mark.skip-->
+```bash
+# Example
 # Apply multiple templates from URLs
-influx apply -o example-org \
-  -u https://example.com/templates/template1.yml \
-  -u https://example.com/templates/template2.yml
+influx apply -o ORG_NAME \
+  -u https://raw.githubusercontent.com/influxdata/community-templates/master/docker/docker.yml \
+  -u https://raw.githubusercontent.com/influxdata/community-templates/master/github/github.yml
 ```
 
-### Apply templates from both files and URLs
-To apply templates from both files and URLs in a single command, include multiple
+### Apply templates from files and URLs
+To apply templates from files and URLs in a single command, include multiple
 file or directory paths and URLs, each with the appropriate `-f` or `-u` flag.
 
-```sh
-# Syntax
-influx apply -o <INFLUX_ORG> -u <FILE_URL> -f <FILE_PATH>
+<!--test:next
+```bash
+influx apply -o ORG_NAME \
+  -u https://raw.githubusercontent.com/influxdata/community-templates/master/raspberry-pi/raspberry-pi-system.yml \
+  -u https://raw.githubusercontent.com/influxdata/community-templates/master/minio/minio.yml \
+  -f /path/to/templates/TEMPLATE_FILE_1.yml \
+  -f /path/to/templates/TEMPLATE_FILE_2.yml \
+  --recurse \
+  --force yes
+```
+-->
 
+<!--pytest.mark.skip-->
+```bash
 # Example
-influx apply -o example-org \
-  -u https://example.com/templates/template1.yml \
-  -u https://example.com/templates/template2.yml \
-  -f ~/templates/custom-template.yml \
-  -f ~/templates/iot/home/ \
+influx apply -o ORG_NAME \
+  -u https://raw.githubusercontent.com/influxdata/community-templates/master/raspberry-pi/raspberry-pi-system.yml \
+  -u https://raw.githubusercontent.com/influxdata/community-templates/master/minio/minio.yml \
+  -f /path/to/templates/TEMPLATE_FILE_1.yml \
+  -f /path/to/templates/TEMPLATE_FILE_2.yml \
   --recurse
 ```
 
 ### Define environment references
+
+{{% oss-only %}}
+
 Some templates include [environment references](/influxdb/v2/tools/influxdb-templates/create/#include-user-definable-resource-names) that let you provide custom resource names.
 The `influx apply` command prompts you to provide a value for each environment
 reference in the template.
@@ -211,12 +296,37 @@ You can also provide values for environment references by including an `--env-re
 flag with a key-value pair comprised of the environment reference key and the
 value to replace it.
 
-```sh
-influx apply -o example-org -f /path/to/template.yml \
-  --env-ref=bucket-name-1=myBucket
+<!--test:next
+```bash
+# Example
+influx apply -o ORG_NAME -f /path/to/templates/TEMPLATE_FILE.yml \
+  --env-ref=bucket-name-1=myBucket \
+  --env-ref=label-name-1=Label1 \
+  --env-ref=label-name-2=Label2 \
+  --force yes
+```
+-->
+
+<!--pytest.mark.skip-->
+```bash
+# Example
+influx apply -o ORG_NAME -f /path/to/templates/TEMPLATE_FILE.yml \
+  --env-ref=bucket-name-1=myBucket \
   --env-ref=label-name-1=Label1 \
   --env-ref=label-name-2=Label2
 ```
+
+{{% /oss-only %}}
+
+{{% cloud-only %}}
+
+> [!Warning]
+>
+> #### Environment reference substitution not supported
+>  
+> This feature is not supported by InfluxDB Cloud.
+
+{{% /cloud-only %}}
 
 ### Include a secret when installing a template
 Some templates use [secrets](/influxdb/v2/admin/secrets/) in queries.
@@ -224,20 +334,27 @@ Secret values are not included in templates.
 To define secret values when installing a template, include the `--secret` flag
 with the secret key-value pair.
 
-```sh
-# Syntax
-influx apply -o <INFLUX_ORG> -f <FILE_PATH> \
-  --secret=<secret-key>=<secret-value>
+<!--test:next
+```bash
+# Define multiple secrets when applying a template
+influx apply -o ORG_NAME -f /path/to/templates/TEMPLATE_FILE.yml \
+  --secret=FOO=bar \
+  --secret=BAZ=quz \
+  --force yes
+```
+-->
 
+<!--pytest.mark.skip-->
+```bash
 # Examples
 # Define a single secret when applying a template
-influx apply -o example-org -f /path/to/template.yml \
+influx apply -o ORG_NAME -f /path/to/templates/TEMPLATE_FILE.yml \
   --secret=FOO=BAR
 
 # Define multiple secrets when applying a template
-influx apply -o example-org -f /path/to/template.yml \
+influx apply -o ORG_NAME -f /path/to/templates/TEMPLATE_FILE.yml \
   --secret=FOO=bar \
   --secret=BAZ=quz
 ```
 
-_To add a secret after applying a template, see [Add secrets](/influxdb/v2/admin/secrets/manage-secrets/add/)._
+_To add a secret after applying a template, see [Add secrets](/influxdb/v2/admin/secrets/add/)._

--- a/cypress/support/map-files-to-urls.js
+++ b/cypress/support/map-files-to-urls.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import { execSync } from 'child_process';
+import process from 'process';
+
+// Get file paths from command line arguments
+const filePaths = process.argv.slice(2);
+
+// Parse options
+const debugMode = process.argv.includes('--debug');
+
+// Filter for content files
+const contentFiles = filePaths.filter(file => 
+  file.startsWith('content/') && (file.endsWith('.md') || file.endsWith('.html'))
+);
+
+if (contentFiles.length === 0) {
+  console.log('No content files to check.');
+  process.exit(0);
+}
+
+// Map file paths to URL paths
+function mapFilePathToUrl(filePath) {
+  // Remove content/ prefix
+  let url = filePath.replace(/^content/, '');
+  
+  // Handle _index files (both .html and .md)
+  url = url.replace(/\/_index\.(html|md)$/, '/');
+  
+  // Handle regular .md files
+  url = url.replace(/\.md$/, '/');
+  
+  // Handle regular .html files
+  url = url.replace(/\.html$/, '/');
+  
+  // Ensure URL starts with a slash
+  if (!url.startsWith('/')) {
+    url = '/' + url;
+  }
+  
+  return url;
+}
+
+const urls = contentFiles.map(mapFilePathToUrl);
+const urlList = urls.join(',');
+
+console.log(`Testing links in URLs: ${urlList}`);
+
+// Create environment object with the cypress_test_subjects variable
+const envVars = {
+  ...process.env,
+  cypress_test_subjects: urlList,
+  NODE_OPTIONS: '--max-http-header-size=80000 --max-old-space-size=4096'
+};
+
+// Run Cypress tests with the mapped URLs
+try {
+  // Choose run mode based on debug flag
+  if (debugMode) {
+    // For debug mode, set the environment variable and open Cypress
+    // The user will need to manually select the test file
+    console.log('Opening Cypress in debug mode.');
+    console.log('Please select the "article-links.cy.js" test file when Cypress opens.');
+    
+    execSync('npx cypress open --e2e', {
+      stdio: 'inherit',
+      env: envVars
+    });
+  } else {
+    // For normal mode, run the test automatically
+    execSync(`npx cypress run --spec "cypress/e2e/content/article-links.cy.js"`, {
+      stdio: 'inherit',
+      env: envVars
+    });
+  }
+} catch (error) {
+  console.error('Link check failed:', error);
+  process.exit(1);
+}

--- a/test/scripts/prepare-content.sh
+++ b/test/scripts/prepare-content.sh
@@ -98,8 +98,7 @@ function substitute_placeholders {
       s|NUMBER_OF_DAYS|365|g;
       s|@path/to/line-protocol.txt|data/home-sensor-data.lp|g;
       s|/path/to/custom/assets-dir|/app/custom-assets|g;
-      s|/path/to/TEMPLATE_FILE.yml|/root/influxdb-templates/TEMPLATE_FILE.yml|g;
-      s|/path/to/TEMPLATE_FILE.json|/root/influxdb-templates/TEMPLATE_FILE.json|g;
+      s|/path/to/templates/|/root/influxdb/templates/|g;
       ' $file
 
       # v2-specific replacements.


### PR DESCRIPTION
- Tests pass, although I had to clone most of them so I could use `--force` to skip the prompt.
