### PR TITLE
fix(clustered): Warn about excessive table counts (closes influxdata/DAR#519):

### DIFF
--- a/content/influxdb3/clustered/admin/databases/create.md
+++ b/content/influxdb3/clustered/admin/databases/create.md
@@ -161,6 +161,16 @@ Your database's table limit can be raised beyond the default limit of 500.
 InfluxData has production examples of clusters with 20,000+ active tables across
 multiple databases.
 
+> [!Warning]
+> #### Excessive table counts can impact performance and stability
+> 
+> High table counts, especially those concurrently receiving writes and queries,
+> can increase catalog overhead which can affect performance and stability.
+> What constitutes "excessive" depends on multiple factors such as query latency
+> requirements, write bandwidth, and cluster capacity to handle rapid backfills.
+> If you're considering more than doubling the default limit, test your
+> configuration thoroughly.
+
 Increasing your table limit affects your {{% product-name omit=" Clustered" %}}
 cluster in the following ways:
 


### PR DESCRIPTION
 - Addresses the concern about catalog overhead   affecting performance and stability
 - Explains that excessive depends on multiple factors   (query latency, write bandwidth, cluster capacity)
 - Provides guidance about testing when doubling the   default limit