### PR TITLE
Fix API trigger_specification and update API refs for 3.2

### DIFF
--- a/api-docs/influxdb3/core/v3/ref.yml
+++ b/api-docs/influxdb3/core/v3/ref.yml
@@ -922,9 +922,25 @@ paths:
       summary: Delete a database
       description: |
         Soft deletes a database.
-        The database is scheduled for deletion and unavailable for querying.  
+        The database is scheduled for deletion and unavailable for querying.
+        Use the `hard_delete_at` parameter to schedule a hard deletion.
       parameters:
         - $ref: '#/components/parameters/db'
+        - name: hard_delete_at
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: |
+            Schedule the database for hard deletion at the specified time.
+            If not provided, the database will be soft deleted.
+            Use ISO 8601 date-time format (for example, "2025-12-31T23:59:59Z").
+
+            #### Deleting a database cannot be undone
+            
+            Deleting a database is a destructive action.
+            Once a database is deleted, data stored in that database cannot be recovered.
       responses:
         '200':
           description: Success. Database deleted.
@@ -961,7 +977,13 @@ paths:
       summary: Delete a table
       description: |
         Soft deletes a table.
-        The table is scheduled for deletion and unavailable for querying.  
+        The table is scheduled for deletion and unavailable for querying.
+        Use the `hard_delete_at` parameter to schedule a hard deletion.
+
+        #### Deleting a table cannot be undone
+        
+        Deleting a table is a destructive action.
+        Once a table is deleted, data stored in that table cannot be recovered.
       parameters:
         - $ref: '#/components/parameters/db'
         - name: table
@@ -969,6 +991,16 @@ paths:
           required: true
           schema:
             type: string
+        - name: hard_delete_at
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: |
+            Schedule the table for hard deletion at the specified time.
+            If not provided, the table will be soft deleted.
+            Use ISO 8601 format (for example, "2025-12-31T23:59:59Z").
       responses:
         '200':
           description: Success (no content). The table has been deleted.
@@ -1078,7 +1110,7 @@ paths:
                   In `"cron:CRON_EXPRESSION"`, `CRON_EXPRESSION` uses extended 6-field cron format.
                   The cron expression `0 0 6 * * 1-5` means the trigger will run at 6:00 AM every weekday (Monday to Friday).
                 value:
-                  db: DATABASE_NAME
+                  db: mydb
                   plugin_filename: schedule.py
                   trigger_name: schedule_cron_trigger
                   trigger_specification: cron:0 0 6 * * 1-5
@@ -1136,7 +1168,7 @@ paths:
                   db: mydb
                   plugin_filename: request.py
                   trigger_name: hello_world_trigger
-                  trigger_specification: path:hello-world
+                  trigger_specification: request:hello-world
               cron_friday_afternoon:
                 summary: Cron trigger for Friday afternoons
                 description: |
@@ -1365,16 +1397,16 @@ paths:
           description: Plugin not enabled.
       tags:
         - Processing engine
-  /api/v3/engine/{plugin_path}:
+  /api/v3/engine/{request_path}:
     parameters:
-      - name: plugin_path
+      - name: request_path
         description: |
-          The path configured in the request trigger specification "path:<plugin_path>"` for the plugin.
+          The path configured in the request trigger specification for the plugin.
 
           For example, if you define a trigger with the following:
 
           ```json
-          trigger-spec: "path:hello-world"
+          trigger_specification: "request:hello-world"
           ```
 
           then, the HTTP API exposes the following plugin endpoint:
@@ -1390,7 +1422,7 @@ paths:
       operationId: GetProcessingEnginePluginRequest
       summary: On Request processing engine plugin request
       description: |
-        Executes the On Request processing engine plugin specified in `<plugin_path>`.
+        Executes the On Request processing engine plugin specified in the trigger's `plugin_filename`.
         The request can include request headers, query string parameters, and a request body, which InfluxDB passes to the plugin.
 
         An On Request plugin implements the following signature:
@@ -1417,7 +1449,7 @@ paths:
       operationId: PostProcessingEnginePluginRequest
       summary: On Request processing engine plugin request
       description: |
-        Executes the On Request processing engine plugin specified in `<plugin_path>`.
+        Executes the On Request processing engine plugin specified in the trigger's `plugin_filename`.
         The request can include request headers, query string parameters, and a request body, which InfluxDB passes to the plugin.
 
         An On Request plugin implements the following signature:
@@ -1868,7 +1900,7 @@ components:
             `schedule.py` or `endpoints/report.py`.
             The path can be absolute or relative to the `--plugins-dir` directory configured when starting InfluxDB 3.
 
-            The plugin file must implement the trigger interface associated with the trigger's specification (`trigger_spec`).
+            The plugin file must implement the trigger interface associated with the trigger's specification.
         trigger_name:
           type: string
         trigger_specification:
@@ -1911,12 +1943,12 @@ components:
             - `table:TABLE_NAME` - Triggers on write events to a specific table
 
             ### On-demand triggers
-            Format: `path:ENDPOINT_NAME`
+            Format: `request:REQUEST_PATH`
 
-            Creates an HTTP endpoint `/api/v3/engine/ENDPOINT_NAME` for manual invocation:
-            - `path:hello-world` - Creates endpoint `/api/v3/engine/hello-world`
-            - `path:data-export` - Creates endpoint `/api/v3/engine/data-export`
-          pattern: ^(cron:[0-9 *,/-]+|every:[0-9]+[smhd]|all_tables|table:[a-zA-Z_][a-zA-Z0-9_]*|path:[a-zA-Z0-9_-]+)$
+            Creates an HTTP endpoint `/api/v3/engine/REQUEST_PATH` for manual invocation:
+            - `request:hello-world` - Creates endpoint `/api/v3/engine/hello-world`
+            - `request:data-export` - Creates endpoint `/api/v3/engine/data-export`
+          pattern: ^(cron:[0-9 *,/-]+|every:[0-9]+[smhd]|all_tables|table:[a-zA-Z_][a-zA-Z0-9_]*|request:[a-zA-Z0-9_-]+)$
           example: cron:0 0 6 * * 1-5
         trigger_arguments:
           type: object
@@ -2013,6 +2045,65 @@ components:
         - m
         - h
       type: string
+    UpdateDatabaseRequest:
+      type: object
+      properties:
+        retention_period:
+          type: string
+          description: |
+            The retention period for the database. Specifies how long data should be retained.
+            Use duration format (for example, "1d", "1h", "30m", "7d").
+          example: "7d"
+      description: Request schema for updating database configuration.
+    UpdateTableRequest:
+      type: object
+      properties:
+        db:
+          type: string
+          description: The name of the database containing the table.
+        table:
+          type: string
+          description: The name of the table to update.
+        retention_period:
+          type: string
+          description: |
+            The retention period for the table. Specifies how long data in this table should be retained.
+            Use duration format (for example, "1d", "1h", "30m", "7d").
+          example: "30d"
+      required:
+        - db
+        - table
+      description: Request schema for updating table configuration.
+    LicenseResponse:
+      type: object
+      properties:
+        license_type:
+          type: string
+          description: The type of license (for example, "enterprise", "trial").
+          example: "enterprise"
+        expires_at:
+          type: string
+          format: date-time
+          description: The expiration date of the license in ISO 8601 format.
+          example: "2025-12-31T23:59:59Z"
+        features:
+          type: array
+          items:
+            type: string
+          description: List of features enabled by the license.
+          example:
+            - "clustering"
+            - "processing_engine"
+            - "advanced_auth"
+        status:
+          type: string
+          enum:
+            - "active"
+            - "expired"
+            - "invalid"
+          description: The current status of the license.
+          example: "active"
+      description: Response schema for license information.
   responses:
     Unauthorized:
       description: Unauthorized access.

--- a/api-docs/influxdb3/enterprise/v3/ref.yml
+++ b/api-docs/influxdb3/enterprise/v3/ref.yml
@@ -1240,7 +1240,7 @@ paths:
                   plugin_filename: request.py
                   trigger_name: hello_world_trigger
                   # trigger_specification: "request:hello-world" - For 3.2.1 (issue#6171)
-                  trigger_specification: '{"request_path": {"path": "hello-world"}}'
+                  trigger_specification: {"request_path": {"path": "hello-world"}}
               cron_friday_afternoon:
                 summary: Cron trigger for Friday afternoons
                 description: |
@@ -2056,7 +2056,6 @@ components:
         trigger_name:
           type: string
         trigger_specification:
-          type: string
           description: |
             Specifies when and how the processing engine trigger should be invoked.
 

--- a/api-docs/influxdb3/enterprise/v3/ref.yml
+++ b/api-docs/influxdb3/enterprise/v3/ref.yml
@@ -1239,7 +1239,8 @@ paths:
                   db: mydb
                   plugin_filename: request.py
                   trigger_name: hello_world_trigger
-                  trigger_specification: "request:hello-world"
+                  # trigger_specification: "request:hello-world" - For 3.2.1 (issue#6171)
+                  trigger_specification: '{"request_path": {"path": "hello-world"}}'
               cron_friday_afternoon:
                 summary: Cron trigger for Friday afternoons
                 description: |
@@ -1472,19 +1473,22 @@ paths:
     parameters:
       - name: request_path
         description: |
-          The path configured in the request trigger specification "request:<request_path>"` for the plugin.
+          The path configured in the request trigger specification for the plugin.
 
           For example, if you define a trigger with the following:
 
           ```json
-          trigger_specification: "request:hello-world"
+          trigger_specification: {"request_path": {"path": "hello-world"}}
           ```
