### PR TITLE
Influxdb3: Core and list tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules
 !api-docs/**/.config.yml
 /api-docs/redoc-static.html*
 /cypress/screenshots/*
+/influxdb3cli-build-scripts/content
 .vscode/*
 .idea
 **/config.toml

--- a/content/influxdb3/core/admin/tokens/admin/list.md
+++ b/content/influxdb3/core/admin/tokens/admin/list.md
@@ -3,7 +3,7 @@ title: List admin tokens
 description: >
   Use the `influxdb3` CLI or the `/api/v3` HTTP API
   to list admin tokens for your {{< product-name >}} instance.
-  Use the  `influxdb3 show tokens` command to list all tokens or use SQL to query token metadata directly from the `SYSTEM.TOKENS` table.
+  Use the  `influxdb3 show tokens` command to list all tokens or use SQL to query token metadata directly from the `system.tokens` table.
 menu:
   influxdb3_core:
     parent: Admin tokens

--- a/content/influxdb3/core/admin/tokens/admin/list.md
+++ b/content/influxdb3/core/admin/tokens/admin/list.md
@@ -19,7 +19,7 @@ list_code_example: |
   curl -G \
   "http://{{< influxdb/host >}}/api/v3/query_sql" \
   --data-urlencode "db=_internal" \
-  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS WHERE permissions = '*:*:*'" \
+  --data-urlencode "q=SELECT * FROM system.tokens WHERE permissions = '*:*:*'" \
   --header 'Accept: application/json' \
   --header "Authorization: Bearer AUTH_TOKEN"
   ```

--- a/content/influxdb3/core/admin/tokens/admin/list.md
+++ b/content/influxdb3/core/admin/tokens/admin/list.md
@@ -1,9 +1,9 @@
 ---
-title: List an admin token
+title: List admin tokens
 description: >
-  Use the `influxdb3 show tokens` command
-  to list the [admin token](/influxdb3/enterprise/admin/tokens/admin/) for your {{< product-name omit="Clustered" >}} instance.
-  An admin token grants access to all actions on the server.
+  Use the `influxdb3` CLI or the `/api/v3` HTTP API
+  to list admin tokens for your {{< product-name >}} instance.
+  Use the  `influxdb3 show tokens` command to list all tokens or use SQL to query token metadata directly from the `SYSTEM.TOKENS` table.
 menu:
   influxdb3_core:
     parent: Admin tokens
@@ -12,6 +12,16 @@ list_code_example: |
   ##### CLI
   ```bash
   influxdb3 show tokens 
+  ```
+
+  ##### HTTP API
+  ```bash
+  curl -G \
+  "http://{{< influxdb/host >}}/api/v3/query_sql" \
+  --data-urlencode "db=_internal" \
+  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS WHERE permissions = '*:*:*'" \
+  --header 'Accept: application/json' \
+  --header "Authorization: Bearer AUTH_TOKEN"
   ```
 source: /shared/influxdb3-admin/tokens/admin/list.md
 ---

--- a/content/influxdb3/core/reference/cli/influxdb3/create/token.md
+++ b/content/influxdb3/core/reference/cli/influxdb3/create/token.md
@@ -10,6 +10,6 @@ weight: 400
 source: /shared/influxdb3-cli/create/token.md
 ---
 
-<!--
-The content of this file is at content/shared/influxdb3-cli/create/token.md
+<!-- The content for this page is at
+// SOURCE content/shared/influxdb3-cli/create/token.md
 -->

--- a/content/influxdb3/core/reference/cli/influxdb3/show/_index.md
+++ b/content/influxdb3/core/reference/cli/influxdb3/show/_index.md
@@ -11,5 +11,6 @@ source: /shared/influxdb3-cli/show/_index.md
 ---
 
 <!--
-The content of this file is at content/shared/influxdb3-cli/show/_index.md
+The content of this file is at
+// SOURCE content/shared/influxdb3-cli/show/_index.md
 -->

--- a/content/influxdb3/core/reference/cli/influxdb3/show/tokens.md
+++ b/content/influxdb3/core/reference/cli/influxdb3/show/tokens.md
@@ -1,0 +1,16 @@
+---
+title: influxdb3 show tokens 
+description: >
+  The `influxdb3 show tokens` command lists authentication tokens in your
+  InfluxDB 3 Core server.
+menu:
+  influxdb3_core:
+    parent: influxdb3 show
+    name: influxdb3 show tokens 
+weight: 400
+source: /shared/influxdb3-cli/show/tokens.md
+---
+
+<!--The content of this file is at 
+// SOURCE content/shared/influxdb3-cli/show/tokens.md
+-->

--- a/content/influxdb3/enterprise/admin/tokens/admin/list.md
+++ b/content/influxdb3/enterprise/admin/tokens/admin/list.md
@@ -3,7 +3,7 @@ title: List admin tokens
 description: >
   Use the `influxdb3` CLI or the `/api/v3` HTTP API
   to list admin tokens for your {{< product-name >}} instance.
-  Use the  `influxdb3 show tokens` command to list all tokens or use SQL to query token metadata directly from the `SYSTEM.TOKENS` table.
+  Use the  `influxdb3 show tokens` command to list all tokens or use SQL to query token metadata directly from the `system.tokens` table.
 menu:
   influxdb3_enterprise:
     parent: Admin tokens
@@ -19,7 +19,7 @@ list_code_example: |
   curl -G \
   "http://{{< influxdb/host >}}/api/v3/query_sql" \
   --data-urlencode "db=_internal" \
-  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS WHERE permissions = '*:*:*'" \
+  --data-urlencode "q=SELECT * FROM system.tokens WHERE permissions = '*:*:*'" \
   --header 'Accept: application/json' \
   --header "Authorization: Bearer AUTH_TOKEN"
   ```

--- a/content/influxdb3/enterprise/admin/tokens/admin/list.md
+++ b/content/influxdb3/enterprise/admin/tokens/admin/list.md
@@ -1,9 +1,9 @@
 ---
-title: List an admin token
+title: List admin tokens
 description: >
-  Use the `influxdb3 show tokens` command
-  to list the [admin token](/influxdb3/enterprise/admin/tokens/admin/) for your {{< product-name omit="Clustered" >}} instance.
-  An admin token grants access to all actions on the server.
+  Use the `influxdb3` CLI or the `/api/v3` HTTP API
+  to list admin tokens for your {{< product-name >}} instance.
+  Use the  `influxdb3 show tokens` command to list all tokens or use SQL to query token metadata directly from the `SYSTEM.TOKENS` table.
 menu:
   influxdb3_enterprise:
     parent: Admin tokens
@@ -12,6 +12,16 @@ list_code_example: |
   ##### CLI
   ```bash
   influxdb3 show tokens 
+  ```
+
+  ##### HTTP API
+  ```bash
+  curl -G \
+  "http://{{< influxdb/host >}}/api/v3/query_sql" \
+  --data-urlencode "db=_internal" \
+  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS WHERE permissions = '*:*:*'" \
+  --header 'Accept: application/json' \
+  --header "Authorization: Bearer AUTH_TOKEN"
   ```
 source: /shared/influxdb3-admin/tokens/admin/list.md
 ---

--- a/content/influxdb3/enterprise/admin/tokens/resource/create.md
+++ b/content/influxdb3/enterprise/admin/tokens/resource/create.md
@@ -80,10 +80,6 @@ your {{% product-name %}} instance.
 In your terminal, enter `influxdb3 create token` and provide the following:
 
 - `--permission`: Token permissions (read, write) in the `RESOURCE_TYPE:RESOURCE_NAMES:ACTIONS` format--for example:
-- `--name`: A unique name for the token
-- _Options_, for example:
-  -  `--expiry`: The token expiration time as a duration.
-      If an expiration isn't set, the token does not expire until revoked.
 
   ```
   db:DATABASE1,DATABASE2:read,write
@@ -93,7 +89,10 @@ In your terminal, enter `influxdb3 create token` and provide the following:
   - `DATABASE1,DATABASE2`: A comma-separated list of database names to grant permissions to.
     The resource names part supports the `*` wildcard, which grants read or write permissions to all databases.
   - `read,write`: A comma-separated list of permissions to grant to the token.
-
+- `--name`: A unique name for the token
+- _Options_, for example:
+  -  `--expiry`: The token expiration time as a duration.
+      If an expiration isn't set, the token does not expire until revoked.
 {{% code-placeholders "Read-write on DATABASE1, DATABASE2|DATABASE1,DATABASE2|1y|read,write" %}}
 ```bash
 influxdb3 create token \

--- a/content/influxdb3/enterprise/admin/tokens/resource/create.md
+++ b/content/influxdb3/enterprise/admin/tokens/resource/create.md
@@ -13,19 +13,20 @@ weight: 201
 list_code_example: |
   ##### CLI
   ```bash
-  influxdb3 create token --permission \
-    --token ADMIN_TOKEN \
-    --expiry 1y \
+  influxdb3 create token \
+    --permission "db:DATABASE1,DATABASE2:read,write" \
     --name "Read-write on DATABASE1, DATABASE2" \
-    db:DATABASE1,DATABASE2:read,write
+    --token ADMIN_TOKEN \
+    --expiry 1y
   ```
 
   ##### HTTP API
   ```bash
+  curl \
   "http://{{< influxdb/host >}}/api/v3/enterprise/configure/token" \
     --header 'Accept: application/json' \
     --header 'Content-Type: application/json' \
-    --header "Authorization: Bearer ADMIN_TOKEN" \
+    --header "Authorization: Bearer AUTH_TOKEN" \
     --data '{
       "token_name": "Read-write for DATABASE1, DATABASE2",
       "permissions": [{
@@ -41,8 +42,8 @@ alt_links:
   cloud-serverless: /influxdb3/cloud-serverless/admin/tokens/create-token/
 ---
 
-Use the [`influxdb3 create token --permission` command](/influxdb3/enterprise/reference/cli/influxdb3/create/token/)
-or the [`/api/v3/configure/token` HTTP API endpoint](/influxdb3/enterprise/api/v3/)
+Use the [`influxdb3 create token --permission` command](/influxdb3/enterprise/reference/cli/influxdb3/create/token/permission/)
+or the [`/api/v3/configure/token` HTTP API endpoint](/influxdb3/enterprise/api/v3/#operation/PostCreateResourceToken)
 to create fine-grained permissions tokens that grant access to resources such as databases and system information.
 Database tokens allow for reading and writing data in your {{< product-name omit="Clustered" >}} instance.
 System tokens allow for reading system information and metrics for your server.
@@ -52,7 +53,7 @@ After you
 can use the token string to authenticate `influxdb3` commands and HTTP API requests
 for managing database and system tokens.
 
-The HTTP API examples in this guide use [cURL](https://curl.se/) to send an API request, but you can use any HTTP client._
+_The HTTP API examples in this guide use [cURL](https://curl.se/) to send an API request, but you can use any HTTP client._
 
 > [!Note]
 > #### Store secure tokens in a secret store
@@ -65,24 +66,24 @@ The HTTP API examples in this guide use [cURL](https://curl.se/) to send an API 
 
 {{< tabs-wrapper >}}
 {{% tabs %}}
-[influxdb3](#)
+[CLI](#)
 [HTTP API](#)
 {{% /tabs %}}
 {{% tab-content %}}
 
 <!------------------------------- BEGIN INFLUXDB3 ----------------------------->
 
-Use the [`influxdb3 create token` command](/influxdb3/enterprise/reference/cli/influxdb3/create/token/)
+Use the [`influxdb3 create token --permission` command](/influxdb3/enterprise/reference/cli/influxdb3/create/token/permission/)
 to create a database token with fine-grained permissions for reading and writing data in
 your {{% product-name %}} instance.
 
-In your terminal, run the `influxdb3 create token --permission` command and provide the following:
+In your terminal, enter `influxdb3 create token` and provide the following:
 
+- `--permission`: Token permissions (read, write) in the `RESOURCE_TYPE:RESOURCE_NAMES:ACTIONS` format--for example:
 - `--name`: A unique name for the token
 - _Options_, for example:
   -  `--expiry`: The token expiration time as a duration.
       If an expiration isn't set, the token does not expire until revoked.
-- Token permissions (read and write) in the `RESOURCE_TYPE:RESOURCE_NAMES:ACTIONS` format--for example:
 
   ```
   db:DATABASE1,DATABASE2:read,write
