### PR TITLE
Manage InfluxDB 3 Distinct Value Caches

### DIFF
--- a/content/influxdb3/core/admin/distinct-value-cache/_index.md
+++ b/content/influxdb3/core/admin/distinct-value-cache/_index.md
@@ -1,0 +1,19 @@
+---
+title: Manage the Distinct Value Cache
+seotitle: Manage the Distinct Value Cache in {{< product-name >}}
+description: >
+  The {{< product-name >}} Distinct Value Cache (DVC) lets you cache distinct
+  values of one or more columns in a table, improving the performance of
+  queries that return distinct tag and field values. 
+menu:
+  influxdb3_core:
+    parent: Administer InfluxDB
+weight: 105
+influxdb3/core/tags: [cache]
+related:
+  - /influxdb3/core/reference/sql/functions/cache/#distinct_cache, distinct_cache SQL function
+source: /shared/influxdb3-admin/distinct-value-cache/_index.md
+---
+
+<!-- The content for this page is located at
+// SOURCE content/shared/influxdb3-admin/distinct-value-cache/_index.md -->

--- a/content/influxdb3/core/admin/distinct-value-cache/create.md
+++ b/content/influxdb3/core/admin/distinct-value-cache/create.md
@@ -1,0 +1,48 @@
+---
+title: Create a Distinct Value Cache
+description: |
+  Use the [`influxdb3 create distinct_cache` command](/influxdb3/core/reference/cli/influxdb3/create/distinct_cache/)
+  to create a Distinct Value Cache.
+menu:
+  influxdb3_core:
+    parent: Manage the Distinct Value Cache
+weight: 201
+influxdb3/core/tags: [cache]
+related:
+  - /influxdb3/core/reference/cli/influxdb3/create/distinct_cache/
+list_code_example: |
+  {{% show-in "core" %}}
+  <!--pytest.mark.skip-->
+
+  ```bash
+  influxdb3 create distinct_cache \
+    --database example-db \
+    --token 00xoXX0xXXx0000XxxxXx0Xx0xx0 \
+    --table wind_data \
+    --columns country,county,city \
+    --max-cardinality 10000 \
+    --max-age 24h \
+    windDistinctCache
+  ```
+  {{% /show-in %}}
+
+  {{% show-in "enterprise" %}}
+  <!--pytest.mark.skip-->
+
+  ```bash
+  influxdb3 create distinct_cache \
+    --database example-db \
+    --token 00xoXX0xXXx0000XxxxXx0Xx0xx0 \
+    --table home \
+    --node-spec node-01,node-02 \
+    --columns country,county,city \
+    --max-cardinality 10000 \
+    --max-age 24h \
+    windDistinctCache
+  ```
+  {{% /show-in %}}
+source: /shared/influxdb3-admin/distinct-value-cache/create.md
+---
+
+<!-- The content for this page is located at
+// SOURCE content/shared/influxdb3-admin/distinct-value-cache/create.md -->

--- a/content/influxdb3/core/admin/distinct-value-cache/delete.md
+++ b/content/influxdb3/core/admin/distinct-value-cache/delete.md
@@ -1,0 +1,27 @@
+---
+title: Delete a Distinct Value Cache
+description: |
+  Use the [`influxdb3 delete distinct_cache` command](/influxdb3/core/reference/cli/influxdb3/delete/distinct_cache/)
+  to delete a Distinct Value Cache.
+menu:
+  influxdb3_core:
+    parent: Manage the Distinct Value Cache
+weight: 204
+influxdb3/core/tags: [cache]
+list_code_example: |
+  <!--pytest.mark.skip-->
+
+  ```bash
+  influxdb3 delete distinct_cache \
+    --database example-db \
+    --token 00xoXX0xXXx0000XxxxXx0Xx0xx0 \
+    --table wind_data \
+    windDistinctCache
+  ```
+related:
+  - /influxdb3/core/reference/cli/influxdb3/delete/distinct_cache/
+source: /shared/influxdb3-admin/distinct-value-cache/delete.md
+---
+
+<!-- The content for this page is located at
+// SOURCE content/shared/influxdb3-admin/distinct-value-cache/delete.md -->

