### PR TITLE
chore(vsflux): Remove Flux VSCode pages, add notice that vsflux is re…

### DIFF
--- a/content/enterprise_influxdb/v1/tools/_index.md
+++ b/content/enterprise_influxdb/v1/tools/_index.md
@@ -6,6 +6,15 @@ menu:
   enterprise_influxdb_v1:
     name: Tools
     weight: 72
+aliases:
+  - /enterprise_influxdb/v1/tools/flux-vscode/
+prepend: |
+  > [!Important]
+  > #### Flux VS Code extension no longer available
+  >
+  > The `vsflux` extension is no longer available in the Visual Studio Marketplace.
+  >  `vsflux` and the `flux-lsp` Flux Language Server Protocol plugin are no longer maintained.
+  > Their repositories have been archived and are no longer receiving updates.
 ---
 
 Use the following tools to work with InfluxDB Enterprise:

--- a/content/enterprise_influxdb/v1/tools/flux-vscode.md
+++ b/content/enterprise_influxdb/v1/tools/flux-vscode.md
@@ -10,6 +10,14 @@ menu:
   enterprise_influxdb_v1:
     name: Flux VS Code extension
     parent: Tools
+draft: true
+prepend: |
+  > [!Important]
+  > #### Flux VS Code extension no longer available
+  >
+  > The `vsflux` extension is no longer available in the Visual Studio Marketplace.
+  >  `vsflux` and the `flux-lsp` Flux Language Server Protocol plugin are no longer maintained.
+  > Their repositories have been archived and are no longer receiving updates.
 ---
 
 The [Flux Visual Studio Code (VS Code) extension](https://marketplace.visualstudio.com/items?itemName=influxdata.flux)

--- a/content/influxdb/cloud/reference/release-notes/cloud-updates.md
+++ b/content/influxdb/cloud/reference/release-notes/cloud-updates.md
@@ -14,6 +14,14 @@ aliases:
 InfluxDB Cloud updates occur frequently. Find a compilation of recent updates below.
 To find information about the latest Flux updates in InfluxDB Cloud, see [Flux release notes](/influxdb/cloud/reference/release-notes/flux/).
 
+## April 2025
+
+### Flux VS Code extension no longer maintained 
+
+`vsflux` is no longer available in the Visual Studio Marketplace.
+The `vsflux` Visual Studio Code extension and the `flux-lsp` Flux Language Server Protocol plugin are no longer maintained.
+Their repositories have been archived and are no longer receiving updates.
+
 ## October 2022
 
 ### Custom data retention periods 

--- a/content/influxdb/cloud/tools/_index.md
+++ b/content/influxdb/cloud/tools/_index.md
@@ -6,6 +6,15 @@ weight: 13
 menu:
   influxdb_cloud:
     name: Tools & integrations
+aliases:
+  - /influxdb/cloud/tools/flux-vscode/
+prepend: |
+  > [!Important]
+  > #### Flux VS Code extension no longer available
+  >
+  > The `vsflux` extension is no longer available in the Visual Studio Marketplace.
+  >  `vsflux` and the `flux-lsp` Flux Language Server Protocol plugin are no longer maintained.
+  > Their repositories have been archived and are no longer receiving updates.
 ---
 
 {{< children >}}

--- a/content/influxdb/cloud/tools/flux-vscode.md
+++ b/content/influxdb/cloud/tools/flux-vscode.md
@@ -11,6 +11,7 @@ menu:
     name: Flux VS Code extension
     parent: Tools & integrations
 source: /shared/influxdb-v2/tools/flux-vscode.md
+draft: true
 ---
 
 <!-- The content of this file is at 

--- a/content/influxdb/v1/tools/_index.md
+++ b/content/influxdb/v1/tools/_index.md
@@ -4,12 +4,20 @@ description: Tools and utilities for interacting with InfluxDB.
 aliases:
     - /influxdb/v1/clients/
     - /influxdb/v1/write_protocols/json/
+    - /influxdb/v1/tools/flux-vscode/
 menu:
   influxdb_v1:
     name: Tools
     weight: 60
 alt_links:
   v2: /influxdb/v2/tools/
+prepend: |
+  > [!Important]
+  > #### Flux VS Code extension no longer available
+  >
+  > The `vsflux` extension is no longer available in the Visual Studio Marketplace.
+  >  `vsflux` and the `flux-lsp` Flux Language Server Protocol plugin are no longer maintained.
+  > Their repositories have been archived and are no longer receiving updates.
 ---
 
 This section covers the available tools for interacting with InfluxDB.
@@ -34,6 +42,7 @@ The list of [client libraries](/influxdb/v1/tools/api_client_libraries/) for int
 ## InfluxDB inch tool
 
 Use the [InfluxDB `inch` tool](/influxdb/v1/tools/inch/) to test InfluxDB performance. Adjust metrics such as the batch size, tag values, and concurrent write streams to test how ingesting different tag cardinalities and metrics affects performance.
+
 
 ## Graphs and dashboards
 
@@ -60,3 +69,12 @@ SHOW TAG VALUES FROM "your.system"."host_info" WITH KEY = “host”
 ```
 
 > **Note:** In Chronograf, you can also filter meta query results for a specified time range by [creating a `custom meta query` template variable](/chronograf/v1/guides/dashboard-template-variables/#create-custom-template-variables) and adding a time range filter.
+
+## Flux tools
+
+> [!NOTE]
+> #### vsflux and Flux-LSP no longer maintained
+>
+> The `vsflux` Flux VS Code extension and the `flux-lsp` language server plugin for Vim are no longer maintained.
+> Their repositories have been archived and are no longer receiving updates.
+> `vsflux` is no longer available in the Visual Studio Marketplace.

--- a/content/influxdb/v1/tools/flux-vscode.md
+++ b/content/influxdb/v1/tools/flux-vscode.md
@@ -12,6 +12,14 @@ menu:
     parent: Tools
 alt_links:
   v2: /influxdb/v2/tools/flux-vscode/
+draft: true
+prepend: |
+  > [!Important]
+  > #### Flux VS Code extension no longer available
+  >
+  > The `vsflux` extension is no longer available in the Visual Studio Marketplace.
+  >  `vsflux` and the `flux-lsp` Flux Language Server Protocol plugin are no longer maintained.
+  > Their repositories have been archived and are no longer receiving updates.
 ---
 
 The [Flux Visual Studio Code (VS Code) extension](https://marketplace.visualstudio.com/items?itemName=influxdata.flux)

--- a/content/influxdb/v2/tools/_index.md
+++ b/content/influxdb/v2/tools/_index.md
@@ -6,6 +6,15 @@ weight: 13
 menu:
   influxdb_v2:
     name: Tools & integrations
+aliases:
+  - /influxdb/v2/tools/flux-vscode/
+prepend: |
+  > [!Important]
+  > #### Flux VS Code extension no longer available
+  >
+  > The `vsflux` extension is no longer available in the Visual Studio Marketplace.
+  >  `vsflux` and the `flux-lsp` Flux Language Server Protocol plugin are no longer maintained.
+  > Their repositories have been archived and are no longer receiving updates.
 ---
 
 {{< children >}}

--- a/content/influxdb/v2/tools/flux-vscode.md
+++ b/content/influxdb/v2/tools/flux-vscode.md
@@ -11,6 +11,7 @@ menu:
     name: Flux VS Code extension
     parent: Tools & integrations
 source: /shared/influxdb-v2/tools/flux-vscode.md
+draft: true
 ---
 
 <!-- The content for this file is located at

--- a/content/shared/influxdb-v2/tools/flux-vim-lsp.md
+++ b/content/shared/influxdb-v2/tools/flux-vim-lsp.md
@@ -1,4 +1,9 @@
 
+> [!Important]
+> #### Flux-LSP no longer maintained
+> The `flux-lsp` Flux Language Server Protocol plugin is no longer maintained.
+> The [`flux-lsp` repo](https://github.com/influxdata/flux-lsp) has been archived and is no longer receiving updates.
+
 ## Requirements
 
 - Vim 8+

--- a/content/shared/influxdb-v2/tools/flux-vscode.md
+++ b/content/shared/influxdb-v2/tools/flux-vscode.md
@@ -1,4 +1,10 @@
 
+> [!Important]
+> #### vsflux and Flux-LSP no longer maintained
+> `vsflux` is no longer available in the Visual Studio Marketplace.
+> The `vsflux` Visual Studio Code extension and the `flux-lsp` Flux Language Server Protocol plugin are no longer maintained.
+> Their repositories have been archived and are no longer receiving updates.
+
 The [Flux Visual Studio Code (VS Code) extension](https://marketplace.visualstudio.com/items?itemName=influxdata.flux)
 provides Flux syntax highlighting, autocompletion, and a direct InfluxDB server
 integration that lets you run Flux scripts natively and show results in VS Code.


### PR DESCRIPTION
…moved from Marketplace extensions, and vsflux and flux-lsp are archived
Fix broken links.

Closes #5990. 
