### PR TITLE
chore: always verify GPG fingerprint

### DIFF
--- a/Dockerfile.pytest
+++ b/Dockerfile.pytest
@@ -7,7 +7,7 @@ FROM golang:latest
 #   Primary key fingerprint: 24C9 75CB A61A 024E E1B6  3178 7C3D 5715 9FC2 F927
 #   Subkey fingerprint:      9D53 9D90 D332 8DC7 D6C8  D3B9 D8FF 8E1F 7DF8 B07E
 ADD https://repos.influxdata.com/influxdata-archive.key ./influxdata-archive.key
-RUN gpg --no-default-keyring --homedir /nonexistent --show-keys ./influxdata-archive.key | grep -q "24C975CBA61A024EE1B631787C3D57159FC2F927" && cat influxdata-archive.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null
+RUN gpg --no-default-keyring --homedir $(mktemp -d) --show-keys --with-fingerprint --with-colons ./influxdata-archive.key 2>&1 | grep -q '^fpr:\+24C975CBA61A024EE1B631787C3D57159FC2F927:$' && cat influxdata-archive.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null
 
 RUN echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.gpg] https://repos.influxdata.com/debian stable main' | tee /etc/apt/sources.list.d/influxdata.list
 

--- a/content/influxdb/v1/introduction/install.md
+++ b/content/influxdb/v1/introduction/install.md
@@ -75,7 +75,7 @@ For Ubuntu/Debian users, add the InfluxData repository with the following comman
 #   Primary key fingerprint: 24C9 75CB A61A 024E E1B6  3178 7C3D 5715 9FC2 F927
 #   Subkey fingerprint:      9D53 9D90 D332 8DC7 D6C8  D3B9 D8FF 8E1F 7DF8 B07E
 wget -q https://repos.influxdata.com/influxdata-archive.key
-echo '943666881a1b8d9b849b74caebf02d3465d6beb716510d86a39f6c8e8dac7515 influxdata-archive.key' | sha256sum -c && cat influxdata-archive.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null
+gpg --show-keys --with-fingerprint --with-colons ./influxdata-archive.key 2>&1 | grep -q '^fpr:\+24C975CBA61A024EE1B631787C3D57159FC2F927:$' && cat influxdata-archive.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null
 echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
 ```
 {{% /code-tab-content %}}
@@ -85,8 +85,8 @@ echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.gpg] https://repo
 # influxdata-archive.key GPG fingerprint:
 #   Primary key fingerprint: 24C9 75CB A61A 024E E1B6  3178 7C3D 5715 9FC2 F927
 #   Subkey fingerprint:      9D53 9D90 D332 8DC7 D6C8  D3B9 D8FF 8E1F 7DF8 B07E
-wget -q https://repos.influxdata.com/influxdata-archive.key
-echo '943666881a1b8d9b849b74caebf02d3465d6beb716510d86a39f6c8e8dac7515 influxdata-archive.key' | sha256sum -c && cat influxdata-archive.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null
+curl --silent --location -O https://repos.influxdata.com/influxdata-archive.key
+gpg --show-keys --with-fingerprint --with-colons ./influxdata-archive.key 2>&1 | grep -q '^fpr:\+24C975CBA61A024EE1B631787C3D57159FC2F927:$' && cat influxdata-archive.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null
 echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
 ```
 {{% /code-tab-content %}}

--- a/content/influxdb/v2/install/_index.md
+++ b/content/influxdb/v2/install/_index.md
@@ -43,14 +43,14 @@ with your OS version:_
 For newer releases (for example, Ubuntu 20.04 LTS and newer, Debian Buster
 and newer) that support subkey verification:
 
