### PR TITLE
fix: remove dvc/lvc reload temporarily

### DIFF
--- a/content/shared/influxdb3-admin/distinct-value-cache/_index.md
+++ b/content/shared/influxdb3-admin/distinct-value-cache/_index.md
@@ -15,9 +15,6 @@ have multiple DVCs.
   {{% show-in "core" %}}
   - [Distinct Value Caches are flushed when the server stops](#distinct-value-caches-are-flushed-when-the-server-stops)
   {{% /show-in %}}
-  {{% show-in "enterprise" %}}
-  - [Distinct Value Caches are rebuilt on restart](#distinct-value-caches-are-rebuilt-on-restart)
-  {{% /show-in %}}
 
 Consider a dataset with the following schema:
 
@@ -75,9 +72,6 @@ node requires to maintain it. Consider the following:
 {{% show-in "core" %}}
 - [Distinct Value Caches are flushed when the server stops](#distinct-value-caches-are-flushed-when-the-server-stops)
 {{% /show-in %}}
-{{% show-in "enterprise" %}}
-- [Distinct Value Caches are rebuilt on restart](#distinct-value-caches-are-rebuilt-on-restart)
-{{% /show-in %}}
 
 ### High cardinality limits
 
@@ -95,12 +89,4 @@ Because the DVC is an in-memory cache, the cache is flushed any time the server
 stops. After a server restart, {{% product-name %}} only writes new values to
 the DVC when you write data, so there may be a period of time when some values are 
 unavailable in the DVC.
-{{% /show-in %}}
-
-{{% show-in "enterprise" %}}
-### Distinct Value Caches are rebuilt on restart
-
-Because the DVC is an in-memory cache, the cache is flushed any time the server 
-stops. After a server restarts, {{< product-name >}} uses persisted data to
-rebuild the DVC.
 {{% /show-in %}}

--- a/content/shared/influxdb3-admin/last-value-cache/_index.md
+++ b/content/shared/influxdb3-admin/last-value-cache/_index.md
@@ -17,9 +17,6 @@ An LVC is associated with a table, which can have multiple LVCs.
   {{% show-in "core" %}}
   - [Last Value Caches are flushed when the server stops](#last-value-caches-are-flushed-when-the-server-stops)
   {{% /show-in %}}
-  {{% show-in "enterprise" %}}
-  - [Last Value Caches are rebuilt on restart](#last-value-caches-are-rebuilt-on-restart)
-  {{% /show-in %}}
   - [Defining value columns](#defining-value-columns)
 
 Consider a dataset with the following schema (similar to the
@@ -88,11 +85,7 @@ maintain it. Consider the following:
 - [Value count](#value-count)
 {{% show-in "core" %}}
 - [Last Value Caches are flushed when the server stops](#last-value-caches-are-flushed-when-the-server-stops)
-{{% /show-in %}}
-{{% show-in "enterprise" %}}
-- [Last Value Caches are rebuilt on restart](#last-value-caches-are-rebuilt-on-restart)
-{{% /show-in %}}
-- [Defining value columns](#defining-value-columns)
+{{% /show-in %}}lue-columns)
 
 ### High cardinality key columns
 
@@ -139,14 +132,6 @@ Because the LVC is an in-memory cache, the cache is flushed any time the server
 stops. After a server restart, {{% product-name %}} only writes new values to the LVC when 
 you write data, so there may be a period of time when some values are 
 unavailable in the LVC.
-{{% /show-in %}}
-
-{{% show-in "enterprise" %}}
-### Last Value Caches are rebuilt on restart
-
-Because the LVC is an in-memory cache, the cache is flushed any time the server 
-stops. After a server restarts, {{< product-name >}} uses persisted data to
-rebuild the LVC.
 {{% /show-in %}}
 
 ### Defining value columns


### PR DESCRIPTION
This information was published before it should have been. This is not accurate yet and DVC will take a bit more time.

Removing for now.