### PR TITLE
feat(mono): Manage admin tokens

### DIFF
--- a/content/influxdb3/cloud-dedicated/admin/tokens/database/create.md
+++ b/content/influxdb3/cloud-dedicated/admin/tokens/database/create.md
@@ -3,7 +3,7 @@ title: Create a database token
 description: >
   Use the [`influxctl token create` command](/influxdb3/cloud-dedicated/reference/cli/influxctl/token/create/)
   or the [Management HTTP API](/influxdb3/cloud-dedicated/api/management/)
-  to [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) for reading and writing data in your InfluxDB Cloud Dedicated cluster.
+  to create a [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) for reading and writing data in your InfluxDB Cloud Dedicated cluster.
   Provide a token description and permissions for databases.
 menu:
   influxdb3_cloud_dedicated:

--- a/content/influxdb3/clustered/admin/tokens/database/create.md
+++ b/content/influxdb3/clustered/admin/tokens/database/create.md
@@ -2,7 +2,7 @@
 title: Create a database token
 description: >
   Use the [`influxctl token create` command](/influxdb3/clustered/reference/cli/influxctl/token/create/)
-  to create a database token for reading and writing data in your InfluxDB cluster.
+  to create a [database token](/influxdb3/clustered/admin/tokens/database/) for reading and writing data in your InfluxDB cluster.
   Provide a token description and permissions for databases.
 menu:
   influxdb3_clustered:

--- a/content/influxdb3/core/admin/tokens/_index.md
+++ b/content/influxdb3/core/admin/tokens/_index.md
@@ -1,0 +1,17 @@
+---
+title: Manage tokens
+description: >
+  InfluxDB 3 uses tokens to authenticate and authorize access to resources and data stored in {{< product-name >}}.
+  Use the `influxdb3` CLI or `/api/v3` HTTP API to manage tokens
+  for your {{% product-name %}} instance.
+menu:
+  influxdb3_core:
+    parent: Administer InfluxDB
+weight: 202
+---
+
+InfluxDB 3 uses tokens to authenticate and authorize access to resources and data stored in {{< product-name >}}.
+Use the `influxdb3` CLI or `/api/v3` HTTP API to manage tokens
+for your {{% product-name %}} instance.
+
+{{< children hlevel="h2" readmore=true hr=true >}}

--- a/content/influxdb3/core/admin/tokens/admin/_index.md
+++ b/content/influxdb3/core/admin/tokens/admin/_index.md
@@ -1,0 +1,19 @@
+---
+title: Manage admin tokens
+seotitle: Manage admin tokens in {{< product-name >}} 
+description: >
+  Manage admin tokens in your {{< product-name >}} instance.
+  An admin token grants
+  access to all actions (CLI commands and API endpoints) for the server.
+menu:
+  influxdb3_core:
+    parent: Manage tokens
+    name: Admin tokens
+weight: 101
+influxdb3/core/tags: [tokens]
+source: /shared/influxdb3-admin/tokens/_index.md
+---
+
+<!-- The content for this page is at
+// SOURCE content/shared/influxdb3-admin/tokens/_index.md
+--> 