@@ -93,25 +94,20 @@ In your terminal, run the `influxdb3 create token --permission` command and prov
     The resource names part supports the `*` wildcard, which grants read or write permissions to all databases.
   - `read,write`: A comma-separated list of permissions to grant to the token.
 
-{{% code-placeholders "DATABASE1|DATABASE2|1y" %}}
-
+{{% code-placeholders "Read-write on DATABASE1, DATABASE2|DATABASE1,DATABASE2|1y|read,write" %}}
 ```bash
 influxdb3 create token \
---permission \
---expiry 1y \
---name "Read-write on DATABASE1, DATABASE2" \
-"db:DATABASE1,DATABASE2:read,write"
+  --permission "db:DATABASE1,DATABASE2:read,write" \
+  --name "Read-write on DATABASE1, DATABASE2" \
+  --expiry 1y
 ```
-
 {{% /code-placeholders %}}
 
 Replace the following:
 
-- {{% code-placeholder-key %}}`DATABASE1`{{% /code-placeholder-key %}}, {{% code-placeholder-key %}}`DATABASE2`{{% /code-placeholder-key %}}:
-  your {{% product-name %}} [database](/influxdb3/enterprise/admin/databases/)
+- {{% code-placeholder-key %}}`DATABASE1`{{% /code-placeholder-key %}}, {{% code-placeholder-key %}}`DATABASE2`{{% /code-placeholder-key %}}: your {{% product-name %}} [database](/influxdb3/enterprise/admin/databases/)
 - {{% code-placeholder-key %}}`1y`{{% /code-placeholder-key %}}:
-  the token expiration time as a
-  duration.
+  the token expiration time as a duration
 
 The output is the token string in plain text.
 
@@ -160,7 +156,6 @@ The following example shows how to use the HTTP API to create a database token:
      "expiry_secs": 300000
   }'
 ```
-
 {{% /code-placeholders %}}
 
 Replace the following in your request:
@@ -168,7 +163,7 @@ Replace the following in your request:
 - {{% code-placeholder-key %}}`DATABASE1`{{% /code-placeholder-key %}}, {{% code-placeholder-key %}}`DATABASE2`{{% /code-placeholder-key %}}:
   your {{% product-name %}} [database](/influxdb3/enterprise/admin/databases/)
 - {{% code-placeholder-key %}}`300000`{{% /code-placeholder-key %}}:
-  the token expiration time in seconds.
+  the token expiration time in seconds
 
 The response body contains token details, including the `token` field with the
 token string in plain text.
@@ -183,41 +178,36 @@ token string in plain text.
 - [Create a token with read and write access to all databases](#create-a-token-with-read-and-write-access-to-all-databases)
 - [Create a token with read-only access to a database](#create-a-token-with-read-only-access-to-a-database)
 - [Create a token with read-only access to multiple databases](#create-a-token-with-read-only-access-to-multiple-databases)
-- [Create a token with mixed permissions to multiple databases](#create-a-token-with-mixed-permissions-to-multiple-databases)
 - [Create a token that expires in seven days](#create-a-token-that-expires-in-seven-days)
 
 In the examples below, replace the following:
 
 - {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}: your {{< product-name >}} [database](/influxdb3/enterprise/admin/databases/)
 - {{% code-placeholder-key %}}`DATABASE2_NAME`{{% /code-placeholder-key %}}: your {{< product-name >}} [database](/influxdb3/enterprise/admin/databases/)
-- {{% code-placeholder-key %}}`ADMIN TOKEN`{{% /code-placeholder-key %}}: the [admin token](/influxdb3/enterprise/admin/tokens/admin/) for your {{% product-name %}} instance 
-{{% code-placeholders "DATABASE_NAME|DATABASE2_NAME|ADMIN_TOKEN" %}}
+- {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}}: the {{% token-link "" "admin" %}} for your {{% product-name %}} instance 
 
 #### Create a token with read and write access to a database
 
+{{% code-placeholders "DATABASE_NAME|AUTH_TOKEN" %}}
 {{< code-tabs-wrapper >}}
 {{% code-tabs %}}
-[influxdb3](#)
+[CLI](#)
 [HTTP API](#)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
-
 ```bash
 influxdb3 create token \
-  --permission \
-  --name "Read/write token for DATABASE_NAME" \
-  db:DATABASE_NAME:read,write
+  --permission "db:DATABASE_NAME:read,write" \
+  --name "Read/write token for DATABASE_NAME"
 ```
-
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
-
 ```bash
 curl \
   "http://{{< influxdb/host >}}/api/v3/enterprise/configure/token" \
   --header 'Accept: application/json' \
   --header 'Content-Type: application/json' \
-  --header "Authorization: Bearer ADMIN_TOKEN" \
+  --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{
     "token_name": "Read/write token for DATABASE_NAME",
     "permissions": [{
@@ -227,35 +217,32 @@ curl \
     }]
   }'
 ```
-
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
+{{% /code-placeholders %}}
 
 #### Create a token with read and write access to all databases
 
+{{% code-placeholders "AUTH_TOKEN" %}}
 {{< code-tabs-wrapper >}}
 {{% code-tabs %}}
-[influxdb3](#)
+[CLI](#)
 [HTTP API](#)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
-
 ```bash
 influxdb3 create token \
-  --permission \
-  --name "Read/write token for all databases" \
-  db:*:read,write
+  --permission "db:*:read,write" \
+  --name "Read/write token for all databases"
 ```
-
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
-
 ```bash
 curl \
   "http://{{< influxdb/host >}}/api/v3/enterprise/configure/token" \
   --header 'Accept: application/json' \
   --header 'Content-Type: application/json' \
-  --header "Authorization: Bearer ADMIN_TOKEN" \
+  --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{
     "token_name": "Read/write token for all databases",
     "permissions": [{
@@ -265,35 +252,32 @@ curl \
     }]
   }'
 ```
-
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
+{{% /code-placeholders %}}
 
 #### Create a token with read-only access to a database
 
+{{% code-placeholders "DATABASE_NAME|AUTH_TOKEN" %}}
 {{< code-tabs-wrapper >}}
 {{% code-tabs %}}
-[influxdb3](#)
+[CLI](#)
 [HTTP API](#)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
-
 ```bash
 influxdb3 create token \
-  --permission \
-  --name "Read-only token for DATABASE_NAME" \
-  db:DATABASE_NAME:read
+  --permission "db:DATABASE_NAME:read" \
+  --name "Read-only token for DATABASE_NAME"
 ```
-
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
-
 ```bash
 curl \
   "http://{{< influxdb/host >}}/api/v3/enterprise/configure/token" \
   --header 'Accept: application/json' \
   --header 'Content-Type: application/json' \
-  --header "Authorization: Bearer ADMIN_TOKEN" \
+  --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{
     "token_name": "Read-only token for DATABASE_NAME",
     "permissions": [{
@@ -303,37 +287,34 @@ curl \
     }]
   }'
 ```
-
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
+{{% /code-placeholders %}}
 
 #### Create a token with read-only access to multiple databases
 
+{{% code-placeholders "DATABASE_NAME|DATABASE2_NAME|AUTH_TOKEN" %}}
 {{< code-tabs-wrapper >}}
 {{% code-tabs %}}
-[influxdb3](#)
+[CLI](#)
 [HTTP API](#)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
-
 ```bash
 influxdb3 create token \
-  --permission \
-  --name "Read-only token for DATABASE_NAME and DATABASE2_NAME" \
-  db:DATABASE_NAME,DATABASE2_NAME:read
+  --permission "db:DATABASE_NAME,DATABASE2_NAME:read" \
+  --name "Read-only token for DATABASE_NAME, DATABASE2_NAME"
 ```
-
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
-
 ```bash
 curl \
   "http://{{< influxdb/host >}}/api/v3/enterprise/configure/token" \
   --header 'Accept: application/json' \
   --header 'Content-Type: application/json' \
-  --header "Authorization: Bearer ADMIN_TOKEN" \
+  --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{
-    "token_name": "Read-only token for DATABASE_NAME and DATABASE2_NAME",
+    "token_name": "Read-only token for DATABASE_NAME, DATABASE2_NAME",
     "permissions": [{
       "resource_type": "db",
       "resource_identifier": ["DATABASE_NAME","DATABASE2_NAME"],
@@ -341,36 +322,33 @@ curl \
     }]
   }'
 ```
-
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
+{{% /code-placeholders %}}
 
 #### Create a token that expires in seven days
 
+{{% code-placeholders "DATABASE_NAME|7d|604800|AUTH_TOKEN" %}}
 {{< code-tabs-wrapper >}}
 {{% code-tabs %}}
-[influxdb3](#)
+[CLI](#)
 [HTTP API](#)
 {{% /code-tabs %}}
 {{% code-tab-content %}}
-
 ```bash
 influxdb3 create token \
-  --permission \
-  --expiry 7d \
+  --permission "db:DATABASE_NAME:read,write" \
   --name "Read/write token for DATABASE_NAME with 7d expiration" \
-  db:DATABASE_NAME:read,write
+  --expiry 7d
 ```
-
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
-
 ```bash
 curl \
   "http://{{< influxdb/host >}}/api/v3/enterprise/configure/token" \
   --header 'Accept: application/json' \
   --header 'Content-Type: application/json' \