-
+          
           then, the HTTP API exposes the following plugin endpoint:
             
           ```
           <INFLUXDB3_HOST>/api/v3/engine/hello-world
           ```
+
+          ***Note:*** Currently, due to a bug in InfluxDB 3 Enterprise, the request trigger specification is different from Core.
+
         in: path
         required: true
         schema:
@@ -2091,12 +2095,25 @@ components:
             - `table:TABLE_NAME` - Triggers on write events to a specific table
 
             ### On-demand triggers
-            Format: `request:REQUEST_PATH`
+            Format: `{"request_path": {"path": "REQUEST_PATH"}}`
 
             Creates an HTTP endpoint `/api/v3/engine/REQUEST_PATH` for manual invocation:
-            - `request:hello-world` - Creates endpoint `/api/v3/engine/hello-world`
-            - `request:data-export` - Creates endpoint `/api/v3/engine/data-export`
-          pattern: ^(cron:[0-9 *,/-]+|every:[0-9]+[smhd]|all_tables|table:[a-zA-Z_][a-zA-Z0-9_]*|request:[a-zA-Z0-9_-]+)$
+            - `{"request_path": {"path": "hello-world"}}` - Creates endpoint `/api/v3/engine/hello-world`
+            - `{"request_path": {"path": "data-export"}}` - Creates endpoint `/api/v3/engine/data-export`
+
+            ***Note:*** Currently, due to a bug in InfluxDB 3 Enterprise, the request trigger specification is different from Core. Use the JSON object format shown above.
+
+          oneOf:
+            - type: string
+              pattern: ^(cron:[0-9 *,/-]+|every:[0-9]+[smhd]|all_tables|table:[a-zA-Z_][a-zA-Z0-9_]*)$
+            - type: object
+              properties:
+                request_path:
+                  type: object
+                  properties:
+                    path:
+                      type: string
+                      pattern: ^[a-zA-Z0-9_-]+$
           example: cron:0 0 6 * * 1-5
         trigger_arguments:
           type: object

--- a/api-docs/influxdb3/enterprise/v3/ref.yml
+++ b/api-docs/influxdb3/enterprise/v3/ref.yml
@@ -922,9 +922,25 @@ paths:
       summary: Delete a database
       description: |
         Soft deletes a database.
-        The database is scheduled for deletion and unavailable for querying.  
+        The database is scheduled for deletion and unavailable for querying.
+        Use the `hard_delete_at` parameter to schedule a hard deletion.
       parameters:
         - $ref: '#/components/parameters/db'
+        - name: hard_delete_at
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: |
+            Schedule the database for hard deletion at the specified time.
+            If not provided, the database will be soft deleted.
+            Use ISO 8601 date-time format (for example, "2025-12-31T23:59:59Z").
+
+            #### Deleting a database cannot be undone
+            
+            Deleting a database is a destructive action.
+            Once a database is deleted, data stored in that database cannot be recovered.
       responses:
         '200':
           description: Success. Database deleted.
@@ -961,7 +977,13 @@ paths:
       summary: Delete a table
       description: |
         Soft deletes a table.
-        The table is scheduled for deletion and unavailable for querying.  
+        The table is scheduled for deletion and unavailable for querying.
+        Use the `hard_delete_at` parameter to schedule a hard deletion.
+
+        #### Deleting a table cannot be undone
+        
+        Deleting a table is a destructive action.
+        Once a table is deleted, data stored in that table cannot be recovered.
       parameters:
         - $ref: '#/components/parameters/db'
         - name: table
@@ -969,6 +991,16 @@ paths:
           required: true
           schema:
             type: string
+        - name: hard_delete_at
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: |
+            Schedule the table for hard deletion at the specified time.
+            If not provided, the table will be soft deleted.
+            Use ISO 8601 format (for example, "2025-12-31T23:59:59Z").
       responses:
         '200':
           description: Success (no content). The table has been deleted.
@@ -978,6 +1010,77 @@ paths:
           description: Table not found.
       tags:
         - Table
+    patch:
+      operationId: PatchConfigureTable
+      summary: Update a table
+      description: |
+        Updates table configuration, such as retention period.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTableRequest'
+      responses:
+        '200':
+          description: Success. The table has been updated.
+        '400':
+          description: Bad request.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Table not found.
+      tags:
+        - Table
+  /api/v3/configure/database/{db}:
+    patch:
+      operationId: PatchConfigureDatabase
+      summary: Update a database
+      description: |
+        Updates database configuration, such as retention period.
+      parameters:
+        - name: db
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The name of the database to update.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateDatabaseRequest'
+      responses:
+        '200':
+          description: Success. The database has been updated.
+        '400':
+          description: Bad request.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Database not found.
+      tags:
+        - Database
+  /api/v3/show/license:
+    get:
+      operationId: GetShowLicense
+      summary: Show license information
+      description: |
+        Retrieves information about the current InfluxDB 3 Enterprise license.
+      responses:
+        '200':
+          description: Success. The response body contains license information.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LicenseResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Access denied.
+      tags:
+        - Server information
   /api/v3/configure/distinct_cache:
     post:
       operationId: PostConfigureDistinctCache
@@ -1136,7 +1239,7 @@ paths:
                   db: mydb
                   plugin_filename: request.py
                   trigger_name: hello_world_trigger
-                  trigger_specification: path:hello-world
+                  trigger_specification: "request:hello-world"
               cron_friday_afternoon:
                 summary: Cron trigger for Friday afternoons
                 description: |
@@ -1365,16 +1468,16 @@ paths:
           description: Plugin not enabled.
       tags:
         - Processing engine
-  /api/v3/engine/{plugin_path}:
+  /api/v3/engine/{request_path}:
     parameters:
-      - name: plugin_path
+      - name: request_path
         description: |
-          The path configured in the request trigger specification "path:<plugin_path>"` for the plugin.
+          The path configured in the request trigger specification "request:<request_path>"` for the plugin.
 
           For example, if you define a trigger with the following:
 
           ```json
-          trigger-spec: "path:hello-world"
+          trigger_specification: "request:hello-world"
           ```
 
           then, the HTTP API exposes the following plugin endpoint:
@@ -1390,7 +1493,7 @@ paths:
       operationId: GetProcessingEnginePluginRequest
       summary: On Request processing engine plugin request
       description: |
-        Executes the On Request processing engine plugin specified in `<plugin_path>`.
+        Executes the On Request processing engine plugin specified in the trigger's `plugin_filename`.
         The request can include request headers, query string parameters, and a request body, which InfluxDB passes to the plugin.
 
         An On Request plugin implements the following signature:
@@ -1417,7 +1520,7 @@ paths:
       operationId: PostProcessingEnginePluginRequest
       summary: On Request processing engine plugin request
       description: |
-        Executes the On Request processing engine plugin specified in `<plugin_path>`.
+        Executes the On Request processing engine plugin specified in the trigger's `plugin_filename`.
         The request can include request headers, query string parameters, and a request body, which InfluxDB passes to the plugin.
 
         An On Request plugin implements the following signature:
@@ -1812,6 +1915,16 @@ components:
       properties:
         db:
           type: string
+          pattern: '^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$|^[a-zA-Z0-9]$'
+          description: |-
+            The database name. Database names cannot contain underscores (_).
+            Names must start and end with alphanumeric characters and can contain hyphens (-) in the middle.
+        retention_period:
+          type: string
+          description: |-
+            The retention period for the database. Specifies how long data should be retained.
+            Use duration format (for example, "1d", "1h", "30m", "7d").
+          example: "7d"
       required:
         - db
     CreateTableRequest:
@@ -1843,6 +1956,12 @@ components:
             required:
               - name
               - type
+        retention_period:
+          type: string
+          description: |-
+            The retention period for the table. Specifies how long data in this table should be retained.
+            Use duration format (for example, "1d", "1h", "30m", "7d").
+          example: "30d"
       required:
         - db
         - table
@@ -1929,7 +2048,7 @@ components:
             `schedule.py` or `endpoints/report.py`.
             The path can be absolute or relative to the `--plugins-dir` directory configured when starting InfluxDB 3.
 
-            The plugin file must implement the trigger interface associated with the trigger's specification (`trigger_spec`).
+            The plugin file must implement the trigger interface associated with the trigger's specification.
         trigger_name:
           type: string
         trigger_specification:
@@ -1972,12 +2091,12 @@ components:
             - `table:TABLE_NAME` - Triggers on write events to a specific table
 
             ### On-demand triggers
