### PR TITLE
fix(ent3): Remove 'enterprise' from /api/v3/configure/token/admin end…

### DIFF
--- a/content/influxdb3/enterprise/admin/tokens/admin/create.md
+++ b/content/influxdb3/enterprise/admin/tokens/admin/create.md
@@ -16,7 +16,7 @@ list_code_example: |
   ```
   #### HTTP API
   ```bash
-  curl -X POST "http://{{< influxdb/host >}}/api/v3/enterprise/configure/token/admin" \
+  curl -X POST "http://{{< influxdb/host >}}/api/v3/configure/token/admin" \
     --header 'Accept: application/json' \
     --header 'Content-Type: application/json'
   ```

--- a/content/shared/influxdb3-admin/tokens/admin/create.md
+++ b/content/shared/influxdb3-admin/tokens/admin/create.md
@@ -35,7 +35,6 @@ across sessions, assign the token string to the `INFLUXDB3_AUTH_TOKEN` environme
 {{% tab-content %}}
 Use the following endpoint to create an admin token:
 
-{{% show-in "core" %}}
 {{% api-endpoint method="POST" endpoint="/api/v3/configure/token/admin" api-ref="/influxdb3/version/api/v3/#operation/PostCreateAdminToken" %}}
 
 ```bash
@@ -43,15 +42,5 @@ curl -X POST "http://{{< influxdb/host >}}/api/v3/configure/token/admin" \
 --header 'Accept: application/json' \
 --header 'Content-Type: application/json'
 ```
-{{% /show-in %}}
-{{% show-in "enterprise" %}}
-{{% api-endpoint method="POST" endpoint="/api/v3/enterprise/configure/token/admin" api-ref="/influxdb3/version/api/v3/#operation/PostCreateAdminToken" %}}
-
-```bash
-curl -X POST "http://{{< influxdb/host >}}/api/v3/{{< product-key >}}/configure/token/admin" \
---header 'Accept: application/json' \
---header 'Content-Type: application/json'
-```
-{{% /show-in %}}
 {{% /tab-content %}}
 {{< /tabs-wrapper >}}

--- a/content/shared/influxdb3-admin/tokens/admin/regenerate.md
+++ b/content/shared/influxdb3-admin/tokens/admin/regenerate.md
@@ -56,36 +56,18 @@ The output contains the new token string and InfluxDB deactivates the previous t
 <!----------------------------BEGIN HTTP API----------------------------------->
 Use the following HTTP API endpoint:
 
-{{% show-in "core" %}}
 {{% api-endpoint method="POST" endpoint="/api/v3/configure/token/admin/regenerate" api-ref="/influxdb3/version/api/v3/configure/token/admin/regenerate" %}}
-{{% /show-in %}}
-
-{{% show-in "enterprise" %}}
-{{% api-endpoint method="POST" endpoint="/api/v3/enterprise/configure/token/admin/regenerate" api-ref="/influxdb3/version/api/v3/enterprise/configure/token/admin" %}}
-{{% /show-in %}}
 
 In your request, send an `Authorization` header with your current admin token string 
 --for example:
 
-{{% show-in "core" %}}
 {{% code-placeholders "ADMIN_TOKEN" %}}
 ```bash
-curl -X POST "http://{{< influxdb/host >}}/api/v3/configure/token/admin" \
+curl -X POST "http://{{< influxdb/host >}}/api/v3/configure/token/admin/regenerate" \
   --header "Authorization: Bearer ADMIN_TOKEN" \
   --header "Accept: application/json"
 ```
 {{% /code-placeholders %}}
-{{% /show-in %}}
-
-{{% show-in "enterprise" %}}
-{{% code-placeholders "ADMIN_TOKEN" %}}
-```bash
-curl -X POST "http://{{< influxdb/host >}}/api/v3/enterprise/configure/token/admin" \
-  --header "Authorization: Bearer ADMIN_TOKEN" \
-  --header "Accept: application/json"
-```
-{{% /code-placeholders %}}
-{{% /show-in %}}
 
 In your command, replace {{% code-placeholder-key %}}`ADMIN_TOKEN`{{% /code-placeholder-key %}} with the current token string.
 


### PR DESCRIPTION
…point

Enterprise now uses the unified endpoint for admin token creation.

Completes the cleanup started in:
#6064
#6068 
#6063

