### PR TITLE
Correcting POST request body property names in query SQL

### DIFF
--- a/api-docs/influxdb3/core/v3/ref.yml
+++ b/api-docs/influxdb3/core/v3/ref.yml
@@ -1844,12 +1844,12 @@ components:
     QueryRequestObject:
       type: object
       properties:
-        database:
+        db:
           description: |
             The name of the database to query.
-            Required if the query (`query_str`) doesn't specify the database.
+            Required if the query (`q`) doesn't specify the database.
           type: string
-        query_str:
+        q:
           description: The query to execute.
           type: string
         format:
@@ -1868,11 +1868,11 @@ components:
           type: object
           additionalProperties: true
       required:
-        - database
-        - query_str
+        - db
+        - q
       example:
-        database: mydb
-        query_str: SELECT * FROM mytable
+        db: mydb
+        q: SELECT * FROM mytable
         format: json
         params: {}
     CreateDatabaseRequest:


### PR DESCRIPTION
…API docs

fix: align POST /api/v3/query_sql property names with GET params

Update QueryRequestObject schema to use 'db' and 'q' instead of
'database' and 'query_str' for consistency with GET endpoint.

Closes #6239