--- a/content/influxdb3/core/admin/tokens/admin/create.md
+++ b/content/influxdb3/core/admin/tokens/admin/create.md
@@ -1,0 +1,24 @@
+---
+title: Create an admin token
+description: >
+  Use the [`influxdb3 create token --admin` command](/influxdb3/core/reference/cli/influxdb3/create/token/)
+  or the [HTTP API](/influxdb3/core/api/v3/)
+  to create an [admin token](/influxdb3/core/admin/tokens/admin/) for your {{< product-name omit="Clustered" >}} instance.
+  An admin token grants access to all actions on the server.
+menu:
+  influxdb3_core:
+    parent: Admin tokens
+weight: 201
+list_code_example: |
+  ##### CLI
+  ```bash
+  influxdb3 create token --admin 
+alt_links:
+  cloud-dedicated: /influxdb3/cloud-dedicated/admin/tokens/create-token/
+  cloud-serverless: /influxdb3/cloud-serverless/admin/tokens/create-token/
+source: /shared/influxdb3-admin/tokens/admin/create.md
+---
+
+<!-- The content for this page is at
+// SOURCE content/shared/influxdb3-admin/tokens/admin/create.md
+-->

--- a/content/influxdb3/core/admin/tokens/admin/list.md
+++ b/content/influxdb3/core/admin/tokens/admin/list.md
@@ -1,0 +1,21 @@
+---
+title: List an admin token
+description: >
+  Use the `influxdb3 show tokens` command
+  to list the [admin token](/influxdb3/enterprise/admin/tokens/admin/) for your {{< product-name omit="Clustered" >}} instance.
+  An admin token grants access to all actions on the server.
+menu:
+  influxdb3_core:
+    parent: Admin tokens
+weight: 201
+list_code_example: |
+  ##### CLI
+  ```bash
+  influxdb3 show tokens 
+  ```
+source: /shared/influxdb3-admin/tokens/admin/list.md
+---
+
+<!-- The content for this page is at
+// SOURCE content/shared/influxdb3-admin/tokens/admin/list.md
+-->

--- a/content/influxdb3/core/admin/tokens/admin/regenerate.md
+++ b/content/influxdb3/core/admin/tokens/admin/regenerate.md
@@ -1,0 +1,25 @@
+---
+title: Regenerate an admin token
+description: >
+  Use the [`influxdb3 create token --admin` command](/influxdb3/core/reference/cli/influxdb3/create/token/)
+  or the [HTTP API](/influxdb3/core/api/v3/)
+  to regenerate an [admin token](/influxdb3/core/admin/tokens/admin/) for your {{< product-name omit="Clustered" >}} instance.
+  An admin token grants access to all actions on the server.
+  Regenerating an admin token deactivates the previous token.
+menu:
+  influxdb3_core:
+    parent: Admin tokens
+weight: 201
+list_code_example: |
+  ##### CLI
+  ```bash
+  influxdb3 create token --admin \
+    --token ADMIN_TOKEN \
+    --regenerate
+  ```
+source: /shared/influxdb3-admin/tokens/admin/regenerate.md
+---
+
+<!-- The content for this page is at
+// SOURCE content/shared/influxdb3-admin/tokens/admin/create.md
+-->

--- a/content/influxdb3/enterprise/admin/tokens/_index.md
+++ b/content/influxdb3/enterprise/admin/tokens/_index.md
@@ -1,0 +1,17 @@
+---
+title: Manage tokens
+description: >
+  InfluxDB 3 uses tokens to authenticate and authorize access to resources and data stored in your {{< product-name >}}.
+  Use the `influxdb3` CLI or `/api/v3` HTTP API to manage tokens
+  for your {{% product-name %}} instance.
+menu:
+  influxdb3_enterprise:
+    parent: Administer InfluxDB
+weight: 202
+---
+
+InfluxDB 3 uses tokens to authenticate and authorize access to resources and data stored in your {{< product-name >}}.
+Use the `influxdb3` CLI or `/api/v3` HTTP API to manage tokens
+for your {{% product-name %}} instance.
+
+{{< children hlevel="h2" readmore=true hr=true >}}

--- a/content/influxdb3/enterprise/admin/tokens/admin/_index.md
+++ b/content/influxdb3/enterprise/admin/tokens/admin/_index.md
@@ -1,0 +1,19 @@
+---
+title: Manage admin tokens
+seotitle: Manage admin tokens in {{< product-name >}} 
+description: >
+  Manage admin tokens in your {{< product-name >}} instance.
+  An admin token grants
+  access to all actions (CLI commands and API endpoints) for the server.
+menu:
+  influxdb3_enterprise:
+    parent: Manage tokens
+    name: Admin tokens
+weight: 101
+influxdb3/enterprise/tags: [tokens]
+source: /shared/influxdb3-admin/tokens/admin/_index.md
+---
+
+<!-- The content for this page is at
+// SOURCE content/shared/influxdb3-admin/tokens/admin/_index.md
+--> 

--- a/content/influxdb3/enterprise/admin/tokens/admin/create.md
+++ b/content/influxdb3/enterprise/admin/tokens/admin/create.md
@@ -1,0 +1,24 @@
+---
+title: Create an admin token
+description: >
+  Use the [`influxdb3 create token --admin` command](/influxdb3/enterprise/reference/cli/influxdb3/create/token/)
+  or the [HTTP API](/influxdb3/enterprise/api/v3/)
+  to create an [admin token](/influxdb3/enterprise/admin/tokens/admin/) for your {{< product-name omit="Clustered" >}} instance.
+  An admin token grants access to all actions on the server.
+menu:
+  influxdb3_enterprise:
+    parent: Admin tokens
+weight: 201
+list_code_example: |
+  ##### CLI
+  ```bash
+  influxdb3 create token --admin 
+alt_links:
+  cloud-dedicated: /influxdb3/cloud-dedicated/admin/tokens/create-token/
+  cloud-serverless: /influxdb3/cloud-serverless/admin/tokens/create-token/
+source: /shared/influxdb3-admin/tokens/admin/create.md
+---
+
+<!-- The content for this page is at
+// SOURCE content/shared/influxdb3-admin/tokens/admin/create.md
+-->

