### PR TITLE
fix: url fixes in API reference section

### DIFF
--- a/api-docs/influxdb3/enterprise/v3/ref.yml
+++ b/api-docs/influxdb3/enterprise/v3/ref.yml
@@ -1351,7 +1351,7 @@ paths:
       tags:
         - Authentication
         - Token
-  /api/v3/configure/enterprise/token/admin:
+  /api/v3/configure/token/admin:
     post:
       operationId: PostCreateAdminToken
       summary: Create admin token
@@ -1374,7 +1374,7 @@ paths:
       tags:
         - Authentication
         - Token
-  /api/v3/configure/enterprise/token/admin/regenerate:
+  /api/v3/configure/token/admin/regenerate:
     post:
       operationId: PostRegenerateAdminToken
       summary: Regenerate admin token


### PR DESCRIPTION
- removes extra `/enterprise` in 'create admin token' section
- removes extra `/enterprise` in 'regenerate admin token' section

This is a continuation https://github.com/influxdata/docs-v2/pull/6063 - another place where `/enterprise` isn't necessary so it's been removed.

Although this fixes the issue I'm not sure if there are other places where this is incorrect. @jstirnaman it'd be good to confirm if there are other places to fix (quick grepping through I cannot find it).