### PR TITLE
Remove references to OCI in Clustered

### DIFF
--- a/assets/js/release-toc.js
+++ b/assets/js/release-toc.js
@@ -5,13 +5,13 @@
   * release notes pages.
 */
 
-// Use jQuery filter to get an array of all the *release* h2 elements
-const releases = $('h2').filter(
-  (_i, el) => !el.id.match(/checkpoint-releases/)
+// Get all h2 elements that are not checkpoint-releases
+const releases = Array.from(document.querySelectorAll('h2')).filter(
+  el => !el.id.match(/checkpoint-releases/)
 );
 
 // Extract data about each release from the array of releases
-releaseData = releases.map((_i, el) => ({
+const releaseData = releases.map(el => ({
   name: el.textContent,
   id: el.id,
   class: el.getAttribute('class'),
@@ -19,8 +19,8 @@ releaseData = releases.map((_i, el) => ({
 }));
 
 // Use release data to generate a list item for each release
-getReleaseItem = (releaseData) => {
-  var li = document.createElement("li");
+function getReleaseItem(releaseData) {
+  const li = document.createElement("li");
   if (releaseData.class !== null) {
     li.className = releaseData.class;
   }
@@ -29,9 +29,10 @@ getReleaseItem = (releaseData) => {
   return li;
 }
 
-// Use jQuery each to build the release table of contents
-releaseData.each((_i, release) => {
-  $('#release-toc ul')[0].appendChild(getReleaseItem(release));
+// Build the release table of contents
+const releaseTocUl = document.querySelector('#release-toc ul');
+releaseData.forEach(release => {
+  releaseTocUl.appendChild(getReleaseItem(release));
 });
 
 /*
@@ -39,20 +40,30 @@ releaseData.each((_i, release) => {
   * number specified in the `show` attribute of `ul.release-list`.
   * Once all the release items are visible, the "Show More" button is hidden.
 */
-$('#release-toc .show-more').click(function () {
-  const itemHeight = 1.885; // Item height in rem
-  const releaseNum = releaseData.length;
-  const maxHeight = releaseNum * itemHeight;
-  const releaseIncrement = Number($('#release-list')[0].getAttribute('show'));
-  const currentHeight = Number(
-    $('#release-list')[0].style.height.match(/\d+\.?\d+/)[0]
-  );
-  const potentialHeight = currentHeight + releaseIncrement * itemHeight;
-  const newHeight = potentialHeight > maxHeight ? maxHeight : potentialHeight;
+const showMoreBtn = document.querySelector('#release-toc .show-more');
+if (showMoreBtn) {
+  showMoreBtn.addEventListener('click', function () {
+    const itemHeight = 1.885; // Item height in rem
+    const releaseNum = releaseData.length;
+    const maxHeight = releaseNum * itemHeight;
+    const releaseList = document.getElementById('release-list');
+    const releaseIncrement = Number(releaseList.getAttribute('show'));
+    const currentHeightMatch = releaseList.style.height.match(/\d+\.?\d+/);
+    const currentHeight = currentHeightMatch
+      ? Number(currentHeightMatch[0])
+      : 0;
+    const potentialHeight = currentHeight + releaseIncrement * itemHeight;
+    const newHeight = potentialHeight > maxHeight ? maxHeight : potentialHeight;
 
-  $('#release-list')[0].style.height = `${newHeight}rem`;
+    releaseList.style.height = `${newHeight}rem`;
 
-  if (newHeight >= maxHeight) {
-    $('#release-toc .show-more').fadeOut(100);
-  }
-});
+    if (newHeight >= maxHeight) {
+      // Simple fade out
+      showMoreBtn.style.transition = 'opacity 0.1s';
+      showMoreBtn.style.opacity = 0;
+      setTimeout(() => {
+        showMoreBtn.style.display = 'none';
+      }, 100);
+    }
+  });
+}

--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -3,7 +3,8 @@
   "baseUrl": ".",
   "paths": {
    "*": [
-    "*"
+    "*",
+    "../node_modules/*"
    ]
   }
  }

--- a/content/influxdb3/clustered/admin/upgrade.md
+++ b/content/influxdb3/clustered/admin/upgrade.md
@@ -66,8 +66,8 @@ us-docker.pkg.dev/influxdb2-artifacts/clustered/influxdb:PACKAGE_VERSION
 
 ### Identify the version to upgrade to
 
-All available InfluxDB Clustered package versions are provided at
-[oci.influxdata.com](https://oci.influxdata.com).
+All available InfluxDB Clustered package versions are provided in the
+[InfluxDB Clustered release notes](/influxdb3/clustered/reference/release-notes/clustered/).
 Find the package version you want to upgrade to and copy the version number.
 
 
@@ -76,7 +76,7 @@ Find the package version you want to upgrade to and copy the version number.
 Some InfluxDB Clustered releases are _checkpoint releases_ that introduce a
 breaking change to an InfluxDB component.
 Checkpoint releases are only made when absolutely necessary and are clearly
-identified at [oci.influxdata.com](https://oci.influxdata.com).
+identified in the [InfluxDB Clustered release notes](/influxdb3/clustered/reference/release-notes/clustered/).
 
 **When upgrading, always upgrade to each checkpoint release first, before proceeding
 to newer versions.**


### PR DESCRIPTION
Closes influxdata/DAR#503

- Removed references to OCI in Clustered docs
- Fixed toc-contents js by removing jQuery dependency

---

- [x] Rebased/mergeable
