### PR TITLE
chore(v1): Install and run v1 OSS and Enterprise with Docker:

### DIFF
--- a/content/enterprise_influxdb/v1/administration/monitor/logs.md
+++ b/content/enterprise_influxdb/v1/administration/monitor/logs.md
@@ -120,13 +120,13 @@ You can view the file [here](https://github.com/influxdb/influxdb/blob/master/sc
 
 InfluxDB 1.5 introduces the option to log HTTP request traffic separately from the other InfluxDB log output. When HTTP request logging is enabled, the HTTP logs are intermingled by default with internal InfluxDB logging. By redirecting the HTTP request log entries to a separate file, both log files are easier to read, monitor, and debug.
 
-See [Redirecting HTTP request logging](/enterprise_influxdb/v1/administration/logs/#redirecting-http-access-logging) in the InfluxDB OSS documentation.
+For more information, see the [InfluxDB OSS v1 HTTP access logging documentation](/influxdb/v1/administration/logs/#http-access-logging).
 
 ## Structured logging
 
 With InfluxDB 1.5, structured logging is supported and enable machine-readable and more developer-friendly log output formats. The two new structured log formats, `logfmt` and `json`, provide easier filtering and searching with external tools and simplifies integration of InfluxDB logs  with Splunk, Papertrail, Elasticsearch, and other third party tools.
 
-See [Structured logging](/enterprise_influxdb/v1/administration/logs/#structured-logging) in the InfluxDB OSS documentation.
+For more information, see the [InfluxDB OSS v1 structured logging documentation](/influxdb/v1/administration/logs/#structured-logging).
 
 ## Tracing
 

--- a/content/enterprise_influxdb/v1/introduction/installation/_index.md
+++ b/content/enterprise_influxdb/v1/introduction/installation/_index.md
@@ -11,6 +11,10 @@ menu:
     name: Install
     weight: 103
     parent: Introduction
+related:
+  - /enterprise_influxdb/v1/introduction/installation/docker/
+  - /enterprise_influxdb/v1/introduction/installation/single-server/
+  - /enterprise_influxdb/v1/introduction/installation/fips-compliant/
 ---
 
 Complete the following steps to install an InfluxDB Enterprise cluster in your own environment:
@@ -20,7 +24,3 @@ Complete the following steps to install an InfluxDB Enterprise cluster in your o
 3. [Install Chronograf](/enterprise_influxdb/v1/introduction/installation/chrono_install/)
 
 {{< influxdbu title="Installing InfluxDB Enterprise" summary="Learn about InfluxDB architecture and how to install InfluxDB Enterprise with step-by-step instructions." action="Take the course" link="https://university.influxdata.com/courses/installing-influxdb-enterprise-tutorial/" >}}
-
-#### Other installation options
-- [Install InfluxDB Enterprise on a single server](/enterprise_influxdb/v1/introduction/installation/single-server/)
-- [Federal Information Processing Standards (FIPS)-compliant InfluxDB Enterprise](/enterprise_influxdb/v1/introduction/installation/fips-compliant/)

--- a/content/enterprise_influxdb/v1/introduction/installation/data_node_installation.md
+++ b/content/enterprise_influxdb/v1/introduction/installation/data_node_installation.md
@@ -327,7 +327,7 @@ influxdb  2706  0.2  7.0 571008 35376 ?        Sl   15:37   0:16 /usr/bin/influx
 ```
 
 If you do not see the expected output, the process is either not launching or is exiting prematurely.
-Check the [logs](/enterprise_influxdb/v1/administration/logs/)
+Check the [logs](/enterprise_influxdb/v1/administration/monitor/logs/)
 for error messages and verify the previous setup steps are complete.
 
 If you see the expected output, repeat for the remaining data nodes.
@@ -394,6 +394,10 @@ to the cluster.
 
 {{% /expand %}}
 {{< /expand-wrapper >}}
+
+## Docker installation
+
+For Docker-based installations, see [Install and run InfluxDB v1 Enterprise with Docker](/enterprise_influxdb/v1/introduction/installation/docker/) for complete instructions on setting up data nodes using Docker images.
 
 ## Next steps
 

--- a/content/enterprise_influxdb/v1/introduction/installation/docker/_index.md
+++ b/content/enterprise_influxdb/v1/introduction/installation/docker/_index.md
@@ -1,0 +1,238 @@
+---
+title: Install and run InfluxDB v1 Enterprise with Docker
+description: Install and run InfluxDB v1 Enterprise using Docker images for meta nodes and data nodes.
+menu:
+  enterprise_influxdb_v1:
+    name: Install with Docker
+    weight: 30
+    parent: Install
+related:
+  - /enterprise_influxdb/v1/introduction/installation/docker/docker-troubleshooting/
+---
+
+InfluxDB v1 Enterprise provides Docker images for both meta nodes and data nodes to simplify cluster deployment and management.
+Using Docker allows you to quickly set up and run InfluxDB Enterprise clusters with consistent configurations.
+
+> [!Important]
+> #### Enterprise license required
+> You must have a valid license to run InfluxDB Enterprise.
+> Contact <sales@influxdata.com> for licensing information or obtain a 14-day demo license via the [InfluxDB Enterprise portal](https://portal.influxdata.com/users/new).
+
+## Docker image variants
+
+InfluxDB Enterprise provides two specialized Docker images:
+
+- **`influxdb:meta`**: Enterprise meta node package for clustering
+- **`influxdb:data`**: Enterprise data node package for clustering
+
+## Requirements
+
+- [Docker](https://docs.docker.com/get-docker/) installed and running
+- Valid [InfluxData license key](#enterprise-license-required)
+- Network connectivity between nodes
+- At least 3 meta nodes (odd number recommended)
+- At least 2 data nodes
+
+## Set up an InfluxDB Enterprise cluster with Docker
+
+### 1. Create a Docker network
+
+Create a custom Docker network to allow communication between meta and data nodes:
+
+```bash
+docker network create influxdb
+```
+
+### 2. Start meta nodes
+
+Start three meta nodes using the `influxdb:meta` image.
+Each meta node requires a unique hostname and the Enterprise license key:
+
+```bash
+# Start first meta node
+docker run -d \
+  --name=influxdb-meta-0 \
+  --network=influxdb \
+  -h influxdb-meta-0 \
+  -e INFLUXDB_ENTERPRISE_LICENSE_KEY=your-license-key \
+  influxdb:meta
+
+# Start second meta node
+docker run -d \
+  --name=influxdb-meta-1 \
+  --network=influxdb \
+  -h influxdb-meta-1 \
+  -e INFLUXDB_ENTERPRISE_LICENSE_KEY=your-license-key \
+  influxdb:meta
+
+# Start third meta node
+docker run -d \
+  --name=influxdb-meta-2 \
+  --network=influxdb \
+  -h influxdb-meta-2 \
+  -e INFLUXDB_ENTERPRISE_LICENSE_KEY=your-license-key \
+  influxdb:meta
+```
+
+### 3. Configure meta nodes to know each other
+
+From the first meta node, add the other meta nodes to the cluster:
+
+```bash
+# Add the second meta node
+docker exec influxdb-meta-0 \
+  influxd-ctl add-meta influxdb-meta-1:8091
+
+# Add the third meta node
+docker exec influxdb-meta-0 \
+  influxd-ctl add-meta influxdb-meta-2:8091
+```
+
+### 4. Start data nodes
+
+Start two or more data nodes using the `influxdb:data` image:
+
+```bash
+# Start first data node
+docker run -d \
+  --name=influxdb-data-0 \
+  --network=influxdb \
+  -h influxdb-data-0 \
+  -e INFLUXDB_ENTERPRISE_LICENSE_KEY=your-license-key \
+  influxdb:data
+
+# Start second data node
+docker run -d \
+  --name=influxdb-data-1 \
+  --network=influxdb \
+  -h influxdb-data-1 \
+  -e INFLUXDB_ENTERPRISE_LICENSE_KEY=your-license-key \
+  influxdb:data
+```
+
+### 5. Add data nodes to the cluster
+
+From the first meta node, register each data node with the cluster:
+
+```bash
+# Add first data node
+docker exec influxdb-meta-0 \
+  influxd-ctl add-data influxdb-data-0:8088
+
+# Add second data node
+docker exec influxdb-meta-0 \
+  influxd-ctl add-data influxdb-data-1:8088
+```
+
+### 6. Verify the cluster
+
+Check that all nodes are properly added to the cluster:
+
+```bash
+docker exec influxdb-meta-0 influxd-ctl show
+```
+
+Expected output:
+```
+Data Nodes
+==========
+ID   TCP Address            Version
+4    influxdb-data-0:8088   1.x.x-cX.X.X
+5    influxdb-data-1:8088   1.x.x-cX.X.X
+
+Meta Nodes
+==========
+TCP Address            Version
+influxdb-meta-0:8091   1.x.x-cX.X.X
+influxdb-meta-1:8091   1.x.x-cX.X.X
+influxdb-meta-2:8091   1.x.x-cX.X.X
+```
+
+## Configuration options
+
+### Using environment variables
+
+You can configure {{% product-name %}} using environment variables with the format `INFLUXDB_<SECTION>_<NAME>`.
+
+Common environment variables:
+- `INFLUXDB_REPORTING_DISABLED=true`
+- `INFLUXDB_META_DIR=/path/to/metadir`
+- `INFLUXDB_ENTERPRISE_REGISTRATION_ENABLED=true`
+- `INFLUXDB_ENTERPRISE_LICENSE_KEY=your-license-key`
+
+For all available environment variables, see how to [Configure Enterprise](/enterprise_influxdb/v1/administration/configure/).
+
+### Using configuration files
+
+You can also mount custom configuration files:
+
+```bash
+# Mount custom meta configuration
+docker run -d \
+  --name=influxdb-meta-0 \
+  --network=influxdb \
+  -h influxdb-meta-0 \
+  -v /path/to/influxdb-meta.conf:/etc/influxdb/influxdb-meta.conf \
+  -e INFLUXDB_ENTERPRISE_LICENSE_KEY=your-license-key \
+  influxdb:meta
+
+# Mount custom data configuration
+docker run -d \
+  --name=influxdb-data-0 \
+  --network=influxdb \
+  -h influxdb-data-0 \
+  -v /path/to/influxdb.conf:/etc/influxdb/influxdb.conf \
+  -e INFLUXDB_ENTERPRISE_LICENSE_KEY=your-license-key \
+  influxdb:data
+```
+
+## Exposing ports
+
+To access your InfluxDB Enterprise cluster from outside Docker, expose the necessary ports:
+
+```bash
+# Data node with HTTP API port exposed
+docker run -d \
+  --name=influxdb-data-0 \
+  --network=influxdb \
+  -h influxdb-data-0 \
+  -p 8086:8086 \
+  -e INFLUXDB_ENTERPRISE_LICENSE_KEY=your-license-key \
+  influxdb:data
+```
+
+## Persistent data storage
+
+To persist data beyond container lifecycles, mount volumes:
+
+```bash
+# Meta node with persistent storage
+docker run -d \
+  --name=influxdb-meta-0 \
+  --network=influxdb \
+  -h influxdb-meta-0 \
+  -v influxdb-meta-0-data:/var/lib/influxdb \
+  -e INFLUXDB_ENTERPRISE_LICENSE_KEY=your-license-key \
+  influxdb:meta
+
+# Data node with persistent storage
+docker run -d \
+  --name=influxdb-data-0 \
+  --network=influxdb \
+  -h influxdb-data-0 \
+  -v influxdb-data-0-data:/var/lib/influxdb \
+  -e INFLUXDB_ENTERPRISE_LICENSE_KEY=your-license-key \
+  influxdb:data
+```
+
+## Next steps
+
+Once your InfluxDB Enterprise cluster is running:
+
+1. [Set up authentication and authorization](/enterprise_influxdb/v1/administration/configure/security/authentication/) for your cluster.
+2. [Enable TLS encryption](/enterprise_influxdb/v1/guides/enable-tls/) for secure communication.
+3. [Install and set up Chronograf](/enterprise_influxdb/v1/introduction/installation/chrono_install) for cluster management and visualization.
+4. Configure your load balancer to send client traffic to data nodes. For more information, see [Data node installation](/enterprise_influxdb/v1/introduction/installation/data_node_installation/).
+5. [Monitor your cluster](/enterprise_influxdb/v1/administration/monitor/) for performance and reliability.
+6. [Write data with the InfluxDB API](/enterprise_influxdb/v1/guides/write_data/).
+7. [Query data with the InfluxDB API](/enterprise_influxdb/v1/guides/query_data/).

--- a/content/enterprise_influxdb/v1/introduction/installation/docker/docker-troubleshooting.md
+++ b/content/enterprise_influxdb/v1/introduction/installation/docker/docker-troubleshooting.md
@@ -1,0 +1,226 @@
+---
+title: Docker troubleshooting for InfluxDB v1 Enterprise
+description: Common Docker-specific issues and solutions for InfluxDB v1 Enterprise deployments.
+menu:
+  enterprise_influxdb_v1:
+    name: Docker troubleshooting
+    weight: 35
+    parent: Install with Docker 
+related:
+  - /enterprise_influxdb/v1/introduction/installation/docker/
+  - /enterprise_influxdb/v1/troubleshooting/
+  - /enterprise_influxdb/v1/administration/monitor/logs/
+---
+
+This guide covers common Docker-specific issues and solutions when running InfluxDB v1 Enterprise in containers.
+
+## Common Docker issues
+
+### License key issues
+
+#### Problem: Container fails to start with license error
+
+**Symptoms:**
+```
+license key verification failed
+```
+
+**Solution:**
+1. Verify your license key is valid and not expired
+2. Ensure the license key environment variable is set correctly:
+   ```bash
+   -e INFLUXDB_ENTERPRISE_LICENSE_KEY=your-actual-license-key
+   ```
+3. If nodes cannot reach `portal.influxdata.com`, use a license file instead:
+   ```bash
+   -v /path/to/license.json:/etc/influxdb/license.json
+   -e INFLUXDB_ENTERPRISE_LICENSE_PATH=/etc/influxdb/license.json
+   ```
+
+### Network connectivity issues
+
+#### Problem: Nodes cannot communicate with each other
+
+**Symptoms:**
+- Meta nodes fail to join cluster
+- Data nodes cannot connect to meta nodes
+- `influxd-ctl show` shows missing nodes
+
+**Solution:**
+1. Ensure all containers are on the same Docker network:
+   ```bash
+   docker network create influxdb
+   # Add --network=influxdb to all container runs
+   ```
+2. Use container hostnames consistently:
+   ```bash
+   # Use hostname (-h) that matches container name
+   -h influxdb-meta-0 --name=influxdb-meta-0
+   ```
+3. Verify network connectivity between containers:
+   ```bash
+   docker exec influxdb-meta-0 ping influxdb-meta-1
+   ```
+
+#### Problem: Cannot access InfluxDB from host machine
+
+**Symptoms:**
+- Connection refused when trying to connect to InfluxDB API
+- Client tools cannot reach the database
+
+**Solution:**
+Expose the HTTP API port (8086) when starting data nodes:
+```bash
+docker run -d \
+  --name=influxdb-data-0 \
+  --network=influxdb \
+  -h influxdb-data-0 \
+  -p 8086:8086 \
+  -e INFLUXDB_ENTERPRISE_LICENSE_KEY=your-license-key \
+  influxdb:data
+```
+
+### Configuration issues
+
+#### Problem: Custom configuration not being applied
+
+**Symptoms:**
+- Environment variables ignored
+- Configuration file changes not taking effect
+
+**Solution:**
+1. For environment variables, use the correct format `INFLUXDB_$SECTION_$NAME`:
+   ```bash
+   # Correct
+   -e INFLUXDB_REPORTING_DISABLED=true
+   -e INFLUXDB_META_DIR=/custom/meta/dir
+   
+   # Incorrect
+   -e REPORTING_DISABLED=true
+   ```
+
+2. For configuration files, ensure proper mounting:
+   ```bash
+   # Mount config file correctly
+   -v /host/path/influxdb.conf:/etc/influxdb/influxdb.conf
+   ```
+
+3. Verify file permissions on mounted configuration files:
+   ```bash
+   # Config files should be readable by influxdb user (uid 1000)
+   chown 1000:1000 /host/path/influxdb.conf
+   chmod 644 /host/path/influxdb.conf
+   ```
+
+### Data persistence issues
+
+#### Problem: Data lost when container restarts
+
+**Symptoms:**
+- Databases and data disappear after container restart
+- Cluster state not preserved
+
+**Solution:**
+Mount data directories as volumes:
+```bash
+# For meta nodes
+-v influxdb-meta-0-data:/var/lib/influxdb
+
+# For data nodes
+-v influxdb-data-0-data:/var/lib/influxdb
+```
+
+### Resource and performance issues
+
+#### Problem: Containers running out of memory
+
+**Symptoms:**
+- Containers being killed by Docker
+- OOMKilled status in `docker ps`
+
+**Solution:**
+1. Increase memory limits:
+   ```bash
+   --memory=4g --memory-swap=8g
+   ```
+
+2. Monitor memory usage:
+   ```bash
+   docker stats influxdb-data-0
+   ```
+
+3. Optimize InfluxDB configuration for available resources.
+
+#### Problem: Poor performance in containerized environment
+
+**Solution:**
+1. Ensure adequate CPU and memory allocation
+2. Use appropriate Docker storage drivers
+3. Consider host networking for high-throughput scenarios:
+   ```bash
+   --network=host
+   ```
+
+## Debugging commands
+
+### Check container logs
+```bash
+# View container logs
+docker logs influxdb-meta-0
+docker logs influxdb-data-0
+
+# Follow logs in real-time
+docker logs -f influxdb-meta-0
+```
+
+### Verify cluster status
+```bash
+# Check cluster status from any meta node
+docker exec influxdb-meta-0 influxd-ctl show
+
+# Check individual node status
+docker exec influxdb-meta-0 influxd-ctl show-shards
+```
+
+### Network troubleshooting
+```bash
+# Test connectivity between containers
+docker exec influxdb-meta-0 ping influxdb-data-0
+docker exec influxdb-meta-0 telnet influxdb-data-0 8088
+
+# Check which ports are listening
+docker exec influxdb-meta-0 netstat -tlnp
+```
+
+### Configuration verification
+```bash
+# Check effective configuration
+docker exec influxdb-meta-0 cat /etc/influxdb/influxdb-meta.conf
+docker exec influxdb-data-0 cat /etc/influxdb/influxdb.conf
+
+# Verify environment variables
+docker exec influxdb-meta-0 env | grep INFLUXDB
+```
+
+## Best practices for Docker deployments
+
+1. **Use specific image tags** instead of `latest` for production deployments
+2. **Implement health checks** to monitor container status
+3. **Use Docker Compose** for complex multi-container setups
+4. **Mount volumes** for data persistence
+5. **Set resource limits** to prevent resource exhaustion
+6. **Use secrets management** for license keys in production
+7. **Implement proper logging** and monitoring
+8. **Regular backups** of data volumes
+
+## Getting additional help
+
+If you continue to experience issues:
+
+1. Check the [general troubleshooting guide](/enterprise_influxdb/v1/troubleshooting/)
+2. Review [InfluxDB Enterprise logs](/enterprise_influxdb/v1/administration/monitor/logs/)
+3. Contact [InfluxData support](https://support.influxdata.com/) with:
+   - Docker version and configuration
+   - Container logs
+   - Cluster status output
+   - Network configuration details

--- a/content/enterprise_influxdb/v1/introduction/installation/meta_node_installation.md
+++ b/content/enterprise_influxdb/v1/introduction/installation/meta_node_installation.md
@@ -365,6 +365,10 @@ the cluster._
 {{% /expand %}}
 {{< /expand-wrapper >}}
 
+## Docker installation
+
+For Docker-based installations, see [Install and run InfluxDB v1 Enterprise with Docker](/enterprise_influxdb/v1/introduction/installation/docker/) for complete instructions on setting up meta nodes using Docker images.
+
 After your meta nodes are part of your cluster,
 [install data nodes](/enterprise_influxdb/v1/introduction/installation/data_node_installation/).
 

--- a/content/enterprise_influxdb/v1/introduction/installation/single-server.md
+++ b/content/enterprise_influxdb/v1/introduction/installation/single-server.md
@@ -475,7 +475,7 @@ sudo systemctl start influxdb
     ```
 
     If you do not see the expected output, the process is either not launching or is exiting prematurely.
-    Check the [logs](/enterprise_influxdb/v1/administration/logs/)
+    Check the [logs](/enterprise_influxdb/v1/administration/monitor/logs/)
     for error messages and verify the previous setup steps are complete.
 
 5. **Use `influxd-ctl` to add the data process to the InfluxDB Enterprise "cluster"**:
@@ -542,9 +542,7 @@ For Chronograf installation instructions, see
 [Install Chronograf](/chronograf/v1/introduction/installation/).
 
 ## Next steps
-- Add more users if necessary.
-  See [Manage users and permissions](/enterprise_influxdb/v1/administration/manage/users-and-permissions/)
-  for more information.
-- [Enable TLS](/enterprise_influxdb/v1/guides/enable-tls/).
-- [Write data with the InfluxDB API](/enterprise_influxdb/v1/guides/write_data/).
-- [Query data with the InfluxDB API](/enterprise_influxdb/v1/guides/query_data/).
+- For information about adding users, see [Manage users and permissions](/enterprise_influxdb/v1/administration/manage/users-and-permissions/)
+- [Enable TLS](/enterprise_influxdb/v1/guides/enable-tls/)
+- [Write data with the InfluxDB API](/enterprise_influxdb/v1/guides/write_data/)
+- [Query data with the InfluxDB API](/enterprise_influxdb/v1/guides/query_data/)

--- a/content/influxdb/v1/introduction/get-started/_index.md
+++ b/content/influxdb/v1/introduction/get-started/_index.md
@@ -1,19 +1,9 @@
 ---
 title: Get started with InfluxDB OSS
-description: Get started with InfluxDB OSS.
-# v2.0 alias below routes old external links here temporarily.
+description: Get started with InfluxDB OSS. Learn how to create databases, write data, and query your time series data.
 aliases:
   - /influxdb/v1/introduction/getting_started/
   - /influxdb/v1/introduction/getting-started/
-  - /influxdb/v2/introduction/getting-started/
-  - /influxdb/v2/introduction/getting-started/
-  - /influxdb/v2/introduction/getting_started/
-  - /influxdb/v2/introduction/getting_started/
-  - /influxdb/v2/introduction/getting_started/
-  - /influxdb/v2/introduction/getting_started/
-  - /influxdb/v2/introduction/getting_started/
-  - /influxdb/v2/introduction/getting-started/
-
 menu:
   influxdb_v1:
     name: Get started with InfluxDB
@@ -23,21 +13,29 @@ alt_links:
   v2: /influxdb/v2/get-started/
 ---
 
-With InfluxDB open source (OSS) [installed](/influxdb/v1/introduction/installation), you're ready to start doing some awesome things.
-In this section we'll use the `influx` [command line interface](/influxdb/v1/tools/shell/) (CLI), which is included in all
-InfluxDB packages and is a lightweight and simple way to interact with the database.
-The CLI communicates with InfluxDB directly by making requests to the InfluxDB API over port `8086` by default.
+With InfluxDB open source (OSS) [installed](/influxdb/v1/introduction/installation), you're ready to start working with time series data.
+This guide uses the `influx` [command line interface](/influxdb/v1/tools/shell/) (CLI), which is included with InfluxDB
+and provides direct access to the database.
+The CLI communicates with InfluxDB through the HTTP API on port `8086`.
 
-> **Note:** The database can also be used by making raw HTTP requests.
-See [Writing Data](/influxdb/v1/guides/writing_data/) and [Querying Data](/influxdb/v1/guides/querying_data/)
-for examples with the `curl` application.
+> [!Tip]
+> **Docker users**: Access the CLI from your container using:
+> ```bash
+> docker exec -it <container-name> influx
+> ```
+
+> [!Note]
+> #### Directly access the API 
+> You can also interact with InfluxDB using the HTTP API directly.
+> See [Writing Data](/influxdb/v1/guides/writing_data/) and [Querying Data](/influxdb/v1/guides/querying_data/)for examples using `curl`.
 
 ## Creating a database
 
-If you've installed InfluxDB locally, the `influx` command should be available via the command line.
-Executing `influx` will start the CLI and automatically connect to the local InfluxDB instance
-(assuming you have already started the server with `service influxdb start` or by running `influxd` directly).
-The output should look like this:
+After installing InfluxDB locally, the `influx` command is available from your terminal.
+Running `influx` starts the CLI and connects to your local InfluxDB instance
+(ensure InfluxDB is running with `service influxdb start` or `influxd`).
+To start the CLI and connect to the local InfluxDB instance, run the following command.
+The [`-precision` argument](/influxdb/v1/tools/shell/#influx-arguments) specifies the format and precision of any returned timestamps.
 
 ```bash
 $ influx -precision rfc3339
@@ -46,15 +44,12 @@ InfluxDB shell {{< latest-patch >}}
 >
 ```
 
-> **Notes:**
->
-* The InfluxDB API runs on port `8086` by default.
-Therefore, `influx` will connect to port `8086` and `localhost` by default.
-If you need to alter these defaults, run `influx --help`.
-* The [`-precision` argument](/influxdb/v1/tools/shell/#influx-arguments) specifies the format/precision of any returned timestamps.
-In the example above, `rfc3339` tells InfluxDB to return timestamps in [RFC3339 format](https://www.ietf.org/rfc/rfc3339.txt) (`YYYY-MM-DDTHH:MM:SS.nnnnnnnnnZ`).
+The `influx` CLI connects to port `localhost:8086` (the default).
+The timestamp precision `rfc3339` tells InfluxDB to return timestamps in [RFC3339 format](https://www.ietf.org/rfc/rfc3339.txt) (`YYYY-MM-DDTHH:MM:SS.nnnnnnnnnZ`).
 
-The command line is now ready to take input in the form of the Influx Query Language (a.k.a InfluxQL) statements.
+To view available options for customizing CLI connection parameters or other settings, run `influx --help` in your terminal.
+
+The command line is ready to take input in the form of the Influx Query Language (InfluxQL) statements.
 To exit the InfluxQL shell, type `exit` and hit return.
 
 A fresh install of InfluxDB has no databases (apart from the system `_internal`),
@@ -75,7 +70,6 @@ Throughout this guide, we'll use the database name `mydb`:
 > **Note:** After hitting enter, a new prompt appears and nothing else is displayed.
 In the CLI, this means the statement was executed and there were no errors to display.
 There will always be an error displayed if something went wrong.
-No news is good news!
 
 Now that the `mydb` database is created, we'll use the `SHOW DATABASES` statement
 to display all existing databases:
@@ -203,6 +197,30 @@ including support for Go-style regex. For example:
 --
 > SELECT * FROM "cpu_load_short" WHERE "value" > 0.9
 ```
+
+## Using the HTTP API
+
+You can also interact with InfluxDB using HTTP requests with tools like `curl`:
+
+### Create a database
+```bash
+curl -G http://localhost:8086/query --data-urlencode "q=CREATE DATABASE mydb"
+```
+
+### Write data
+```bash
+curl -i -XPOST 'http://localhost:8086/write?db=mydb' \
+  --data-binary 'cpu,host=serverA,region=us_west value=0.64'
+```
+
+### Query data
+```bash
+curl -G 'http://localhost:8086/query?pretty=true' \
+  --data-urlencode "db=mydb" \
+  --data-urlencode "q=SELECT * FROM cpu"
+```
+
+## Next steps
 
 This is all you need to know to write data into InfluxDB and query it back.
 To learn more about the InfluxDB write protocol,

--- a/content/influxdb/v1/introduction/get-started/_index.md
+++ b/content/influxdb/v1/introduction/get-started/_index.md
@@ -27,7 +27,7 @@ The CLI communicates with InfluxDB through the HTTP API on port `8086`.
 > [!Note]
 > #### Directly access the API 
 > You can also interact with InfluxDB using the HTTP API directly.
-> See [Writing Data](/influxdb/v1/guides/writing_data/) and [Querying Data](/influxdb/v1/guides/querying_data/)for examples using `curl`.
+> See [Writing Data](/influxdb/v1/guides/writing_data/) and [Querying Data](/influxdb/v1/guides/querying_data/) for examples using `curl`.
 
 ## Creating a database
 

--- a/content/influxdb/v1/introduction/install.md
+++ b/content/influxdb/v1/introduction/install.md
@@ -24,6 +24,7 @@ By default, InfluxDB uses the following network ports:
 
 - TCP port `8086` is available for client-server communication using the InfluxDB API.
 - TCP port `8088` is available for the RPC service to perform back up and restore operations.
+- TCP port `2003` is available for the Graphite protocol (when enabled).
 
 In addition to the ports above, InfluxDB also offers multiple plugins that may
 require [custom ports](/influxdb/v1/administration/ports/).
@@ -51,10 +52,11 @@ you may want to check out our
 [SLES & openSUSE](#)
 [FreeBSD/PC-BSD](#)
 [macOS](#)
+[Docker](#)
 {{% /tabs %}}
 {{% tab-content %}}
 For instructions on how to install the Debian package from a file,
-please see the
+see the
 [downloads page](https://influxdata.com/downloads/).
 
 Debian and Ubuntu users can install the latest stable version of InfluxDB using the
@@ -195,6 +197,28 @@ InfluxDB v{{< latest-patch version="1.8" >}} (git: unknown unknown)
 {{% /note %}}
 
 {{% /tab-content %}}
+
+{{% tab-content %}}
+
+Use Docker to run InfluxDB v1 in a container.
+
+For comprehensive Docker installation instructions, configuration options, and initialization features, see:
+
+**[Install and run with Docker ›](/influxdb/v1/introduction/install/docker/)**
+
+Quick start:
+
+```bash
+# Pull the latest InfluxDB v1.x image
+docker pull influxdb:{{< latest-patch version="1" >}}
+
+# Start InfluxDB with persistent storage
+docker run -p 8086:8086 \
+  -v $PWD/data:/var/lib/influxdb \
+  influxdb:{{< latest-patch version="1" >}}
+```
+
+{{% /tab-content %}}
 {{< /tabs-wrapper >}}
 
 ### Verify the authenticity of downloaded binary (optional)
@@ -273,6 +297,12 @@ For example:
 
 InfluxDB first checks for the `-config` option and then for the environment
 variable.
+
+### Configuring InfluxDB with Docker
+
+For detailed Docker configuration instructions including environment variables, configuration files, initialization options, and examples, see:
+
+**[Install and run with Docker ›](/influxdb/v1/introduction/install/docker/)**
 
 See the [Configuration](/influxdb/v1/administration/config/) documentation for more information.
 

--- a/content/influxdb/v1/introduction/install/docker.md
+++ b/content/influxdb/v1/introduction/install/docker.md
@@ -1,0 +1,157 @@
+---
+title: Install and run InfluxDB using Docker
+description: >
+  Install and run InfluxDB OSS v1.x using Docker. Configure and operate InfluxDB in a Docker container.
+menu:
+  influxdb_v1:
+    name: Use Docker 
+    weight: 60
+    parent: Install InfluxDB
+related:
+  - /influxdb/v1/introduction/install/, Install InfluxDB OSS v1
+  - /influxdb/v1/introduction/get-started/, Get started with InfluxDB OSS v1
+  - /influxdb/v1/administration/authentication_and_authorization/, Authentication and authorization in InfluxDB OSS v1
+  - /influxdb/v1/guides/write_data/, Write data to InfluxDB OSS v1
+  - /influxdb/v1/guides/query_data/, Query data in InfluxDB OSS v1
+  - /influxdb/v1/administration/config/, Configure InfluxDB OSS v1
+alt_links:
+  core: /influxdb3/core/install/
+  v2: /influxdb/v2/install/use-docker-compose/
+---
+
+Install and run InfluxDB OSS v1.x using Docker containers.
+This guide covers Docker installation, configuration, and initialization options.
+
+## Install and run InfluxDB
+
+### Pull the InfluxDB v1.x image
+
+```bash
+docker pull influxdb:{{< latest-patch version="1" >}}
+```
+
+### Start InfluxDB
+
+Start a basic InfluxDB container with persistent storage:
+
+```bash
+docker run -p 8086:8086 \
+  -v $PWD/data:/var/lib/influxdb \
+  influxdb:{{< latest-patch version="1" >}}
+```
+
+InfluxDB is now running and available at http://localhost:8086.
+
+## Configure InfluxDB
+
+### Using environment variables
+
+Configure InfluxDB settings using environment variables:
+
+```bash
+docker run -p 8086:8086 \
+  -v $PWD/data:/var/lib/influxdb \
+  -e INFLUXDB_REPORTING_DISABLED=true \
+  -e INFLUXDB_HTTP_AUTH_ENABLED=true \
+  -e INFLUXDB_HTTP_LOG_ENABLED=true \
+  influxdb:{{< latest-patch version="1" >}}
+```
+
+### Using a configuration file
+
+Generate a default configuration file:
+
+```bash
+docker run --rm influxdb:{{< latest-patch version="1" >}} influxd config > influxdb.conf
+```
+
+Start InfluxDB with your custom configuration:
+
+```bash
+docker run -p 8086:8086 \
+  -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf:ro \
+  -v $PWD/data:/var/lib/influxdb \
+  influxdb:{{< latest-patch version="1" >}}
+```
+
+## Initialize InfluxDB
+
+### Automatic initialization (for development)
+
+> [!Warning]
+> Automatic initialization with InfluxDB v1 is not recommended for production.
+> Use this approach only for development and testing.
+
+Automatically create a database and admin user on first startup:
+
+```bash
+docker run -p 8086:8086 \
+  -v $PWD/data:/var/lib/influxdb \
+  -e INFLUXDB_DB=mydb \
+  -e INFLUXDB_HTTP_AUTH_ENABLED=true \
+  -e INFLUXDB_ADMIN_USER=admin \
+  -e INFLUXDB_ADMIN_PASSWORD=supersecretpassword \
+  influxdb:{{< latest-patch version="1" >}}
+```
+
+Environment variables for user creation:
+- `INFLUXDB_USER`: Create a user with no privileges
+- `INFLUXDB_USER_PASSWORD`: Password for the user
+- `INFLUXDB_READ_USER`: Create a user who can read from `INFLUXDB_DB`
+- `INFLUXDB_READ_USER_PASSWORD`: Password for the read user
+- `INFLUXDB_WRITE_USER`: Create a user who can write to `INFLUXDB_DB`
+- `INFLUXDB_WRITE_USER_PASSWORD`: Password for the write user
+
+### Custom initialization scripts
+
+InfluxDB v1.x Docker containers support custom initialization scripts for testing scenarios:
+
+Create an initialization script (`init-scripts/setup.iql`):
+
+```sql
+CREATE DATABASE sensors;
+CREATE DATABASE logs;
+
+CREATE USER "telegraf" WITH PASSWORD 'secret123';
+GRANT WRITE ON "sensors" TO "telegraf";
+
+CREATE USER "grafana" WITH PASSWORD 'secret456';
+GRANT READ ON "sensors" TO "grafana";
+GRANT READ ON "logs" TO "grafana";
+
+CREATE RETENTION POLICY "one_week" ON "sensors" DURATION 1w REPLICATION 1 DEFAULT;
+```
+
+Run with initialization scripts:
+
+```bash
+docker run -p 8086:8086 \
+  -v $PWD/data:/var/lib/influxdb \
+  -v $PWD/init-scripts:/docker-entrypoint-initdb.d \
+  influxdb:{{< latest-patch version="1" >}}
+```
+
+Supported script types:
+- Shell scripts (`.sh`)
+- InfluxDB query language files (`.iql`)
+
+> [!Important]
+> Initialization scripts only run on first startup when the data directory is empty.
+> Scripts execute in alphabetical order based on filename.
+
+## Access the InfluxDB CLI
+
+To access the InfluxDB command line interface from within the Docker container:
+
+```bash
+docker exec -it <container-name> influx
+```
+
+Replace `<container-name>` with your InfluxDB container name or ID.
+
+## Next steps
+
+Once you have InfluxDB running in Docker, see the [Get started guide](/influxdb/v1/introduction/get-started/) to:
+- Create databases
+- Write and query data
+- Learn InfluxQL basics

--- a/content/influxdb/v2/install/use-docker-compose.md
+++ b/content/influxdb/v2/install/use-docker-compose.md
@@ -13,6 +13,8 @@ related:
   - /influxdb/v2/reference/cli/influx/config/
   - /influxdb/v2/reference/cli/influx/
   - /influxdb/v2/admin/tokens/
+alt_links:
+  v1: /influxdb/v1/introduction/install/docker/
 ---
 
 Use Docker Compose to install and set up InfluxDB v2, the time series platform

--- a/content/influxdb3/enterprise/install/_index.md
+++ b/content/influxdb3/enterprise/install/_index.md
@@ -11,4 +11,4 @@ alt_links:
   v1: /influxdb/v1/introduction/install/
 ---
 
-<!--SOURCE - content/shared/influxdb3/install.md -->
+<!-- SOURCE content/shared/influxdb3/install.md -->


### PR DESCRIPTION
Migrates v1 OSS and Enterprise sections from the DockerHub README into new pages in docs-v2.
#6019 will update the DockerHub README to link to the new pages:
- https://docs.influxdata.com/influxdb/v1/introduction/install/docker/
- http://docs.influxdata.com/enterprise_influxdb/v1/introduction/installation/docker/

### Summary
  
- Add a new section page for Installing and running with Docker.o

  1. Created main Docker installation page (docker.md) with:
    - Complete Docker setup instructions for Enterprise clusters
    - Environment variable configuration options
    - Persistent storage examples
    - Network setup guidance
    - License key requirements using GitHub note callout syntax
  2. Enhanced existing installation pages:
    - Added Docker installation sections to both meta and data node installation pages
    - Updated the main installation index to include Docker as an option
  3. Created Docker troubleshooting guide (docker-troubleshooting.md) with:
    - Common Docker-specific issues and solutions
    - Debugging commands and best practices
    - Positioned next to the Docker installation guide
  4. Added proper cross-references:
    - Used related frontmatter to link Docker installation to troubleshooting
    - Updated navigation and references throughout

  The migration preserves all the essential Docker README content while
  integrating it properly into the existing InfluxDB Enterprise v1 documentation
   structure, following the project's style guidelines and conventions.

Related to #6019 

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