--- a/content/influxdb3/enterprise/admin/tokens/admin/list.md
+++ b/content/influxdb3/enterprise/admin/tokens/admin/list.md
@@ -1,0 +1,21 @@
+---
+title: List an admin token
+description: >
+  Use the `influxdb3 show tokens` command
+  to list the [admin token](/influxdb3/enterprise/admin/tokens/admin/) for your {{< product-name omit="Clustered" >}} instance.
+  An admin token grants access to all actions on the server.
+menu:
+  influxdb3_enterprise:
+    parent: Admin tokens
+weight: 201
+list_code_example: |
+  ##### CLI
+  ```bash
+  influxdb3 show tokens 
+  ```
+source: /shared/influxdb3-admin/tokens/admin/list.md
+---
+
+<!-- The content for this page is at
+// SOURCE content/shared/influxdb3-admin/tokens/admin/list.md
+-->

--- a/content/influxdb3/enterprise/admin/tokens/admin/regenerate.md
+++ b/content/influxdb3/enterprise/admin/tokens/admin/regenerate.md
@@ -1,0 +1,25 @@
+---
+title: Regenerate an admin token
+description: >
+  Use the [`influxdb3 create token --admin` command](/influxdb3/enterprise/reference/cli/influxdb3/create/token/)
+  or the [HTTP API](/influxdb3/enterprise/api/v3/)
+  to regenerate an [admin token](/influxdb3/enterprise/admin/tokens/admin/) for your {{< product-name omit="Clustered" >}} instance.
+  An admin token grants access to all actions on the server.
+  Regenerating an admin token deactivates the previous token.
+menu:
+  influxdb3_enterprise:
+    parent: Admin tokens
+weight: 201
+list_code_example: |
+  ##### CLI
+  ```bash
+  influxdb3 create token --admin \
+    --token ADMIN_TOKEN \
+    --regenerate
+  ```
+source: /shared/influxdb3-admin/tokens/admin/regenerate.md
+---
+
+<!-- The content for this page is at
+// SOURCE content/shared/influxdb3-admin/tokens/admin/create.md
+-->

--- a/content/influxdb3/enterprise/admin/tokens/resource/list.md
+++ b/content/influxdb3/enterprise/admin/tokens/resource/list.md
@@ -1,0 +1,36 @@
+---
+title: List database tokens
+description: >
+  Use the `influxdb3 show tokens` command
+  to list database tokens in your InfluxDB 3 Enterprise instance.
+menu:
+  influxdb3_enterprise:
+    parent: Database tokens
+weight: 202
+list_code_example: |
+  ##### CLI
+  ```bash
+  influxdb3 show tokens \
+    --token ADMIN_TOKEN
+    --host http://{{< influxdb/host >}}
+  ```
+
+  ##### API
+  ```bash
+  curl \
+    --location "http://{{< influxdb/host >}}/api/v3/configure/tokens" \
+    --header "Accept: application/json" \
+    --header "Authorization: Bearer ADMIN_TOKEN"
+  ```
+
+aliases:
+  - /influxdb3/enterprise/admin/tokens/list/
+related:
+  - /influxdb3/enterprise/reference/cli/influxdb3/token/list/
+  - /influxdb3/enterprise/reference/api/
+source: /shared/influxdb3-admin/tokens/database/list.md
+---
+
+<!-- The content for this page is at
+// file://content/shared/influxdb3-admin/tokens/database/list.md
+-->

