### PR TITLE
feat(influxdb3): v3.2.1 release notes

### DIFF
--- a/api-docs/influxdb3/enterprise/v3/ref.yml
+++ b/api-docs/influxdb3/enterprise/v3/ref.yml
@@ -1239,8 +1239,7 @@ paths:
                   db: mydb
                   plugin_filename: request.py
                   trigger_name: hello_world_trigger
-                  # trigger_specification: "request:hello-world" - For 3.2.1 (issue#6171)
-                  trigger_specification: {"request_path": {"path": "hello-world"}}
+                  trigger_specification: request:hello-world
               cron_friday_afternoon:
                 summary: Cron trigger for Friday afternoons
                 description: |
@@ -1478,17 +1477,14 @@ paths:
           For example, if you define a trigger with the following:
 
           ```json
-          trigger_specification: {"request_path": {"path": "hello-world"}}
+          trigger_specification: "request:hello-world"
           ```
-          
+
           then, the HTTP API exposes the following plugin endpoint:
             
           ```
           <INFLUXDB3_HOST>/api/v3/engine/hello-world
           ```
-
-          ***Note:*** Currently, due to a bug in InfluxDB 3 Enterprise, the request trigger specification is different from Core.
-
         in: path
         required: true
         schema:
@@ -2094,25 +2090,12 @@ components:
             - `table:TABLE_NAME` - Triggers on write events to a specific table
 
             ### On-demand triggers
-            Format: `{"request_path": {"path": "REQUEST_PATH"}}`
+            Format: `request:REQUEST_PATH`
 
             Creates an HTTP endpoint `/api/v3/engine/REQUEST_PATH` for manual invocation:
-            - `{"request_path": {"path": "hello-world"}}` - Creates endpoint `/api/v3/engine/hello-world`
-            - `{"request_path": {"path": "data-export"}}` - Creates endpoint `/api/v3/engine/data-export`
-
-            ***Note:*** Currently, due to a bug in InfluxDB 3 Enterprise, the request trigger specification is different from Core. Use the JSON object format shown above.
-
-          oneOf:
-            - type: string
-              pattern: ^(cron:[0-9 *,/-]+|every:[0-9]+[smhd]|all_tables|table:[a-zA-Z_][a-zA-Z0-9_]*)$
-            - type: object
-              properties:
-                request_path:
-                  type: object
-                  properties:
-                    path:
-                      type: string
-                      pattern: ^[a-zA-Z0-9_-]+$
+            - `request:hello-world` - Creates endpoint `/api/v3/engine/hello-world`
+            - `request:data-export` - Creates endpoint `/api/v3/engine/data-export`
+          pattern: ^(cron:[0-9 *,/-]+|every:[0-9]+[smhd]|all_tables|table:[a-zA-Z_][a-zA-Z0-9_]*|request:[a-zA-Z0-9_-]+)$
           example: cron:0 0 6 * * 1-5
         trigger_arguments:
           type: object

--- a/content/shared/influxdb3-cli/create/trigger.md
+++ b/content/shared/influxdb3-cli/create/trigger.md
@@ -113,15 +113,3 @@ influxdb3 create trigger \
 Creating a trigger in a disabled state prevents it from running immediately. You can enable it later when you're ready to activate it.
 
 {{% /code-placeholders %}}
