### PR TITLE
fix: update docs for Docker

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -301,10 +301,11 @@ services:
     working_dir: /app
   influxdb3-core:
     container_name: influxdb3-core
-    image: quay.io/influxdb/influxdb3-core:latest
+    image: influxdb:3-core
     ports:
       - 8181:8181
     command:
+      - influxdb3
       - serve
       - --node-id=sensors_node0
       - --log-filter=debug

--- a/content/influxdb3/core/install.md
+++ b/content/influxdb3/core/install.md
@@ -139,7 +139,7 @@ The image is available for x86_64 (AMD64) and ARM64 architectures.
 
 <!--pytest.mark.skip-->
 ```bash
-docker pull quay.io/influxdb/influxdb3-{{< product-key >}}:latest
+docker pull influxdb:3-{{< product-key >}}
 ```
 
 Docker automatically pulls the appropriate image for your system architecture.
@@ -150,14 +150,14 @@ To specify the system architecture, use platform-specific tags--for example:
 # For x86_64/AMD64
 docker pull \
 --platform linux/amd64 \
-quay.io/influxdb/influxdb3-{{< product-key >}}:latest
+influxdb:3-{{< product-key >}}
 ```
 
 ```bash
 # For ARM64
 docker pull \
 --platform linux/arm64 \
-quay.io/influxdb/influxdb3-{{< product-key >}}:latest
+influxdb:3-{{< product-key >}}
 ```
 
 > [!Note]
@@ -173,10 +173,11 @@ quay.io/influxdb/influxdb3-{{< product-key >}}:latest
    services:
      influxdb3-{{< product-key >}}:
        container_name: influxdb3-{{< product-key >}}
-       image: quay.io/influxdb/influxdb3-{{< product-key >}}:latest
+       image: influxdb:3-{{< product-key >}}
        ports:
          - 9999:9999
        command:
+         - influxdb3
          - serve
          - --node-id=node0
          - --object-store=file

--- a/content/influxdb3/enterprise/install.md
+++ b/content/influxdb3/enterprise/install.md
@@ -131,7 +131,7 @@ source ~/.zshrc
 
 ## Docker image
 
-Use the `influxdb3-{{< product-key >}}` Docker image to deploy {{< product-name >}} in a
+Use the `influxdb:3-{{< product-key >}}` Docker image to deploy {{< product-name >}} in a
 Docker container.
 The image is available for x86_64 (AMD64) and ARM64 architectures.
 
@@ -139,7 +139,7 @@ The image is available for x86_64 (AMD64) and ARM64 architectures.
 
 <!--pytest.mark.skip-->
 ```bash
-docker pull quay.io/influxdb/influxdb3-{{< product-key >}}:latest
+docker pull influxdb:3-{{< product-key >}}
 ```
 
 Docker automatically pulls the appropriate image for your system architecture.
@@ -150,14 +150,14 @@ To specify the system architecture, use platform-specific tags--for example:
 # For x86_64/AMD64
 docker pull \
 --platform linux/amd64 \
-quay.io/influxdb/influxdb3-{{< product-key >}}:latest
+influxdb:3-{{< product-key >}}
 ```
 
 ```bash
 # For ARM64
 docker pull \
 --platform linux/arm64 \
-quay.io/influxdb/influxdb3-{{< product-key >}}:latest
+influxdb:3-{{< product-key >}}
 ```
 
 > [!Note]
@@ -173,10 +173,11 @@ quay.io/influxdb/influxdb3-{{< product-key >}}:latest
    services:
      influxdb3-{{< product-key >}}:
        container_name: influxdb3-{{< product-key >}}
-       image: quay.io/influxdb/influxdb3-{{< product-key >}}:latest
+       image: influxdb:3-{{< product-key >}}
        ports:
          - 9999:9999
        command:
+         - influxdb3
          - serve
          - --node-id=node0
          - --cluster-id=cluster0


### PR DESCRIPTION
Fixes the install guides to point to Docker instead of Quay in all locations.