### PR TITLE
WIP: Clarifying Processing engine instances

### DIFF
--- a/content/shared/v3-core-plugins/_index.md
+++ b/content/shared/v3-core-plugins/_index.md
@@ -36,6 +36,16 @@ influxdb3 serve \
   --plugin-dir /path/to/plugins
 ```
 
+### Set up the Processing engine in a distributed environment
+
+In a multi-instance InfluxDB 3 Enterprise deployment:
+
+- Configure the `--plugin-dir` option on **all ingestor nodes** where you want plugins to process incoming data
+- Querier nodes do not require the `--plugin-dir` option unless you're using HTTP-triggered plugins
+- Compactor nodes do not need the `--plugin-dir` option
+
+Each ingestor node should point to its own plugin directory that contains identical plugin files.
+
 ## Add a Processing engine plugin
 
 A plugin is a Python file that contains a specific function signature that corresponds to a trigger type.


### PR DESCRIPTION
Closes # #5932

**Objective:** 

To clarify which InfluxDB 3 components should be configured with the --plugin-dir flag to enable the Processing engine. To also specify which component’s URL should be provided when users are asked to enter their InfluxDB 3 Enterprise URL.

**To-do**

- [ ] Clarified that the --plugin-dir flag should be set on [specific component(s)] based on internal guidance (to be updated with final decision).
- [ ] Specified that the Enterprise URL should point to either the querier or ingestor, not the compactor.
- [ ] Updated phrasing for consistency and user clarity.

**Why This Matters**

Users deploying InfluxDB 3 in distributed environments need clear guidance on how to configure each component correctly. These updates help prevent misconfigurations and improve the onboarding experience for users enabling the Processing engine.

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
