### PR TITLE
Change --aws-access-key to --aws-access-key-id

### DIFF
--- a/content/shared/v3-enterprise-get-started/_index.md
+++ b/content/shared/v3-enterprise-get-started/_index.md
@@ -196,7 +196,7 @@ influxdb3 serve \
   --cluster-id=cluster01 \
   --object-store=s3 \
   --bucket=BUCKET \
-  --aws-access-key=AWS_ACCESS_KEY \
+  --aws-access-key-id=AWS_ACCESS_KEY_ID \
   --aws-secret-access-key=AWS_SECRET_ACCESS_KEY
 ```
 
@@ -210,7 +210,7 @@ influxdb3 serve \
   --cluster-id=cluster01 \
   --object-store=s3 \
   --bucket=BUCKET \
-  --aws-access-key=AWS_ACCESS_KEY \
+  --aws-access-key-id=AWS_ACCESS_KEY_ID \
   --aws-secret-access-key=AWS_SECRET_ACCESS_KEY \
   --aws-endpoint=ENDPOINT \
   --aws-allow-http


### PR DESCRIPTION
Change --aws-access-key to --aws-access-key-id
object store flag, otherwise get error:
```
error: unexpected argument '--aws-access-key' found

  tip: a similar argument exists: '--aws-access-key-id'
```

Closes #

_Describe your proposed changes here._

- [x ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
