### PR TITLE
fix(api-docs): Ask AI hides menu toggle at 800px

### DIFF
--- a/api-docs/template.hbs
+++ b/api-docs/template.hbs
@@ -55,7 +55,7 @@
       askAI.setAttribute('data-modal-example-questions', 'How do I write and query data with the {{title}}?, How do I use client libraries for the {{title}}?');
       askAI.setAttribute('data-button-height', '65px');
       askAI.setAttribute('data-button-width', '65px');
-      if (window.matchMedia('(max-width: 600px)').matches) {
+      if (window.matchMedia('(max-width: 800px)').matches) {
         // For mobile devices (smaller than 600px)
         askAI.setAttribute('data-button-position-bottom', '130px');
       } else {


### PR DESCRIPTION
Increase the mediaQuery breakpoint for AskAI to avoid covering the menu toggle.

