### PR TITLE
Add .no-shorthand to `create token --admin` options

### DIFF
--- a/content/shared/influxdb3-cli/create/token/admin.md
+++ b/content/shared/influxdb3-cli/create/token/admin.md
@@ -7,7 +7,7 @@ Create an operator token or named admin token.
 influxdb3 create token --admin [OPTIONS]
 ```
 
-## Options
+## Options {.no-shorthand}
 
 | Option | Description |
 |:-------|:------------|


### PR DESCRIPTION
This adds the `no-shorthand` class to the options table on https://docs.influxdata.com/influxdb3/core/reference/cli/influxdb3/create/token/admin/. As this table only has two columns, the shorthand CSS is applied to the description instead, making `<code>` tags pretty hard to read:

![A table of various options for the admin command. All the code snippets have a negative margin, so overlap/obscure the previous word.](https://github.com/user-attachments/assets/8b12aba0-adac-4b35-858f-5e4a0b4652b4)

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
