### PR TITLE
6095 discord for core and ent

### DIFF
--- a/content/shared/v3-core-get-started/_index.md
+++ b/content/shared/v3-core-get-started/_index.md
@@ -45,6 +45,12 @@ This guide covers InfluxDB 3 Core (the open source release), including the follo
 - [Distinct values cache](#distinct-values-cache)
 - [Python plugins and the processing engine](#python-plugins-and-the-processing-engine)
 
+> [!Tip]
+> #### Find support for {{% product-name %}}
+>
+> The [InfluxDB Discord server](https://discord.gg/9zaNCW2PRT) is the best place to find support for {{% product-name %}}.
+> For other InfluxDB versions, see the [Support and feedback](#bug-reports-and-feedback) options.
+
 ### Install and startup
 
 {{% product-name %}} runs on **Linux**, **macOS**, and **Windows**.

--- a/content/shared/v3-enterprise-get-started/_index.md
+++ b/content/shared/v3-enterprise-get-started/_index.md
@@ -44,6 +44,12 @@ This guide covers Enterprise as well as InfluxDB 3 Core, including the following
 - [Python plugins and the processing engine](#python-plugins-and-the-processing-engine)
 - [Multi-server setups](#multi-server-setup)
 
+> [!Tip]
+> #### Find support for {{% product-name %}}
+>
+> The [InfluxDB Discord server](https://discord.gg/9zaNCW2PRT) is the best place to find support for {{% product-name %}}.
+> For other InfluxDB versions, see the [Support and feedback](#bug-reports-and-feedback) options.
+
 ### Install and startup
 
 {{% product-name %}} runs on **Linux**, **macOS**, and **Windows**.

--- a/layouts/partials/article/feedback.html
+++ b/layouts/partials/article/feedback.html
@@ -53,14 +53,11 @@
       To find support, use the following resources:
     </p>
     <ul>
-      {{ if eq $product "influxdb3" }}
-      <li><a class="discord" href="https://discord.gg/9zaNCW2PRT" target="_blank"><strong>InfluxDB Discord Server</strong> <em style="opacity:.5">(Preferred for InfluxDB 3 Core and Enterprise)</em></a></li>
-      <li><a class="community" href="https://community.influxdata.com/" target="_blank">InfluxData Community</a></li>
-      <li><a class="slack" href="https://influxdata.com/slack" target="_blank">InfluxDB Community Slack</a></li>
-      {{ else }}
-      <li><a class="community" href="https://community.influxdata.com/" target="_blank">InfluxData Community</a></li>
-      <li><a class="slack" href="https://influxdata.com/slack" target="_blank">InfluxDB Community Slack</a></li>
+      {{ if and (eq $product "influxdb3") (or (eq $version "core") (eq $version "enterprise")) }}
+        <li><a class="discord" href="https://discord.gg/9zaNCW2PRT" target="_blank"><strong>InfluxDB Discord Server</strong> <em style="opacity:.5">(Preferred for InfluxDB 3 Core and Enterprise)</em></a></li>
       {{ end }}
+      <li><a class="community" href="https://community.influxdata.com/" target="_blank">InfluxData Community</a></li>
+      <li><a class="slack" href="https://influxdata.com/slack" target="_blank">InfluxDB Community Slack</a></li>
       <li><a class="reddit" href="https://reddit.com/r/influxdb" target="_blank">InfluxDB Subreddit</a></li>
     </ul>
     {{ if not (in $supportBlacklist $product) }}

--- a/layouts/partials/article/feedback.html
+++ b/layouts/partials/article/feedback.html
@@ -53,9 +53,14 @@
       To find support, use the following resources:
     </p>
     <ul>
-      <li><a class="discord" href="https://discord.gg/9zaNCW2PRT" target="_blank" >InfluxDB Discord Server <em style="opacity:.5">(Preferred)</em></a></li>
+      {{ if eq $product "influxdb3" }}
+      <li><a class="discord" href="https://discord.gg/9zaNCW2PRT" target="_blank"><strong>InfluxDB Discord Server</strong> <em style="opacity:.5">(Preferred for InfluxDB 3 Core and Enterprise)</em></a></li>
       <li><a class="community" href="https://community.influxdata.com/" target="_blank">InfluxData Community</a></li>
       <li><a class="slack" href="https://influxdata.com/slack" target="_blank">InfluxDB Community Slack</a></li>
+      {{ else }}
+      <li><a class="community" href="https://community.influxdata.com/" target="_blank">InfluxData Community</a></li>
+      <li><a class="slack" href="https://influxdata.com/slack" target="_blank">InfluxDB Community Slack</a></li>
+      {{ end }}
       <li><a class="reddit" href="https://reddit.com/r/influxdb" target="_blank">InfluxDB Subreddit</a></li>
     </ul>
     {{ if not (in $supportBlacklist $product) }}


### PR DESCRIPTION
Add callout to core/get-started and enterprise/get-started
Only show Discord support option if core or enterprise
Closes https://github.com/influxdata/docs-v2/issues/6095
