### PR TITLE
Update Grafana token instructions for Core and Entperprise

### DIFF
--- a/content/shared/influxdb3-visualize/grafana.md
+++ b/content/shared/influxdb3-visualize/grafana.md
@@ -68,10 +68,13 @@ When creating an InfluxDB data source that uses SQL to query data:
 2.  Under **InfluxDB Details**:
 
     - **Database**: Provide a default database name to query.
-    - **Token**: Provide an arbitrary string.
+    - **Token**: Provide an arbitrary, non-empty string.
 
       > [!Note]
       > While in beta, {{< product-name >}} does not require an authorization token.
+      > However, if you included a `--token` option or defined the
+      > `INFLUXDB3_AUTH_TOKEN` environment variable when starting your
+      > {{< product-name >}} server, provide that token.
 
     - **Insecure Connection**: If _not_ using HTTPS, enable this option.
 

--- a/content/shared/influxdb3-visualize/grafana.md
+++ b/content/shared/influxdb3-visualize/grafana.md
@@ -110,8 +110,8 @@ When creating an InfluxDB data source that uses InfluxQL to query data:
 
     - **HTTP Method**: Choose one of the available HTTP request methods to use when querying data:
 
-        - **POST** ({{< req text="Recommended" >}})
-        - **GET**
+      - **POST** ({{< req text="Recommended" >}})
+      - **GET**
 
 3.  Click **Save & test**.
 
@@ -138,9 +138,10 @@ use Grafana to build, run, and inspect queries against {{< product-name >}}.
 > {{% sql/sql-schema-intro %}}
 > To learn more, see [Query Data](/influxdb3/version/query-data/sql/).
 
-1. Click **Explore**.
-2. In the dropdown, select the saved InfluxDB data source to query.
-3. Use the SQL query form to build your query:
+1.  Click **Explore**.
+2.  In the dropdown, select the saved InfluxDB data source to query.
+3.  Use the SQL query form to build your query:
+
     - **Table**: Select the measurement to query.
     - **Column**: Select one or more fields and tags to return as columns in query results.
       
@@ -164,7 +165,8 @@ use Grafana to build, run, and inspect queries against {{< product-name >}}.
         You can sort by time and multiple fields or tags.
         To sort in descending order, select **DESC**.
 
-4. {{< req text="Recommended" color="green" >}}: Change format to **Time series**.
+4.  {{< req text="Recommended" color="green" >}}: Change format to **Time series**.
+
     - Use the **Format** dropdown to change the format of the query results.
       For example, to visualize the query results as a time series, select **Time series**.
 
@@ -175,9 +177,10 @@ use Grafana to build, run, and inspect queries against {{< product-name >}}.
 {{% tab-content %}}
 <!------------------------------- BEGIN INFLUXQL ------------------------------>
 
-1. Click **Explore**.
-2. In the dropdown, select the **InfluxDB** data source that you want to query.
-3. Use the InfluxQL query form to build your query:
+1.  Click **Explore**.
+2.  In the dropdown, select the **InfluxDB** data source that you want to query.
+3.  Use the InfluxQL query form to build your query:
+
     - **FROM**: Select the measurement that you want to query.
     - **WHERE**: To filter the query results, enter a conditional expression.
     - **SELECT**: Select fields to query and an aggregate function to apply to each.
@@ -186,6 +189,7 @@ use Grafana to build, run, and inspect queries against {{< product-name >}}.
     - **GROUP BY**: By default, Grafana groups data by time to downsample results
       and improve query performance.
       You can also add other tags to group by.
+      
 4. Click **Run query** to execute the query.
 
 <!-------------------------------- END INFLUXQL ------------------------------->


### PR DESCRIPTION
Closes https://github.com/influxdata/DAR/issues/491

Clarifies that the `Token` string in an InfluxDB data source configuration should be an arbitrary, non-empty string. However, if you started the server with a token, you should provide that token.

- [x] Rebased/mergeable