--  Private key file: [`influxdata-archive.key`](https://repos.influxdata.com/influxdata-archive.key)
--  Public key: `943666881a1b8d9b849b74caebf02d3465d6beb716510d86a39f6c8e8dac7515`
+-  GPG key file: [`influxdata-archive.key`](https://repos.influxdata.com/influxdata-archive.key)
+-  Primary key fingerprint: `24C975CBA61A024EE1B631787C3D57159FC2F927`
 
 For older versions (for example, CentOS/RHEL 7, Ubuntu 18.04 LTS, or Debian
 Stretch) that don't support subkeys for verification:
 
--  Private key file: [`influxdata-archive_compat.key`](https://repos.influxdata.com/influxdata-archive_compat.key)
--  Public key: `393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c`
+-  GPG key file: [`influxdata-archive_compat.key`](https://repos.influxdata.com/influxdata-archive_compat.key)
+-  Signing key fingerprint: `9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E`
 
 {{% /expand %}}
 
@@ -136,8 +136,7 @@ binary releases:
 {{% code-placeholders "https://repos.influxdata.com/influxdata-archive.key" %}}
 
 ```sh
-curl --silent --location \
- https://repos.influxdata.com/influxdata-archive.key \
+curl --silent --location https://repos.influxdata.com/influxdata-archive.key \
  | gpg --import - 2>&1 \
  | grep 'InfluxData Package Signing Key <support@influxdata.com>'
 ```
@@ -344,16 +343,16 @@ To install {{% product-name %}} on Linux, do one of the following:
 2. Run the command for your OS version to install the InfluxData key,
    add the InfluxData repository, and install `influxdb`.
 
-   _Before running the command, replace the checksum and key filename with the
+   _Before running the command, replace the fingerprint and key filename with the
    key-pair from the preceding step._
 
    ```bash
    # Ubuntu and Debian
    # Add the InfluxData key to verify downloads and add the repository
-   curl --silent --location -O \
-   https://repos.influxdata.com/influxdata-archive.key
-   echo "943666881a1b8d9b849b74caebf02d3465d6beb716510d86a39f6c8e8dac7515  influxdata-archive.key" \
-   | sha256sum --check - && cat influxdata-archive.key \
+   curl --silent --location -O https://repos.influxdata.com/influxdata-archive.key
+   gpg --show-keys --with-fingerprint --with-colons ./influxdata-archive.key 2>&1 \
+   | grep -q '^fpr:\+24C975CBA61A024EE1B631787C3D57159FC2F927:$' \
+   && cat influxdata-archive.key \
    | gpg --dearmor \
    | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null \
    && echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.gpg] https://repos.influxdata.com/debian stable main' \
@@ -366,10 +365,10 @@ To install {{% product-name %}} on Linux, do one of the following:
    ```bash
    # RedHat and CentOS
    # Add the InfluxData key to verify downloads
-   curl --silent --location -O \
-   https://repos.influxdata.com/influxdata-archive.key \
-   && echo "943666881a1b8d9b849b74caebf02d3465d6beb716510d86a39f6c8e8dac7515  influxdata-archive.key" \
-   | sha256sum --check - && cat influxdata-archive.key \
+   curl --silent --location -O https://repos.influxdata.com/influxdata-archive.key
+   gpg --show-keys --with-fingerprint --with-colons ./influxdata-archive.key 2>&1 \
+   | grep -q '^fpr:\+24C975CBA61A024EE1B631787C3D57159FC2F927:$' \
+   && cat influxdata-archive.key \
    | gpg --dearmor \
    | tee /etc/pki/rpm-gpg/RPM-GPG-KEY-influxdata > /dev/null
 

--- a/content/influxdb3/cloud-dedicated/reference/cli/influxctl/_index.md
+++ b/content/influxdb3/cloud-dedicated/reference/cli/influxctl/_index.md
@@ -176,7 +176,7 @@ To download the Linux `influxctl` package, do one of the following:
 #   Primary key fingerprint: 24C9 75CB A61A 024E E1B6  3178 7C3D 5715 9FC2 F927
 #   Subkey fingerprint:      9D53 9D90 D332 8DC7 D6C8  D3B9 D8FF 8E1F 7DF8 B07E
 wget -q https://repos.influxdata.com/influxdata-archive.key
-echo '943666881a1b8d9b849b74caebf02d3465d6beb716510d86a39f6c8e8dac7515 influxdata-archive.key' | sha256sum -c && cat influxdata-archive.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null
+gpg --show-keys --with-fingerprint --with-colons ./influxdata-archive.key 2>&1 | grep -q '^fpr:\+24C975CBA61A024EE1B631787C3D57159FC2F927:$' && cat influxdata-archive.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null
 echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
 
 sudo apt-get update && sudo apt-get install influxctl

--- a/content/influxdb3/clustered/reference/cli/influxctl/_index.md
+++ b/content/influxdb3/clustered/reference/cli/influxctl/_index.md
@@ -166,7 +166,7 @@ To download the Linux `influxctl` package, do one of the following:
 #   Primary key fingerprint: 24C9 75CB A61A 024E E1B6  3178 7C3D 5715 9FC2 F927
 #   Subkey fingerprint:      9D53 9D90 D332 8DC7 D6C8  D3B9 D8FF 8E1F 7DF8 B07E
 wget -q https://repos.influxdata.com/influxdata-archive.key
-echo '943666881a1b8d9b849b74caebf02d3465d6beb716510d86a39f6c8e8dac7515 influxdata-archive.key' | sha256sum -c && cat influxdata-archive.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null
+gpg --show-keys --with-fingerprint --with-colons ./influxdata-archive.key 2>&1 | grep -q '^fpr:\+24C975CBA61A024EE1B631787C3D57159FC2F927:$' && cat influxdata-archive.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null
 echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
 ```
 

--- a/content/telegraf/v1/install.md
+++ b/content/telegraf/v1/install.md
@@ -126,14 +126,14 @@ Before running the [install](#install) sample code, substitute the key-pair comp
 For newer OS releases (for example, Ubuntu 20.04 LTS and newer, Debian Buster
 and newer) that support subkey verification:
 
--  Private key file: [`influxdata-archive.key`](https://repos.influxdata.com/influxdata-archive.key)
--  Public key: `943666881a1b8d9b849b74caebf02d3465d6beb716510d86a39f6c8e8dac7515`
+-  GPG key file: [`influxdata-archive.key`](https://repos.influxdata.com/influxdata-archive.key)
+-  Primary key fingerprint: `24C975CBA61A024EE1B631787C3D57159FC2F927`
 
 For older versions (for example, CentOS/RHEL 7, Ubuntu 18.04 LTS, or Debian
 Stretch) that don't support subkeys for verification:
 
--  Private key file: [`influxdata-archive_compat.key`](https://repos.influxdata.com/influxdata-archive_compat.key)
--  Public key: `393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c`
+-  GPG key file: [`influxdata-archive_compat.key`](https://repos.influxdata.com/influxdata-archive_compat.key)
+-  Signing key fingerprint: `9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E`
 
 _For security, InfluxData periodically rotates keys and publishes the new key pairs._
 
@@ -175,10 +175,10 @@ repository:
 <!------------------------BEGIN UBUNTU 20.04 LTS AND NEWER--------------------->
 
 ```bash
-curl --silent --location -O \
-https://repos.influxdata.com/influxdata-archive.key \
-&& echo "943666881a1b8d9b849b74caebf02d3465d6beb716510d86a39f6c8e8dac7515  influxdata-archive.key" \
-| sha256sum -c - && cat influxdata-archive.key \
+curl --silent --location -O https://repos.influxdata.com/influxdata-archive.key
+gpg --show-keys --with-fingerprint --with-colons ./influxdata-archive.key 2>&1 \
+| grep -q '^fpr:\+24C975CBA61A024EE1B631787C3D57159FC2F927:$' \
+&& cat influxdata-archive.key \
 | gpg --dearmor \
 | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null \
 && echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.gpg] https://repos.influxdata.com/debian stable main' \
@@ -193,10 +193,9 @@ sudo apt-get update && sudo apt-get install telegraf
 
 ```bash
 # influxdata-archive_compat.key GPG Fingerprint: 9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E
-curl --silent --location -O \
-https://repos.influxdata.com/influxdata-archive_compat.key \
-&& echo "393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c  influxdata-archive_compat.key" \
-| sha256sum -c - \
+curl --silent --location -O https://repos.influxdata.com/influxdata-archive_compat.key
+gpg --show-keys --with-fingerprint --with-colons ./influxdata-archive_compat.key 2>&1 \
+| grep -q '^fpr:\+9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E:$' \
 && cat influxdata-archive_compat.key \
 | gpg --dearmor \
 | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg > /dev/null

--- a/test/Dockerfile.test-oss.centos
+++ b/test/Dockerfile.test-oss.centos
@@ -14,15 +14,15 @@ LABEL "com.influxdata.docs"="https://docs.influxdata.com/influxdb/v2/install/?t=
 
 ARG INFLUXDB_LATEST_PATCH=2.7.10
 ARG TELEGRAF_LATEST_PATCH=1.32.3
-ARG PUBLIC_SHA=943666881a1b8d9b849b74caebf02d3465d6beb716510d86a39f6c8e8dac7515
 # ARG basearch=aarch64
 
 # Install InfluxDB keys to verify client installs.
 
 RUN curl --silent --location -O \
   https://repos.influxdata.com/influxdata-archive.key \
-  && echo "${PUBLIC_SHA} influxdata-archive.key" \
-  | sha256sum -c && cat influxdata-archive.key \
+  && gpg --homedir $(mktemp -d) --show-keys --with-fingerprint --with-colons ./influxdata-archive.key 2>&1 \
+  | grep -q '^fpr:\+24C975CBA61A024EE1B631787C3D57159FC2F927:$' \
+  && cat influxdata-archive.key \
   | gpg --dearmor \
   | tee /etc/pki/rpm-gpg/RPM-GPG-KEY-influxdata > /dev/null
 

--- a/test/Dockerfile.test-oss.ubuntu
+++ b/test/Dockerfile.test-oss.ubuntu
@@ -13,16 +13,15 @@ LABEL description="InfluxData Docs Test OSS install on Ubuntu"
 
 LABEL "com.influxdata.docs"="https://docs.influxdata.com/influxdb/v2/install/?t=Linux"
 
-ARG PUBLIC_SHA=943666881a1b8d9b849b74caebf02d3465d6beb716510d86a39f6c8e8dac7515
-
 # Install gnupg2 and curl to verify client installs.
 RUN apt-get update && apt-get install -y gnupg2 curl
 
 # Install InfluxDB keys to verify client installs.
 RUN curl --silent --location -O \
   https://repos.influxdata.com/influxdata-archive.key \
-  && echo "${PUBLIC_SHA} influxdata-archive.key" \
-  | sha256sum -c && cat influxdata-archive.key \
+  && gpg --homedir $(mktemp -d) --show-keys --with-fingerprint --with-colons ./influxdata-archive.key 2>&1 \
+  | grep -q '^fpr:\+24C975CBA61A024EE1B631787C3D57159FC2F927:$' \
+  && cat influxdata-archive.key \
   | gpg --dearmor \
   | tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null \
   && echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.gpg] https://repos.influxdata.com/debian stable main' \


### PR DESCRIPTION
The influxdata-archive.key is designed to have a good user experience during key rotations, but in order to do that, we need to properly verify the key file's fingerprint and not its sha256sum (since the primary key's fingerprint won't change with key rotations, but the sha256sum necessarily will).

Update documentation for this to establish best practice and prepare users for the upcoming key rotation (and fixed a couple of small things related to this along the way).

Adjust dockerfiles to use this methodology (all dockerfiles verified to successfully build after these changes).