--- a/content/shared/influxdb3-admin/tokens/_index.md
+++ b/content/shared/influxdb3-admin/tokens/_index.md
@@ -1,0 +1,10 @@
+Manage tokens to authenticate and authorize access to resources and data in your
+{{< product-name >}} instance.
+
+> [!Note]
+> #### Store secure tokens in a secret store
+> 
+> Token strings are returned _only_ on token creation.
+> We recommend storing database tokens in a **secure secret store**.
+
+{{< children hlevel="h2" readmore=true hr=true >}}

--- a/content/shared/influxdb3-admin/tokens/admin/_index.md
+++ b/content/shared/influxdb3-admin/tokens/admin/_index.md
@@ -1,0 +1,6 @@
+  
+Manage admin tokens in your {{< product-name >}} instance.
+An admin token grants
+access to all actions (CLI commands and API endpoints) for the server.
+
+{{< children hlevel="h2" readmore=true hr=true >}}

--- a/content/shared/influxdb3-admin/tokens/admin/create.md
+++ b/content/shared/influxdb3-admin/tokens/admin/create.md
@@ -1,0 +1,33 @@
+
+Use the [`influxdb3 create token --admin` subcommand](/influxdb3/version/reference/cli/influxdb3/create/token/)
+or the [HTTP API](/influxdb3/version/api/v3/)
+to create an [admin token](/influxdb3/version/admin/tokens/admin/) for your {{< product-name omit="Clustered" >}} instance.
+An admin token grants full access to all actions for your InfluxDB 3 instance.
+
+> [!Note]
+> #### Store secure tokens in a secret store
+> 
+> Token strings are returned _only_ on token creation.
+> We recommend storing database tokens in a **secure secret store**.
+> If you lose the admin token string, you must regenerate the token.
+
+## Create an admin token
+
+- [Use the influxdb3 CLI](#use-the-influxdb3-cli)
+- [Use the HTTP API](#use-the-http-api) 
+
+### Use the influxdb3 CLI
+
+Use the `influxdb3 create token --admin` command:
+
+```bash
+influxdb3 create token --admin
+```
+
+The command returns the token string in plain text.
+
+To use the token as the default for later commands, and to persist the token
+across sessions, assign the token string to the `INFLUXDB3_AUTH_TOKEN` environment variable.
+
+> [!Caution]
+> Protect your admin token. Anyone with access to the admin token has full control over your {{< product-name >}} instance.

--- a/content/shared/influxdb3-admin/tokens/admin/list.md
+++ b/content/shared/influxdb3-admin/tokens/admin/list.md
@@ -1,0 +1,29 @@
+Use the `influxdb3` CLI to list tokens, including admin tokens.
+
+## Use the CLI
+
+```bash
+influxdb3 show tokens
+```
+
+The command lists metadata for all tokens in your InfluxDB 3 instance, including
+the `_admin` token.
+The token metadata includes the hash of the token string.
+InfluxDB 3 does not store the token string.
+
+### Output formats
+
+The `influxdb3 show tokens` command supports output formats:
+
+- `pretty` _(default)_
+- `json`
+- `jsonl`
+- `csv`
+<!-- - `parquet` _(must [output to a file](#output-to-a-parquet-file))_ -->
+
+Use the `--format` flag to specify the output format:
+
+```sh
+influxdb3 show tokens \
+  --format json
+```

--- a/content/shared/influxdb3-admin/tokens/admin/regenerate.md
+++ b/content/shared/influxdb3-admin/tokens/admin/regenerate.md
@@ -1,0 +1,15 @@
+
+## Use the CLI to regenerate an admin token
+
+To regenerate an admin token, you can use the `--regenerate` flag with the `influxdb3 create token --admin` subcommand. This revokes the existing admin token.
+
+```bash
+influxdb3 create token --admin \
+  --token ADMIN_TOKEN
+  --host {{< influxdb/host >}}
+  --regenerate
+```
+
+In your command, replace `ADMIN_TOKEN` with the current token string.
+
+By default, `influxdb3` asks for confirmation before regenerating the token.


### PR DESCRIPTION
Add Core and Enterprise guides for managing admin tokens
Doesn't include using API for several operations bc I can't get the endpoints that used to work work now and the request URL is no longer logged by the server.
