### PR TITLE
Add info on trial@influxdata.com for help with trial licenses

### DIFF
--- a/layouts/partials/article/feedback.html
+++ b/layouts/partials/article/feedback.html
@@ -62,7 +62,9 @@
       <li><a class="reddit" href="https://reddit.com/r/influxdb" target="_blank">InfluxDB Subreddit</a></li>
     </ul>
     {{ if not (in $supportBlacklist $product) }}
-      <p><strong>Customers with an annual or support contract</strong> can <a href="https://support.influxdata.com/">contact InfluxData Support</a>.</p>
+      <p><strong>Customers with an annual or support contract</strong> can <a href="https://support.influxdata.com/">contact InfluxData Support</a>.
+         <strong>Customers using a trial license</strong> can email trial@influxdata.com for assistance.</p>
+
     {{ end }}
   </div>
   <div class="actions">


### PR DESCRIPTION
Requested from support.

This is to inform Enterprise trial users that they can get help by emailing trial@influxdat.com

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
