### PR TITLE
chore(qol): Add claude instructions file for the project

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,13 +1,16 @@
-# GitHub Copilot Instructions for InfluxData Documentation
+# Instructions for InfluxData Documentation
 
 ## Purpose and scope
 
-GitHub Copilot should help document InfluxData products by creating clear, accurate technical content with proper code examples, frontmatter, and formatting.
+Help document InfluxData products by creating clear, accurate technical content with proper code examples, frontmatter, and formatting.
 
 ## Documentation structure
 
 - **Product version data**: `/data/products.yml`
-- **Products**:
+- **InfluxData products**:
+  - InfluxDB 3 Explorer
+    - Documentation source path: `/content/influxdb3/explorer`
+    - Published for the web: https://docs.influxdata.com/influxdb3/explorer/
   - InfluxDB 3 Core
     - Documentation source path: `/content/influxdb3/core`
     - Published for the web: https://docs.influxdata.com/influxdb3/core/
@@ -92,7 +95,8 @@ GitHub Copilot should help document InfluxData products by creating clear, accur
 
 ## Markdown and shortcodes
 
-- Include proper frontmatter for each page:
+- Include proper frontmatter for Markdown pages in `content/**/*.md` (except for
+  shared content files in `content/shared/`):
 
   ```yaml
   title: # Page title (h1)
@@ -180,3 +184,17 @@ Table: keys: [_start, _stop, _field, _measurement]
 ## Related repositories
 
 - **Internal documentation assistance requests**: https://github.com/influxdata/DAR/issues Documentation
+
+## Additional instruction files
+
+For specific workflows and content types, also refer to:
+
+- **InfluxDB 3 code placeholders**: `.github/instructions/influxdb3-code-placeholders.instructions.md` - Guidelines for placeholder formatting, descriptions, and shortcode usage in InfluxDB 3 documentation
+- **Contributing guidelines**: `.github/instructions/contributing.instructions.md` - Detailed style guidelines, shortcode usage, frontmatter requirements, and development workflows
+- **Content-specific instructions**: Check `.github/instructions/` directory for specialized guidelines covering specific documentation patterns and requirements
+
+## Integration with specialized instructions
+
+When working on InfluxDB 3 documentation (Core/Enterprise), prioritize the placeholder guidelines from `influxdb3-code-placeholders.instructions.md`.
+
+For general documentation structure, shortcodes, and development workflows, follow the comprehensive guidelines in `contributing.instructions.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# Instructions for InfluxData Documentation
+
+## Purpose and scope
+
+Claude should help document InfluxData products by creating clear, accurate technical content with proper code examples, frontmatter, and formatting.
+
+## Project overview
+
+See @README.md
+
+## Available NPM commands
+
+@package.json
+
+## Instructions for contributing
+
+See @.github/copilot-instructions.md for style guidelines and
+product-specific documentation paths and URLs managed in this project.
+
+See @.github/instructions/contributing.instructions.md for contributing
+information including using shortcodes and running tests.
+
+See @.github/instructions/influxdb3-code-placeholders.instructions.md for using
+placeholders in code samples and CLI commands.
+

--- a/build-scripts/build-copilot-instructions.js
+++ b/build-scripts/build-copilot-instructions.js
@@ -46,11 +46,11 @@ function buildContributingInstructions() {
 applyTo: "content/**/*.md, layouts/**/*.html"
 ---
 
-# GitHub Copilot Instructions for InfluxData Documentation
+# Contributing instructions for InfluxData Documentation
 
 ## Purpose and scope
 
-GitHub Copilot should help document InfluxData products
+Help document InfluxData products
 by creating clear, accurate technical content with proper
 code examples, frontmatter, shortcodes, and formatting.
 


### PR DESCRIPTION
  The CLAUDE.md file successfully references 5 key files, all of which exist and are accessible:

  1. @README → README.md - Project overview and setup
  2. @package.json → package.json - NPM scripts and dependencies
  3. @.github/copilot-instructions.md → Main style guidelines and product info
  4. @.github/instructions/contributing.instructions.md → Detailed contributing guide
  5. @.github/instructions/influxdb3-code-placeholders.instructions.md → InfluxDB 3 specific guidelines

  📊 Current Structure Analysis

  The CLAUDE.md file acts as a minimal index that:
  - Delegates detailed instructions to other files
  - Uses Claude's @ symbol notation for file references
  - Provides a clear hierarchy of information

  💡 Key Instructions Coverage

  Through the linked files, Claude has access to:
  - Product documentation paths for all InfluxDB versions
  - Style guidelines following Google Developer Documentation standards
  - Shortcode usage with extensive examples
  - Testing procedures including pytest-codeblocks
  - Development workflows with Docker and Node.js
  - Placeholder conventions for code examples
  - Frontmatter requirements for Hugo pages

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
