### PR TITLE
fix: incorrect enterprise admin token creation link

### DIFF
--- a/api-docs/influxdb3/enterprise/v3/ref.yml
+++ b/api-docs/influxdb3/enterprise/v3/ref.yml
@@ -157,7 +157,7 @@ tags:
       1. [Create an admin token](#section/Authentication) for the InfluxDB 3 Enterprise API.
 
          ```bash
-         curl -X POST "http://localhost:8181/api/v3/enterprise/configure/token/admin"
+         curl -X POST "http://localhost:8181/api/v3/configure/token/admin"
          ```
       2. [Check the status](#section/Server-information) of the InfluxDB server.
 


### PR DESCRIPTION
This commit fixes the link by removing `/enterprise/` in the URL for creating admin token in enterprise

Both core and enterprise share the same endpoints mounted at the root level for managing admin/operator token. Only enterprise specific features are mounted on `/enterprise`.

There is no issue but relevant slack convo [here](https://influxdata.slack.com/archives/C084G9LR2HL/p1747159957471499)