### PR TITLE
fix: fix link formatting

### DIFF
--- a/content/influxdb/v1/introduction/get-started.md
+++ b/content/influxdb/v1/introduction/get-started.md
@@ -209,5 +209,4 @@ To learn more about the InfluxDB write protocol,
 check out the guide on [Writing Data](/influxdb/v1/guides/writing_data/).
 To further explore the query language,
 check out the guide on [Querying Data](/influxdb/v1/guides/querying_data/).
-For more information on InfluxDB concepts, check out the [Key Concepts]
-(/influxdb/v1/concepts/key_concepts/) page.
+For more information on InfluxDB concepts, check out the [Key Concepts](/influxdb/v1/concepts/key_concepts/) page.


### PR DESCRIPTION
An extra space between the `()` and `[]` broke the link formatting:

![Screenshot from 2025-03-28 12-03-10](https://github.com/user-attachments/assets/01fc1fa0-653f-4239-9364-ef8715a27d04)

This space was removed.


- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [X] Rebased/mergeable
