### PR TITLE
fix(api): don't ignore .config.yml files inside of api-docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules
 /resources
 .hugo_build.lock
 /content/influxdb*/**/api/**/*.html
+!api-docs/**/.config.yml
 /api-docs/redoc-static.html*
 .vscode/*
 .idea

--- a/api-docs/influxdb3/core/.config.yml
+++ b/api-docs/influxdb3/core/.config.yml
@@ -1,0 +1,12 @@
+plugins:
+  - '../../openapi/plugins/docs-plugin.js'
+extends:
+  - recommended
+  - docs/all
+x-influxdata-product-name: InfluxDB 3 Core
+
+apis:
+  v3@3:
+    root: v3/ref.yml
+    x-influxdata-docs-aliases:
+      - /influxdb3/core/api/

--- a/api-docs/influxdb3/enterprise/.config.yml
+++ b/api-docs/influxdb3/enterprise/.config.yml
@@ -1,0 +1,12 @@
+plugins:
+  - '../../openapi/plugins/docs-plugin.js'
+extends:
+  - recommended
+  - docs/all
+x-influxdata-product-name: InfluxDB 3 Enterprise 
+
+apis:
+  v3@3:
+    root: v3/ref.yml
+    x-influxdata-docs-aliases:
+      - /influxdb3/enterprise/api/


### PR DESCRIPTION
- Adds missing `.config.yml` files needed for generating Core and Enterprise API references
- Don't ignore `.config.yml` files in `api-docs`.
