### PR TITLE
Clarify token usage and add CLI/HTTP auth examples 

### DIFF
--- a/content/shared/influxdb3-admin/tokens/_index.md
+++ b/content/shared/influxdb3-admin/tokens/_index.md
@@ -10,6 +10,7 @@ The mechanism for providing your token depends on the client you use to interact
 {{% tabs %}}
 [influxdb3 CLI](#influxdb3-cli-auth)
 [cURL](#curl-auth)
+[Python (requests)](#python-auth-requests)
 {{% /tabs %}}
 
 {{% tab-content %}}
@@ -60,6 +61,35 @@ curl "http://localhost:8181/api/v3/query_sql" \
 {{% /code-placeholders %}}
 
 Replace `your-token` with your actual InfluxDB 3 token.
+
+{{% /tab-content %}}
+
+{{% tab-content %}}
+
+Use Python with the `requests` library to send an authenticated query:
+
+{{% code-placeholders "YOUR_TOKEN" %}}
+
+```python
+import requests
+
+url = "http://localhost:8181/api/v3/query_sql"
+headers = {
+    "Authorization": "Bearer YOUR_TOKEN",
+    "Content-Type": "application/json"
+}
+data = {
+    "db": "example-db",
+    "sql": "SELECT * FROM 'example-table' WHERE time > now() - INTERVAL '10 minutes'"
+}
+
+response = requests.post(url, json=data, headers=headers)
+print(response.json())
+```
+
+{{% /code-placeholders %}}
+
+Replace `YOUR_TOKEN` with your InfluxDB 3 token.
 
 {{% /tab-content %}}
 

--- a/content/shared/influxdb3-admin/tokens/_index.md
+++ b/content/shared/influxdb3-admin/tokens/_index.md
@@ -5,41 +5,64 @@ Manage tokens to authenticate and authorize access to resources and data in your
 Before running CLI commands or making HTTP API requests, you must provide a valid token to authenticate.
 The mechanism for providing your token depends on the client you use to interact with {{% product-name %}}--for example:
 
-{{< code-tabs-wrapper >}}
+{{< tabs-wrapper >}}
 
-{{% code-tabs %}}
-[CLI](#cli-auth)
-[HTTP API](#http-api-auth)
-{{% /code-tabs %}}
+{{% tabs %}}
+[influxdb3 CLI](#influxdb3-cli-auth)
+[cURL](#curl-auth)
+{{% /tabs %}}
 
-{{% code-tab-content %}}
+{{% tab-content %}}
 
-{{% code-placeholders "your-token" %}}
+When using the `influxdb3` CLI, you can use the `--token` option to provide your authorization token.
+
+{{% code-placeholders "YOUR_TOKEN" %}}
 ```bash
-# Export your token as an environment variable
-export INFLUXDB3_AUTH_TOKEN=your-token
+# Include the --token option in your influxdb3 command
+influxdb3 query \
+  --token YOUR_TOKEN \
+  --database example-db \
+  "SELECT * FROM 'example-table' WHERE time > now() - INTERVAL '10 minutes'"
 ```
 {{% /code-placeholders %}}
 
-Replace `your-token` with your actual InfluxDB 3 token.
+You can also set the `INFLUXDB3_AUTH_TOKEN` environment variable to automatically provide your
+authorization token to all `influxdb3` commands.
 
-{{% /code-tab-content %}}
+{{% code-placeholders "YOUR_TOKEN" %}}
+```bash
+# Export your token as an environment variable
+export INFLUXDB3_AUTH_TOKEN=YOUR_TOKEN
 
-{{% code-tab-content %}}
+# Run an influxdb3 command without the --token option
+influxdb3 query \
+  --database example-db \
+  "SELECT * FROM 'example-table' WHERE time > now() - INTERVAL '10 minutes'"
+```
+{{% /code-placeholders %}}
 
-{{% code-placeholders "your-token" %}}
+Replace `YOUR_TOKEN` with your authorization token.
+
+{{% /tab-content %}}
+
+{{% tab-content %}}
+
+{{% code-placeholders "AUTH_TOKEN" %}}
 
 ```bash
 # Add your token to the HTTP Authorization header
---header "Authorization: Bearer your-token"
+curl "http://localhost:8181/api/v3/query_sql" \
+  --header "Authorization: Bearer AUTH_TOKEN" \
+  --data-urlencode "db=example-db" \
+  --data-urlencode "q=SELECT * FROM 'example-table' WHERE time > now() - INTERVAL '10 minutes'"
 ```
 
 {{% /code-placeholders %}}
 
 Replace `your-token` with your actual InfluxDB 3 token.
 
-{{% /code-tab-content %}}
+{{% /tab-content %}}
 
-{{< /code-tabs-wrapper >}}
+{{< /tabs-wrapper >}}
 
 {{< children hlevel="h2" readmore=true hr=true >}}

--- a/content/shared/influxdb3-admin/tokens/_index.md
+++ b/content/shared/influxdb3-admin/tokens/_index.md
@@ -10,7 +10,6 @@ The mechanism for providing your token depends on the client you use to interact
 {{% tabs %}}
 [influxdb3 CLI](#influxdb3-cli-auth)
 [cURL](#curl-auth)
-[Python (requests)](#python-auth-requests)
 {{% /tabs %}}
 
 {{% tab-content %}}
@@ -49,42 +48,16 @@ Replace `YOUR_TOKEN` with your authorization token.
 {{% tab-content %}}
 
 {{% code-placeholders "AUTH_TOKEN" %}}
-
 ```bash
 # Add your token to the HTTP Authorization header
 curl "http://{{< influxdb/host >}}/api/v3/query_sql" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --data-urlencode "db=example-db" \
   --data-urlencode "q=SELECT * FROM 'example-table' WHERE time > now() - INTERVAL '10 minutes'"
-
-{{% /tab-content %}}
-
-{{% tab-content %}}
-
-Use Python with the `requests` library to send an authenticated query:
-
-{{% code-placeholders "YOUR_TOKEN" %}}
-
-```python
-import requests
-
-url = "http://localhost:8181/api/v3/query_sql"
-headers = {
-    "Authorization": "Bearer YOUR_TOKEN",
-    "Content-Type": "application/json"
-}
-data = {
-    "db": "example-db",
-    "sql": "SELECT * FROM 'example-table' WHERE time > now() - INTERVAL '10 minutes'"
-}
-
-response = requests.post(url, json=data, headers=headers)
-print(response.json())
 ```
-
 {{% /code-placeholders %}}
 
-Replace `YOUR_TOKEN` with your InfluxDB 3 token.
+Replace `AUTH_TOKEN` with your actual InfluxDB 3 token.
 
 {{% /tab-content %}}
 

--- a/content/shared/influxdb3-admin/tokens/_index.md
+++ b/content/shared/influxdb3-admin/tokens/_index.md
@@ -1,4 +1,46 @@
-Manage tokens to authenticate and authorize access to resources and data in your
-{{< product-name >}} instance.
+Manage tokens to authenticate and authorize access to resources and data in your {{< product-name >}} instance.
+
+## Provide your token
+
+Before running CLI commands or making HTTP API requests, you must provide a valid token to authenticate.
+
+Use one of the following methods to provide your token:
+
+{{< code-tabs-wrapper >}}
+
+{{% code-tabs %}}
+[CLI](#cli-auth)
+[HTTP API](#http-api-auth)
+{{% /code-tabs %}}
+
+{{% code-tab-content %}}
+
+{{% code-placeholders "your-token" %}}
+```bash
+# Export your token as an environment variable
+export INFLUXDB3_AUTH_TOKEN=your-token
+```
+{{% /code-placeholders %}}
+
+Replace `your-token` with your actual InfluxDB 3 token.
+
+{{% /code-tab-content %}}
+
+{{% code-tab-content %}}
+
+{{% code-placeholders "your-token" %}}
+
+```bash
+# Add your token to the HTTP Authorization header
+--header "Authorization: Bearer your-token"
+```
+
+{{% /code-placeholders %}}
+
+Replace `your-token` with your actual InfluxDB 3 token.
+
+{{% /code-tab-content %}}
+
+{{< /code-tabs-wrapper >}}
 
 {{< children hlevel="h2" readmore=true hr=true >}}

--- a/content/shared/influxdb3-admin/tokens/_index.md
+++ b/content/shared/influxdb3-admin/tokens/_index.md
@@ -3,8 +3,7 @@ Manage tokens to authenticate and authorize access to resources and data in your
 ## Provide your token
 
 Before running CLI commands or making HTTP API requests, you must provide a valid token to authenticate.
-
-Use one of the following methods to provide your token:
+The mechanism for providing your token depends on the client you use to interact with {{% product-name %}}--for example:
 
 {{< code-tabs-wrapper >}}
 

--- a/content/shared/influxdb3-admin/tokens/admin/list.md
+++ b/content/shared/influxdb3-admin/tokens/admin/list.md
@@ -12,7 +12,7 @@ data and resources in your InfluxDB 3 instance.
 > #### Required permissions
 >
 > Listing admin tokens requires a valid InfluxDB {{% token-link "admin" %}}{{% show-in "enterprise" %}} or a token with read access to the `_internal` system database{{% /show-in %}}.
-> For more information about providing a token, see <LINK_TO_NEW_TOKEN_CONTENT>.
+> For more information about providing a token, see [provide your token](/influxdb3/core/admin/tokens/#provide-your-token).
 
 
 ## List all tokens

--- a/content/shared/influxdb3-admin/tokens/admin/list.md
+++ b/content/shared/influxdb3-admin/tokens/admin/list.md
@@ -8,7 +8,13 @@ data and resources in your InfluxDB 3 instance.
 > Token metadata includes the hashed token string.
 > InfluxDB 3 does not store the raw token string.
 
-To run the following examples, you must set the `INFLUXDB3_AUTH_TOKEN` environment variable with a valid InfluxDB {{% token-link "admin" %}}. {{% show-in "enterprise" %}}Alternatively use a token with read permission on the `_internal` system database.{{% /show-in %}} Use one of the following methods to set or include your token:
+## Prerequisites
+
+Before running the following examples, obtain a valid InfluxDB {{% token-link "admin" %}}.  
+
+{{% show-in "enterprise" %}}Alternatively, use a token with read access to the `_internal` system database.{{% /show-in %}}
+
+Use one of the following methods to provide your token:
 
 {{% code-placeholders "your-token" %}}
 

--- a/content/shared/influxdb3-admin/tokens/admin/list.md
+++ b/content/shared/influxdb3-admin/tokens/admin/list.md
@@ -8,8 +8,39 @@ data and resources in your InfluxDB 3 instance.
 > Token metadata includes the hashed token string.
 > InfluxDB 3 does not store the raw token string.
 
-In the following examples, replace {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}} with your InfluxDB {{% token-link "admin" %}}
-{{% show-in "enterprise" %}} or a token with read permission on the `_internal` system database`{{% /show-in %}}.
+To run the following examples, you must set the `INFLUXDB3_AUTH_TOKEN` environment variable with a valid InfluxDB {{% token-link "admin" %}}. {{% show-in "enterprise" %}}Alternatively use a token with read permission on the `_internal` system database.{{% /show-in %}} Use one of the following methods to set or include your token:
+
+{{% code-placeholders "your-token" %}}
+
+{{< code-tabs-wrapper >}}
+
+{{% code-tabs %}}
+[CLI](#cli-auth)
+[HTTP API](#http-api-auth)
+{{% /code-tabs %}}
+
+{{% code-tab-content %}}
+```bash
+# Set your InfluxDB 3 token as an environment variable
+export INFLUXDB3_AUTH_TOKEN=your-token
+```
+{{% /code-tab-content %}}
+
+{{% code-tab-content %}}
+
+```bash
+# Add your token to the HTTP Authorization header
+--header "Authorization: Bearer your-token"
+```
+
+{{% /code-tab-content %}}
+
+{{< /code-tabs-wrapper >}}
+
+{{% /code-placeholders %}}
+
+Replace `your-token` with your actual InfluxDB 3 token.
+
 
 ## List all tokens
 

--- a/content/shared/influxdb3-admin/tokens/admin/list.md
+++ b/content/shared/influxdb3-admin/tokens/admin/list.md
@@ -8,44 +8,11 @@ data and resources in your InfluxDB 3 instance.
 > Token metadata includes the hashed token string.
 > InfluxDB 3 does not store the raw token string.
 
-## Prerequisites
-
-Before running the following examples, obtain a valid InfluxDB {{% token-link "admin" %}}.  
-
-{{% show-in "enterprise" %}}Alternatively, use a token with read access to the `_internal` system database.{{% /show-in %}}
-
-Use one of the following methods to provide your token:
-
-{{% code-placeholders "your-token" %}}
-
-{{< code-tabs-wrapper >}}
-
-{{% code-tabs %}}
-[CLI](#cli-auth)
-[HTTP API](#http-api-auth)
-{{% /code-tabs %}}
-
-{{% code-tab-content %}}
-```bash
-# Set your InfluxDB 3 token as an environment variable
-export INFLUXDB3_AUTH_TOKEN=your-token
-```
-{{% /code-tab-content %}}
-
-{{% code-tab-content %}}
-
-```bash
-# Add your token to the HTTP Authorization header
---header "Authorization: Bearer your-token"
-```
-
-{{% /code-tab-content %}}
-
-{{< /code-tabs-wrapper >}}
-
-{{% /code-placeholders %}}
-
-Replace `your-token` with your actual InfluxDB 3 token.
+> [!Important]
+> #### Required permissions
+>
+> Listing admin tokens requires a valid InfluxDB {{% token-link "admin" %}}{{% show-in "enterprise" %}} or a token with read access to the `_internal` system database{{% /show-in %}}.
+> For more information about providing a token, see <LINK_TO_NEW_TOKEN_CONTENT>.
 
 
 ## List all tokens


### PR DESCRIPTION
Closes #6056

- Clarifies how to authenticate using INFLUXDB3_AUTH_TOKEN for both CLI and HTTP API.

- Adds a code tab block showing both methods and aligns examples with tested behavior.


