### PR TITLE
fix(code-controls): Broken in code-blocks that contain the URL select…

### DIFF
--- a/assets/js/code-controls.js
+++ b/assets/js/code-controls.js
@@ -68,7 +68,7 @@ function initialize() {
   // Trigger copy failure state lifecycle
 
   $('.copy-code').click(function () {
-    let text = $(this).closest('.code-controls').prev('pre')[0].innerText;
+    let text = $(this).closest('.code-controls').prevAll('pre:has(code)')[0].innerText;
 
     const copyContent = async () => {
       try {
@@ -90,7 +90,7 @@ Disable scrolling on the body.
 Disable user selection on everything but the fullscreen codeblock.
 */
   $('.fullscreen-toggle').click(function () {
-    var code = $(this).closest('.code-controls').prev('pre').clone();
+    var code = $(this).closest('.code-controls').prevAll('pre:has(code)').clone();
 
     $('#fullscreen-code-placeholder').replaceWith(code[0]);
     $('body').css('overflow', 'hidden');


### PR DESCRIPTION
…or widget: Replace jQuery .prev() with .prevAll() to find all siblings (in case they include other elements like the URL selector widget), and then take the first pre element that has a code child.

Fixes https://influxdata.slack.com/archives/C084G9LR2HL/p1742229715680079
