### PR TITLE
Update Processing Engine example path to examples/wal_plugin

### DIFF
--- a/content/shared/v3-core-plugins/_index.md
+++ b/content/shared/v3-core-plugins/_index.md
@@ -63,7 +63,7 @@ You can copy example plugins from the [influxdb3_plugins repository](https://git
 git clone https://github.com/influxdata/influxdb3_plugins.git
 
 # Copy example plugins to your plugin directory
-cp -r influxdb3_plugins/examples/write/* /path/to/plugins/
+cp -r influxdb3_plugins/examples/wal_plugin/* /path/to/plugins/
 ```
 
 #### Directly from GitHub


### PR DESCRIPTION
Closes ##5933

**Objective**
To update the Processing Engine documentation to fix an outdated file path reference in the plugin example.

**Changes Made**
Corrected the plugin example path from examples/write to the accurate examples/wal_plugin location in the influxdb3_plugins repository.

**Impact**
The previous example path no longer exists in the influxdb3_plugins repo, which could confuse users attempting to follow the Processing Engine documentation. This fix ensures users are directed to the correct location for the working example, reducing friction during setup and experimentation.