-            Format: `path:ENDPOINT_NAME`
+            Format: `request:REQUEST_PATH`
 
-            Creates an HTTP endpoint `/api/v3/engine/ENDPOINT_NAME` for manual invocation:
-            - `path:hello-world` - Creates endpoint `/api/v3/engine/hello-world`
-            - `path:data-export` - Creates endpoint `/api/v3/engine/data-export`
-          pattern: ^(cron:[0-9 *,/-]+|every:[0-9]+[smhd]|all_tables|table:[a-zA-Z_][a-zA-Z0-9_]*|path:[a-zA-Z0-9_-]+)$
+            Creates an HTTP endpoint `/api/v3/engine/REQUEST_PATH` for manual invocation:
+            - `request:hello-world` - Creates endpoint `/api/v3/engine/hello-world`
+            - `request:data-export` - Creates endpoint `/api/v3/engine/data-export`
+          pattern: ^(cron:[0-9 *,/-]+|every:[0-9]+[smhd]|all_tables|table:[a-zA-Z_][a-zA-Z0-9_]*|request:[a-zA-Z0-9_-]+)$
           example: cron:0 0 6 * * 1-5
         trigger_arguments:
           type: object
@@ -2074,6 +2193,65 @@ components:
         - m
         - h
       type: string
+    UpdateDatabaseRequest:
+      type: object
+      properties:
+        retention_period:
+          type: string
+          description: |
+            The retention period for the database. Specifies how long data should be retained.
+            Use duration format (for example, "1d", "1h", "30m", "7d").
+          example: "7d"
+      description: Request schema for updating database configuration.
+    UpdateTableRequest:
+      type: object
+      properties:
+        db:
+          type: string
+          description: The name of the database containing the table.
+        table:
+          type: string
+          description: The name of the table to update.
+        retention_period:
+          type: string
+          description: |
+            The retention period for the table. Specifies how long data in this table should be retained.
+            Use duration format (for example, "1d", "1h", "30m", "7d").
+          example: "30d"
+      required:
+        - db
+        - table
+      description: Request schema for updating table configuration.
+    LicenseResponse:
+      type: object
+      properties:
+        license_type:
+          type: string
+          description: The type of license (for example, "enterprise", "trial").
+          example: "enterprise"
+        expires_at:
+          type: string
+          format: date-time
+          description: The expiration date of the license in ISO 8601 format.
+          example: "2025-12-31T23:59:59Z"
+        features:
+          type: array
+          items:
+            type: string
+          description: List of features enabled by the license.
+          example:
+            - "clustering"
+            - "processing_engine"
+            - "advanced_auth"
+        status:
+          type: string
+          enum:
+            - "active"
+            - "expired"
+            - "invalid"
+          description: The current status of the license.
+          example: "active"
+      description: Response schema for license information.
   responses:
     Unauthorized:
       description: Unauthorized access.

--- a/content/shared/influxdb3-cli/create/trigger.md
+++ b/content/shared/influxdb3-cli/create/trigger.md
@@ -27,7 +27,7 @@ influxdb3 create trigger [OPTIONS] \
 | `-d`   | `--database`        | _({{< req >}})_ Name of the database to operate on                                                       |
 |        | `--token`           | _({{< req >}})_ Authentication token                                                                     |
 |        | `--plugin-filename` | _({{< req >}})_ Name of the file, stored in the server's `plugin-dir`, that contains the Python plugin code to run     | 
-|        | `--trigger-spec`    | Trigger specification--for example `table:<TABLE_NAME>` or `all_tables`                                  |
+|        | `--trigger-spec`    | Trigger specification: `table:<TABLE_NAME>`, `all_tables`, `every:<DURATION>`, `cron:<EXPRESSION>`, or `request:<REQUEST_PATH>`                             |
 |        | `--disabled`        | Create the trigger in disabled state                                                                     |
 |        | `--tls-ca`          | Path to a custom TLS certificate authority (for testing or self-signed certificates)                     |
 | `-h`   | `--help`            | Print help information                                                                                   |
@@ -113,3 +113,15 @@ influxdb3 create trigger \
 Creating a trigger in a disabled state prevents it from running immediately. You can enable it later when you're ready to activate it.
 
 {{% /code-placeholders %}}