--- a/content/influxdb3/core/admin/distinct-value-cache/query.md
+++ b/content/influxdb3/core/admin/distinct-value-cache/query.md
@@ -1,0 +1,26 @@
+---
+title: Query a Distinct Value Cache
+description: |
+  Use the [`distinct_cache()` SQL function](/influxdb3/core/reference/sql/functions/cache/#distinct_cache)
+  in the `FROM` clause of an SQL `SELECT` statement to query data from the
+  Distinct Value Cache.
+menu:
+  influxdb3_core:
+    parent: Manage the Distinct Value Cache
+weight: 202
+influxdb3/core/tags: [cache]
+list_code_example: |
+  ```sql
+  SELECT * FROM distinct_cache('table-name', 'cache-name')
+  ```
+
+  > [!Important]
+  > You must use SQL to query the DVC.
+  > InfluxQL does not support the `distinct_cache()` function.
+related:
+  - /influxdb3/core/reference/sql/functions/cache/#distinct_cache, distinct_cache SQL function
+source: /shared/influxdb3-admin/distinct-value-cache/query.md
+---
+
+<!-- The content for this page is located at
+// SOURCE content/shared/influxdb3-admin/distinct-value-cache/query.md -->

--- a/content/influxdb3/core/admin/distinct-value-cache/show.md
+++ b/content/influxdb3/core/admin/distinct-value-cache/show.md
@@ -1,0 +1,25 @@
+---
+title: Show information about Distinct Value Caches
+description: |
+  Use the `influxdb3 show system table` command to query and output Distinct Value
+  Cache information from the `distinct_caches` system table.
+menu:
+  influxdb3_core:
+    parent: Manage the Distinct Value Cache
+    name: Show Distinct Value Caches
+weight: 203
+influxdb3/core/tags: [cache]
+list_code_example: |
+  <!-- pytest.mark.skip -->
+
+  ```bash
+  influxdb3 show system \
+    --database example-db \
+    --token 00xoXX0xXXx0000XxxxXx0Xx0xx0 \
+    table distinct_caches
+  ```
+source: /shared/influxdb3-admin/distinct-value-cache/show.md
+---
+
+<!-- The content for this page is located at
+// SOURCE content/shared/influxdb3-admin/distinct-value-cache/show.md -->

--- a/content/influxdb3/enterprise/admin/distinct-value-cache/_index.md
+++ b/content/influxdb3/enterprise/admin/distinct-value-cache/_index.md
@@ -1,0 +1,19 @@
+---
+title: Manage the Distinct Value Cache
+seotitle: Manage the Distinct Value Cache in {{< product-name >}}
+description: >
+  The {{< product-name >}} Distinct Value Cache (DVC) lets you cache distinct
+  values of one or more columns in a table, improving the performance of
+  queries that return distinct tag and field values. 
+menu:
+  influxdb3_enterprise:
+    parent: Administer InfluxDB
+weight: 105
+influxdb3/enterprise/tags: [cache]
+related:
+  - /influxdb3/enterprise/reference/sql/functions/cache/#distinct_cache, distinct_cache SQL function
+source: /shared/influxdb3-admin/distinct-value-cache/_index.md
+---
+
+<!-- The content for this page is located at
+// SOURCE content/shared/influxdb3-admin/distinct-value-cache/_index.md -->

--- a/content/influxdb3/enterprise/admin/distinct-value-cache/create.md
+++ b/content/influxdb3/enterprise/admin/distinct-value-cache/create.md
@@ -1,0 +1,48 @@
+---
+title: Create a Distinct Value Cache
+description: |
+  Use the [`influxdb3 create distinct_cache` command](/influxdb3/enterprise/reference/cli/influxdb3/create/distinct_cache/)
+  to create a Distinct Value Cache.
+menu:
+  influxdb3_enterprise:
+    parent: Manage the Distinct Value Cache
+weight: 201
+influxdb3/enterprise/tags: [cache]
+related:
+  - /influxdb3/enterprise/reference/cli/influxdb3/create/distinct_cache/
+list_code_example: |
+  {{% show-in "core" %}}
+  <!--pytest.mark.skip-->
+
+  ```bash
+  influxdb3 create distinct_cache \
+    --database example-db \
+    --token 00xoXX0xXXx0000XxxxXx0Xx0xx0 \
+    --table wind_data \
+    --columns country,county,city \
+    --max-cardinality 10000 \
+    --max-age 24h \
+    windDistinctCache
+  ```
+  {{% /show-in %}}
+
+  {{% show-in "enterprise" %}}
+  <!--pytest.mark.skip-->
+
+  ```bash
+  influxdb3 create distinct_cache \
+    --database example-db \
+    --token 00xoXX0xXXx0000XxxxXx0Xx0xx0 \
+    --table home \
+    --node-spec node-01,node-02 \
+    --columns country,county,city \
+    --max-cardinality 10000 \
+    --max-age 24h \
+    windDistinctCache
+  ```
+  {{% /show-in %}}
+source: /shared/influxdb3-admin/distinct-value-cache/create.md
+---
+
+<!-- The content for this page is located at
+// SOURCE content/shared/influxdb3-admin/distinct-value-cache/create.md -->

--- a/content/influxdb3/enterprise/admin/distinct-value-cache/delete.md
+++ b/content/influxdb3/enterprise/admin/distinct-value-cache/delete.md
@@ -1,0 +1,27 @@
+---
+title: Delete a Distinct Value Cache
+description: |
+  Use the [`influxdb3 delete distinct_cache` command](/influxdb3/enterprise/reference/cli/influxdb3/delete/distinct_cache/)
+  to delete a Distinct Value Cache.
+menu:
+  influxdb3_enterprise:
+    parent: Manage the Distinct Value Cache
+weight: 204
+influxdb3/enterprise/tags: [cache]
+list_code_example: |
+  <!--pytest.mark.skip-->
+
+  ```bash
+  influxdb3 delete distinct_cache \
+    --database example-db \
+    --token 00xoXX0xXXx0000XxxxXx0Xx0xx0 \
+    --table wind_data \
+    windDistinctCache
+  ```
+related:
+  - /influxdb3/enterprise/reference/cli/influxdb3/delete/distinct_cache/
+source: /shared/influxdb3-admin/distinct-value-cache/delete.md
+---
+
+<!-- The content for this page is located at
+// SOURCE content/shared/influxdb3-admin/distinct-value-cache/delete.md -->

--- a/content/influxdb3/enterprise/admin/distinct-value-cache/query.md
+++ b/content/influxdb3/enterprise/admin/distinct-value-cache/query.md
@@ -1,0 +1,26 @@
+---
+title: Query a Distinct Value Cache
+description: |
+  Use the [`distinct_cache()` SQL function](/influxdb3/enterprise/reference/sql/functions/cache/#distinct_cache)
+  in the `FROM` clause of an SQL `SELECT` statement to query data from the
+  Distinct Value Cache.
+menu:
+  influxdb3_enterprise:
+    parent: Manage the Distinct Value Cache
+weight: 202
+influxdb3/enterprise/tags: [cache]
+list_code_example: |
+  ```sql
+  SELECT * FROM distinct_cache('table-name', 'cache-name')
+  ```
+
+  > [!Important]
+  > You must use SQL to query the DVC.
+  > InfluxQL does not support the `distinct_cache()` function.
+related:
+  - /influxdb3/enterprise/reference/sql/functions/cache/#distinct_cache, distinct_cache SQL function
+source: /shared/influxdb3-admin/distinct-value-cache/query.md
+---
+
+<!-- The content for this page is located at
+// SOURCE content/shared/influxdb3-admin/distinct-value-cache/query.md -->

--- a/content/influxdb3/enterprise/admin/distinct-value-cache/show.md
+++ b/content/influxdb3/enterprise/admin/distinct-value-cache/show.md
@@ -1,0 +1,25 @@
+---
+title: Show information about Distinct Value Caches
+description: |
+  Use the `influxdb3 show system table` command to query and output Distinct Value
+  Cache information from the `distinct_caches` system table.
+menu:
+  influxdb3_enterprise:
+    parent: Manage the Distinct Value Cache
+    name: Show Distinct Value Caches
+weight: 203
+influxdb3/enterprise/tags: [cache]
+list_code_example: |
+  <!-- pytest.mark.skip -->
+
+  ```bash
+  influxdb3 show system \
+    --database example-db \
+    --token 00xoXX0xXXx0000XxxxXx0Xx0xx0 \
+    table distinct_caches
+  ```
+source: /shared/influxdb3-admin/distinct-value-cache/show.md
+---
+
+<!-- The content for this page is located at
+// SOURCE content/shared/influxdb3-admin/distinct-value-cache/show.md -->

--- a/content/shared/influxdb3-admin/distinct-value-cache/_index.md
+++ b/content/shared/influxdb3-admin/distinct-value-cache/_index.md
@@ -1,0 +1,106 @@
+
+The {{< product-name >}} Distinct Value Cache (DVC) lets you cache distinct
+values of one or more columns in a table, improving the performance of
+queries that return distinct tag and field values. 
+
+The DVC is an in-memory cache that stores distinct values for specific columns
+in a table. When you create an DVC, you can specify what columns' distinct
+values to cache, the maximum number of distinct value combinations to cache, and
+the maximum age of cached values. A DVC is associated with a table, which can
+have multiple DVCs.
+
+{{< children type="anchored-list" >}}
+- [Important things to know about the Distinct Value Cache](#important-things-to-know-about-the-distinct-value-cache)
+  - [High cardinality limits](#high-cardinality-limits)
+  {{% show-in "core" %}}
+  - [Distinct Value Caches are flushed when the server stops](#distinct-value-caches-are-flushed-when-the-server-stops)
+  {{% /show-in %}}
+  {{% show-in "enterprise" %}}
+  - [Distinct Value Caches are rebuilt on restart](#distinct-value-caches-are-rebuilt-on-restart)
+  {{% /show-in %}}
+
+Consider a dataset with the following schema:
+
+- wind_data (table)
+  - tags:
+    - country
+      - _multiple European countries_
+    - county
+      - _multiple European counties_
+    - city
+      - _multiple European cities_
+  - fields:  
+    - wind_speed (float)
+    - wind_direction (integer)
+
+If you cache distinct values for `country`, `county`, and `city`, the DVC looks
+similar to this:
+
+| country        | county            | city         |
+| :------------- | :---------------- | :----------- |
+| Austria        | Salzburg          | Salzburg     |
+| Austria        | Vienna            | Vienna       |
+| Belgium        | Antwerp           | Antwerp      |
+| Belgium        | West Flanders     | Bruges       |
+| Czech Republic | Liberec Region    | Liberec      |
+| Czech Republic | Prague            | Prague       |
+| Denmark        | Capital Region    | Copenhagen   |
+| Denmark        | Southern Denmark  | Odense       |
+| Estonia        | Ida-Viru County   | Kohtla-Järve |
+| Estonia        | Ida-Viru County   | Narva        |
+| ...            | ...               | ...          |
+
+> [!Important]
+> #### Repeated values in DVC results
+> 
+> Distinct values may appear multiple times in a column when querying the DVC,
+> but only when associated with distinct values in other columns.
+> If you query a single column in the DVC, no values are repeated in the results.
+
+> [!Note]
+> #### Null column values
+>
+> _Null_ column values are still considered values and are cached in the DVC.
+> If you write data to a table and don't provide a value for an existing column,
+> the column value is cached as _null_ and treated as a distinct value.
+
+{{< children hlevel="h2" >}}
+
+## Important things to know about the Distinct Value Cache
+
+DVCs are stored in memory; the larger the cache, the more memory your InfluxDB 3
+node requires to maintain it. Consider the following:
+
+- [High cardinality limits](#high-cardinality-limits)
+{{% show-in "core" %}}
+- [Distinct Value Caches are flushed when the server stops](#distinct-value-caches-are-flushed-when-the-server-stops)
+{{% /show-in %}}
+{{% show-in "enterprise" %}}
+- [Distinct Value Caches are rebuilt on restart](#distinct-value-caches-are-rebuilt-on-restart)
+{{% /show-in %}}
+
+### High cardinality limits
+
+“Cardinality” refers to the number of unique key column combinations in your 
+cached data and essentially defines the maximum number of rows to store in your
+DVC. While the InfluxDB 3 storage engine is not limited by cardinality, 
+it does affect the DVC. You can define a custom maximum cardinality limit for
+a DVC, but higher cardinality increases memory requirements for 
+storing the DVC and can affect DVC query performance.
+
+{{% show-in "core" %}}
+### Distinct Value Caches are flushed when the server stops
+
+Because the DVC is an in-memory cache, the cache is flushed any time the server 
+stops. After a server restart, {{% product-name %}} only writes new values to
+the DVC when you write data, so there may be a period of time when some values are 
+unavailable in the DVC.
+{{% /show-in %}}
+
+{{% show-in "enterprise" %}}
+### Distinct Value Caches are rebuilt on restart
+
+Because the DVC is an in-memory cache, the cache is flushed any time the server 
+stops. After a server restarts, {{< product-name >}} uses persisted data to
+rebuild the DVC.
+{{% /show-in %}}

--- a/content/shared/influxdb3-admin/distinct-value-cache/create.md
+++ b/content/shared/influxdb3-admin/distinct-value-cache/create.md
@@ -1,0 +1,108 @@
+
+Use the [`influxdb3 create distinct_cache` command](/influxdb3/version/reference/cli/influxdb3/create/distinct_cache/)
+to create a Distinct Value Cache (DVC). Provide the following:
+
+- **Database** (`-d`, `--database`): _({{< req >}})_ The name of the database to
+  associate the DVC with. You can also use the `INFLUXDB3_DATABASE_NAME`
+  environment variable to specify the database.
+- **Token** (`--token`): _({{< req >}})_ Your {{< product-name >}}
+  authentication token with write access to the specified table.
+  You can also use the `INFLUXDB3_AUTH_TOKEN` environment variable to specify
+  the token.
+- **Table** (`-t`, `--table`): _({{< req >}})_ The name of the table to
+  associate the DVC with.
+{{% show-in "enterprise" %}}
+- **Node specification** (`-n`, `--node-spec`): Specify which nodes the DVC
+  should be configured on.
+{{% /show-in %}}
+- **Columns** (`--columns`): _({{< req >}})_ Specify which columns to cache
+  distinct values for. These are typically tag columns but can also be
+  string fields.
+- **Maximum cardinality** (`--max-cardinality`): Specify the maximum number of
+  distinct value combinations to store in the cache. The default maximum
+  cardinality is `100000`.
+- **Maximum age** (`--max-age`): Specify the maximum age of distinct values to
+  keep in the DVC in
+  [humantime](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html)
+  form. The default maximum age is `24 hours`.
+- **Cache name**: A unique name for the cache. If you don’t provide one,
+  InfluxDB automatically generates a cache name for you.
+
+{{% show-in "core" %}}
+<!----------------------------- BEGIN CORE EXAMPLE ---------------------------->
+{{% code-placeholders "(DATABASE|TABLE|DVC)_NAME|AUTH_TOKEN|NODE_SPEC|COLUMNS|MAX_(CARDINALITY|AGE)" %}}
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 create distinct_cache \
+  --database DATABASE_NAME \
+  --token AUTH_TOKEN \
+  --table TABLE_NAME \
+  --columns COLUMNS \
+  --max-cardinality MAX_CARDINALITY \
+  --max-age MAX_AGE \
+  DVC_NAME
+```
+{{% /code-placeholders %}}
+<!------------------------------ END CORE EXAMPLE ----------------------------->
+{{% /show-in %}}
+
+{{% show-in "enterprise" %}}
+<!-------------------------- BEGIN ENTERPRISE EXAMPLE ------------------------->
+{{% code-placeholders "(DATABASE|TABLE|DVC)_NAME|AUTH_TOKEN|NODE_SPEC|COLUMNS|MAX_(CARDINALITY|AGE)" %}}
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 create distinct_cache \
+  --database DATABASE_NAME \
+  --token AUTH_TOKEN \
+  --table TABLE_NAME \
+  --node_spec NODE_SPEC \
+  --columns COLUMNS \
+  --max-cardinality MAX_CARDINALITY \
+  --max-age MAX_AGE \
+  DVC_NAME
+```
+{{% /code-placeholders %}}
+<!--------------------------- END ENTERPRISE EXAMPLE -------------------------->
+{{% /show-in %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
+  the name of the database to associate the DVC with
+- {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}}:
+  your {{< product-name >}} authentication token with write access to the
+  specified database
+- {{% code-placeholder-key %}}`TABLE_NAME`{{% /code-placeholder-key %}}:
+  the name of the table to associate the DVC with
+{{% show-in "enterprise" %}}
+- {{% code-placeholder-key %}}`NODE_SPEC`{{% /code-placeholder-key %}}:
+  a comma-delimited list of node IDs to configure the DVC on--for example:
+  `node-01,node-02`.
+{{% /show-in %}}
+- {{% code-placeholder-key %}}`COLUMNS`{{% /code-placeholder-key %}}:
+  a comma-delimited list of columns to cache distinct values for--for example:
+  `country,county,city`
+- {{% code-placeholder-key %}}`MAX_CARDINALITY`{{% /code-placeholder-key %}}:
+  the number of last values to cache per series--for example: `10000`
+- {{% code-placeholder-key %}}`MAX_AGE`{{% /code-placeholder-key %}}:
+  the maximum age of distinct values to keep in the cache in
+  [humantime](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html)
+  form--for example: `6h`, `1 day`, `1 week`
+- {{% code-placeholder-key %}}`DVC_NAME`{{% /code-placeholder-key %}}:
+  a unique name for the DVC
+
+> [!Note]
+> #### Values are cached on write
+>
+> Values are cached on write. When you create a cache, it will not cache
+> previously written points, only newly written points.
+>
+> #### DVC size and persistence
+>
+> The DVC is stored in memory, so it's important to consider the size and
+> persistence of the cache. For more information, see
+> [Important things to know about the Distinct Value Cache](/influxdb3/version/admin/last-value-cache/#important-things-to-know-about-the-last-value-cache).

--- a/content/shared/influxdb3-admin/distinct-value-cache/create.md
+++ b/content/shared/influxdb3-admin/distinct-value-cache/create.md
@@ -87,7 +87,7 @@ Replace the following:
   a comma-delimited list of columns to cache distinct values for--for example:
   `country,county,city`
 - {{% code-placeholder-key %}}`MAX_CARDINALITY`{{% /code-placeholder-key %}}:
-  the number of last values to cache per series--for example: `10000`
+  the maximum number of distinct value combinations to cache--for example: `10000`
 - {{% code-placeholder-key %}}`MAX_AGE`{{% /code-placeholder-key %}}:
   the maximum age of distinct values to keep in the cache in
   [humantime](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html)
@@ -105,4 +105,4 @@ Replace the following:
 >
 > The DVC is stored in memory, so it's important to consider the size and
 > persistence of the cache. For more information, see
-> [Important things to know about the Distinct Value Cache](/influxdb3/version/admin/last-value-cache/#important-things-to-know-about-the-last-value-cache).
+> [Important things to know about the Distinct Value Cache](/influxdb3/version/admin/distinct-value-cache/#important-things-to-know-about-the-distinct-value-cache).

--- a/content/shared/influxdb3-admin/distinct-value-cache/delete.md
+++ b/content/shared/influxdb3-admin/distinct-value-cache/delete.md
@@ -1,40 +1,40 @@
 
-Use the [`influxdb3 delete last_cache` command](/influxdb3/version/reference/cli/influxdb3/delete/last_cache/)
-to delete a Last Value Cache (LVC). Provide the following:
+Use the [`influxdb3 delete distinct_cache` command](/influxdb3/version/reference/cli/influxdb3/delete/distinct_cache/)
+to delete a Distinct Value Cache (DVC). Provide the following:
 
 - **Database** (`-d`, `--database`): _({{< req >}})_ The name of the database
-  that the LVC you want to delete is associated with. You can also use the
+  that the DVC you want to delete is associated with. You can also use the
   `INFLUXDB3_DATABASE_NAME` environment variable to specify the database.
 - **Token** (`--token`): _({{< req >}})_ Your {{< product-name >}}
   authentication token with write access to the specified database.
   You can also use the `INFLUXDB3_AUTH_TOKEN` environment variable to specify
-  the database.
+  the token.
 - **Table** (`-t`, `--table`): _({{< req >}})_ The name of the table that the
-  LVC you want to delete is associated with.
-- **Cache name**: The name of the LVC to delete.
+  DVC you want to delete is associated with.
+- **Cache name**: The name of the DVC to delete.
 
-{{% code-placeholders "(DATABASE|TABLE|LVC)_NAME|AUTH_TOKEN" %}}
+{{% code-placeholders "(DATABASE|TABLE|DVC)_NAME|AUTH_TOKEN" %}}
 ```bash
-influxdb3 delete last_cache \
+influxdb3 delete distinct_cache \
   --database DATABASE_NAME \
   --token AUTH_TOKEN \
   --table TABLE_NAME \
-  LVC_NAME
+  DVC_NAME
 ```
 {{% /code-placeholders %}}
 
 Replace the following:
 
 - {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
-  the name of the database that the LVC you want to delete is associated with
+  the name of the database that the DVC you want to delete is associated with
 - {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}}:
   your {{< product-name >}} authentication token with write access to the
   specified database
 - {{% code-placeholder-key %}}`TABLE_NAME`{{% /code-placeholder-key %}}:
-  the name of the table that the LVC you want to delete is associated with
-- {{% code-placeholder-key %}}`LVC`{{% /code-placeholder-key %}}:
-  the name of the LVC to delete
+  the name of the table associated with the DVC you want to delete
+- {{% code-placeholder-key %}}`DVC_NAME`{{% /code-placeholder-key %}}:
+  the name of the DVC to delete
 
 > [!Caution]
 > This is a destructive action that cannot be undone. Once deleted, any queries
-> against the deleted LVC will return an error.
+> against the deleted DVC will return an error.

--- a/content/shared/influxdb3-admin/distinct-value-cache/query.md
+++ b/content/shared/influxdb3-admin/distinct-value-cache/query.md
@@ -1,0 +1,33 @@
+
+Use the [`distinct_cache()` SQL function](/influxdb3/version/reference/sql/functions/cache/#distinct_cache)
+in the `FROM` clause of an SQL `SELECT` statement to query data from the
+Distinct Value Cache (DVC).
+
+> [!Important]
+> You must use SQL to query the DVC.
+> InfluxQL does not support the `distinct_cache()` function.
+
+`distinct_cache()` supports the following arguments:
+
+- **table_name**: _({{< req >}})_ The name of the table the DVC is associated with
+  formatted as a string literal.
+- **cache_name**: The name of the DVC to query formatted as a string literal.
+  This argument is only required if there is more than one DVC associated with
+  the specified table.
+
+```sql
+SELECT * FROM distinct_cache('table_name', 'cache_name')
+```
+
+You can use other [SQL clauses](/influxdb3/version/reference/sql/#statements-and-clauses)
+to modify query results. For example, you can use the `WHERE` clause to return
+the distinct tag values associated with another distinct tag value:
+
+```sql
+SELECT
+  city
+FROM
+  distinct_cache('wind_data', 'windDistinctCache')
+WHERE
+  country = 'Spain'
+```

--- a/content/shared/influxdb3-admin/distinct-value-cache/show.md
+++ b/content/shared/influxdb3-admin/distinct-value-cache/show.md
@@ -1,0 +1,69 @@
+
+Use the [`influxdb3 show system table` command](/influxdb3/version/reference/cli/influxdb3/show/syste/table/)
+to query and output Distinct Value Cache information from the `distinct_caches`
+system table.
+
+{{% code-placeholders "DATABASE_NAME|AUTH_TOKEN" %}}
+<!-- pytest.mark.skip -->
+
+```bash
+influxdb3 show system \
+  --database DATABASE_NAME \
+  --token AUTH_TOKEN \
+  table distinct_caches
+```
+{{% /code-placeholders %}}
+
+This returns a table similar to the following:
+
+| table     | name             | column_ids | column_names            | max_cardinality | max_age_seconds |
+| :-------- | :--------------- | :--------- | :---------------------- | --------------: | --------------: |
+| wind_data | wind_distinct    | [0, 1, 2]  | [country, county, city] |          100000 |           86400 |
+| weather   | weather_distinct | [0]        | [location]              |             100 |          604800 |
+| bitcoin   | bitcoin_dis      | [0, 1]     | [code, crypto]          |            5000 |           86400 |
+| home      | home_distinct    | [0, 1]     | [room, wall]            |           12000 |        15770000 |
+
+## Query specific columns from the distinct_caches system table
+
+Use the `--select` option to query specific columns from the `distinct_caches`
+system table. Provide a comma-delimited list of columns to return:
+
+{{% code-placeholders "DATABASE_NAME|AUTH_TOKEN" %}}
+<!-- pytest.mark.skip -->
+
+```bash
+influxdb3 show system \
+  --database DATABASE_NAME \
+  --token AUTH_TOKEN \
+  table distinct_caches \
+  --select name,column_names,max_age_seconds
+```
+{{% /code-placeholders %}}
+
+## Sort distinct_caches system table output
+
+Use the `--order-by` option to sort data from the `distinct_caches` system table by
+specific columns. Provide a comma-delimited list of columns to sort by:
+
+{{% code-placeholders "DATABASE_NAME|AUTH_TOKEN" %}}
+<!-- pytest.mark.skip -->
+
+```bash
+influxdb3 show system \
+  --database DATABASE_NAME \
+  --token AUTH_TOKEN \
+  table distinct_caches \
+  --order-by max_cardinality,max_age_seconds
+```
+{{% /code-placeholders %}}
+
+> [!Note]
+> Results are sorted in ascending order based on the provided columns.
+
+In the examples above, replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
+  the name of the database to query system data from
+- {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}}:
+  your {{< product-name >}} authentication token with read access to the
+  specified database

--- a/content/shared/influxdb3-admin/last-value-cache/create.md
+++ b/content/shared/influxdb3-admin/last-value-cache/create.md
@@ -8,7 +8,7 @@ to create a Last Value Cache (LVC). Provide the following:
 - **Token** (`--token`): _({{< req >}})_ Your {{< product-name >}}
   authentication token with write access to the specified table.
   You can also use the `INFLUXDB3_AUTH_TOKEN` environment variable to specify
-  the database.
+  the token.
 - **Table** (`-t`, `--table`): _({{< req >}})_ The name of the table to
   associate the LVC with.
 {{% show-in "enterprise" %}}


### PR DESCRIPTION
Adds administrative docs for the Distinct Value Cache in InfluxDB 3 Core and Enteprise.

- [x] Rebased/mergeable
