### PR TITLE
Adapt templates to generator tool definitions

### DIFF
--- a/telegraf-build/templates/aggregator_plugin.tmpl
+++ b/telegraf-build/templates/aggregator_plugin.tmpl
@@ -6,10 +6,14 @@ menu:
     name: {{.Name}}
     identifier: aggregator-{{.ID}}
 tags: [{{.Name}}, "aggregator-plugins", "configuration"{{range .Tags}}, "{{.}}"{{end}}]
-{{if .Introduced}}introduced: "{{.Introduced}}"{{end}}
-{{if .Deprecated}}deprecated: "{{.Deprecated}}"{{end}}
-{{if .Removal}}removal: "{{.Removal}}"{{end}}
-{{if .OS}}os_support: "{{.OS}}"{{end}}
+introduced: "{{.Introduced}}"
+{{- with .Deprecated}}
+deprecated: {{.}}
+{{- end}}
+{{- with .Removal}}
+removal: {{.}}
+{{- end}}
+os_support: "{{.OSTags | join ", "}}"
 related:
   - /telegraf/v1/configure_plugins/
   - {{.URL}}, {{.Name}} Plugin Source

--- a/telegraf-build/templates/input_plugin.tmpl
+++ b/telegraf-build/templates/input_plugin.tmpl
@@ -6,10 +6,14 @@ menu:
     name: {{.Name}}
     identifier: input-{{.ID}}
 tags: [{{.Name}}, "input-plugins", "configuration"{{range .Tags}}, "{{.}}"{{end}}]
-{{if .Introduced}}introduced: "{{.Introduced}}"{{end}}
-{{if .Deprecated}}deprecated: "{{.Deprecated}}"{{end}}
-{{if .Removal}}removal: "{{.Removal}}"{{end}}
-{{if .OS}}os_support: "{{.OS}}"{{end}}
+introduced: "{{.Introduced}}"
+{{- with .Deprecated}}
+deprecated: {{.}}
+{{- end}}
+{{- with .Removal}}
+removal: {{.}}
+{{- end}}
+os_support: "{{.OSTags | join ", "}}"
 related:
   - /telegraf/v1/configure_plugins/
   - {{.URL}}, {{.Name}} Plugin Source

--- a/telegraf-build/templates/output_plugin.tmpl
+++ b/telegraf-build/templates/output_plugin.tmpl
@@ -6,10 +6,14 @@ menu:
     name: {{.Name}}
     identifier: output-{{.ID}}
 tags: [{{.Name}}, "output-plugins", "configuration"{{range .Tags}}, "{{.}}"{{end}}]
-{{if .Introduced}}introduced: "{{.Introduced}}"{{end}}
-{{if .Deprecated}}deprecated: "{{.Deprecated}}"{{end}}
-{{if .Removal}}removal: "{{.Removal}}"{{end}}
-{{if .OS}}os_support: "{{.OS}}"{{end}}
+introduced: "{{.Introduced}}"
+{{- with .Deprecated}}
+deprecated: {{.}}
+{{- end}}
+{{- with .Removal}}
+removal: {{.}}
+{{- end}}
+os_support: "{{.OSTags | join ", "}}"
 related:
   - /telegraf/v1/configure_plugins/
   - {{.URL}}, {{.Name}} Plugin Source

--- a/telegraf-build/templates/plugin_list_entry.tmpl
+++ b/telegraf-build/templates/plugin_list_entry.tmpl
@@ -9,7 +9,5 @@
 {{- with .Removal }}
     removal: {{ . }}
 {{- end }}
-{{ with .OS }}
-    os_support: {{ . }}
-{{- end }}
+    os_support: [{{ .OSTags | join ", " }}]
     tags: [{{ .Tags | join ", " }}]

--- a/telegraf-build/templates/processor_plugin.tmpl
+++ b/telegraf-build/templates/processor_plugin.tmpl
@@ -6,10 +6,14 @@ menu:
     name: {{.Name}}
     identifier: processor-{{.ID}}
 tags: [{{.Name}}, "processor-plugins", "configuration"{{range .Tags}}, "{{.}}"{{end}}]
-{{if .Introduced}}introduced: "{{.Introduced}}"{{end}}
-{{if .Deprecated}}deprecated: "{{.Deprecated}}"{{end}}
-{{if .Removal}}removal: "{{.Removal}}"{{end}}
-{{if .OS}}os_support: "{{.OS}}"{{end}}
+introduced: "{{.Introduced}}"
+{{- with .Deprecated}}
+deprecated: {{.}}
+{{- end}}
+{{- with .Removal}}
+removal: {{.}}
+{{- end}}
+os_support: "{{.OSTags | join ", "}}"
 related:
   - /telegraf/v1/configure_plugins/
   - {{.URL}}, {{.Name}} Plugin Source


### PR DESCRIPTION
This PR improves the Telegraf templates used in the internal generator tool.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
