### PR TITLE
Task-based table and db management docs for Dedicated and Clustered

### DIFF
--- a/content/influxdb3/cloud-dedicated/admin/databases/delete.md
+++ b/content/influxdb3/cloud-dedicated/admin/databases/delete.md
@@ -33,17 +33,19 @@ or the [Management HTTP API](/influxdb3/cloud-dedicated/api/management/)
 to delete a database from your {{< product-name omit=" Clustered" >}} cluster.
 
 > [!Warning]
-> 
-> #### Deleting a database cannot be undone
-> 
-> Once a database is deleted, data stored in that database cannot be recovered.
->
 > #### Wait before writing to a new database with the same name
 >
 > After deleting a database from your {{% product-name omit=" Clustered" %}}
 > cluster, you can reuse the name to create a new database, but **wait two to
 > three minutes** after deleting the previous database before writing to the new
 > database to allow write caches to clear.
+>
+> #### Tokens still grant access to databases with the same name
+>
+> [Database tokens](/influxdb3/cloud-dedicated/admin/tokens/database/) are associated to
+> databases by name. If you create a new database with the same name, tokens
+> that granted access to the deleted database will also grant access to the new
+> database.
 
 {{< tabs-wrapper >}}
 {{% tabs %}}

--- a/content/influxdb3/cloud-dedicated/admin/databases/rename.md
+++ b/content/influxdb3/cloud-dedicated/admin/databases/rename.md
@@ -1,0 +1,58 @@
+---
+title: Rename a database
+description: >
+  Use the [`influxctl database rename` command](/influxdb3/cloud-dedicated/reference/cli/influxctl/database/rename/)
+  to rename a database in your {{< product-name omit=" Cluster" >}} cluster.
+menu:
+  influxdb3_cloud_dedicated:
+    parent: Manage databases
+weight: 202
+list_code_example: |
+  ##### CLI
+  ```sh
+  influxctl database rename <DATABASE_NAME> <NEW_DATABASE_NAME>
+  ```
+related:
+  - /influxdb3/cloud-dedicated/reference/cli/influxctl/database/rename/
+  - /influxdb3/cloud-dedicated/admin/tokens/database/create/
+---
+
+Use the [`influxctl database rename` command](/influxdb3/cloud-dedicated/reference/cli/influxctl/database/rename/)
+to rename a database in your {{< product-name omit=" Cluster" >}} cluster.
+
+> [!Note]
+> Renaming a database does not change the database ID, modify data in the database,
+> or update [database tokens](/influxdb3/cloud-dedicated/admin/tokens/database/).
+> After renaming a database, any existing database tokens will stop working and you
+> must create new tokens with permissions for the renamed database.
+
+## Rename a database using the influxctl CLI
+
+{{% code-placeholders "DATABASE_NAME|NEW_DATABASE_NAME" %}}
+```sh
+influxctl database rename DATABASE_NAME NEW_DATABASE_NAME
+```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}: Current name of the database to rename
+- {{% code-placeholder-key %}}`NEW_DATABASE_NAME`{{% /code-placeholder-key %}}: New name for the database
+
+## Update database tokens after renaming
+
+After renaming a database, existing database tokens will no longer work because
+they reference the old database name. Do the following:
+
+1. [Create new database tokens](/influxdb3/cloud-dedicated/admin/tokens/database/create/)
+   with permissions for the renamed database.
+2. Update your applications and clients to use the new tokens.
+3. [Delete the old database tokens](/influxdb3/cloud-dedicated/admin/tokens/database/delete/)
+   that reference the old database name.
+
+{{% note %}}
+#### Renamed database retains its ID
+
+The database ID remains the same after renaming. When you list databases,
+you'll see the new name associated with the original database ID.
+{{% /note %}}