-
-{{% show-in "enterprise" %}}
-> [!Warning]
-> #### Request trigger specification format differs between CLI and API
-> 
-> Due to a bug in InfluxDB 3 Enterprise, the request trigger specification format differs:
-> 
-> - **CLI**: `request:<REQUEST_PATH>` (same as Core CLI and API)
-> - **Enterprise API**: `{"request_path": {"path": "<REQUEST_PATH>"}}`
-> 
-> See the [API reference](/influxdb3/enterprise/api/#operation/PostConfigureProcessingEngineTrigger) for examples. Use `influxdb3 show summary` to verify the actual trigger specification.
-{{% /show-in %}}

--- a/content/shared/influxdb3-get-started/processing-engine.md
+++ b/content/shared/influxdb3-get-started/processing-engine.md
@@ -41,18 +41,6 @@ specifications:
   The plugin receives the HTTP request headers and content, and can parse,
   process, and send the data into the database or to third-party services.
 
-{{% show-in "enterprise" %}}
-> [!Warning]
-> #### Request trigger specification format differs between CLI and API
-> 
-> Due to a bug in InfluxDB 3 Enterprise, the request trigger specification format differs:
-> 
-> - **CLI**: `request:<REQUEST_PATH>` (same as Core CLI and API)
-> - **Enterprise API**: `{"request_path": {"path": "<REQUEST_PATH>"}}`
-> 
-> See the [API reference](/influxdb3/enterprise/api/#operation/PostConfigureProcessingEngineTrigger) for examples. Use `influxdb3 show summary` to verify the actual trigger specification.
-{{% /show-in %}}
-
 ## Activate the processing engine
 
 To activate the processing engine, include the `--plugin-dir <PLUGIN_DIR>` option

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -11,15 +11,17 @@
 
 #### Features
 
-- Allow hard_deleted date of deleted schema to be updated
-- Include hard_deletion_date in `_internal`, `databases`, and `tables`
+- **Enhanced database lifecycle management**:
+  - Allow updating the hard deletion date for already-deleted databases and tables, providing flexibility in managing data retention and compliance requirements
+  - Include `hard_deletion_date` column in `_internal` system tables (`databases` and `tables`) for better visibility into data lifecycle and audit trails
 
 #### Bug Fixes
 
-- Add help text for the new update subcommand (#26569) ([#26569](https://github.com/influxdata/influxdb/pull/26569))
-- `--object-store` is explicitly marked required (#26575) ([#26575](https://github.com/influxdata/influxdb/pull/26575))
-- v1 query API should default to ns for CSV output (#26577) ([#26577](https://github.com/influxdata/influxdb/pull/26577))
-- Existing soft-deleted schema can be hard-deleted (#26574) ([#26574](https://github.com/influxdata/influxdb/pull/26574))
+- **CLI improvements**:
+  - Added help text for the new `update` subcommand for database and table update features ([#26569](https://github.com/influxdata/influxdb/pull/26569))
+  - `--object-store` and storage configuration parameters are required for the `serve` command ([#26575](https://github.com/influxdata/influxdb/pull/26575))
+- **Query processing**: Fixed V1-compatible `/query` HTTP API endpoint to correctly default to nanosecond precision (`ns`) for CSV output, ensuring backward compatibility with InfluxDB 1.x clients and preventing data precision loss ([#26577](https://github.com/influxdata/influxdb/pull/26577))
+- **Database reliability**: Fixed issue preventing hard deletion of soft-deleted databases and tables, enabling complete data removal for compliance and storage management needs ([#26574](https://github.com/influxdata/influxdb/pull/26574))
 
 ### Enterprise
 
@@ -27,11 +29,11 @@ All Core updates are included in Enterprise. Additional Enterprise-specific feat
 
 #### Features
 
-- Amend license info command
+- **License management improvements**: New `influxdb3 show license` command displays detailed license information including type, expiration date, and resource limits, making it easier to monitor license status and compliance
 
 #### Bug Fixes
 
-- Use string representation of TriggerSpecificationDefinition in API
+- **API stability**: Fixed HTTP API trigger specification to use the correct `"request:REQUEST_PATH"` syntax, ensuring proper request-based trigger configuration for processing engine workflows
 
 ## v3.2.0 {date="2025-06-25"}
 

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -5,6 +5,34 @@
 > All updates to Core are automatically included in Enterprise.
 > The Enterprise sections below only list updates exclusive to Enterprise.
 
+## v3.2.1 {date="2025-07-03"}
+
+### Core
+
+#### Features
+
+- Allow hard_deleted date of deleted schema to be updated
+- Include hard_deletion_date in `_internal`, `databases`, and `tables`
+
+#### Bug Fixes
+
+- Add help text for the new update subcommand (#26569) ([#26569](https://github.com/influxdata/influxdb/pull/26569))
+- `--object-store` is explicitly marked required (#26575) ([#26575](https://github.com/influxdata/influxdb/pull/26575))
+- v1 query API should default to ns for CSV output (#26577) ([#26577](https://github.com/influxdata/influxdb/pull/26577))
+- Existing soft-deleted schema can be hard-deleted (#26574) ([#26574](https://github.com/influxdata/influxdb/pull/26574))
+
+### Enterprise
+
+All Core updates are included in Enterprise. Additional Enterprise-specific features and fixes:
+
+#### Features
+
+- Amend license info command
+
+#### Bug Fixes
+
+- Use string representation of TriggerSpecificationDefinition in API
+
 ## v3.2.0 {date="2025-06-25"}
 
 **Core**: revision 1ca3168bee  

--- a/content/shared/v3-core-plugins/_index.md
+++ b/content/shared/v3-core-plugins/_index.md
@@ -224,7 +224,7 @@ def process_scheduled_call(influxdb3_local, call_time, args=None):
 
 #### Create an HTTP request plugin
 
-HTTP request plugins respond to API calls using [`request:`](#trigger-on-http-requests) trigger specifications{{% show-in "enterprise" %}} (CLI) or `{"request_path": {"path": "..."}}` (HTTP API){{% /show-in %}}. Use them for:
+HTTP request plugins respond to API calls using [`request:`](#trigger-on-http-requests) trigger specifications. Use them for:
 
 - Creating custom API endpoints
 - Webhooks for external integrations
@@ -263,7 +263,7 @@ After writing your plugin:
 |------------|----------------------|-----------------|
 | Data write | `table:<TABLE_NAME>` or `all_tables` | When data is written to tables |
 | Scheduled | `every:<DURATION>` or `cron:<EXPRESSION>` | At specified time intervals |
-| HTTP request | `request:<REQUEST_PATH>`{{% show-in "enterprise" %}} (CLI) or `{"request_path": {"path": "<REQUEST_PATH>"}}` (HTTP API){{% /show-in %}} | When HTTP requests are received |
+| HTTP request | `request:<REQUEST_PATH>` | When HTTP requests are received |
 
 ### Use the create trigger command
 
@@ -366,18 +366,6 @@ To view triggers associated with a database, use the `influxdb3 show summary` co
 ```bash
 influxdb3 show summary --database my_database --token AUTH_TOKEN
 ```
-
-{{% show-in "enterprise" %}}
-> [!Warning]
-> #### Request trigger specification format differs between CLI and API
-> 
-> Due to a bug in InfluxDB 3 Enterprise, the request trigger specification format differs:
-> 
-> - **CLI**: `request:<REQUEST_PATH>` (same as Core CLI and API)
-> - **Enterprise API**: `{"request_path": {"path": "<REQUEST_PATH>"}}`
-> 
-> See the [API reference](/influxdb3/enterprise/api/#operation/PostConfigureProcessingEngineTrigger) for examples. Use `influxdb3 show summary` to verify the actual trigger specification.
-{{% /show-in %}}
 
 ### Pass arguments to plugins
 
@@ -600,19 +588,7 @@ Each plugin must run on a node that supports its trigger type:
 |--------------------|--------------------------|-----------------------------|
 | Data write         | `table:` or `all_tables` | Ingester nodes              |
 | Scheduled          | `every:` or `cron:`      | Any node with scheduler     |
-| HTTP request       | `request:`{{% show-in "enterprise" %}} (CLI) or `{"request_path": {"path": "..."}}` (HTTP API){{% /show-in %}} | Nodes that serve API traffic|
-
-{{% show-in "enterprise" %}}
-> [!Note]
-> #### Request trigger specification format differs between CLI and API
-> 
-> Due to a bug in InfluxDB 3 Enterprise, the request trigger specification format differs:
-> 
-> - **CLI**: `request:<REQUEST_PATH>` (same as Core CLI and API)
-> - **Enterprise API**: `{"request_path": {"path": "<REQUEST_PATH>"}}`
-> 
-> See the [API reference](/influxdb3/enterprise/api/#operation/PostConfigureProcessingEngineTrigger) for examples.
-{{% /show-in %}}
+| HTTP request       | `request:`               | Nodes that serve API traffic|
 
 For example:
 - Run write-ahead log (WAL) plugins on ingester nodes.

--- a/content/shared/v3-core-plugins/_index.md
+++ b/content/shared/v3-core-plugins/_index.md
@@ -26,7 +26,9 @@ Once you have all the prerequisites in place, follow these steps to implement th
 - [Add a Processing Engine plugin](#add-a-processing-engine-plugin)
 - [Set up a trigger](#set-up-a-trigger)
 - [Advanced trigger configuration](#advanced-trigger-configuration)
+{{% show-in "enterprise" %}}
 - [Distributed cluster considerations](#distributed-cluster-considerations)
+{{% /show-in %}}
 
 ## Set up the Processing Engine
 
@@ -66,7 +68,9 @@ When running {{% product-name %}} in a distributed setup, follow these steps to 
 >
 > Configure your plugin directory on the same system as the nodes that run the triggers and plugins.
 
+{{% show-in "enterprise" %}}
 For more information about configuring distributed environments, see the [Distributed cluster considerations](#distributed-cluster-considerations) section.
+{{% /show-in %}}
 
 ## Add a Processing Engine plugin
 

--- a/data/products.yml
+++ b/data/products.yml
@@ -6,7 +6,7 @@ influxdb3_core:
   versions: [core]
   list_order: 2
   latest: core
-  latest_patch: 3.2.0
+  latest_patch: 3.2.1
   placeholder_host: localhost:8181
   ai_sample_questions:
     - How do I install and run InfluxDB 3 Core?
@@ -21,7 +21,7 @@ influxdb3_enterprise:
   versions: [enterprise]
   list_order: 2
   latest: enterprise
-  latest_patch: 3.2.0
+  latest_patch: 3.2.1
   placeholder_host: localhost:8181
   ai_sample_questions:
     - How do I install and run InfluxDB 3 Enterprise?


### PR DESCRIPTION
Core and Enterprise release notes for v3.2.1.
Release notes were generated from influxdb and influxdb_pro diff v3.2.0..v3.2.1.
Added details and improved formatting.
Removed Core and Enterprise `request` trigger spec divergence
Fixed link