### PR TITLE
feat: Remove --ram-pool-data-bytes flag in docs

### DIFF
--- a/content/influxdb3/core/reference/cli/influxdb3/serve.md
+++ b/content/influxdb3/core/reference/cli/influxdb3/serve.md
@@ -82,7 +82,6 @@ influxdb3 serve [OPTIONS] --node-id <HOST_IDENTIFIER_PREFIX>
 |                  | `--datafusion-config`                                | _See [configuration options](/influxdb3/core/reference/config-options/#datafusion-config)_                                |
 |                  | `--max-http-request-size`                            | _See [configuration options](/influxdb3/core/reference/config-options/#max-http-request-size)_                            |
 |                  | `--http-bind`                                        | _See [configuration options](/influxdb3/core/reference/config-options/#http-bind)_                                        |
-|                  | `--ram-pool-data-bytes`                              | _See [configuration options](/influxdb3/core/reference/config-options/#ram-pool-data-bytes)_                              |
 |                  | `--exec-mem-pool-bytes`                              | _See [configuration options](/influxdb3/core/reference/config-options/#exec-mem-pool-bytes)_                              |
 |                  | `--gen1-duration`                                    | _See [configuration options](/influxdb3/core/reference/config-options/#gen1-duration)_                                    |
 |                  | `--wal-flush-interval`                               | _See [configuration options](/influxdb3/core/reference/config-options/#wal-flush-interval)_                               |

--- a/content/influxdb3/core/reference/config-options.md
+++ b/content/influxdb3/core/reference/config-options.md
@@ -107,7 +107,6 @@ influxdb3 serve
   - [max-http-request-size](#max-http-request-size)
   - [http-bind](#http-bind)
 - [Memory](#memory)
-  - [ram-pool-data-bytes](#ram-pool-data-bytes)
   - [exec-mem-pool-bytes](#exec-mem-pool-bytes)
   - [buffer-mem-limit-mb](#buffer-mem-limit-mb)
   - [force-snapshot-mem-threshold](#force-snapshot-mem-threshold)
@@ -779,22 +778,9 @@ Defines the address on which InfluxDB serves HTTP API requests.
 
 ### Memory
 
-- [ram-pool-data-bytes](#ram-pool-data-bytes)
 - [exec-mem-pool-bytes](#exec-mem-pool-bytes)
 - [buffer-mem-limit-mb](#buffer-mem-limit-mb)
 - [force-snapshot-mem-threshold](#force-snapshot-mem-threshold)
-
-#### ram-pool-data-bytes
-
-Specifies the size of the RAM cache used to store data, in bytes.
-
-**Default:** `1073741824`
-
-| influxdb3 serve option  | Environment variable            |
-| :---------------------- | :------------------------------ |
-| `--ram-pool-data-bytes` | `INFLUXDB3_RAM_POOL_DATA_BYTES` |
-
----
 
 #### exec-mem-pool-bytes
 

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/serve.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/serve.md
@@ -87,7 +87,6 @@ influxdb3 serve [OPTIONS] \
 |                  | `--datafusion-config`                                | _See [configuration options](/influxdb3/enterprise/reference/config-options/#datafusion-config)_                                |
 |                  | `--max-http-request-size`                            | _See [configuration options](/influxdb3/enterprise/reference/config-options/#max-http-request-size)_                            |
 |                  | `--http-bind`                                        | _See [configuration options](/influxdb3/enterprise/reference/config-options/#http-bind)_                                        |
-|                  | `--ram-pool-data-bytes`                              | _See [configuration options](/influxdb3/enterprise/reference/config-options/#ram-pool-data-bytes)_                              |
 |                  | `--exec-mem-pool-bytes`                              | _See [configuration options](/influxdb3/enterprise/reference/config-options/#exec-mem-pool-bytes)_                              |
 |                  | `--gen1-duration`                                    | _See [configuration options](/influxdb3/enterprise/reference/config-options/#gen1-duration)_                                    |
 |                  | `--wal-flush-interval`                               | _See [configuration options](/influxdb3/enterprise/reference/config-options/#wal-flush-interval)_                               |

--- a/content/influxdb3/enterprise/reference/config-options.md
+++ b/content/influxdb3/enterprise/reference/config-options.md
@@ -111,7 +111,6 @@ influxdb3 serve
   - [max-http-request-size](#max-http-request-size)
   - [http-bind](#http-bind)
 - [Memory](#memory)
-  - [ram-pool-data-bytes](#ram-pool-data-bytes)
   - [exec-mem-pool-bytes](#exec-mem-pool-bytes)
   - [force-snapshot-mem-threshold](#force-snapshot-mem-threshold)
 - [Write-Ahead Log (WAL)](#write-ahead-log-wal)
@@ -827,22 +826,9 @@ Defines the address on which InfluxDB serves HTTP API requests.
 
 ### Memory
 
-- [ram-pool-data-bytes](#ram-pool-data-bytes)
 - [exec-mem-pool-bytes](#exec-mem-pool-bytes)
 - [buffer-mem-limit-mb](#buffer-mem-limit-mb)
 - [force-snapshot-mem-threshold](#force-snapshot-mem-threshold)
-
-#### ram-pool-data-bytes
-
-Specifies the size of the RAM cache used to store data, in bytes.
-
-**Default:** `1073741824`
-
-| influxdb3 serve option  | Environment variable            |
-| :---------------------- | :------------------------------ |
-| `--ram-pool-data-bytes` | `INFLUXDB3_RAM_POOL_DATA_BYTES` |
-
----
 
 #### exec-mem-pool-bytes
 


### PR DESCRIPTION
This command no longer exists in InfluxDB 3 Core/Enterprise. This commit removes any reference to this flag.

Closes https://github.com/influxdata/influxdb/issues/26343
Closes #6034