--- a/content/influxdb3/cloud-dedicated/admin/databases/undelete.md
+++ b/content/influxdb3/cloud-dedicated/admin/databases/undelete.md
@@ -1,0 +1,70 @@
+---
+title: Undelete a database
+description: >
+  Use the [`influxctl database undelete` command](/influxdb3/cloud-dedicated/reference/cli/influxctl/database/undelete/)
+  to restore a previously deleted database in your {{< product-name omit=" Cluster" >}} cluster.
+menu:
+  influxdb3_cloud_dedicated:
+    parent: Manage databases
+weight: 204
+list_code_example: |
+  ```sh
+  influxctl database undelete <DATABASE_NAME>
+  ```
+related:
+  - /influxdb3/cloud-dedicated/reference/cli/influxctl/database/undelete/
+  - /influxdb3/cloud-dedicated/admin/databases/delete/
+  - /influxdb3/cloud-dedicated/admin/tokens/database/create/
+---
+
+Use the [`influxctl database undelete` command](/influxdb3/cloud-dedicated/reference/cli/influxctl/database/undelete/)
+to restore a previously deleted database in your {{< product-name omit=" Cluster" >}} cluster.
+
+> [!Important]
+> To undelete a database:
+> 
+> - The database name must match the name of the deleted database.
+> - A new database with the same name cannot already exist.
+> - You must have appropriate permissions to manage databases.
+
+When you undelete a database, it is restored with the same retention period,
+table limits, and column limits as when it was deleted.
+
+> [!Warning]
+> Databases can only be undeleted for
+> {{% show-in "cloud-dedicated" %}}approximately 14 days{{% /show-in %}}{{% show-in "clustered" %}}a configurable "hard-delete" grace period{{% /show-in %}}
+> after they are deleted.
+> After this grace period, all Parquet files associated with the deleted database
+> are permanently removed and the database cannot be undeleted.
+
+## Undelete a database using the influxctl CLI
+
+{{% code-placeholders "DATABASE_NAME" %}}
+```sh
+influxctl database undelete DATABASE_NAME
+```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
+  Name of the deleted database to restore
+
+## Recreate tokens for the database
+
+After successfully undeleting a database:
+
+1.  **Verify the database was restored** by [listing all databases](/influxdb3/cloud-dedicated/admin/databases/list/).
+2.  **If you previously deleted tokens associated with the deleted database, create new database tokens**
+    - Any tokens that existed before deletion are not restored.
+    [Create new database tokens](/influxdb3/cloud-dedicated/admin/tokens/database/create/)
+    with appropriate permissions for the restored database.
+3.  **Update your applications** to use the new database tokens.
+
+{{% note %}}
+#### Undeleted databases retain their original configuration
+
+When a database is undeleted, it retains the same database ID, retention period,
+and table/column limits it had before deletion. However, database tokens are not
+restored and must be recreated.
+{{% /note %}}

--- a/content/influxdb3/cloud-dedicated/admin/tables/delete.md
+++ b/content/influxdb3/cloud-dedicated/admin/tables/delete.md
@@ -1,0 +1,53 @@
+---
+title: Delete a table
+description: >
+  Use the Admin UI or the [`influxctl table delete` command](/influxdb3/cloud-dedicated/reference/cli/influxctl/table/delete/)
+  to delete a table from a database in your {{< product-name omit=" Cluster" >}} cluster.
+menu:
+  influxdb3_cloud_dedicated:
+    parent: Manage tables
+weight: 203
+list_code_example: |
+  ```sh
+  influxctl table delete <DATABASE_NAME> <TABLE_NAME>
+  ```
+related:
+  - /influxdb3/cloud-dedicated/reference/cli/influxctl/table/delete/
+---
+
+Use the Admin UI or the [`influxctl table delete` command](/influxdb3/cloud-dedicated/reference/cli/influxctl/table/delete/)
+to delete a table from a database in your {{< product-name omit=" Cluster" >}} cluster.
+
+> [!Warning]
+> Deleting a table is irreversible. Once a table is deleted, all data stored in
+> that table is permanently removed and cannot be recovered.
+
+Provide the following arguments:
+
+- **Database name**: Name of the database that contains the table to delete
+- **Table name**: Name of the table to delete
+
+{{% code-placeholders "DATABASE_NAME|TABLE_NAME" %}}
+```sh
+influxctl table delete DATABASE_NAME TABLE_NAME
+```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}: Name of the database that contains the table to delete
+- {{% code-placeholder-key %}}`TABLE_NAME`{{% /code-placeholder-key %}}: Name of the table to delete
+
+When prompted, enter `y` to confirm the deletion.
+
+{{% note %}}
+#### Wait before reusing a deleted table name
+
+After deleting a table, wait a few minutes before attempting to create a new
+table with the same name to ensure the deletion process has fully completed.
+
+{{% product-name %}} creates tables implicitly using table names specified in
+line protocol written to the databases. To prevent the deleted table from being
+immediately recreated by incoming write requests, pause all write requests to
+the table before deleting it.
+{{% /note %}}