-  --header "Authorization: Bearer ADMIN_TOKEN" \
+  --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{
     "token_name": "Read/write token for DATABASE_NAME with 7d expiration",
     "permissions": [{
@@ -381,10 +359,8 @@ curl \
     "expiry_secs": 604800
   }'
 ```
-
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
-
 {{% /code-placeholders %}}
 
 ## Create a system token
@@ -400,7 +376,7 @@ You can create system tokens for the following system resources:
 
 {{< tabs-wrapper >}}
 {{% tabs %}}
-[influxdb3](#)
+[CLI](#)
 [HTTP API](#)
 {{% /tabs %}}
 {{% tab-content %}}
@@ -413,7 +389,6 @@ your {{% product-name %}} instance.
 
 In your terminal, run the `influxdb3 create token --permission` command and provide the following:
 
-  
   - `--name`: A unique name for the token
   - _Options_, for example:
     -  `--expiry`: The token expiration time as a duration.
@@ -428,16 +403,13 @@ In your terminal, run the `influxdb3 create token --permission` command and prov
     - `health`: The specific system resource to grant permissions to.
     - `read`: The permission to grant to the token (system tokens are always read-only).
 
-{{% code-placeholders "1y" %}}
-
+{{% code-placeholders "System health token|1y" %}}
 ```bash
 influxdb3 create token \
---permission \
---expiry 1y \
---name "System health token" \
-"system:health:read"
+  --permission "system:health:read" \
+  --name "System health token" \
+  --expiry 1y
 ```
-
 {{% /code-placeholders %}}
 
 Replace the following:
@@ -475,14 +447,14 @@ In the request body, provide the following parameters:
 
 The following example shows how to use the HTTP API to create a system token:
 
-{{% code-placeholders "300000" %}}
+{{% code-placeholders "AUTH_TOKEN|System health token|300000" %}}
 
 ```bash
 curl \
 "http://{{< influxdb/host >}}/api/v3/enterprise/configure/token" \
 --header 'Accept: application/json' \
 --header 'Content-Type: application/json' \
---header "Authorization: Bearer ADMIN_TOKEN" \
+--header "Authorization: Bearer AUTH_TOKEN" \
 --data '{
   "token_name": "System health token",
   "permissions": [{
@@ -493,7 +465,6 @@ curl \
    "expiry_secs": 300000
 }'
 ```
-
 {{% /code-placeholders %}}
 
 Replace the following in your request:
@@ -507,7 +478,6 @@ token string in plain text.
 <!------------------------------- END cURL ------------------------------------>
 {{% /tab-content %}}
 {{< /tabs-wrapper >}}
-
 
 ## Output format
 

--- a/content/influxdb3/enterprise/admin/tokens/resource/list.md
+++ b/content/influxdb3/enterprise/admin/tokens/resource/list.md
@@ -1,8 +1,10 @@
 ---
 title: List resource tokens
 description: >
-  Use the `influxdb3 show tokens` command
-  to list resource tokens in your InfluxDB 3 Enterprise instance.
+  Use the `influxdb3` CLI or the HTTP API to list resource tokens with fine-grained
+  access permissions in your {{% product-name %}} instance. 
+  Use the  `influxdb3 show tokens` command to list all tokens or use SQL to query token
+  metadata directly from the `SYSTEM.TOKENS` table.
 menu:
   influxdb3_enterprise:
     parent: Resource tokens
@@ -10,18 +12,241 @@ weight: 202
 list_code_example: |
   ##### CLI
   ```bash
-  influxdb3 show tokens \
-    --token ADMIN_TOKEN
-    --host http://{{< influxdb/host >}}
+  influxdb3 show tokens
   ```
-aliases:
-  - /influxdb3/enterprise/admin/tokens/list/
+  
+  ##### HTTP API
+  ```bash
+  curl -G \
+  "http://{{< influxdb/host >}}/api/v3/query_sql" \
+  --data-urlencode "db=_internal" \
+  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS WHERE permissions NOT LIKE '\*%'" \
+  --header 'Accept: application/json' \
+  --header "Authorization: Bearer AUTH_TOKEN" 
+  ```
 related:
   - /influxdb3/enterprise/reference/cli/influxdb3/token/list/
   - /influxdb3/enterprise/reference/api/
-source: /shared/influxdb3-admin/tokens/admin/list.md
 ---
 
-<!-- The content for this page is at
-// SOURCE content/shared/influxdb3-admin/tokens/admin/list.md
--->
+Use the `influxdb3` CLI or the HTTP API to list resource tokens with fine-grained
+access permissions in your {{% product-name %}} instance. 
+Use the  `influxdb3 show tokens` command to list all tokens or use SQL to query token
+metadata directly from the `SYSTEM.TOKENS` table.
+
+Resource tokens have fine-grained permissions for InfluxDB 3 resources, such
+as databases and system tables.
+The permissions are in the format `RESOURCE_TYPE:RESOURCE_NAMES:ACTIONS`.
+
+- `RESOURCE_TYPE` is the type of resource (for example, `db`, `system`)
+- `RESOURCE_NAMES` is the specific resource name (for example, a list of database names or `*` for all)
+- `ACTIONS` is the permission level (`read`, `write`, or `*` for all)
+
+Database resource tokens have permissions in the format `db:database_names:actions`.
+System resource tokens have permissions in the format `system:system_endpoint_names:read`.
+
+_In the following examples, replace {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}}
+with your InfluxDB {{% token-link %}}{{% show-in "enterprise" %}}
+that has read permission on the `_internal` system database{{% /show-in %}}._
+
+## List all tokens
+
+The `influxdb3 show tokens` CLI command lists all admin and resource tokens in your InfluxDB 3 instance.
+
+```bash
+influxdb3 show tokens
+```
+
+## Query token metadata
+
+To filter tokens and retrieve specific details using SQL, query the `system.tokens` table in the
+`_internal` system database--for example:
+
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[CLI](#cli-filter-in-query)
+[HTTP API](#http-api-filter-in-query)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN CLI----------------------------------------->
+
+```bash
+influxdb3 query \
+  --db _internal \
+  "SELECT name, permissions FROM SYSTEM.TOKENS WHERE permissions  NOT LIKE '\*%'"
+```
+<!---------------------------END CLI------------------------------------------->
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+{{% code-placeholders "AUTH_TOKEN" %}}
+<!---------------------------BEGIN HTTP API---------------------------------->
+```bash
+curl -G \
+"http://{{< influxdb/host >}}/api/v3/query_sql" \
+--data-urlencode "db=_internal" \
+--data-urlencode "q=SELECT * FROM SYSTEM.TOKENS WHERE permissions NOT LIKE '\*%'" \
+--header 'Accept: application/json' \
+--header "Authorization: Bearer AUTH_TOKEN" 
+```
+{{% /code-placeholders %}}
+<!-----------------------------END HTTP API------------------------------------>
+{{% /code-tab-content %}}
+{{% /code-tabs-wrapper %}}
+
+## Format the output 
+
+Use the format option to specify the output format for
+the `influxdb3 show tokens` command or the HTTP API response.
+
+{{% product-name %}} supports the following output formats:
+
+- `pretty` _(default for CLI)_
+- `json` _(default for HTTP API)_
+- `jsonl`
+- `csv`
+- `parquet` _([output to a file](#output-to-a-parquet-file))_
+
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[CLI](#format-using-the-cli)
+[HTTP API](#format-using-the-api)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN CLI----------------------------------------->
+
+```bash
+influxdb3 show tokens \
+  --format csv
+```
+<!---------------------------END CLI------------------------------------------->
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN HTTP API---------------------------------->
+
+{{% code-placeholders "AUTH_TOKEN" %}}
+```bash
+curl -G \
+  "http://{{< influxdb/host >}}/api/v3/query_sql" \
+  --data-urlencode "db=_internal" \
+  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS" \
+  --data-urlencode "format=csv" \
+  --header 'Accept: text/csv' \
+  --header "Authorization: Bearer AUTH_TOKEN"
+```
+{{% /code-placeholders %}}
+{{% /code-tab-content %}}
+{{% /code-tabs-wrapper %}}
+
+### Output to a Parquet file
+
+[Parquet](https://parquet.apache.org/) is a binary format.
+
+To output to a Parquet file using the CLI, include the `--output` option 
+with a destination path for the file.
+
+To output a Parquet file using the HTTP API, your client must be able to handle binary data--for example,
+using cURL's `--output` option.
+
+{{% code-placeholders "AUTH_TOKEN|(/PATH/TO/FILE.parquet)" %}}
+{{% code-tabs-wrapper %}}
+{{% code-tabs %}}
+[CLI](#cli-output-to-parquet)
+[HTTP API](#http-api-output-to-parquet)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN CLI----------------------------------------->
+```bash
+influxdb3 show tokens \
+  --format parquet \
+  --output /PATH/TO/FILE.parquet
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN HTTP API---------------------------------->
+```bash
+curl -G \
+  "http://{{< influxdb/host >}}/api/v3/query_sql" \
+  --data-urlencode "db=_internal" \
+  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS" \
+  --data-urlencode "format=parquet" \
+  --header "Accept: application/parquet" \
+  --header "Authorization: Bearer AUTH_TOKEN" \
+  --output /PATH/TO/FILE.parquet
+```
+<!-----------------------------END HTTP API------------------------------------>
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+{{% /code-placeholders %}}
+
+Replace {{% code-placeholder-key %}}`/PATH/TO/FILE.parquet`{{% /code-placeholder-key %}}
+with the path to the file where you want to save the Parquet data.
+
+## Filter the output for resource tokens
+
+You can use tools such as `grep` or `jq` to filter the token list--for example:
+
+Use `grep` to filter for resource (non-admin) tokens:
+
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[CLI](#cli-filter-output-using-grep)
+[HTTP API](#list-tokens-using-the-api)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN CLI----------------------------------------->
+
+```bash
+influxdb3 show tokens --format pretty | grep -v "*:*:*"
+```
+<!---------------------------END CLI------------------------------------------->
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN HTTP API---------------------------------->
+{{% code-placeholders "AUTH_TOKEN" %}}
+```bash
+curl -G \
+  "http://localhost:8181/api/v3/query_sql" \
+  --data-urlencode "db=_internal" \
+  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS" \
+  --data-urlencode "format=jsonl" \
+  --header 'Accept: application/json' \
+  --header "Authorization: Bearer AUTH_TOKEN" |
+grep -v "*:*:*"
+```
+{{% /code-placeholders %}}
+{{% /code-tab-content %}}
+{{% /code-tabs-wrapper %}}
+
+Use `jq` to filter for system tokens and display their permissions:
+
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[CLI](#filter-output-using-the-cli)
+[HTTP API](#filter-output-using-the-api)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN CLI----------------------------------------->
+
+```bash
+influxdb3 show tokens --format json |
+jq '.[] | select(.permissions | startswith("system:")) | {name: .name, permissions: .permissions}'
+```
+<!---------------------------END CLI------------------------------------------->
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN HTTP API---------------------------------->
+{{% code-placeholders "AUTH_TOKEN" %}}
+```bash
+curl -G \
+  "http://{{< influxdb/host >}}/api/v3/query_sql" \
+  --data-urlencode "db=_internal" \
+  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS" \
+  --data-urlencode "format=json" \
+  --header "Accept: application/json" \
+  --header "Authorization: Bearer AUTH_TOKEN" |
+jq '.[] | select(.permissions | startswith("system:")) | {name: .name, permissions: .permissions}'
+```
+{{% /code-placeholders %}}
+<!-----------------------------END HTTP API------------------------------------>
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}

--- a/content/influxdb3/enterprise/admin/tokens/resource/list.md
+++ b/content/influxdb3/enterprise/admin/tokens/resource/list.md
@@ -4,7 +4,7 @@ description: >
   Use the `influxdb3` CLI or the HTTP API to list resource tokens with fine-grained
   access permissions in your {{% product-name %}} instance. 
   Use the  `influxdb3 show tokens` command to list all tokens or use SQL to query token
-  metadata directly from the `SYSTEM.TOKENS` table.
+  metadata directly from the `system.tokens` table.
 menu:
   influxdb3_enterprise:
     parent: Resource tokens
@@ -20,7 +20,7 @@ list_code_example: |
   curl -G \
   "http://{{< influxdb/host >}}/api/v3/query_sql" \
   --data-urlencode "db=_internal" \
-  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS WHERE permissions NOT LIKE '\*%'" \
+  --data-urlencode "q=SELECT * FROM system.tokens WHERE permissions NOT LIKE '\*%'" \
   --header 'Accept: application/json' \
   --header "Authorization: Bearer AUTH_TOKEN" 
   ```
@@ -32,7 +32,7 @@ related:
 Use the `influxdb3` CLI or the HTTP API to list resource tokens with fine-grained
 access permissions in your {{% product-name %}} instance. 
 Use the  `influxdb3 show tokens` command to list all tokens or use SQL to query token
-metadata directly from the `SYSTEM.TOKENS` table.
+metadata directly from the `system.tokens` table.
 
 Resource tokens have fine-grained permissions for InfluxDB 3 resources, such
 as databases and system tables.
@@ -73,7 +73,7 @@ To filter tokens and retrieve specific details using SQL, query the `system.toke
 ```bash
 influxdb3 query \
   --db _internal \
-  "SELECT name, permissions FROM SYSTEM.TOKENS WHERE permissions  NOT LIKE '\*%'"
+  "SELECT name, permissions FROM system.tokens WHERE permissions  NOT LIKE '\*%'"
 ```
 <!---------------------------END CLI------------------------------------------->
 {{% /code-tab-content %}}
@@ -84,7 +84,7 @@ influxdb3 query \
 curl -G \
 "http://{{< influxdb/host >}}/api/v3/query_sql" \
 --data-urlencode "db=_internal" \
---data-urlencode "q=SELECT * FROM SYSTEM.TOKENS WHERE permissions NOT LIKE '\*%'" \
+--data-urlencode "q=SELECT * FROM system.tokens WHERE permissions NOT LIKE '\*%'" \
 --header 'Accept: application/json' \
 --header "Authorization: Bearer AUTH_TOKEN" 
 ```
@@ -128,7 +128,7 @@ influxdb3 show tokens \
 curl -G \
   "http://{{< influxdb/host >}}/api/v3/query_sql" \
   --data-urlencode "db=_internal" \
-  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS" \
+  --data-urlencode "q=SELECT * FROM system.tokens" \
   --data-urlencode "format=csv" \
   --header 'Accept: text/csv' \
   --header "Authorization: Bearer AUTH_TOKEN"
@@ -167,7 +167,7 @@ influxdb3 show tokens \
 curl -G \
   "http://{{< influxdb/host >}}/api/v3/query_sql" \
   --data-urlencode "db=_internal" \
-  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS" \
+  --data-urlencode "q=SELECT * FROM system.tokens" \
   --data-urlencode "format=parquet" \
   --header "Accept: application/parquet" \
   --header "Authorization: Bearer AUTH_TOKEN" \
@@ -196,7 +196,7 @@ Use `grep` to filter for resource (non-admin) tokens:
 <!---------------------------BEGIN CLI----------------------------------------->
 
 ```bash
-influxdb3 show tokens --format pretty | grep -v "*:*:*"
+influxdb3 show tokens --format pretty | grep -v '*:*:*'
 ```
 <!---------------------------END CLI------------------------------------------->
 {{% /code-tab-content %}}
@@ -207,7 +207,7 @@ influxdb3 show tokens --format pretty | grep -v "*:*:*"
 curl -G \
   "http://localhost:8181/api/v3/query_sql" \
   --data-urlencode "db=_internal" \
-  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS" \
+  --data-urlencode "q=SELECT * FROM system.tokens" \
   --data-urlencode "format=jsonl" \
   --header 'Accept: application/json' \
   --header "Authorization: Bearer AUTH_TOKEN" |
@@ -240,7 +240,7 @@ jq '.[] | select(.permissions | startswith("system:")) | {name: .name, permissio
 curl -G \
   "http://{{< influxdb/host >}}/api/v3/query_sql" \
   --data-urlencode "db=_internal" \
-  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS" \
+  --data-urlencode "q=SELECT * FROM system.tokens" \
   --data-urlencode "format=json" \
   --header "Accept: application/json" \
   --header "Authorization: Bearer AUTH_TOKEN" |

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/create/token/_index.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/create/token/_index.md
@@ -1,0 +1,19 @@
+---
+title: influxdb3 create token
+description: >
+  The `influxdb3 create token` command creates an admin token or a resource (fine-grained
+  permissions) token for authenticating and authorizing actions in an {{% product-name %}} instance.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3
+    name: influxdb3 create token
+weight: 300
+aliases:
+  - /influxdb3/enterprise/reference/cli/influxdb3/create/token/admin/
+source: /shared/influxdb3-cli/create/token.md
+---
+
+<!-- 
+The content of this page is at
+// SOURCE content/shared/influxdb3-cli/create/token.md
+-->

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/create/token/permission.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/create/token/permission.md
@@ -5,7 +5,7 @@ description: >
   with fine-grained access permissions for specific resources in {{< product-name >}}.
 menu:
   influxdb3_enterprise:
-    parent: influxdb3
+    parent: influxdb3 create token
     name: influxdb3 create token --permission
 weight: 300
 ---

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/create/token/permission.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/create/token/permission.md
@@ -33,9 +33,9 @@ influxdb3 create token --permission <PERMISSION> --name <NAME> [OPTIONS]
 | | `--token <AUTH_TOKEN>` | The {{% token-link "enterprise" "admin" %}} [env: INFLUXDB3_AUTH_TOKEN=] |
 | | `--expiry <DURATION>` | The token expiration time as a duration (for example, 1h, 7d, 1y). If not set, the token does not expire until revoked |
 | | `--tls-ca <CA_CERT>` | An optional arg to use a custom CA for testing with self-signed certs [env: INFLUXDB3_TLS_CA=] |
-| | `--format <FORMAT>` | Output format for token, supports just json or text [possible values: json, text] |
+| | `--format <FORMAT>` | Output format (`json` or `text` _(default)_) |
 | `-h` | `--help` | Print help information |
-| | `--help-all` | Print more detailed help information |
+| | `--help-all` | Print detailed help information |
 
 ## Permission Format
 

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/create/token/permission.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/create/token/permission.md
@@ -1,0 +1,117 @@
+---
+title: influxdb3 create token --permission
+description: >
+  The `influxdb3 create token` command with the `--permission` option creates a new authentication token
+  with fine-grained access permissions for specific resources in {{< product-name >}}.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3
+    name: influxdb3 create token --permission
+weight: 300
+---
+
+The `influxdb3 create token` command with the `--permission` option creates a new authentication token
+with fine-grained access permissions for specific resources in {{< product-name >}}.
+
+Fine-grained access permissions allow you to specify the exact actions, such as
+`read` and `write` that a token can perform on a specific resource, such as 
+a database or a system information endpoint.
+
+## Usage
+
+```bash
+influxdb3 create token --permission <PERMISSION> --name <NAME> [OPTIONS]
+```
+
+## Options
+
+| Option | | Description |
+| :----- | :----------- | :----------------------------- |
+| | `--permission <PERMISSION>` | Permissions in `RESOURCE_TYPE:RESOURCE_NAMES:ACTIONS` format--for example, `db:*:read,write`, `system:*:read`. `--permission` may be specified multiple times |
+| | `--name <NAME>` | Name of the token |
+| `-H` | `--host <HOST_URL>` | The host URL of the running InfluxDB 3 Enterprise server [env: INFLUXDB3_HOST_URL=] [default: http://127.0.0.1:8181] |
+| | `--token <AUTH_TOKEN>` | The {{% token-link "enterprise" "admin" %}} [env: INFLUXDB3_AUTH_TOKEN=] |
+| | `--expiry <DURATION>` | The token expiration time as a duration (for example, 1h, 7d, 1y). If not set, the token does not expire until revoked |
+| | `--tls-ca <CA_CERT>` | An optional arg to use a custom CA for testing with self-signed certs [env: INFLUXDB3_TLS_CA=] |
+| | `--format <FORMAT>` | Output format for token, supports just json or text [possible values: json, text] |
+| `-h` | `--help` | Print help information |
+| | `--help-all` | Print more detailed help information |
+
+## Permission Format
+
+The `--permission` option takes a value in the format `RESOURCE_TYPE:RESOURCE_NAMES:ACTIONS`.
+
+- `RESOURCE_TYPE`: Available resource types include:
+  - `db` for databases
+  - `system` for system information endpoints.
+- `RESOURCE_NAMES`: Can be a specific resource name, such as a database name, a
+  comma-separated list of names, or `*` to grant access to all resources of the type.
+- `ACTIONS`: A list of actions. Available actions depend on the resource type.
+
+## Examples
+
+### Create a token with read and write access to a database
+
+```bash
+influxdb3 create token \
+  --permission "db:my_database:read,write" \
+  --name "Read/write token for my_database"
+```
+
+### Create a token with read-only access to a database
+
+```bash
+influxdb3 create token \
+  --permission "db:my_database:read" \
+  --name "Read-only token for my_database"
+```
+
+### Create a token with access to multiple databases
+
+```bash
+influxdb3 create token \
+  --permission "db:database1,database2:read,write" \
+  --name "Multi-database token"
+```
+
+### Create a token with access to all databases
+
+```bash
+influxdb3 create token \
+  --permission "db:*:read,write" \
+  --name "All databases token"
+```
+
+### Create a token that expires in seven days
+
+```bash
+influxdb3 create token \
+  --permission "db:my_database:read,write" \
+  --name "Expiring token" \
+  --expiry 7d
+```
+
+### Create a system token for health information
+
+```bash
+influxdb3 create token \
+  --permission "system:health:read" \
+  --name "System health token"
+```
+
+### Create a token with access to all system information 
+
+```bash
+influxdb3 create token \
+  --permission "system:*:read" \
+  --name "All system information"
+```
+
+### Create a token with multiple permissions
+
+```bash
+influxdb3 create token \
+  --permission "db:database1:read,write" \
+  --permission "system:health:read" \
+  --name "Multi-permission token"
+```

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/show/tokens.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/show/tokens.md
@@ -1,0 +1,16 @@
+---
+title: influxdb3 show tokens 
+description: >
+  The `influxdb3 show tokens` command lists authentication tokens in your
+  InfluxDB 3 Enterprise server.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 show
+    name: influxdb3 show tokens 
+weight: 400
+source: /shared/influxdb3-cli/show/tokens.md
+---
+
+<!--The content of this file is at 
+// SOURCE content/shared/influxdb3-cli/show/tokens.md
+-->

--- a/content/shared/influxdb3-admin/tokens/admin/list.md
+++ b/content/shared/influxdb3-admin/tokens/admin/list.md
@@ -1,29 +1,244 @@
-Use the `influxdb3` CLI to list tokens, including admin tokens.
+Use the `influxdb3` CLI or the `/api/v3` HTTP API to list _admin_ tokens for your
+{{% product-name %}} instance.
 
-## Use the CLI
+Admin tokens have `permissions=*:*:*`, which allows access to all
+data and resources in your InfluxDB 3 instance.
+
+> [!NOTE]
+> Token metadata includes the hashed token string.
+> InfluxDB 3 does not store the token string.
+
+In the following examples, replace {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}} with your InfluxDB {{% token-link "admin" %}}
+{{% show-in "enterprise" %}} or a token with read permission on the `_internal` system database`{{% /show-in %}}.
+
+## List all tokens
+
+The `influxdb3 show tokens` CLI command lists all admin and resource tokens in your InfluxDB 3 instance.
 
 ```bash
 influxdb3 show tokens
 ```
 
-The command lists metadata for all tokens in your InfluxDB 3 instance, including
-the `_admin` token.
-The token metadata includes the hash of the token string.
-InfluxDB 3 does not store the token string.
+## Query token metadata
 
-### Output formats
+To filter tokens and retrieve specific details using SQL, query the `system.tokens` table in the
+`_internal` system database--for example:
 
-The `influxdb3 show tokens` command supports output formats:
+### Filter for admin tokens
 
-- `pretty` _(default)_
-- `json`
+{{% code-placeholders "AUTH_TOKEN" %}}
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[CLI](#cli-query-tokens)
+[HTTP API](#http-api-query-tokens)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN CLI----------------------------------------->
+```bash
+influxdb3 query \
+  --database _internal \
+  --format csv \
+  "SELECT name, permissions FROM SYSTEM.TOKENS WHERE permissions = '*:*:*'"
+```
+<!---------------------------END CLI------------------------------------------->
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN HTTP API---------------------------------->
+```bash
+curl -G \
+  "http://{{< influxdb/host >}}/api/v3/query_sql" \
+  --data-urlencode "db=_internal" \
+  --data-urlencode "q=SELECT name, permissions FROM SYSTEM.TOKENS WHERE permissions = '*:*:*'" \
+  --data-urlencode "format=csv" \
+  --header 'Accept: text/csv' \
+  --header "Authorization: Bearer AUTH_TOKEN"
+```
+<!-----------------------------END HTTP API------------------------------------>
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+{{% /code-placeholders %}}
+
+### Filter by date
+
+{{% code-placeholders "AUTH_TOKEN" %}}
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[CLI](#cli-filter-in-query)
+[HTTP API](#http-api-filter-in-query)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN CLI----------------------------------------->
+```bash
+influxdb3 query \
+  --db _internal \
+  "SELECT name, permissions FROM SYSTEM.TOKENS WHERE created_at > '2025-01-01 00:00:00'"
+```
+<!---------------------------END CLI------------------------------------------->
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN HTTP API---------------------------------->
+```bash
+curl -G \
+"http://{{< influxdb/host >}}/api/v3/query_sql" \
+--data-urlencode "db=_internal" \
+--data-urlencode "q=SELECT name, permissions FROM SYSTEM.TOKENS WHERE created_at > '2025-01-01 00:00:00'" \
+--header "Accept: application/json" \
+--header "Authorization: Bearer AUTH_TOKEN" 
+```
+<!-----------------------------END HTTP API------------------------------------>
+{{% /code-tab-content %}}
+{{% /code-tabs-wrapper %}}
+{{% /code-placeholders %}}
+
+## Output formats
+
+Use the format option to specify the output format for
+commands.
+
+{{% product-name %}} commands used in this guide support the following output formats:
+
+- `json` _(default for HTTP API)_
+- `pretty` _(default for CLI)_
 - `jsonl`
 - `csv`
-<!-- - `parquet` _(must [output to a file](#output-to-a-parquet-file))_ -->
+- `parquet` _([output to a file](#output-to-a-parquet-file))_
 
-Use the `--format` flag to specify the output format:
-
-```sh
+{{% code-placeholders "AUTH_TOKEN" %}}
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[CLI](#format-using-the-cli)
+[HTTP API](#format-using-the-api)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN CLI----------------------------------------->
+```bash
 influxdb3 show tokens \
-  --format json
+  --format jsonl
 ```
+<!---------------------------END CLI------------------------------------------->
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN HTTP API---------------------------------->
+```bash
+curl -G \
+  "http://{{< influxdb/host >}}/api/v3/query_sql" \
+  --data-urlencode "db=_internal" \
+  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS" \
+  --data-urlencode "format=csv" \
+  --header 'Accept: text/csv' \
+  --header "Authorization: Bearer AUTH_TOKEN"
+```
+{{% /code-tab-content %}}
+{{% /code-tabs-wrapper %}}
+{{% /code-placeholders %}}
+
+### Output to a Parquet file
+
+[Parquet](https://parquet.apache.org/) is a binary format.
+
+To output to a Parquet file using the CLI, include the `--output` option 
+with a destination path for the file.
+
+To output a Parquet file using the HTTP API, your client must be able to handle binary data--for example,
+using cURL's `--output` option.
+
+{{% code-placeholders "AUTH_TOKEN|(/PATH/TO/FILE.parquet)" %}}
+{{% code-tabs-wrapper %}}
+{{% code-tabs %}}
+[CLI](#cli-output-to-parquet)
+[HTTP API](#http-api-output-to-parquet)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN CLI----------------------------------------->
+```bash
+influxdb3 show tokens \
+  --format parquet \
+  --output /PATH/TO/FILE.parquet
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN HTTP API---------------------------------->
+```bash
+curl -G \
+"http://{{< influxdb/host >}}/api/v3/query_sql" \
+--data-urlencode "db=_internal" \
+--data-urlencode "q=SELECT * FROM SYSTEM.TOKENS" \
+--data-urlencode "format=parquet" \
+--header "Accept: application/parquet" \
+--header "Authorization: Bearer AUTH_TOKEN" \
+--output /PATH/TO/FILE.parquet
+```
+<!-----------------------------END HTTP API------------------------------------>
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+{{% /code-placeholders %}}
+
+Replace {{% code-placeholder-key %}}`/PATH/TO/FILE.parquet`{{% /code-placeholder-key %}}
+with the path to the file where you want to save the Parquet data.
+
+## Filter the token list
+
+Use command-line tools such as `grep` or `jq` to filter the output of the
+`influxdb3 show tokens` command or the HTTP API response--for example:
+
+{{% code-placeholders "AUTH_TOKEN" %}}
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[CLI](#cli-filter-admin-using-grep)
+[HTTP API](#http-api-filter-admin-using-grep)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN CLI----------------------------------------->
+```bash
+influxdb3 show tokens --format pretty |
+grep _admin
+```
+<!---------------------------END CLI------------------------------------------->
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN HTTP API---------------------------------->
+```bash
+curl -G \
+  "http://{{< influxdb/host >}}/api/v3/query_sql" \
+  --data-urlencode "db=_internal" \
+  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS" \
+  --data-urlencode "format=pretty" \
+  --header "Accept: application/json" \
+  --header "Authorization: Bearer AUTH_TOKEN" |
+grep _admin 
+```
+<!-----------------------------END HTTP API------------------------------------>
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+{{% /code-placeholders %}}
+
+{{% code-placeholders "AUTH_TOKEN" %}}
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[CLI](#cli-filter-output-using-jq)
+[HTTP API](#http-api-filter-output-using-jq)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN CLI----------------------------------------->
+```bash
+influxdb3 show tokens --format json |
+jq '.[] | {name: .name, permissions: .permissions}'
+```
+<!---------------------------END CLI------------------------------------------->
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+<!---------------------------BEGIN HTTP API---------------------------------->
+```bash
+curl -G \
+  "http://{{< influxdb/host >}}/api/v3/query_sql" \
+  --data-urlencode "db=_internal" \
+  --data-urlencode "q=SELECT name, created_at FROM SYSTEM.TOKENS WHERE permissions = '*:*:*' AND created_at > '2025-01-01 00:00:00'" \
+  --data-urlencode "format=json" \
+  --header "Accept: application/json" \
+  --header "Authorization: Bearer AUTH_TOKEN" |
+jq '.[] | {name: .name, created_at: .created_at}'
+```
+<!-----------------------------END HTTP API------------------------------------>
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+{{% /code-placeholders %}}

--- a/content/shared/influxdb3-admin/tokens/admin/list.md
+++ b/content/shared/influxdb3-admin/tokens/admin/list.md
@@ -6,7 +6,7 @@ data and resources in your InfluxDB 3 instance.
 
 > [!NOTE]
 > Token metadata includes the hashed token string.
-> InfluxDB 3 does not store the token string.
+> InfluxDB 3 does not store the raw token string.
 
 In the following examples, replace {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}} with your InfluxDB {{% token-link "admin" %}}
 {{% show-in "enterprise" %}} or a token with read permission on the `_internal` system database`{{% /show-in %}}.
@@ -38,7 +38,7 @@ To filter tokens and retrieve specific details using SQL, query the `system.toke
 influxdb3 query \
   --database _internal \
   --format csv \
-  "SELECT name, permissions FROM SYSTEM.TOKENS WHERE permissions = '*:*:*'"
+  "SELECT name, permissions FROM system.tokens WHERE permissions = '*:*:*'"
 ```
 <!---------------------------END CLI------------------------------------------->
 {{% /code-tab-content %}}
@@ -48,7 +48,7 @@ influxdb3 query \
 curl -G \
   "http://{{< influxdb/host >}}/api/v3/query_sql" \
   --data-urlencode "db=_internal" \
-  --data-urlencode "q=SELECT name, permissions FROM SYSTEM.TOKENS WHERE permissions = '*:*:*'" \
+  --data-urlencode "q=SELECT name, permissions FROM system.tokens WHERE permissions = '*:*:*'" \
   --data-urlencode "format=csv" \
   --header 'Accept: text/csv' \
   --header "Authorization: Bearer AUTH_TOKEN"
@@ -71,7 +71,7 @@ curl -G \
 ```bash
 influxdb3 query \
   --db _internal \
-  "SELECT name, permissions FROM SYSTEM.TOKENS WHERE created_at > '2025-01-01 00:00:00'"
+  "SELECT name, permissions FROM system.tokens WHERE created_at > '2025-01-01 00:00:00'"
 ```
 <!---------------------------END CLI------------------------------------------->
 {{% /code-tab-content %}}
@@ -81,7 +81,7 @@ influxdb3 query \
 curl -G \
 "http://{{< influxdb/host >}}/api/v3/query_sql" \
 --data-urlencode "db=_internal" \
---data-urlencode "q=SELECT name, permissions FROM SYSTEM.TOKENS WHERE created_at > '2025-01-01 00:00:00'" \
+--data-urlencode "q=SELECT name, permissions FROM system.tokens WHERE created_at > '2025-01-01 00:00:00'" \
 --header "Accept: application/json" \
 --header "Authorization: Bearer AUTH_TOKEN" 
 ```
@@ -123,7 +123,7 @@ influxdb3 show tokens \
 curl -G \
   "http://{{< influxdb/host >}}/api/v3/query_sql" \
   --data-urlencode "db=_internal" \
-  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS" \
+  --data-urlencode "q=SELECT * FROM system.tokens" \
   --data-urlencode "format=csv" \
   --header 'Accept: text/csv' \
   --header "Authorization: Bearer AUTH_TOKEN"
@@ -162,7 +162,7 @@ influxdb3 show tokens \
 curl -G \
 "http://{{< influxdb/host >}}/api/v3/query_sql" \
 --data-urlencode "db=_internal" \
---data-urlencode "q=SELECT * FROM SYSTEM.TOKENS" \
+--data-urlencode "q=SELECT * FROM system.tokens" \
 --data-urlencode "format=parquet" \
 --header "Accept: application/parquet" \
 --header "Authorization: Bearer AUTH_TOKEN" \
@@ -201,7 +201,7 @@ grep _admin
 curl -G \
   "http://{{< influxdb/host >}}/api/v3/query_sql" \
   --data-urlencode "db=_internal" \
-  --data-urlencode "q=SELECT * FROM SYSTEM.TOKENS" \
+  --data-urlencode "q=SELECT * FROM system.tokens" \
   --data-urlencode "format=pretty" \
   --header "Accept: application/json" \
   --header "Authorization: Bearer AUTH_TOKEN" |
@@ -232,7 +232,7 @@ jq '.[] | {name: .name, permissions: .permissions}'
 curl -G \
   "http://{{< influxdb/host >}}/api/v3/query_sql" \
   --data-urlencode "db=_internal" \
-  --data-urlencode "q=SELECT name, created_at FROM SYSTEM.TOKENS WHERE permissions = '*:*:*' AND created_at > '2025-01-01 00:00:00'" \
+  --data-urlencode "q=SELECT name, created_at FROM system.tokens WHERE permissions = '*:*:*' AND created_at > '2025-01-01 00:00:00'" \
   --data-urlencode "format=json" \
   --header "Accept: application/json" \
   --header "Authorization: Bearer AUTH_TOKEN" |

--- a/content/shared/influxdb3-cli/create/token.md
+++ b/content/shared/influxdb3-cli/create/token.md
@@ -6,8 +6,15 @@ The `influxdb3 create token` command creates a new authentication token.
 <!--pytest.mark.skip-->
 
 ```bash
-influxdb3 create token
+influxdb3 create token <COMMAND> [OPTIONS]
 ```
+
+## Commands
+
+| Command | Description                                                                 |
+| :----- | :----------- | :------------------------------ |
+| `--admin` | Create an admin token for the {{< product-name >}} server. |
+{{% show-in "enterprise" %}}| [`--permission`](/influxdb3/enterprise/reference/cli/influxdb3/create/token/permission/) | Create a resource token with fine-grained access permissions. |{{% /show-in %}}
 
 ## Options
 
@@ -15,3 +22,11 @@ influxdb3 create token
 | :----- | :----------- | :------------------------------ |
 | `-h`   | `--help`     | Print help information          |
 |        | `--help-all` | Print detailed help information |
+
+## Examples
+
+### Create an admin token
+
+```bash
+influxdb3 create token --admin
+```

--- a/content/shared/influxdb3-cli/show/_index.md
+++ b/content/shared/influxdb3-cli/show/_index.md
@@ -15,6 +15,7 @@ influxdb3 show <SUBCOMMAND>
 | :---------------------------------------------------------------------- | :--------------------------------------------- |
 | [databases](/influxdb3/version/reference/cli/influxdb3/show/databases/) | List database                                  |
 | [system](/influxdb3/version/reference/cli/influxdb3/show/system/)       | Display system table data                      |
+| [tokens](/influxdb3/version/reference/cli/influxdb3/show/tokens/)       | List authentication tokens                      |
 | help                                                                    | Print command help or the help of a subcommand |
 
 ## Options

--- a/content/shared/influxdb3-cli/show/tokens.md
+++ b/content/shared/influxdb3-cli/show/tokens.md
@@ -1,5 +1,4 @@
-
-The `influxdb3 show databases` command lists databases in your
+The `influxdb3 show tokens` command lists authentication tokens in your
 {{< product-name >}} server.
 
 ## Usage
@@ -7,7 +6,7 @@ The `influxdb3 show databases` command lists databases in your
 <!--pytest.mark.skip-->
 
 ```bash
-influxdb3 show databases [OPTIONS]
+influxdb3 show tokens [OPTIONS]
 ```
 
 ## Options
@@ -16,8 +15,8 @@ influxdb3 show databases [OPTIONS]
 | :----- | :--------------- | :--------------------------------------------------------------------------------------- |
 | `-H`   | `--host`         | Host URL of the running {{< product-name >}} server (default is `http://127.0.0.1:8181`) |
 |        | `--token`        | _({{< req >}})_ Authentication token                                                     |
-|        | `--show-deleted` | Include databases marked as deleted in the output                                        |
 |        | `--format`       | Output format (`pretty` _(default)_, `json`, `jsonl`, `csv`, or `parquet`)               |
+|        | `--output`       | Path where to save output when using the `parquet` format                                |
 |        | `--tls-ca`       | Path to a custom TLS certificate authority (for testing or self-signed certificates)     |
 | `-h`   | `--help`         | Print help information                                                                   |
 |        | `--help-all`     | Print detailed help information                                                          |
@@ -26,50 +25,50 @@ influxdb3 show databases [OPTIONS]
 
 You can use the following environment variables to set command options:
 
-| Environment Variable      | Option       |
-| :------------------------ | :----------- |
-| `INFLUXDB3_HOST_URL`      | `--host`     |
-| `INFLUXDB3_DATABASE_NAME` | `--database` |
-| `INFLUXDB3_AUTH_TOKEN`    | `--token`    |
+| Environment Variable   | Option    |
+| :-------------------- | :-------- |
+| `INFLUXDB3_HOST_URL`  | `--host`  |
+| `INFLUXDB3_AUTH_TOKEN`| `--token` |
 
 ## Examples
 
-- [List all databases](#list-all-databases)
-- [List all databases, including deleted databases](#list-all-databases-including-deleted-databases)
-- [List databases in JSON-formatted output](#list-databases-in-json-formatted-output)
+- [List all tokens](#list-all-tokens)
+- [List tokens in different output formats](#list-tokens-in-different-output-formats)
+- [Output tokens to a Parquet file](#output-tokens-to-a-parquet-file)
 
-### List all databases
-
-<!--pytest.mark.skip-->
-
-```bash
-influxdb3 show databases
-```
-
-### List all databases, including deleted databases
+### List all tokens
 
 <!--pytest.mark.skip-->
 
 ```bash
-influxdb3 show databases --show-deleted
+influxdb3 show tokens
 ```
 
-### List databases in JSON-formatted output
+### List tokens in different output formats
+
+You can specify the output format using the `--format` option:
 
 <!--pytest.mark.skip-->
 
 ```bash
-influxdb3 show databases --format json
+# JSON format
+influxdb3 show tokens --format json
+
+# JSON Lines format
+influxdb3 show tokens --format jsonl
+
+# CSV format
+influxdb3 show tokens --format csv
 ```
 
-### List databases in Parquet-formatted output
+### Output tokens to a Parquet file
 
 [Parquet](https://parquet.apache.org/) is a binary format.
 Use the `--output` option to specify the file where you want to save the Parquet data.
 
 <!--pytest.mark.skip-->
 ```bash
-influxdb3 show databases 
+influxdb3 show tokens \
   --format parquet \
-  --output /Users/me/databases.parquet
+  --output /Users/me/tokens.parquet
 ```

--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -733,6 +733,7 @@ For more information about the Python client library, see the [`influxdb3-python
 
 
 ### Query using InfluxDB 3 Explorer (Beta)
+
 You can use the InfluxDB 3 Explorer query interface by downloading the Docker image.
 
 ```bash

--- a/content/shared/v3-enterprise-get-started/_index.md
+++ b/content/shared/v3-enterprise-get-started/_index.md
@@ -349,8 +349,9 @@ To create a system token, use the `influxdb3 create token` subcommand and pass t
 - Token permissions as a string literal in the `RESOURCE_TYPE:RESOURCE_NAMES:ACTIONS` format--for example:
   - `"system:health:read"` or `"system:*:read"`
     - `system:`: The `system` resource type, which specifies the token is for a database.
-    - `health`: The system resource (endpoint) to grant permissions to. This part supports the `*` wildcard, which grants permissions to all databases.
-    - `read`: Grant read permission to system information resources.
+    - `health`: The list of system resources (endpoints) to grant permissions to.
+      This part supports the `*` wildcard, which grants permissions to all endpoints.
+    - `read`: The list of permissions to grant. _Only `read` is supported for system resources._
 
 The following example shows how to create a system token that expires in 1 year and has read permissions for all system endpoints on the server:
 

--- a/influxdb3cli-build-scripts/generate-cli-docs.js
+++ b/influxdb3cli-build-scripts/generate-cli-docs.js
@@ -1,0 +1,725 @@
+// generate-cli-docs.js
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const OUTPUT_DIR = path.join(__dirname, 'content', 'shared', 'influxdb3-cli');
+const BASE_CMD = 'influxdb3';
+const DEBUG = true; // Set to true for verbose logging
+
+// Debug logging function
+function debug(message, data) {
+  if (DEBUG) {
+    console.log(`DEBUG: ${message}`);
+    if (data) console.log(JSON.stringify(data, null, 2));
+  }
+}
+
+// Function to remove ANSI escape codes
+function stripAnsiCodes(str) {
+  // Regular expression to match ANSI escape codes
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/[][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
+}
+
+// Ensure output directories exist
+function ensureDirectoryExistence(filePath) {
+  const dirname = path.dirname(filePath);
+  if (fs.existsSync(dirname)) {
+    return true;
+  }
+  ensureDirectoryExistence(dirname);
+  fs.mkdirSync(dirname);
+}
+
+// Get all available commands and subcommands
+function getCommands() {
+  try {
+    debug('Getting base commands');
+    let helpOutput = execSync(`${BASE_CMD} --help`).toString();
+    helpOutput = stripAnsiCodes(helpOutput); // Strip ANSI codes
+    debug('Cleaned help output received', helpOutput);
+    
+    // Find all command sections (Common Commands, Resource Management, etc.)
+    const commandSections = helpOutput.match(/^[A-Za-z\s]+:\s*$([\s\S]+?)(?=^[A-Za-z\s]+:\s*$|\n\s*$|\n[A-Z]|\n\n|$)/gm);
+    
+    if (!commandSections || commandSections.length === 0) {
+      debug('No command sections found in help output');
+      return [];
+    }
+    
+    debug(`Found ${commandSections.length} command sections`);
+    
+    let commands = [];
+    
+    // Process each section to extract commands
+    commandSections.forEach(section => {
+      // Extract command lines (ignoring section headers)
+      const cmdLines = section.split('\n')
+        .slice(1) // Skip the section header
+        .map(line => line.trim())
+        .filter(line => line && !line.startsWith('-') && !line.startsWith('#')); // Skip empty lines, flags and comments
+      
+      debug('Command lines in section', cmdLines);
+      
+      // Extract command names and descriptions
+      cmdLines.forEach(line => {
+        // Handle commands with aliases (like "query, q")
+        const aliasMatch = line.match(/^\s*([a-zA-Z0-9_,-\s]+?)\s{2,}(.+)$/);
+        
+        if (aliasMatch) {
+          // Get primary command and any aliases
+          const commandParts = aliasMatch[1].split(',').map(cmd => cmd.trim());
+          const primaryCmd = commandParts[0]; // Use the first as primary
+          const description = aliasMatch[2].trim();
+          
+          commands.push({ 
+            cmd: primaryCmd, 
+            description: description 
+          });
+          
+          debug(`Added command: ${primaryCmd} - ${description}`);
+        }
+      });
+    });
+    
+    debug('Extracted commands', commands);
+    return commands;
+  } catch (error) {
+    console.error('Error getting commands:', error.message);
+    if (DEBUG) console.error(error.stack);
+    return [];
+  }
+}
+
+// Get subcommands for a specific command
+function getSubcommands(cmd) {
+  try {
+    debug(`Getting subcommands for: ${cmd}`);
+    let helpOutput = execSync(`${BASE_CMD} ${cmd} --help`).toString();
+    helpOutput = stripAnsiCodes(helpOutput); // Strip ANSI codes
+    debug(`Cleaned help output for ${cmd} received`, helpOutput);
+    
+    // Look for sections containing commands (similar to top-level help)
+    // First try to find a dedicated Commands: section
+    let subcommands = [];
+    
+    // Try to find a dedicated "Commands:" section first
+    const commandsMatch = helpOutput.match(/Commands:\s+([\s\S]+?)(?=^[A-Za-z\s]+:\s*$|\n\s*$|\n[A-Z]|\n\n|$)/m);
+    
+    if (commandsMatch) {
+      debug(`Found dedicated Commands section for ${cmd}`);
+      const cmdLines = commandsMatch[1].split('\n')
+        .map(line => line.trim())
+        .filter(line => line && !line.startsWith('-') && !line.startsWith('#')); // Skip empty lines, flags, comments
+      
+      cmdLines.forEach(line => {
+        const match = line.match(/^\s*([a-zA-Z0-9_,-\s]+?)\s{2,}(.+)$/);
+        if (match) {
+          // Get primary command name (before any commas for aliases)
+          const commandName = match[1].split(',')[0].trim();
+          const description = match[2].trim();
+          
+          subcommands.push({
+            cmd: `${cmd} ${commandName}`,
+            description: description
+          });
+          
+          debug(`Added subcommand: ${cmd} ${commandName} - ${description}`);
+        }
+      });
+    } else {
+      // Look for sections like "Common Commands:", "Resource Management:", etc.
+      const sectionMatches = helpOutput.match(/^[A-Za-z\s]+:\s*$([\s\S]+?)(?=^[A-Za-z\s]+:\s*$|\n\s*$|\n[A-Z]|\n\n|$)/gm);
+      
+      if (sectionMatches) {
+        debug(`Found ${sectionMatches.length} sections with potential commands for ${cmd}`);
+        
+        sectionMatches.forEach(section => {
+          const cmdLines = section.split('\n')
+            .slice(1) // Skip the section header
+            .map(line => line.trim())
+            .filter(line => line && !line.startsWith('-') && !line.startsWith('#')); // Skip empty lines, flags, comments
+          
+          cmdLines.forEach(line => {
+            const match = line.match(/^\s*([a-zA-Z0-9_,-\s]+?)\s{2,}(.+)$/);
+            if (match) {
+              // Get primary command name (before any commas for aliases)
+              const commandName = match[1].split(',')[0].trim();
+              const description = match[2].trim();
+              
+              subcommands.push({
+                cmd: `${cmd} ${commandName}`,
+                description: description
+              });
+              
+              debug(`Added subcommand from section: ${cmd} ${commandName} - ${description}`);
+            }
+          });
+        });
+      }
+    }
+    
+    debug(`Extracted ${subcommands.length} subcommands for ${cmd}`, subcommands);
+    return subcommands;
+  } catch (error) {
+    debug(`Error getting subcommands for ${cmd}:`, error.message);
+    return [];
+  }
+}
+
+// Helper functions to generate descriptions for different command types
+function getQueryDescription(cmd, fullCmd) {
+  return ` executes a query against a running {{< product-name >}} server.`;
+}
+
+function getWriteDescription(cmd, fullCmd) {
+  return ` writes data to a running {{< product-name >}} server.`;
+}
+
+function getShowDescription(cmd, fullCmd) {
+  const cmdParts = cmd.split(' ');
+  const resourceType = cmdParts.length > 1 ? cmdParts[1] : 'resources';
+  return ` lists ${resourceType} in your {{< product-name >}} server.`;
+}
+
+function getCreateDescription(cmd, fullCmd) {
+  const cmdParts = cmd.split(' ');
+  const createType = cmdParts.length > 1 ? cmdParts[1] : 'resources';
+  return ` creates ${createType} in your {{< product-name >}} server.`;
+}
+
+function getDeleteDescription(cmd, fullCmd) {
+  const cmdParts = cmd.split(' ');
+  const deleteType = cmdParts.length > 1 ? cmdParts[1] : 'resources';
+  return ` deletes ${deleteType} from your {{< product-name >}} server.`;
+}
+
+function getServeDescription(cmd, fullCmd) {
+  return ` starts the {{< product-name >}} server.`;
+}
+
+function getDefaultDescription(cmd, fullCmd) {
+  return `.`;
+}
+
+// Helper functions to generate examples for different command types
+function getQueryExample(cmd) {
+  return {
+    title: 'Query data using SQL',
+    code: `${BASE_CMD} ${cmd} --database DATABASE_NAME "SELECT * FROM home"`
+  };
+}
+
+function getWriteExample(cmd) {
+  return {
+    title: 'Write data from a file',
+    code: `${BASE_CMD} ${cmd} --database DATABASE_NAME --file data.lp`
+  };
+}
+
+function getShowExample(cmd) {
+  const cmdParts = cmd.split(' ');
+  const resourceType = cmdParts.length > 1 ? cmdParts[1] : 'resources';
+  return {
+    title: `List ${resourceType}`,
+    code: `${BASE_CMD} ${cmd}`
+  };
+}
+
+function getCreateExample(cmd) {
+  const cmdParts = cmd.split(' ');
+  const resourceType = cmdParts.length > 1 ? cmdParts[1] : 'resource';
+  return {
+    title: `Create a new ${resourceType}`,
+    code: `${BASE_CMD} ${cmd} --name new-${resourceType}-name`
+  };
+}
+
+function getDeleteExample(cmd) {
+  const cmdParts = cmd.split(' ');
+  const resourceType = cmdParts.length > 1 ? cmdParts[1] : 'resource';
+  return {
+    title: `Delete a ${resourceType}`,
+    code: `${BASE_CMD} ${cmd} --name ${resourceType}-to-delete`
+  };
+}
+
+function getServeExample(cmd) {
+  return {
+    title: 'Start the InfluxDB server',
+    code: `${BASE_CMD} serve --node-id my-node --object-store file --data-dir ~/.influxdb3_data`
+  };
+}
+
+function getDefaultExample(fullCmd, cmd) {
+  return {
+    title: `Run the ${fullCmd} command`,
+    code: `${BASE_CMD} ${cmd}`
+  };
+}
+
+// Generate frontmatter for a command
+function generateFrontmatter(cmd) {
+  const parts = cmd.split(' ');
+  const lastPart = parts[parts.length - 1];
+  const fullCmd = cmd === '' ? BASE_CMD : `${BASE_CMD} ${cmd}`;
+  
+  // Determine a good description based on the command
+  let description = '';
+  if (cmd === '') {
+    description = `The ${BASE_CMD} CLI runs and interacts with the {{< product-name >}} server.`;
+  } else {
+    const cmdParts = cmd.split(' ');
+    const lastCmd = cmdParts[cmdParts.length - 1];
+    
+    // Use the description helper functions for consistency
+    switch (lastCmd) {
+      case 'query':
+      case 'q':
+        description = `The \`${fullCmd}\` command${getQueryDescription(cmd, fullCmd)}`;
+        break;
+      case 'write':
+      case 'w':
+        description = `The \`${fullCmd}\` command${getWriteDescription(cmd, fullCmd)}`;
+        break;
+      case 'show':
+        description = `The \`${fullCmd}\` command${getShowDescription(cmd, fullCmd)}`;
+        break;
+      case 'create':
+        description = `The \`${fullCmd}\` command${getCreateDescription(cmd, fullCmd)}`;
+        break;
+      case 'delete':
+        description = `The \`${fullCmd}\` command${getDeleteDescription(cmd, fullCmd)}`;
+        break;
+      case 'serve':
+        description = `The \`${fullCmd}\` command${getServeDescription(cmd, fullCmd)}`;
+        break;
+      default:
+        description = `The \`${fullCmd}\` command${getDefaultDescription(cmd, fullCmd)}`;
+    }
+  }
+  
+  // Create the frontmatter
+  let frontmatter = `---
+title: ${fullCmd}
+description: >
+  ${description}
+`;
+
+  // Add source attribute for shared files
+  if (cmd !== '') {
+    // Build the path relative to the /content/shared/influxdb3-cli/ directory
+    const relativePath = cmd.split(' ').join('/');
+    frontmatter += `source: /shared/influxdb3-cli/${relativePath === '' ? '_index' : relativePath}.md
+`;
+  }
+
+  // Close the frontmatter
+  frontmatter += `---
+
+`;
+
+  return frontmatter;
+}
+
+// Generate Markdown for a command
+function generateCommandMarkdown(cmd) {
+  try {
+    debug(`Generating markdown for command: ${cmd}`);
+    const fullCmd = cmd === '' ? BASE_CMD : `${BASE_CMD} ${cmd}`;
+    let helpOutput = execSync(`${fullCmd} --help`).toString();
+    helpOutput = stripAnsiCodes(helpOutput); // Strip ANSI codes
+    debug(`Cleaned help output for ${fullCmd} received`, helpOutput);
+
+    // Extract sections from help output
+    const usageMatch = helpOutput.match(/Usage:\s+([\s\S]+?)(?:\n\n|$)/);
+    const usage = usageMatch ? usageMatch[1].trim() : '';
+
+    const argsMatch = helpOutput.match(/Arguments:\s+([\s\S]+?)(?:\n\n|$)/);
+    const args = argsMatch ? argsMatch[1].trim() : '';
+
+    // Store option sections separately
+    const optionSections = {};
+    const optionSectionRegex = /^([A-Za-z\s]+ Options?|Required):\s*$([\s\S]+?)(?=\n^[A-Za-z\s]+:|^$|\n\n)/gm;
+    let sectionMatch;
+    while ((sectionMatch = optionSectionRegex.exec(helpOutput)) !== null) {
+      const sectionTitle = sectionMatch[1].trim();
+      const sectionContent = sectionMatch[2].trim();
+      debug(`Found option section: ${sectionTitle}`);
+      optionSections[sectionTitle] = sectionContent;
+    }
+
+    // Fallback if no specific sections found
+    if (Object.keys(optionSections).length === 0) {
+        const flagsMatch = helpOutput.match(/(?:Flags|Options):\s+([\s\S]+?)(?:\n\n|$)/);
+        if (flagsMatch) {
+            debug('Using fallback Flags/Options section');
+            optionSections['Options'] = flagsMatch[1].trim();
+        }
+    }
+    debug('Extracted option sections', optionSections);
+
+
+    // Format flags as a table, processing sections and handling duplicates/multi-lines
+    let flagsTable = '';
+    const addedFlags = new Set(); // Track added long flags
+    const tableRows = [];
+    const sectionOrder = ['Required', ...Object.keys(optionSections).filter(k => k !== 'Required')]; // Prioritize Required
+
+    for (const sectionTitle of sectionOrder) {
+        if (!optionSections[sectionTitle]) continue;
+
+        const sectionContent = optionSections[sectionTitle];
+        const lines = sectionContent.split('\n');
+        let i = 0;
+        while (i < lines.length) {
+            const line = lines[i];
+            // Regex to capture flag and start of description
+            const flagMatch = line.match(/^\s+(?:(-\w),\s+)?(--[\w-]+(?:[=\s]<[^>]+>)?)?\s*(.*)/);
+
+
+            if (flagMatch) {
+                const shortFlag = flagMatch[1] || '';
+                const longFlagRaw = flagMatch[2] || ''; // Might be empty if only short flag exists (unlikely here)
+                const longFlag = longFlagRaw.split(/[=\s]/)[0]; // Get only the flag name, e.g., --cluster-id from --cluster-id <CLUSTER_ID>
+                let description = flagMatch[3].trim();
+
+                // Check for multi-line description (indented lines following)
+                let j = i + 1;
+                while (j < lines.length && lines[j].match(/^\s{4,}/)) { // Look for lines with significant indentation
+                    description += ' ' + lines[j].trim();
+                    j++;
+                }
+                i = j; // Move main index past the multi-line description
+
+                // Clean description
+                description = description
+                    .replace(/\s+\[default:.*?\]/g, '')
+                    .replace(/\s+\[env:.*?\]/g, '')
+                    .replace(/\s+\[possible values:.*?\]/g, '')
+                    .trim();
+
+                // Check if required based on section
+                const isRequired = sectionTitle === 'Required';
+
+                // Add to table if not already added
+                if (longFlag && !addedFlags.has(longFlag)) {
+                    // Use longFlagRaw which includes the placeholder for display
+                    tableRows.push(`| \`${shortFlag}\` | \`${longFlagRaw.trim()}\` | ${isRequired ? '_({{< req >}})_ ' : ''}${description} |`);
+                    addedFlags.add(longFlag);
+                    debug(`Added flag: ${longFlag} (Required: ${isRequired})`);
+                } else if (!longFlag && shortFlag && !addedFlags.has(shortFlag)) {
+                     // Handle case where only short flag might exist (though unlikely for this CLI)
+                     tableRows.push(`| \`${shortFlag}\` |  | ${isRequired ? '_({{< req >}})_ ' : ''}${description} |`);
+                     addedFlags.add(shortFlag); // Use short flag for tracking if no long flag
+                     debug(`Added flag: ${shortFlag} (Required: ${isRequired})`);
+                } else if (longFlag) {
+                    debug(`Skipping duplicate flag: ${longFlag}`);
+                } else {
+                     debug(`Skipping flag line with no long or short flag found: ${line}`);
+                }
+            } else {
+                debug(`Could not parse flag line in section "${sectionTitle}": ${line}`);
+                i++; // Move to next line if current one doesn't match
+            }
+        }
+    }
+
+
+    if (tableRows.length > 0) {
+      // Sort rows alphabetically by long flag, putting required flags first
+      tableRows.sort((a, b) => {
+        const isARequired = a.includes('_({{< req >}})_');
+        const isBRequired = b.includes('_({{< req >}})_');
+        if (isARequired && !isBRequired) return -1;
+        if (!isARequired && isBRequired) return 1;
+        // Extract long flag for sorting (second column content between backticks)
+        const longFlagA = (a.match(/\|\s*`.*?`\s*\|\s*`(--[\w-]+)/) || [])[1] || '';
+        const longFlagB = (b.match(/\|\s*`.*?`\s*\|\s*`(--[\w-]+)/) || [])[1] || '';
+        return longFlagA.localeCompare(longFlagB);
+      });
+      flagsTable = `| Short | Long | Description |\n| :---- | :--- | :---------- |\n${tableRows.join('\n')}`;
+    }
+
+
+    // Extract description from help text (appears before Usage section or other sections)
+    let descriptionText = '';
+    // Updated regex to stop before any known section header
+    const descMatches = helpOutput.match(/^([\s\S]+?)(?=Usage:|Common Commands:|Examples:|Options:|Flags:|Required:|Arguments:|$)/);
+    if (descMatches && descMatches[1]) {
+      descriptionText = descMatches[1].trim();
+    }
+
+    // Example commands
+    const examples = [];
+    // Updated regex to stop before any known section header
+    const exampleMatch = helpOutput.match(/(?:Example|Examples):\s*([\s\S]+?)(?=\n\n|Usage:|Options:|Flags:|Required:|Arguments:|$)/i);
+
+    if (exampleMatch) {
+      // Found examples in help output, use them
+      const exampleBlocks = exampleMatch[1].trim().split(/\n\s*#\s+/); // Split by lines starting with # (section comments)
+
+      exampleBlocks.forEach((block, index) => {
+          const lines = block.trim().split('\n');
+          const titleLine = lines[0].startsWith('#') ? lines[0].substring(1).trim() : `Example ${index + 1}`;
+          const codeLines = lines.slice(titleLine === `Example ${index + 1}` ? 0 : 1) // Skip title line if we extracted it
+                                .map(line => line.replace(/^\s*\d+\.\s*/, '').trim()) // Remove numbering like "1. "
+                                .filter(line => line);
+          if (codeLines.length > 0) {
+             examples.push({ title: titleLine, code: codeLines.join('\n') });
+          }
+      });
+
+    } else {
+      // Fallback example generation
+      if (cmd === '') {
+        // ... (existing base command examples) ...
+      } else {
+        // ... (existing command-specific example generation using helpers) ...
+      }
+    }
+
+    // Construct markdown content
+    const frontmatter = generateFrontmatter(cmd);
+    let markdown = frontmatter;
+
+    markdown += `The \`${fullCmd}\` command`;
+
+    // Use extracted description if available, otherwise fallback
+    if (descriptionText) {
+      markdown += ` ${descriptionText.toLowerCase().replace(/\.$/, '')}.`;
+    } else if (cmd === '') {
+      markdown += ` runs and interacts with the {{< product-name >}} server.`;
+    } else {
+      // Fallback description generation using helpers
+      const cmdParts = cmd.split(' ');
+      const lastCmd = cmdParts[cmdParts.length - 1];
+      switch (lastCmd) {
+        case 'query': case 'q': markdown += getQueryDescription(cmd, fullCmd); break;
+        case 'write': case 'w': markdown += getWriteDescription(cmd, fullCmd); break;
+        case 'show': markdown += getShowDescription(cmd, fullCmd); break;
+        case 'create': markdown += getCreateDescription(cmd, fullCmd); break;
+        case 'delete': markdown += getDeleteDescription(cmd, fullCmd); break;
+        case 'serve': markdown += getServeDescription(cmd, fullCmd); break;
+        default: markdown += getDefaultDescription(cmd, fullCmd);
+      }
+    }
+
+    markdown += `\n\n## Usage\n\n<!--pytest.mark.skip-->\n\n\`\`\`bash\n${usage}\n\`\`\`\n\n`;
+
+    if (args) {
+      markdown += `## Arguments\n\n${args}\n\n`;
+    }
+
+    if (flagsTable) {
+      markdown += `## Options\n\n${flagsTable}\n\n`;
+    }
+
+    if (examples.length > 0) {
+      markdown += `## Examples\n\n`;
+      examples.forEach(ex => {
+        markdown += `### ${ex.title}\n\n<!--pytest.mark.skip-->\n\n\`\`\`bash\n${ex.code}\n\`\`\`\n\n`;
+      });
+    }
+
+    return markdown;
+  } catch (error) {
+    console.error(`Error generating markdown for '${cmd}':`, error.message);
+    if (DEBUG) console.error(error.stack);
+    return null;
+  }
+}
+
+// Generate reference page with proper frontmatter that imports from shared content
+function generateReferencePage(cmd, product) {
+  // Skip the base command since it's not typically needed as a reference
+  if (cmd === '') {
+    return null;
+  }
+  
+  const parts = cmd.split(' ');
+  const fullCmd = cmd === '' ? BASE_CMD : `${BASE_CMD} ${cmd}`;
+  
+  // Build the appropriate menu path
+  let menuParent;
+  if (parts.length === 1) {
+    menuParent = 'influxdb3'; // Top-level command
+  } else {
+    // For nested commands, the parent is the command's parent command
+    menuParent = `influxdb3 ${parts.slice(0, -1).join(' ')}`;
+  }
+  
+  // Determine a good description
+  let description;
+  const lastCmd = parts.length > 0 ? parts[parts.length - 1] : '';
+  
+  switch (lastCmd) {
+    case 'query':
+    case 'q':
+      description = `Use the ${fullCmd} command to query data in your {{< product-name >}} instance.`;
+      break;
+    case 'write':
+    case 'w':
+      description = `Use the ${fullCmd} command to write data to your {{< product-name >}} instance.`;
+      break;
+    case 'show':
+      const showType = parts.length > 1 ? parts[1] : 'resources';
+      description = `Use the ${fullCmd} command to list ${showType} in your {{< product-name >}} instance.`;
+      break;
+    case 'create':
+      const createType = parts.length > 1 ? parts[1] : 'resources';
+      description = `Use the ${fullCmd} command to create ${createType} in your {{< product-name >}} instance.`;
+      break;
+    case 'delete':
+      const deleteType = parts.length > 1 ? parts[1] : 'resources';
+      description = `Use the ${fullCmd} command to delete ${deleteType} from your {{< product-name >}} instance.`;
+      break;
+    case 'serve':
+      description = `Use the ${fullCmd} command to start and run your {{< product-name >}} server.`;
+      break;
+    default:
+      description = `Use the ${fullCmd} command.`;
+  }
+  
+  // Build the path to the shared content
+  const sharedPath = parts.join('/');
+  
+  // Create the frontmatter for the reference page
+  const frontmatter = `---
+title: ${fullCmd}
+description: >
+  ${description}
+menu:
+  ${product}:
+    parent: ${menuParent}
+    name: ${fullCmd}
+weight: 400
+source: /shared/influxdb3-cli/${sharedPath}.md
+---
+
+<!-- The content for this page is at
+// SOURCE content/shared/influxdb3-cli/${sharedPath}.md
+-->`;
+
+  return frontmatter;
+}
+
+// Create the reference page files for different product variants
+async function createReferencePages(cmd) {
+  if (cmd === '') return; // Skip the base command
+  
+  // Define the InfluxDB products that use this CLI
+  const products = [
+    { id: 'influxdb3_core', path: 'influxdb3/core' },
+    { id: 'influxdb3_enterprise', path: 'influxdb3/enterprise' }
+  ];
+  
+  // Generate reference pages for each product
+  for (const product of products) {
+    const frontmatter = generateReferencePage(cmd, product.id);
+    if (!frontmatter) continue;
+    
+    const parts = cmd.split(' ');
+    const cmdPath = parts.join('/');
+    
+    // Create the directory path for the reference file
+    const refDirPath = path.join(__dirname, '..', 'content', product.path, 'reference', 'cli', 'influxdb3', ...parts.slice(0, -1));
+    const refFilePath = path.join(refDirPath, `${parts[parts.length - 1]}.md`);
+    
+    // Create directory if it doesn't exist
+    ensureDirectoryExistence(refFilePath);
+    
+    // Write the reference file
+    fs.writeFileSync(refFilePath, frontmatter);
+    console.log(`Generated reference page: ${refFilePath}`);
+  }
+}
+
+// Process a command and its subcommands recursively
+async function processCommand(cmd = '', depth = 0) {
+  debug(`Processing command: "${cmd}" at depth ${depth}`);
+  
+  // Generate markdown for this command
+  const markdown = generateCommandMarkdown(cmd);
+  if (!markdown) {
+    console.error(`Failed to generate markdown for command: ${cmd}`);
+    return;
+  }
+  
+  // Create file path and write content
+  let filePath;
+  if (cmd === '') {
+    // Base command
+    filePath = path.join(OUTPUT_DIR, '_index.md');
+  } else {
+    const parts = cmd.split(' ');
+    const dirPath = path.join(OUTPUT_DIR, ...parts.slice(0, -1));
+    const fileName = parts[parts.length - 1] === '' ? '_index.md' : `${parts[parts.length - 1]}.md`;
+    filePath = path.join(dirPath, fileName);
+    
+    // For commands with subcommands, also create an index file
+    if (depth < 3) {  // Limit recursion depth
+      try {
+        const subcommandOutput = execSync(`${BASE_CMD} ${cmd} --help`).toString();
+        if (subcommandOutput.includes('Commands:')) {
+          const subDirPath = path.join(OUTPUT_DIR, ...parts);
+          const indexFilePath = path.join(subDirPath, '_index.md');
+          ensureDirectoryExistence(indexFilePath);
+          fs.writeFileSync(indexFilePath, markdown);
+          debug(`Created index file: ${indexFilePath}`);
+        }
+      } catch (error) {
+        debug(`Error checking for subcommands: ${error.message}`);
+      }
+    }
+  }
+  
+  ensureDirectoryExistence(filePath);
+  fs.writeFileSync(filePath, markdown);
+  console.log(`Generated: ${filePath}`);
+  
+  // Create reference pages for this command
+  await createReferencePages(cmd);
+  
+  // Get and process subcommands
+  if (depth < 3) {  // Limit recursion depth
+    const subcommands = getSubcommands(cmd);
+    debug(`Found ${subcommands.length} subcommands for "${cmd}"`);
+    
+    for (const subCmd of subcommands) {
+      await processCommand(subCmd.cmd, depth + 1);
+    }
+  }
+}
+
+// Main function
+async function main() {
+  try {
+    debug('Starting documentation generation');
+    
+    // Process base command
+    await processCommand();
+    
+    // Get top-level commands
+    const commands = getCommands();
+    debug(`Found ${commands.length} top-level commands`);
+    
+    if (commands.length === 0) {
+      console.warn('Warning: No commands were found. Check the influxdb3 CLI help output format.');
+    }
+    
+    // Process each top-level command
+    for (const { cmd } of commands) {
+      await processCommand(cmd, 1);
+    }
+    
+    console.log('Documentation generation complete!');
+  } catch (error) {
+    console.error('Error in main execution:', error.message);
+    if (DEBUG) console.error(error.stack);
+  }
+}
+
+// Run the script
+main();


### PR DESCRIPTION
Closes #6022 #6021
Part of #5966 

Add reference and guides for listing tokens using CLI and API
Update ref and guides for resource token syntax
Add examples, placeholders
Misc. fixes
WIP: added node.js script to generate docs from `influxdb3` CLI help output. Partially works - not for all commands due to differences in help structure and headings.