+
+{{% show-in "enterprise" %}}
+> [!Warning]
+> #### Request trigger specification format differs between CLI and API
+> 
+> Due to a bug in InfluxDB 3 Enterprise, the request trigger specification format differs:
+> 
+> - **CLI**: `request:<REQUEST_PATH>` (same as Core CLI and API)
+> - **Enterprise API**: `{"request_path": {"path": "<REQUEST_PATH>"}}`
+> 
+> See the [API reference](/influxdb3/enterprise/api/#operation/PostConfigureProcessingEngineTrigger) for examples. Use `influxdb3 show summary` to verify the actual trigger specification.
+{{% /show-in %}}

--- a/content/shared/influxdb3-get-started/processing-engine.md
+++ b/content/shared/influxdb3-get-started/processing-engine.md
@@ -162,7 +162,7 @@ affecting actual data. During a plugin test:
 
 To test a plugin:
 
-1.  Save the [example plugin code](#example-python-plugin-for-wal-rows) to a
+1.  Save the [example plugin code](#example-python-plugin-for-data-writes) to a
     plugin file inside of the plugin directory. If you haven't yet written data
     to the table in the example, comment out the lines where it queries.
 2.  To run the test, enter the following command with the following options:

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -16,7 +16,8 @@
 
 - **Hard delete for databases and tables**: Permanently delete databases and tables, enabling complete removal of data structures for compliance and storage management ([#26553](https://github.com/influxdata/influxdb/pull/26553))
 - **AWS credentials auto-reload**: Support dynamic reloading of ephemeral AWS credentials from files, improving security and reliability when using AWS services ([#26537](https://github.com/influxdata/influxdb/pull/26537))
-- **Database retention period support**: Add retention period support for databases via CLI commands (`create database` and `update database` commands) and HTTP APIs ([#26520](https://github.com/influxdata/influxdb/pull/26520))
+- **Database retention period support**: Add retention period support for databases via CLI commands (`create database` and `update database` commands) and HTTP APIs ([#26520](https://github.com/influxdata/influxdb/pull/26520)):
+  - New CLI command: `update database --retention-period`
 - **Configurable lookback duration**: Users can specify lookback duration for PersistedFiles buffer, providing better control over query performance ([#26528](https://github.com/influxdata/influxdb/pull/26528))
 - **WAL replay concurrency control**: Add concurrency limits for WAL (Write-Ahead Log) replay to improve startup performance and resource management ([#26483](https://github.com/influxdata/influxdb/pull/26483))
 - **Enhanced write path**: Separate write path executor with unbounded memory for improved write performance ([#26455](https://github.com/influxdata/influxdb/pull/26455))
@@ -42,7 +43,8 @@ All Core updates are included in Enterprise. Additional Enterprise-specific feat
 - **License management improvements**: 
   - New `influxdb3 show license` command to display current license information
 - **Table-level retention period support**: Add retention period support for individual tables in addition to database-level retention, providing granular data lifecycle management
-  - New CLI command: `influxdb3 create table --retention-period`
+   - New CLI commands: `create table --retention-period` and `update table --retention-period`
+   - Set or clear table-specific retention policies independent of database settings
 - **Compaction improvements**:
   - Address compactor restart issues for better reliability
   - Track compacted generation durations in catalog for monitoring

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -5,6 +5,56 @@
 > All updates to Core are automatically included in Enterprise.
 > The Enterprise sections below only list updates exclusive to Enterprise.
 
+## v3.2.0 {date="2025-06-25"}
+**Core**: revision 1ca3168bee
+
+**Enterprise**: revision 1ca3168bee
+
+### Core
+
+#### Features
+
+- **Hard delete for databases and tables**: Permanently delete databases and tables, enabling complete removal of data structures for compliance and storage management ([#26553](https://github.com/influxdata/influxdb/pull/26553))
+- **AWS credentials auto-reload**: Support dynamic reloading of ephemeral AWS credentials from files, improving security and reliability when using AWS services ([#26537](https://github.com/influxdata/influxdb/pull/26537))
+- **Database retention period support**: Add retention period support for databases via CLI commands (`create database` and `update database` commands) and HTTP APIs ([#26520](https://github.com/influxdata/influxdb/pull/26520))
+- **Configurable lookback duration**: Users can specify lookback duration for PersistedFiles buffer, providing better control over query performance ([#26528](https://github.com/influxdata/influxdb/pull/26528))
+- **WAL replay concurrency control**: Add concurrency limits for WAL (Write-Ahead Log) replay to improve startup performance and resource management ([#26483](https://github.com/influxdata/influxdb/pull/26483))
+- **Enhanced write path**: Separate write path executor with unbounded memory for improved write performance ([#26455](https://github.com/influxdata/influxdb/pull/26455))
+
+#### Bug Fixes
+
+- **WAL corruption handling**: Handle corrupt WAL files during replay without panic, improving data recovery and system resilience ([#26556](https://github.com/influxdata/influxdb/pull/26556))
+- **Database naming validation**: Disallow underscores in database names when created via API to ensure consistency ([#26507](https://github.com/influxdata/influxdb/pull/26507))
+- **Object store cleanup**: Automatic intermediate directory cleanup for file object store, preventing storage bloat ([#26480](https://github.com/influxdata/influxdb/pull/26480))
+
+#### Additional Updates
+
+- Track generation 1 duration in catalog for better performance monitoring ([#26508](https://github.com/influxdata/influxdb/pull/26508))
+- Add retention period support to the catalog ([#26479](https://github.com/influxdata/influxdb/pull/26479))
+- Update help text for improved user experience ([#26509](https://github.com/influxdata/influxdb/pull/26509))
+
+### Enterprise
+
+All Core updates are included in Enterprise. Additional Enterprise-specific features and fixes:
+
+#### Features
+
+- **License management improvements**: 
+  - New `influxdb3 show license` command to display current license information
+- **Table-level retention period support**: Add retention period support for individual tables in addition to database-level retention, providing granular data lifecycle management
+  - New CLI commands: `create table --retention-period` and `update table --retention-period`
+  - Set or clear table-specific retention policies independent of database settings
+- **Compaction improvements**:
+  - Address compactor restart issues for better reliability
+  - Track compacted generation durations in catalog for monitoring
+  - Disable parquet cache for ingest mode to optimize memory usage
+
+#### Bug Fixes
+
+- **Query optimization**: Correctly partition query chunks into generations for improved performance
+- **Data integrity**: Don't delete generation 1 files as part of compaction process
+- **License handling**: Trim whitespace from license file contents after reading to prevent validation issues
+
 ## v3.1.0 {date="2025-05-29"}
 **Core**: revision 482dd8aac580c04f37e8713a8fffae89ae8bc264
 

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -42,8 +42,7 @@ All Core updates are included in Enterprise. Additional Enterprise-specific feat
 - **License management improvements**: 
   - New `influxdb3 show license` command to display current license information
 - **Table-level retention period support**: Add retention period support for individual tables in addition to database-level retention, providing granular data lifecycle management
-  - New CLI commands: `create table --retention-period` and `update table --retention-period`
-  - Set or clear table-specific retention policies independent of database settings
+  - New CLI command: `influxdb3 create table --retention-period`
 - **Compaction improvements**:
   - Address compactor restart issues for better reliability
   - Track compacted generation durations in catalog for monitoring

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -6,8 +6,8 @@
 > The Enterprise sections below only list updates exclusive to Enterprise.
 
 ## v3.2.0 {date="2025-06-25"}
-**Core**: revision 1ca3168bee
 
+**Core**: revision 1ca3168bee  
 **Enterprise**: revision 1ca3168bee
 
 ### Core

--- a/content/shared/v3-core-plugins/_index.md
+++ b/content/shared/v3-core-plugins/_index.md
@@ -23,25 +23,10 @@ Ensure you have:
 Once you have all the prerequisites in place, follow these steps to implement the Processing Engine for your data automation needs.
 
 - [Set up the Processing Engine](#set-up-the-processing-engine)
-  - [Configure distributed environments](#configure-distributed-environments)
 - [Add a Processing Engine plugin](#add-a-processing-engine-plugin)
-  - [Choose a plugin strategy](#choose-a-plugin-strategy)
-  - [Use example plugins](#use-example-plugins)
-  - [Create a custom plugin](#create-a-custom-plugin)
 - [Set up a trigger](#set-up-a-trigger)
-  - [Understand trigger types](#understand-trigger-types)
-  - [Use the create trigger command](#use-the-create-trigger-command)
-  - [Trigger specification examples](#trigger-specification-examples)
-  - [Pass arguments to plugins](#pass-arguments-to-plugins)
-  - [Control trigger execution](#control-trigger-execution)
-  - [Configure error handling for a trigger](#configure-error-handling-for-a-trigger)
 - [Advanced trigger configuration](#advanced-trigger-configuration)
-  - [Access community plugins from GitHub](#access-community-plugins-from-github)
-  - [Configure your triggers](#configure-your-triggers)
-  - [Install Python dependencies](#install-python-dependencies)
 - [Distributed cluster considerations](#distributed-cluster-considerations)
-  - [Match plugin types to the correct node](#match-plugin-types-to-the-correct-node)
-  - [Route third-party clients to querier nodes](#route-third-party-clients-to-querier-nodes)
 
 ## Set up the Processing Engine
 
@@ -239,7 +224,7 @@ def process_scheduled_call(influxdb3_local, call_time, args=None):
 
 #### Create an HTTP request plugin
 
-HTTP request plugins respond to API calls using [`request:`](#trigger-on-http-requests) trigger specifications{{% show-in "enterprise" %}} (CLI) or `{"request_path": {"path": "..."}}` (API){{% /show-in %}}. Use them for:
+HTTP request plugins respond to API calls using [`request:`](#trigger-on-http-requests) trigger specifications{{% show-in "enterprise" %}} (CLI) or `{"request_path": {"path": "..."}}` (HTTP API){{% /show-in %}}. Use them for:
 
 - Creating custom API endpoints
 - Webhooks for external integrations
@@ -278,7 +263,7 @@ After writing your plugin:
 |------------|----------------------|-----------------|
 | Data write | `table:<TABLE_NAME>` or `all_tables` | When data is written to tables |
 | Scheduled | `every:<DURATION>` or `cron:<EXPRESSION>` | At specified time intervals |
-| HTTP request | `request:<REQUEST_PATH>`{{% show-in "enterprise" %}} (CLI) or `{"request_path": {"path": "<REQUEST_PATH>"}}`{{% /show-in %}} | When HTTP requests are received |
+| HTTP request | `request:<REQUEST_PATH>`{{% show-in "enterprise" %}} (CLI) or `{"request_path": {"path": "<REQUEST_PATH>"}}` (HTTP API){{% /show-in %}} | When HTTP requests are received |
 
 ### Use the create trigger command
 
@@ -615,7 +600,7 @@ Each plugin must run on a node that supports its trigger type:
 |--------------------|--------------------------|-----------------------------|
 | Data write         | `table:` or `all_tables` | Ingester nodes              |
 | Scheduled          | `every:` or `cron:`      | Any node with scheduler     |
-| HTTP request       | `request:`{{% show-in "enterprise" %}} (CLI) or `{"request_path": {"path": "..."}}`{{% /show-in %}} | Nodes that serve API traffic|
+| HTTP request       | `request:`{{% show-in "enterprise" %}} (CLI) or `{"request_path": {"path": "..."}}` (HTTP API){{% /show-in %}} | Nodes that serve API traffic|
 
 {{% show-in "enterprise" %}}
 > [!Note]

--- a/helper-scripts/generate-release-notes.sh
+++ b/helper-scripts/generate-release-notes.sh
@@ -1,14 +1,55 @@
 #!/bin/bash
 
 # Script to generate release notes for InfluxDB v3.x releases
-# Usage: ./generate-release-notes.sh <from_version> <to_version> <repo_path>
+# Usage: ./generate-release-notes.sh [--no-fetch] [--pull] <from_version> <to_version> <primary_repo_path> [additional_repo_paths...]
+# 
+# Options:
+#   --no-fetch    Skip fetching latest commits from remote
+#   --pull        Pull latest changes (implies fetch) - use with caution as it may change your working directory
+#
+# Example: ./generate-release-notes.sh v3.1.0 v3.2.0 /path/to/influxdb /path/to/influxdb_pro /path/to/influxdb_iox
+# Example: ./generate-release-notes.sh --no-fetch v3.1.0 v3.2.0 /path/to/influxdb
+# Example: ./generate-release-notes.sh --pull v3.1.0 v3.2.0 /path/to/influxdb /path/to/influxdb_pro
 
 set -e
 
-# Default values
-REPO_PATH="${3:-/Users/ja/Documents/github/influxdb}"
+# Parse command line options
+FETCH_COMMITS=true
+PULL_COMMITS=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --no-fetch)
+            FETCH_COMMITS=false
+            shift
+            ;;
+        --pull)
+            PULL_COMMITS=true
+            FETCH_COMMITS=true
+            shift
+            ;;
+        -*)
+            echo "Unknown option $1"
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+# Parse remaining arguments
 FROM_VERSION="${1:-v3.1.0}"
 TO_VERSION="${2:-v3.2.0}"
+PRIMARY_REPO="${3:-/Users/ja/Documents/github/influxdb}"
+
+# Collect additional repositories (all arguments after the third)
+ADDITIONAL_REPOS=()
+shift 3 2>/dev/null || true
+while [ $# -gt 0 ]; do
+    ADDITIONAL_REPOS+=("$1")
+    shift
+done
 
 # Colors for output
 RED='\033[0;31m'
@@ -18,7 +59,13 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 echo -e "${BLUE}Generating release notes for ${TO_VERSION}${NC}"
-echo -e "Repository: ${REPO_PATH}"
+echo -e "Primary Repository: ${PRIMARY_REPO}"
+if [ ${#ADDITIONAL_REPOS[@]} -gt 0 ]; then
+    echo -e "Additional Repositories:"
+    for repo in "${ADDITIONAL_REPOS[@]}"; do
+        echo -e "  - ${repo}"
+    done
+fi
 echo -e "From: ${FROM_VERSION} To: ${TO_VERSION}\n"
 
 # Function to extract PR number from commit message
@@ -26,28 +73,156 @@ extract_pr_number() {
     echo "$1" | grep -oE '#[0-9]+' | head -1 | sed 's/#//'
 }
 
+# Function to get commits from a repository
+get_commits_from_repo() {
+    local repo_path="$1"
+    local pattern="$2"
+    local format="${3:-%h %s}"
+    
+    if [ -d "$repo_path" ]; then
+        git -C "$repo_path" log --format="$format" "${FROM_VERSION}..${TO_VERSION}" 2>/dev/null | grep -E "$pattern" || true
+    fi
+}
+
+# Function to analyze API-related commits
+analyze_api_changes() {
+    local repo_path="$1"
+    local repo_name="$2"
+    
+    if [ ! -d "$repo_path" ]; then
+        return
+    fi
+    
+    # Look for API-related file changes
+    local api_files=$(git -C "$repo_path" diff --name-only "${FROM_VERSION}..${TO_VERSION}" 2>/dev/null | grep -E "(api|handler|endpoint|route)" | head -10 || true)
+    
+    # Look for specific API endpoint patterns in commit messages and diffs
+    local api_commits=$(git -C "$repo_path" log --format="%h %s" "${FROM_VERSION}..${TO_VERSION}" 2>/dev/null | \
+        grep -iE "(api|endpoint|/write|/query|/ping|/health|/metrics|v1|v2|v3)" || true)
+    
+    if [ -n "$api_files" ] || [ -n "$api_commits" ]; then
+        echo "  Repository: $repo_name"
+        if [ -n "$api_files" ]; then
+            echo "    Modified API files:"
+            echo "$api_files" | while read -r file; do
+                echo "      - $file"
+            done
+        fi
+        if [ -n "$api_commits" ]; then
+            echo "    API-related commits:"
+            echo "$api_commits" | while read -r commit; do
+                echo "      - $commit"
+            done
+        fi
+        echo
+    fi
+}
+
 # Get the release date
-RELEASE_DATE=$(git -C "$REPO_PATH" log -1 --format=%ai "$TO_VERSION" | cut -d' ' -f1)
+RELEASE_DATE=$(git -C "$PRIMARY_REPO" log -1 --format=%ai "$TO_VERSION" | cut -d' ' -f1)
 echo -e "${GREEN}Release Date: ${RELEASE_DATE}${NC}\n"
 
-# Collect commits by category
-echo -e "${YELLOW}Analyzing commits...${NC}"
+# Create array of all repositories
+ALL_REPOS=("$PRIMARY_REPO")
+for repo in "${ADDITIONAL_REPOS[@]}"; do
+    ALL_REPOS+=("$repo")
+done
 
-# Features
-echo -e "\n${GREEN}Features:${NC}"
-FEATURES=$(git -C "$REPO_PATH" log --format="%h %s" "${FROM_VERSION}..${TO_VERSION}" | grep -E "^[a-f0-9]+ feat:" | sed 's/^[a-f0-9]* feat: //')
+# Fetch latest commits from all repositories (if enabled)
+if [ "$FETCH_COMMITS" = true ]; then
+    if [ "$PULL_COMMITS" = true ]; then
+        echo -e "${YELLOW}Pulling latest changes from all repositories...${NC}"
+        echo -e "${RED}Warning: This will modify your working directories!${NC}"
+    else
+        echo -e "${YELLOW}Fetching latest commits from all repositories...${NC}"
+    fi
+    
+    for repo in "${ALL_REPOS[@]}"; do
+        if [ -d "$repo" ]; then
+            repo_name=$(basename "$repo")
+            
+            if [ "$PULL_COMMITS" = true ]; then
+                echo -e "  Pulling changes in $repo_name..."
+                if git -C "$repo" pull origin 2>/dev/null; then
+                    echo -e "    ${GREEN}✓${NC} Successfully pulled changes in $repo_name"
+                else
+                    echo -e "    ${RED}✗${NC} Failed to pull changes in $repo_name (trying fetch only)"
+                    if git -C "$repo" fetch origin 2>/dev/null; then
+                        echo -e "    ${GREEN}✓${NC} Successfully fetched from $repo_name"
+                    else
+                        echo -e "    ${RED}✗${NC} Failed to fetch from $repo_name (continuing with local commits)"
+                    fi
+                fi
+            else
+                echo -e "  Fetching from $repo_name..."
+                if git -C "$repo" fetch origin 2>/dev/null; then
+                    echo -e "    ${GREEN}✓${NC} Successfully fetched from $repo_name"
+                else
+                    echo -e "    ${RED}✗${NC} Failed to fetch from $repo_name (continuing with local commits)"
+                fi
+            fi
+        else
+            echo -e "    ${RED}✗${NC} Repository not found: $repo"
+        fi
+    done
+else
+    echo -e "${YELLOW}Skipping fetch (using local commits only)${NC}"
+fi
 
-# Fixes
-echo -e "\n${GREEN}Bug Fixes:${NC}"
-FIXES=$(git -C "$REPO_PATH" log --format="%h %s" "${FROM_VERSION}..${TO_VERSION}" | grep -E "^[a-f0-9]+ fix:" | sed 's/^[a-f0-9]* fix: //')
+# Collect commits by category from all repositories
+echo -e "\n${YELLOW}Analyzing commits across all repositories...${NC}"
 
-# Breaking changes
-echo -e "\n${GREEN}Breaking Changes:${NC}"
-BREAKING=$(git -C "$REPO_PATH" log --format="%h %s" "${FROM_VERSION}..${TO_VERSION}" | grep -iE "^[a-f0-9]+ .*(BREAKING|breaking change)" | sed 's/^[a-f0-9]* //')
+# Initialize variables
+FEATURES=""
+FIXES=""
+BREAKING=""
+PERF=""
+API_CHANGES=""
 
-# Performance improvements
-echo -e "\n${GREEN}Performance:${NC}"
-PERF=$(git -C "$REPO_PATH" log --format="%h %s" "${FROM_VERSION}..${TO_VERSION}" | grep -E "^[a-f0-9]+ perf:" | sed 's/^[a-f0-9]* perf: //')
+# Collect commits from all repositories
+for repo in "${ALL_REPOS[@]}"; do
+    if [ -d "$repo" ]; then
+        repo_name=$(basename "$repo")
+        echo -e "  Analyzing $repo_name..."
+        
+        # Features
+        repo_features=$(get_commits_from_repo "$repo" "^[a-f0-9]+ feat:" | sed "s/^[a-f0-9]* feat: /- [$repo_name] /")
+        if [ -n "$repo_features" ]; then
+            FEATURES="$FEATURES$repo_features"$'\n'
+        fi
+        
+        # Fixes
+        repo_fixes=$(get_commits_from_repo "$repo" "^[a-f0-9]+ fix:" | sed "s/^[a-f0-9]* fix: /- [$repo_name] /")
+        if [ -n "$repo_fixes" ]; then
+            FIXES="$FIXES$repo_fixes"$'\n'
+        fi
+        
+        # Breaking changes
+        repo_breaking=$(get_commits_from_repo "$repo" "^[a-f0-9]+ .*(BREAKING|breaking change)" | sed "s/^[a-f0-9]* /- [$repo_name] /")
+        if [ -n "$repo_breaking" ]; then
+            BREAKING="$BREAKING$repo_breaking"$'\n'
+        fi
+        
+        # Performance improvements
+        repo_perf=$(get_commits_from_repo "$repo" "^[a-f0-9]+ perf:" | sed "s/^[a-f0-9]* perf: /- [$repo_name] /")
+        if [ -n "$repo_perf" ]; then
+            PERF="$PERF$repo_perf"$'\n'
+        fi
+        
+        # API changes
+        repo_api=$(get_commits_from_repo "$repo" "(api|endpoint|/write|/query|/ping|/health|/metrics|v1|v2|v3)" | sed "s/^[a-f0-9]* /- [$repo_name] /")
+        if [ -n "$repo_api" ]; then
+            API_CHANGES="$API_CHANGES$repo_api"$'\n'
+        fi
+    fi
+done
+
+# Analyze API changes in detail
+echo -e "\n${YELLOW}Analyzing HTTP API changes...${NC}"
+for repo in "${ALL_REPOS[@]}"; do
+    repo_name=$(basename "$repo")
+    analyze_api_changes "$repo" "$repo_name"
+done
 
 # Generate markdown output
 OUTPUT_FILE="release-notes-${TO_VERSION}.md"
@@ -60,16 +235,18 @@ EOF
 
 # Add features
 if [ -n "$FEATURES" ]; then
-    while IFS= read -r line; do
-        PR=$(extract_pr_number "$line")
-        # Clean up the commit message
-        CLEAN_LINE=$(echo "$line" | sed -E 's/ \(#[0-9]+\)$//')
-        if [ -n "$PR" ]; then
-            echo "- $CLEAN_LINE ([#$PR](https://github.com/influxdata/influxdb/pull/$PR))" >> "$OUTPUT_FILE"
-        else
-            echo "- $CLEAN_LINE" >> "$OUTPUT_FILE"
+    echo "$FEATURES" | while IFS= read -r line; do
+        if [ -n "$line" ]; then
+            PR=$(extract_pr_number "$line")
+            # Clean up the commit message
+            CLEAN_LINE=$(echo "$line" | sed -E 's/ \(#[0-9]+\)$//')
+            if [ -n "$PR" ]; then
+                echo "$CLEAN_LINE ([#$PR](https://github.com/influxdata/influxdb/pull/$PR))" >> "$OUTPUT_FILE"
+            else
+                echo "$CLEAN_LINE" >> "$OUTPUT_FILE"
+            fi
         fi
-    done <<< "$FEATURES"
+    done
 else
     echo "- No new features in this release" >> "$OUTPUT_FILE"
 fi
@@ -82,15 +259,17 @@ cat >> "$OUTPUT_FILE" << EOF
 EOF
 
 if [ -n "$FIXES" ]; then
-    while IFS= read -r line; do
-        PR=$(extract_pr_number "$line")
-        CLEAN_LINE=$(echo "$line" | sed -E 's/ \(#[0-9]+\)$//')
-        if [ -n "$PR" ]; then
-            echo "- $CLEAN_LINE ([#$PR](https://github.com/influxdata/influxdb/pull/$PR))" >> "$OUTPUT_FILE"
-        else
-            echo "- $CLEAN_LINE" >> "$OUTPUT_FILE"
+    echo "$FIXES" | while IFS= read -r line; do
+        if [ -n "$line" ]; then
+            PR=$(extract_pr_number "$line")
+            CLEAN_LINE=$(echo "$line" | sed -E 's/ \(#[0-9]+\)$//')
+            if [ -n "$PR" ]; then
+                echo "$CLEAN_LINE ([#$PR](https://github.com/influxdata/influxdb/pull/$PR))" >> "$OUTPUT_FILE"
+            else
+                echo "$CLEAN_LINE" >> "$OUTPUT_FILE"
+            fi
         fi
-    done <<< "$FIXES"
+    done
 else
     echo "- No bug fixes in this release" >> "$OUTPUT_FILE"
 fi
@@ -102,15 +281,17 @@ if [ -n "$BREAKING" ]; then
 ### Breaking Changes
 
 EOF
-    while IFS= read -r line; do
-        PR=$(extract_pr_number "$line")
-        CLEAN_LINE=$(echo "$line" | sed -E 's/ \(#[0-9]+\)$//')
-        if [ -n "$PR" ]; then
-            echo "- $CLEAN_LINE ([#$PR](https://github.com/influxdata/influxdb/pull/$PR))" >> "$OUTPUT_FILE"
-        else
-            echo "- $CLEAN_LINE" >> "$OUTPUT_FILE"
+    echo "$BREAKING" | while IFS= read -r line; do
+        if [ -n "$line" ]; then
+            PR=$(extract_pr_number "$line")
+            CLEAN_LINE=$(echo "$line" | sed -E 's/ \(#[0-9]+\)$//')
+            if [ -n "$PR" ]; then
+                echo "$CLEAN_LINE ([#$PR](https://github.com/influxdata/influxdb/pull/$PR))" >> "$OUTPUT_FILE"
+            else
+                echo "$CLEAN_LINE" >> "$OUTPUT_FILE"
+            fi
         fi
-    done <<< "$BREAKING"
+    done
 fi
 
 # Add performance improvements if any
@@ -120,16 +301,54 @@ if [ -n "$PERF" ]; then
 ### Performance Improvements
 
 EOF
-    while IFS= read -r line; do
-        PR=$(extract_pr_number "$line")
-        CLEAN_LINE=$(echo "$line" | sed -E 's/ \(#[0-9]+\)$//')
-        if [ -n "$PR" ]; then
-            echo "- $CLEAN_LINE ([#$PR](https://github.com/influxdata/influxdb/pull/$PR))" >> "$OUTPUT_FILE"
-        else
-            echo "- $CLEAN_LINE" >> "$OUTPUT_FILE"
+    echo "$PERF" | while IFS= read -r line; do
+        if [ -n "$line" ]; then
+            PR=$(extract_pr_number "$line")
+            CLEAN_LINE=$(echo "$line" | sed -E 's/ \(#[0-9]+\)$//')
+            if [ -n "$PR" ]; then
+                echo "$CLEAN_LINE ([#$PR](https://github.com/influxdata/influxdb/pull/$PR))" >> "$OUTPUT_FILE"
+            else
+                echo "$CLEAN_LINE" >> "$OUTPUT_FILE"
+            fi
         fi
-    done <<< "$PERF"
+    done
 fi
+
+# Add HTTP API changes if any
+if [ -n "$API_CHANGES" ]; then
+    cat >> "$OUTPUT_FILE" << EOF
+
+### HTTP API Changes
+
+EOF
+    echo "$API_CHANGES" | while IFS= read -r line; do
+        if [ -n "$line" ]; then
+            PR=$(extract_pr_number "$line")
+            CLEAN_LINE=$(echo "$line" | sed -E 's/ \(#[0-9]+\)$//')
+            if [ -n "$PR" ]; then
+                echo "$CLEAN_LINE ([#$PR](https://github.com/influxdata/influxdb/pull/$PR))" >> "$OUTPUT_FILE"
+            else
+                echo "$CLEAN_LINE" >> "$OUTPUT_FILE"
+            fi
+        fi
+    done
+fi
+
+# Add API analysis summary
+cat >> "$OUTPUT_FILE" << EOF
+
+### API Analysis Summary
+
+The following endpoints may have been affected in this release:
+- v1 API endpoints: \`/write\`, \`/query\`, \`/ping\`
+- v2 API endpoints: \`/api/v2/write\`, \`/api/v2/query\`
+- v3 API endpoints: \`/api/v3/*\`
+- System endpoints: \`/health\`, \`/metrics\`
+
+Please review the commit details above and consult the API documentation for specific changes.
+
+EOF
 
 echo -e "\n${GREEN}Release notes generated in: ${OUTPUT_FILE}${NC}"
 echo -e "${YELLOW}Please review and edit the generated notes before adding to documentation.${NC}"
+echo -e "${BLUE}API changes have been automatically detected and included.${NC}"

--- a/helper-scripts/generate-release-notes.sh
+++ b/helper-scripts/generate-release-notes.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+# Script to generate release notes for InfluxDB v3.x releases
+# Usage: ./generate-release-notes.sh <from_version> <to_version> <repo_path>
+
+set -e
+
+# Default values
+REPO_PATH="${3:-/Users/ja/Documents/github/influxdb}"
+FROM_VERSION="${1:-v3.1.0}"
+TO_VERSION="${2:-v3.2.0}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}Generating release notes for ${TO_VERSION}${NC}"
+echo -e "Repository: ${REPO_PATH}"
+echo -e "From: ${FROM_VERSION} To: ${TO_VERSION}\n"
+
+# Function to extract PR number from commit message
+extract_pr_number() {
+    echo "$1" | grep -oE '#[0-9]+' | head -1 | sed 's/#//'
+}
+
+# Get the release date
+RELEASE_DATE=$(git -C "$REPO_PATH" log -1 --format=%ai "$TO_VERSION" | cut -d' ' -f1)
+echo -e "${GREEN}Release Date: ${RELEASE_DATE}${NC}\n"
+
+# Collect commits by category
+echo -e "${YELLOW}Analyzing commits...${NC}"
+
+# Features
+echo -e "\n${GREEN}Features:${NC}"
+FEATURES=$(git -C "$REPO_PATH" log --format="%h %s" "${FROM_VERSION}..${TO_VERSION}" | grep -E "^[a-f0-9]+ feat:" | sed 's/^[a-f0-9]* feat: //')
+
+# Fixes
+echo -e "\n${GREEN}Bug Fixes:${NC}"
+FIXES=$(git -C "$REPO_PATH" log --format="%h %s" "${FROM_VERSION}..${TO_VERSION}" | grep -E "^[a-f0-9]+ fix:" | sed 's/^[a-f0-9]* fix: //')
+
+# Breaking changes
+echo -e "\n${GREEN}Breaking Changes:${NC}"
+BREAKING=$(git -C "$REPO_PATH" log --format="%h %s" "${FROM_VERSION}..${TO_VERSION}" | grep -iE "^[a-f0-9]+ .*(BREAKING|breaking change)" | sed 's/^[a-f0-9]* //')
+
+# Performance improvements
+echo -e "\n${GREEN}Performance:${NC}"
+PERF=$(git -C "$REPO_PATH" log --format="%h %s" "${FROM_VERSION}..${TO_VERSION}" | grep -E "^[a-f0-9]+ perf:" | sed 's/^[a-f0-9]* perf: //')
+
+# Generate markdown output
+OUTPUT_FILE="release-notes-${TO_VERSION}.md"
+cat > "$OUTPUT_FILE" << EOF
+## ${TO_VERSION} {date="${RELEASE_DATE}"}
+
+### Features
+
+EOF
+
+# Add features
+if [ -n "$FEATURES" ]; then
+    while IFS= read -r line; do
+        PR=$(extract_pr_number "$line")
+        # Clean up the commit message
+        CLEAN_LINE=$(echo "$line" | sed -E 's/ \(#[0-9]+\)$//')
+        if [ -n "$PR" ]; then
+            echo "- $CLEAN_LINE ([#$PR](https://github.com/influxdata/influxdb/pull/$PR))" >> "$OUTPUT_FILE"
+        else
+            echo "- $CLEAN_LINE" >> "$OUTPUT_FILE"
+        fi
+    done <<< "$FEATURES"
+else
+    echo "- No new features in this release" >> "$OUTPUT_FILE"
+fi
+
+# Add bug fixes
+cat >> "$OUTPUT_FILE" << EOF
+
+### Bug Fixes
+
+EOF
+
+if [ -n "$FIXES" ]; then
+    while IFS= read -r line; do
+        PR=$(extract_pr_number "$line")
+        CLEAN_LINE=$(echo "$line" | sed -E 's/ \(#[0-9]+\)$//')
+        if [ -n "$PR" ]; then
+            echo "- $CLEAN_LINE ([#$PR](https://github.com/influxdata/influxdb/pull/$PR))" >> "$OUTPUT_FILE"
+        else
+            echo "- $CLEAN_LINE" >> "$OUTPUT_FILE"
+        fi
+    done <<< "$FIXES"
+else
+    echo "- No bug fixes in this release" >> "$OUTPUT_FILE"
+fi
+
+# Add breaking changes if any
+if [ -n "$BREAKING" ]; then
+    cat >> "$OUTPUT_FILE" << EOF
+
+### Breaking Changes
+
+EOF
+    while IFS= read -r line; do
+        PR=$(extract_pr_number "$line")
+        CLEAN_LINE=$(echo "$line" | sed -E 's/ \(#[0-9]+\)$//')
+        if [ -n "$PR" ]; then
+            echo "- $CLEAN_LINE ([#$PR](https://github.com/influxdata/influxdb/pull/$PR))" >> "$OUTPUT_FILE"
+        else
+            echo "- $CLEAN_LINE" >> "$OUTPUT_FILE"
+        fi
+    done <<< "$BREAKING"
+fi
+
+# Add performance improvements if any
+if [ -n "$PERF" ]; then
+    cat >> "$OUTPUT_FILE" << EOF
+
+### Performance Improvements
+
+EOF
+    while IFS= read -r line; do
+        PR=$(extract_pr_number "$line")
+        CLEAN_LINE=$(echo "$line" | sed -E 's/ \(#[0-9]+\)$//')
+        if [ -n "$PR" ]; then
+            echo "- $CLEAN_LINE ([#$PR](https://github.com/influxdata/influxdb/pull/$PR))" >> "$OUTPUT_FILE"
+        else
+            echo "- $CLEAN_LINE" >> "$OUTPUT_FILE"
+        fi
+    done <<< "$PERF"
+fi
+
+echo -e "\n${GREEN}Release notes generated in: ${OUTPUT_FILE}${NC}"
+echo -e "${YELLOW}Please review and edit the generated notes before adding to documentation.${NC}"

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,38 @@
+# Documentation Plans
+
+This directory contains plans for recurring documentation tasks and automation.
+
+## Active Plans
+
+### CLI Documentation Synchronization
+- **Location**: `cli-docs-sync/`
+- **Purpose**: Keep InfluxDB 3 CLI reference documentation in sync with actual CLI commands
+- **Current Version**: `plan-v3.2.0.md`
+- **Status**: Ready for execution
+
+### Release Notes Automation
+- **Location**: `release-notes-automation/`
+- **Purpose**: Automate generation of release notes from git commits
+- **Scripts**: Available in `/scripts/generate-release-notes.sh`
+
+## Plan Structure
+
+Each plan directory should contain:
+- `plan-[version].md` - The detailed plan
+- `execution-log.md` - Track progress and notes
+- `templates/` - Reusable templates and patterns
+
+## Usage for Claude
+
+When working with Claude on these plans:
+1. Reference the specific plan file: `@plans/[task]/plan-[version].md`
+2. Update execution logs as you progress
+3. Iterate on plans by creating new versions
+4. Use templates for consistency
+
+## Best Practices
+
+- Keep plans versioned by release or iteration
+- Document lessons learned in execution logs
+- Create reusable templates for recurring patterns
+- Link plans to related scripts and automation

--- a/plans/cli-docs-sync/execution-log.md
+++ b/plans/cli-docs-sync/execution-log.md
@@ -1,0 +1,47 @@
+# CLI Documentation Sync - Execution Log
+
+## v3.2.0 Execution
+
+### Status: Planning Complete ✅
+**Date**: 2025-06-26
+**Plan**: `plan-v3.2.0.md`
+
+### Phase 1: Analysis (Not Started)
+- [ ] Audit existing CLI documentation structure
+- [ ] Extract v3.2.0 changes from release notes
+- [ ] Generate current CLI help output
+
+### Phase 2: Update Documentation (Not Started)
+#### Files to Create:
+- [ ] `/content/shared/influxdb3-cli/update/_index.md`
+- [ ] `/content/shared/influxdb3-cli/update/database.md`
+- [ ] `/content/shared/influxdb3-cli/update/table.md` (Enterprise)
+- [ ] `/content/shared/influxdb3-cli/show/license.md` (Enterprise)
+
+#### Files to Update:
+- [ ] `/content/shared/influxdb3-cli/create/database.md` (add `--retention-period`)
+- [ ] `/content/shared/influxdb3-cli/create/table.md` (add Enterprise `--retention-period`)
+- [ ] `/content/shared/influxdb3-cli/show/_index.md` (add license command)
+- [ ] `/content/shared/influxdb3-cli/delete/database.md` (review hard delete)
+- [ ] `/content/shared/influxdb3-cli/delete/table.md` (review hard delete)
+
+### Phase 3: Automation (Not Started)
+- [ ] Create CLI documentation sync script
+- [ ] Establish documentation standards
+- [ ] Plan CI/CD integration
+
+### Phase 4: Validation (Not Started)
+- [ ] Test documented commands
+- [ ] Verify completeness
+- [ ] Check cross-references
+
+### Notes and Lessons Learned
+- Release notes analysis was crucial for identifying specific CLI changes
+- Having automation scripts in place (`generate-release-notes.sh`) helped identify features
+- Need to distinguish between Core and Enterprise features clearly
+
+### Next Actions
+When ready to execute:
+1. Reference plan: `@plans/cli-docs-sync/plan-v3.2.0.md`
+2. Start with Phase 1 analysis
+3. Update this log as progress is made

--- a/plans/cli-docs-sync/plan-v3.2.0.md
+++ b/plans/cli-docs-sync/plan-v3.2.0.md
@@ -1,0 +1,165 @@
+# Plan: Update InfluxDB 3 CLI Reference Documentation for v3.2.0
+
+## Phase 1: Analyze Current State and Changes
+
+### 1. Audit existing CLI documentation structure
+**Existing files in `/content/shared/influxdb3-cli/`:**
+- `/content/shared/influxdb3-cli/create/_index.md`
+- `/content/shared/influxdb3-cli/create/database.md` ⚠️ **NEEDS UPDATE** (add `--retention-period`)
+- `/content/shared/influxdb3-cli/create/distinct_cache.md`
+- `/content/shared/influxdb3-cli/create/file_index.md`
+- `/content/shared/influxdb3-cli/create/last_cache.md`
+- `/content/shared/influxdb3-cli/create/table.md` ⚠️ **NEEDS UPDATE** (add Enterprise `--retention-period`)
+- `/content/shared/influxdb3-cli/create/token/_index.md`
+- `/content/shared/influxdb3-cli/create/token/admin.md`
+- `/content/shared/influxdb3-cli/create/trigger.md`
+- `/content/shared/influxdb3-cli/delete/_index.md`
+- `/content/shared/influxdb3-cli/delete/database.md` ⚠️ **REVIEW** (hard delete features)
+- `/content/shared/influxdb3-cli/delete/distinct_cache.md`
+- `/content/shared/influxdb3-cli/delete/file_index.md`
+- `/content/shared/influxdb3-cli/delete/last_cache.md`
+- `/content/shared/influxdb3-cli/delete/table.md` ⚠️ **REVIEW** (hard delete features)
+- `/content/shared/influxdb3-cli/delete/trigger.md`
+- `/content/shared/influxdb3-cli/disable/_index.md`
+- `/content/shared/influxdb3-cli/disable/trigger.md`
+- `/content/shared/influxdb3-cli/enable/_index.md`
+- `/content/shared/influxdb3-cli/enable/trigger.md`
+- `/content/shared/influxdb3-cli/query.md`
+- `/content/shared/influxdb3-cli/show/_index.md` ⚠️ **NEEDS UPDATE** (add license command)
+- `/content/shared/influxdb3-cli/show/databases.md`
+- `/content/shared/influxdb3-cli/show/system/_index.md`
+- `/content/shared/influxdb3-cli/show/system/summary.md`
+- `/content/shared/influxdb3-cli/show/system/table-list.md`
+- `/content/shared/influxdb3-cli/show/system/table.md`
+- `/content/shared/influxdb3-cli/show/tokens.md`
+- `/content/shared/influxdb3-cli/test/_index.md`
+- `/content/shared/influxdb3-cli/test/schedule_plugin.md`
+- `/content/shared/influxdb3-cli/test/wal_plugin.md`
+- `/content/shared/influxdb3-cli/write.md`
+
+### 2. Extract v3.2.0 changes from release notes
+**From `/content/shared/v3-core-enterprise-release-notes/_index.md`:**
+
+**Core v3.2.0 Features:**
+- Database retention period support: `create database --retention-period`, `update database --retention-period`
+- Hard delete for databases and tables
+- AWS credentials auto-reload
+- WAL improvements
+
+**Enterprise v3.2.0 Features:**
+- License management: `influxdb3 show license`
+- Table retention period support: `create table --retention-period`, `update table --retention-period`
+- All Core features plus Enterprise-specific enhancements
+
+### 3. Generate current CLI help output
+- Run `influxdb3 --help` for both Core and Enterprise versions
+- Extract new commands, options, and help text
+- Compare with existing documentation
+
+## Phase 2: Update Documentation Files
+
+### Files to Create (NEW):
+- `/content/shared/influxdb3-cli/update/_index.md` 🆕
+- `/content/shared/influxdb3-cli/update/database.md` 🆕 (retention period management)
+- `/content/shared/influxdb3-cli/update/table.md` 🆕 (Enterprise-only, retention period management)
+- `/content/shared/influxdb3-cli/show/license.md` 🆕 (Enterprise-only)
+
+### Files to Update (EXISTING):
+- `/content/shared/influxdb3-cli/create/database.md` ⚠️ (add `--retention-period` option)
+- `/content/shared/influxdb3-cli/create/table.md` ⚠️ (add Enterprise `--retention-period` option)
+- `/content/shared/influxdb3-cli/show/_index.md` ⚠️ (include license command)
+- `/content/shared/influxdb3-cli/delete/database.md` ⚠️ (review hard delete options)
+- `/content/shared/influxdb3-cli/delete/table.md` ⚠️ (review hard delete options)
+
+### Content Changes by Category:
+
+**1. Retention Period Documentation:**
+- Update `/content/shared/influxdb3-cli/create/database.md` with `--retention-period` option
+- Create `/content/shared/influxdb3-cli/update/` directory structure
+- Create `/content/shared/influxdb3-cli/update/database.md` for retention management
+- Update `/content/shared/influxdb3-cli/create/table.md` with Enterprise `--retention-period` option
+- Create `/content/shared/influxdb3-cli/update/table.md` for Enterprise table retention management
+
+**2. License Management Documentation:**
+- Update `/content/shared/influxdb3-cli/show/_index.md` to include license command
+- Create `/content/shared/influxdb3-cli/show/license.md` for Enterprise license display
+
+**3. Hard Delete Documentation:**
+- Review and update `/content/shared/influxdb3-cli/delete/database.md` with hard delete options
+- Review and update `/content/shared/influxdb3-cli/delete/table.md` with hard delete options
+
+## Phase 3: Automation and Process Improvements
+
+### Immediate Improvements:
+1. **Create CLI documentation sync script:**
+   ```bash
+   # Script: /Users/ja/Documents/github/docs-v2/scripts/sync-cli-docs.sh
+   # - Extract help text from influxdb3 CLI
+   # - Compare with existing docs
+   # - Generate report of differences
+   # - Auto-update basic command syntax
+   ```
+
+2. **Establish documentation standards:**
+   - Standardize frontmatter across CLI docs
+   - Create templates for command documentation
+   - Define Enterprise vs Core content patterns using Hugo shortcodes
+
+### Long-term Automation Strategy:
+1. **CI/CD Integration:**
+   - Add GitHub Actions workflow to detect CLI changes
+   - Auto-generate CLI help extraction on new releases
+   - Create pull requests for documentation updates
+
+2. **Release Process Integration:**
+   - Include CLI documentation review in release checklist
+   - Link release notes to specific CLI documentation updates
+   - Automated cross-referencing between release notes and CLI docs
+
+3. **Content Management Improvements:**
+   - Use Hugo shortcodes for Enterprise-specific content
+   - Implement version-aware documentation
+   - Create shared content templates for common CLI patterns
+
+## Phase 4: Validation and Testing
+
+### Content accuracy verification:
+- Test all documented commands and options against actual CLIs
+- Verify Enterprise vs Core feature availability
+- Cross-reference with actual CLI behavior
+
+### Documentation completeness check:
+- Ensure all v3.2.0 features are documented
+- Verify examples and use cases
+- Check internal links and cross-references
+
+## Suggested Recurring Process
+
+### Pre-release (during development):
+- Monitor CLI changes in pull requests
+- Update documentation as features are added
+- Maintain CLI help extraction automation
+
+### At release (when tagging versions):
+- Run automated CLI documentation sync
+- Review and approve auto-generated updates
+- Publish updated documentation
+
+### Post-release (after release):
+- Validate documentation accuracy
+- Gather user feedback on CLI documentation
+- Plan improvements for next cycle
+
+## Related Documentation Paths
+
+### InfluxDB 3 Product Documentation (affects CLI usage examples):
+- `/content/influxdb3/core/write-data/influxdb3-cli.md`
+- `/content/influxdb3/enterprise/write-data/influxdb3-cli.md`
+- `/content/shared/influxdb3-write-guides/influxdb3-cli.md`
+
+### Admin Documentation (affects retention and license features):
+- `/content/influxdb3/core/admin/`
+- `/content/influxdb3/enterprise/admin/`
+- `/content/influxdb3/enterprise/admin/license.md`
+
+This plan ensures comprehensive documentation updates for v3.2.0 while establishing sustainable processes for future releases.

--- a/test/influxdb3/engine.test.sh
+++ b/test/influxdb3/engine.test.sh
@@ -1,0 +1,20 @@
+# Create a processing engine request trigger 
+# // SECTION - influxdb3-core
+curl -v -X POST "http://localhost:8181/api/v3/configure/processingengine/trigger" \
+ --header "Authorization: Bearer ${INFLUXDB3_ENTERPRISE_ADMIN_TOKEN}" \
+ --json '{
+  "db": "sensors",
+  "plugin_filename": "request.py",
+  "trigger_name": "Process request trigger",
+  "trigger_specification": "request:process-request"
+}'
+
+# // SECTION - influxdb3-enterprise
+curl -v -X POST "http://localhost:8181/api/v3/configure/processingengine/trigger" \
+ --header "Authorization: Bearer ${INFLUXDB3_ENTERPRISE_ADMIN_TOKEN}" \
+ --json '{
+  "db": "sensors",
+  "plugin_filename": "request.py",
+  "trigger_name": "Process request trigger",
+  "trigger_specification": {"request_path": {"path": "process-request"}}
+}'


### PR DESCRIPTION
Resolves issue https://github.com/influxdata/docs-v2/issues/6161 with InfluxDB 3.2 API reference updates.

## API Reference Updates
- Add `hard_delete_at` parameter to database and table deletion endpoints for scheduled hard deletion
- Add update database and update table endpoints with retention period configuration
- Add license endpoint response schema
- Fix request trigger specification format from `path:` to `request:` in Core API
- Fix OpenAPI schema validation error in Enterprise API by removing conflicting type declaration

## Processing Engine Documentation Fixes
- Standardize terminology across documentation:
  - "Data write" (not "WAL flush" or "On WAL flush")
  - "Scheduled" (not "On Schedule")
  - "HTTP request" (not "On Request")
- Fix placeholder inconsistencies: use REQUEST_PATH instead of ENDPOINT_PATH
- Add Enterprise-specific warnings about request trigger format differences
- Update trigger specification format in Enterprise API to use JSON object format
- Add proper table of contents with consistent structure
- Improve distributed cluster configuration documentation

## Enterprise Request Trigger Bug Documentation
Due to a bug in InfluxDB 3 Enterprise, the request trigger specification format differs between CLI and API:
- CLI: `request:<REQUEST_PATH>` (same as Core CLI and API)
- Enterprise API: `{"request_path": {"path": "<REQUEST_PATH>"}}`

This difference is now properly documented with warnings in all relevant sections.