--- a/content/influxdb3/cloud-dedicated/admin/tables/list.md
+++ b/content/influxdb3/cloud-dedicated/admin/tables/list.md
@@ -1,7 +1,8 @@
 ---
 title: List tables
 description: >
-  Use the Admin UI, the [`SHOW TABLES` SQL statement](/influxdb3/cloud-dedicated/query-data/sql/explore-schema/#list-measurements-in-a-database),
+  Use the Admin UI, the [`influxctl table list` command](/influxdb3/cloud-dedicated/reference/cli/influxctl/table/list/),
+  the [`SHOW TABLES` SQL statement](/influxdb3/cloud-dedicated/query-data/sql/explore-schema/#list-measurements-in-a-database),
   or the [`SHOW MEASUREMENTS` InfluxQL statement](/influxdb3/cloud-dedicated/query-data/influxql/explore-schema/#list-measurements-in-a-database)
   to list tables in a database.
 menu:
@@ -9,23 +10,30 @@ menu:
     parent: Manage tables
 weight: 201
 list_code_example: |
-  ###### SQL
+  ##### CLI
+  ```sh
+  influxctl table list <DATABASE_NAME>
+  ```
+
+  ##### SQL
 
   ```sql
   SHOW TABLES
   ```
 
-  ###### InfluxQL
+  ##### InfluxQL
   
   ```sql
   SHOW MEASUREMENTS
   ```
 related:
+  - /influxdb3/cloud-dedicated/reference/cli/influxctl/table/list/
   - /influxdb3/cloud-dedicated/query-data/sql/explore-schema/
   - /influxdb3/cloud-dedicated/query-data/influxql/explore-schema/
 ---
 
-Use the Admin UI, the [`SHOW TABLES` SQL statement](/influxdb3/cloud-dedicated/query-data/sql/explore-schema/#list-measurements-in-a-database),
+Use the Admin UI, the [`influxctl table list` command](/influxdb3/cloud-dedicated/reference/cli/influxctl/table/list/),
+the [`SHOW TABLES` SQL statement](/influxdb3/cloud-dedicated/query-data/sql/explore-schema/#list-measurements-in-a-database),
 or the [`SHOW MEASUREMENTS` InfluxQL statement](/influxdb3/cloud-dedicated/query-data/influxql/explore-schema/#list-measurements-in-a-database)
 to list tables in a database.
 
@@ -36,9 +44,11 @@ to list tables in a database.
 {{% tabs %}}
 [Admin UI](#admin-ui)
 [influxctl](#influxctl)
+[SQL & InfluxQL](#sql--influxql)
 {{% /tabs %}}
 {{% tab-content %}}
 <!------------------------------- BEGIN ADMIN UI ------------------------------>
+
 The InfluxDB Cloud Dedicated administrative UI includes a portal for managing
 tables. You can view the list of tables associated with a database and
 their details, including:
@@ -47,47 +57,93 @@ their details, including:
 - Table ID
 - Table size (in bytes) 
 
-1. To access the {{< product-name >}} Admin UI, visit the following URL in your browser:
+1.  To access the {{< product-name >}} Admin UI, visit the following URL in your browser:
 
-   <pre>
-   <a href="https://console.influxdata.com">https://console.influxdata.com</a>
-   </pre>
-2. Use the credentials provided by InfluxData to log into the Admin UI.
-   If you don't have login credentials, [contact InfluxData support](https://support.influxdata.com).
+    <pre>
+    <a href="https://console.influxdata.com">https://console.influxdata.com</a>
+    </pre>
 
-   After you log in, the Account Management portal displays [account information](/influxdb3/cloud-dedicated/admin/account/)
-   and lists all clusters associated with your account.
-3. In the cluster list, find the cluster that contains the database and table. You can **Search** for clusters by name or ID to filter the list and use the sort button and column headers to sort the list.
-4. Click the cluster row to view the list of databases associated with the cluster.
-5. In the database list, find the database that contains the table. You can **Search** for databases by name or ID to filter the list and use the sort button and column headers to sort the list.
-6. Click the database row to view the list of tables associated with the database.
-7. The table list displays the following table details:
-   - Name
-   - Table ID
-   - Table size (in bytes)
-8. You can **Search** for tables by name or ID to filter the list and use the sort button and column headers to sort the list.
+2.  Use the credentials provided by InfluxData to log into the Admin UI.
+    If you don't have login credentials, [contact InfluxData support](https://support.influxdata.com).
 
-You can **Search** for databases by name or ID to filter the list and use the sort button and column headers to sort the list. 
+    After you log in, the Account Management portal displays [account information](/influxdb3/cloud-dedicated/admin/account/)
+    and lists all clusters associated with your account.
 
+3.  In the cluster list, find the cluster that contains the database and table.
+    You can **Search** for clusters by name or ID to filter the list and use the sort button and column headers to sort the list.
+4.  Click the cluster row to view the list of databases associated with the cluster.
+5.  In the database list, find the database that contains the table.
+    You can **Search** for databases by name or ID to filter the list and use
+    the sort button and column headers to sort the list.
+6.  Click the database row to view the list of tables associated with the database.
+7.  The table list displays the following table details:
+
+    - Name
+    - Table ID
+    - Table size (in bytes)
+
+8.  You can **Search** for tables by name or ID to filter the list and use the
+    sort button and column headers to sort the list.
+
+You can **Search** for databases by name or ID to filter the list and use the
+sort button and column headers to sort the list. 
+
+<!-------------------------------- END ADMIN UI ------------------------------->
 {{% /tab-content %}}
 {{% tab-content %}}
-<!------------------------------- BEGIN INFLUXCTL ------------------------------>
-###### SQL
+<!------------------------------ BEGIN INFLUXCTL ------------------------------>
+
+Use the [`influxctl table list` command](/influxdb3/cloud-dedicated/reference/cli/influxctl/table/list/)
+to list all tables in a database in your {{< product-name omit=" Cluster" >}} cluster.
+
+{{% code-placeholders "DATABASE_NAME" %}}
+<!-- pytest.mark.skip -->
+```bash
+influxctl table list DATABASE_NAME
+```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}: 
+  Name of the database containing the tables to list
+
+### Output formats
+
+The `influxctl table list` command supports the following output formats:
+
+- `table` (default): Human-readable table format
+- `json`: JSON format for programmatic use
+
+Use the `--format` flag to specify the output format:
+
+{{% code-placeholders "DATABASE_NAME" %}}
+```sh
+influxctl table list --format json DATABASE_NAME
+```
+{{% /code-placeholders %}}
+
+<!------------------------------- END INFLUXCTL ------------------------------->
+{{% /tab-content %}}
+{{% tab-content %}}
+<!----------------------------- BEGIN SQL/INFLUXQL ---------------------------->
+
+## List tables with the influxctl query command
+
+To list tables using SQL or InfluxQL, use the `influxctl query` command to pass
+the appropriate statement.
+
+### SQL
 
 ```sql
 SHOW TABLES
 ```
 
-###### InfluxQL
+### InfluxQL
 
 ```sql
 SHOW MEASUREMENTS
 ```
-
-## List tables with the influxctl CLI
-
-To list tables using the `influxctl` CLI, use the `influxctl query` command to pass
-the `SHOW TABLES` SQL statement.
 
 Provide the following with your command:
 
@@ -98,15 +154,27 @@ Provide the following with your command:
 - **Database name**: Name of the database to query. Uses the `database` setting
   from the [`influxctl` connection profile](/influxdb3/cloud-dedicated/reference/cli/influxctl/#configure-connection-profiles)
   or the `--database` command flag.
-- **SQL query**: SQL query with the `SHOW TABLES` statement.
+- **SQL query**: SQL query with the `SHOW TABLES` statement or InfluxQL query with the `SHOW MEASUREMENTS` statement.
 
 {{% code-placeholders "DATABASE_(TOKEN|NAME)" %}}
 
-```sh
+##### SQL
+<!-- pytest.mark.skip -->
+```bash
 influxctl query \
   --token DATABASE_TOKEN \
   --database DATABASE_NAME \
   "SHOW TABLES"
+```
+
+##### InfluxQL
+<!-- pytest.mark.skip -->
+```bash
+influxctl query \
+  --token DATABASE_TOKEN \
+  --database DATABASE_NAME \
+  --language influxql \
+  "SHOW MEASUREMENTS"
 ```
 
 {{% /code-placeholders %}}
@@ -118,5 +186,6 @@ Replace the following:
 - {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
   Name of the database to query
 
+<!------------------------------ END SQL/INFLUXQL ----------------------------->
 {{% /tab-content %}}
 {{< /tabs-wrapper >}}

--- a/content/influxdb3/clustered/admin/databases/delete.md
+++ b/content/influxdb3/clustered/admin/databases/delete.md
@@ -33,16 +33,19 @@ influxctl database delete DATABASE_NAME
 {{% /code-placeholders %}}
 
 > [!Warning]
-> #### Deleting a database cannot be undone
-> 
-> Once a database is deleted, data stored in that database cannot be recovered.
-> 
 > #### Wait before writing to a new database with the same name
 >
 > After deleting a database from your {{% product-name omit=" Clustered" %}}
 > cluster, you can reuse the name to create a new database, but **wait two to
 > three minutes** after deleting the previous database before writing to the new
 > database to allow write caches to clear.
+>
+> #### Tokens still grant access to databases with the same name
+>
+> [Database tokens](/influxdb3/version/admin/tokens/database/) are associated to
+> databases by name. If you create a new database with the same name, tokens
+> that granted access to the deleted database will also grant access to the new
+> database.
 > 
 > #### Never directly modify the Catalog
 > 

--- a/content/influxdb3/clustered/admin/databases/rename.md
+++ b/content/influxdb3/clustered/admin/databases/rename.md
@@ -1,0 +1,58 @@
+---
+title: Rename a database
+description: >
+  Use the [`influxctl database rename` command](/influxdb3/clustered/reference/cli/influxctl/database/rename/)
+  to rename a database in your {{< product-name omit=" Cluster" >}} cluster.
+menu:
+  influxdb3_clustered:
+    parent: Manage databases
+weight: 202
+list_code_example: |
+  ##### CLI
+  ```sh
+  influxctl database rename <DATABASE_NAME> <NEW_DATABASE_NAME>
+  ```
+related:
+  - /influxdb3/clustered/reference/cli/influxctl/database/rename/
+  - /influxdb3/clustered/admin/tokens/database/create/
+---
+
+Use the [`influxctl database rename` command](/influxdb3/clustered/reference/cli/influxctl/database/rename/)
+to rename a database in your {{< product-name omit=" Cluster" >}} cluster.
+
+> [!Note]
+> Renaming a database does not change the database ID, modify data in the database,
+> or update [database tokens](/influxdb3/clustered/admin/tokens/database/).
+> After renaming a database, any existing database tokens will stop working and you
+> must create new tokens with permissions for the renamed database.
+
+## Rename a database using the influxctl CLI
+
+{{% code-placeholders "DATABASE_NAME|NEW_DATABASE_NAME" %}}
+```sh
+influxctl database rename DATABASE_NAME NEW_DATABASE_NAME
+```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}: Current name of the database to rename
+- {{% code-placeholder-key %}}`NEW_DATABASE_NAME`{{% /code-placeholder-key %}}: New name for the database
+
+## Update database tokens after renaming
+
+After renaming a database, existing database tokens will no longer work because
+they reference the old database name. Do the following:
+
+1. [Create new database tokens](/influxdb3/clustered/admin/tokens/database/create/)
+   with permissions for the renamed database.
+2. Update your applications and clients to use the new tokens.
+3. [Delete the old database tokens](/influxdb3/clustered/admin/tokens/database/delete/)
+   that reference the old database name.
+
+{{% note %}}
+#### Renamed database retains its ID
+
+The database ID remains the same after renaming. When you list databases,
+you'll see the new name associated with the original database ID.
+{{% /note %}}

--- a/content/influxdb3/clustered/admin/databases/undelete.md
+++ b/content/influxdb3/clustered/admin/databases/undelete.md
@@ -1,0 +1,70 @@
+---
+title: Undelete a database
+description: >
+  Use the [`influxctl database undelete` command](/influxdb3/clustered/reference/cli/influxctl/database/undelete/)
+  to restore a previously deleted database in your {{< product-name omit=" Cluster" >}} cluster.
+menu:
+  influxdb3_clustered:
+    parent: Manage databases
+weight: 204
+list_code_example: |
+  ```sh
+  influxctl database undelete <DATABASE_NAME>
+  ```
+related:
+  - /influxdb3/clustered/reference/cli/influxctl/database/undelete/
+  - /influxdb3/clustered/admin/databases/delete/
+  - /influxdb3/clustered/admin/tokens/database/create/
+---
+
+Use the [`influxctl database undelete` command](/influxdb3/clustered/reference/cli/influxctl/database/undelete/)
+to restore a previously deleted database in your {{< product-name omit=" Cluster" >}} cluster.
+
+> [!Important]
+> To undelete a database:
+> 
+> - The database name must match the name of the deleted database.
+> - A new database with the same name cannot already exist.
+> - You must have appropriate permissions to manage databases.
+
+When you undelete a database, it is restored with the same retention period,
+table limits, and column limits as when it was deleted.
+
+> [!Warning]
+> Databases can only be undeleted for
+> {{% show-in "cloud-dedicated" %}}approximately 14 days{{% /show-in %}}{{% show-in "clustered" %}}a configurable "hard-delete" grace period{{% /show-in %}}
+> after they are deleted.
+> After this grace period, all Parquet files associated with the deleted database
+> are permanently removed and the database cannot be undeleted.
+
+## Undelete a database using the influxctl CLI
+
+{{% code-placeholders "DATABASE_NAME" %}}
+```sh
+influxctl database undelete DATABASE_NAME
+```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
+  Name of the deleted database to restore
+
+## Recreate tokens for the database
+
+After successfully undeleting a database:
+
+1.  **Verify the database was restored** by [listing all databases](/influxdb3/clustered/admin/databases/list/).
+2.  **If you previously deleted tokens associated with the deleted database, create new database tokens**
+    - Any tokens that existed before deletion are not restored.
+    [Create new database tokens](/influxdb3/clustered/admin/tokens/database/create/)
+    with appropriate permissions for the restored database.
+3.  **Update your applications** to use the new database tokens.
+
+{{% note %}}
+#### Undeleted databases retain their original configuration
+
+When a database is undeleted, it retains the same database ID, retention period,
+and table/column limits it had before deletion. However, database tokens are not
+restored and must be recreated.
+{{% /note %}}

--- a/content/influxdb3/clustered/admin/tables/delete.md
+++ b/content/influxdb3/clustered/admin/tables/delete.md
@@ -1,0 +1,53 @@
+---
+title: Delete a table
+description: >
+  Use the Admin UI or the [`influxctl table delete` command](/influxdb3/clustered/reference/cli/influxctl/table/delete/)
+  to delete a table from a database in your {{< product-name omit=" Cluster" >}} cluster.
+menu:
+  influxdb3_clustered:
+    parent: Manage tables
+weight: 203
+list_code_example: |
+  ```sh
+  influxctl table delete <DATABASE_NAME> <TABLE_NAME>
+  ```
+related:
+  - /influxdb3/clustered/reference/cli/influxctl/table/delete/
+---
+
+Use the Admin UI or the [`influxctl table delete` command](/influxdb3/clustered/reference/cli/influxctl/table/delete/)
+to delete a table from a database in your {{< product-name omit=" Cluster" >}} cluster.
+
+> [!Warning]
+> Deleting a table is irreversible. Once a table is deleted, all data stored in
+> that table is permanently removed and cannot be recovered.
+
+Provide the following arguments:
+
+- **Database name**: Name of the database that contains the table to delete
+- **Table name**: Name of the table to delete
+
+{{% code-placeholders "DATABASE_NAME|TABLE_NAME" %}}
+```sh
+influxctl table delete DATABASE_NAME TABLE_NAME
+```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}: Name of the database that contains the table to delete
+- {{% code-placeholder-key %}}`TABLE_NAME`{{% /code-placeholder-key %}}: Name of the table to delete
+
+When prompted, enter `y` to confirm the deletion.
+
+{{% note %}}
+#### Wait before reusing a deleted table name
+
+After deleting a table, wait a few minutes before attempting to create a new
+table with the same name to ensure the deletion process has fully completed.
+
+{{% product-name %}} creates tables implicitly using table names specified in
+line protocol written to the databases. To prevent the deleted table from being
+immediately recreated by incoming write requests, pause all write requests to
+the table before deleting it.
+{{% /note %}}

--- a/content/influxdb3/clustered/admin/tables/delete.md
+++ b/content/influxdb3/clustered/admin/tables/delete.md
@@ -40,14 +40,13 @@ Replace the following:
 
 When prompted, enter `y` to confirm the deletion.
 
-{{% note %}}
-#### Wait before reusing a deleted table name
-
-After deleting a table, wait a few minutes before attempting to create a new
-table with the same name to ensure the deletion process has fully completed.
-
-{{% product-name %}} creates tables implicitly using table names specified in
-line protocol written to the databases. To prevent the deleted table from being
-immediately recreated by incoming write requests, pause all write requests to
-the table before deleting it.
-{{% /note %}}
+> [!Note]
+> #### Wait before reusing a deleted table name
+> 
+> After deleting a table, wait a few minutes before attempting to create a new
+> table with the same name to ensure the deletion process has fully completed.
+> 
+> {{% product-name %}} creates tables implicitly using table names specified in
+> line protocol written to the databases. To prevent the deleted table from being
+> immediately recreated by incoming write requests, pause all write requests to
+> the table before deleting it.

--- a/content/influxdb3/clustered/admin/tables/list.md
+++ b/content/influxdb3/clustered/admin/tables/list.md
@@ -1,7 +1,8 @@
 ---
 title: List tables
 description: >
-  Use the [`SHOW TABLES` SQL statement](/influxdb3/clustered/query-data/sql/explore-schema/#list-measurements-in-a-database)
+  Use the [`influxctl table list` command](/influxdb3/clustered/reference/cli/influxctl/table/list/),
+  the [`SHOW TABLES` SQL statement](/influxdb3/clustered/query-data/sql/explore-schema/#list-measurements-in-a-database),
   or the [`SHOW MEASUREMENTS` InfluxQL statement](/influxdb3/clustered/query-data/influxql/explore-schema/#list-measurements-in-a-database)
   to list tables in a database.
 menu:
@@ -9,48 +10,95 @@ menu:
     parent: Manage tables
 weight: 201
 list_code_example: |
-  ###### SQL
+  ##### CLI
+  ```sh
+  influxctl table list <DATABASE_NAME>
+  ```
+
+  ##### SQL
 
   ```sql
   SHOW TABLES
   ```
 
-  ###### InfluxQL
+  ##### InfluxQL
   
   ```sql
   SHOW MEASUREMENTS
   ```
 related:
+  - /influxdb3/clustered/reference/cli/influxctl/table/list/
   - /influxdb3/clustered/query-data/sql/explore-schema/
   - /influxdb3/clustered/query-data/influxql/explore-schema/
 ---
 
-Use the [`SHOW TABLES` SQL statement](/influxdb3/clustered/query-data/sql/explore-schema/#list-measurements-in-a-database)
+Use the [`influxctl table list` command](/influxdb3/clustered/reference/cli/influxctl/table/list/),
+the [`SHOW TABLES` SQL statement](/influxdb3/clustered/query-data/sql/explore-schema/#list-measurements-in-a-database),
 or the [`SHOW MEASUREMENTS` InfluxQL statement](/influxdb3/clustered/query-data/influxql/explore-schema/#list-measurements-in-a-database)
 to list tables in a database.
 
 > [!Note]
 > With {{< product-name >}}, tables and measurements are synonymous.
 
-###### SQL
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[influxctl](#influxctl)
+[SQL & InfluxQL](#sql--influxql)
+{{% /tabs %}}
+{{% tab-content %}}
+<!------------------------------- BEGIN INFLUXCTL ----------------------------->
+
+Use the [`influxctl table list` command](/influxdb3/clustered/reference/cli/influxctl/table/list/)
+to list all tables in a database in your {{< product-name omit=" Cluster" >}}.
+
+{{% code-placeholders "DATABASE_NAME" %}}
+<!-- pytest.mark.skip -->
+```bash
+influxctl table list DATABASE_NAME
+```
+{{% /code-placeholders %}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}: 
+  Name of the database containing the tables to list
+
+### Output formats
+
+The `influxctl table list` command supports the following output formats:
+
+- `table` (default): Human-readable table format
+- `json`: JSON format for programmatic use
+
+Use the `--format` flag to specify the output format:
+
+{{% code-placeholders "DATABASE_NAME" %}}
+```sh
+influxctl table list --format json DATABASE_NAME
+```
+{{% /code-placeholders %}}
+
+<!------------------------------- END INFLUXCTL ------------------------------->
+{{% /tab-content %}}
+{{% tab-content %}}
+<!----------------------------- BEGIN SQL/INFLUXQL ---------------------------->
+
+## List tables with the influxctl query command
+
+To list tables using SQL or InfluxQL, use the `influxctl query` command to pass
+the appropriate statement.
+
+### SQL
 
 ```sql
 SHOW TABLES
 ```
 
-###### InfluxQL
+### InfluxQL
 
 ```sql
 SHOW MEASUREMENTS
 ```
-
-## List tables with the influxctl CLI
-
-To list tables using the `influxctl` CLI, use the `influxctl query` command to pass
-the `SHOW TABLES` SQL statement.
-
-> [!Note]
-> The `influxctl query` command only supports SQL queries; not InfluxQL.
 
 Provide the following with your command:
 
@@ -61,15 +109,27 @@ Provide the following with your command:
 - **Database name**: Name of the database to query. Uses the `database` setting
   from the [`influxctl` connection profile](/influxdb3/clustered/reference/cli/influxctl/#configure-connection-profiles)
   or the `--database` command flag.
-- **SQL query**: SQL query with the `SHOW TABLES` statement.
+- **SQL query**: SQL query with the `SHOW TABLES` statement or InfluxQL query with the `SHOW MEASUREMENTS` statement.
 
 {{% code-placeholders "DATABASE_(TOKEN|NAME)" %}}
 
-```sh
+##### SQL
+<!-- pytest.mark.skip -->
+```bash
 influxctl query \
   --token DATABASE_TOKEN \
   --database DATABASE_NAME \
   "SHOW TABLES"
+```
+
+##### InfluxQL
+<!-- pytest.mark.skip -->
+```bash
+influxctl query \
+  --token DATABASE_TOKEN \
+  --database DATABASE_NAME \
+   --language influxql \
+  "SHOW MEASUREMENTS"
 ```
 
 {{% /code-placeholders %}}
@@ -80,4 +140,12 @@ Replace the following:
   Database token with read access to the queried database
 - {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
   Name of the database to query
+
+> [!Note]
+> The `influxctl query` command only supports SQL queries; not InfluxQL.
+> To use InfluxQL, query InfluxDB through the API using InfluxQL request parameters.
+
+<!------------------------------ END SQL/INFLUXQL ----------------------------->
+{{% /tab-content %}}
+{{< /tabs-wrapper >}}
 


### PR DESCRIPTION
Adds and updates task-based documentation for using the new and updated `influxctl` commands in InfluxDB Cloud Dedicated and InfluxDB Clustered.

- Rename a database
- Undelete a database
- Delete a table

---

- [x] Rebased/mergeable
