### PR TITLE
Update write_lp API docs

### DIFF
--- a/api-docs/influxdb3/core/v3/ref.yml
+++ b/api-docs/influxdb3/core/v3/ref.yml
@@ -422,9 +422,18 @@ paths:
       summary: Write line protocol
       description: |
         Writes line protocol to the specified database.
+        
+        This is the native InfluxDB 3 Core write endpoint that provides enhanced control 
+        over write behavior with advanced parameters for high-performance and fault-tolerant operations.
 
         Use this endpoint to send data in [line protocol](/influxdb3/core/reference/syntax/line-protocol/) format to InfluxDB.
         Use query parameters to specify options for writing data.
+        
+        ## Features
+        
+        - **Partial writes**: Use `accept_partial=true` to allow partial success when some lines in a batch fail
+        - **Asynchronous writes**: Use `no_sync=true` to skip waiting for WAL synchronization, allowing faster response times but sacrificing durability guarantees  
+        - **Flexible precision**: Automatic timestamp precision detection with `precision=auto` (default)
       parameters:
         - $ref: '#/components/parameters/dbWriteParam'
         - $ref: '#/components/parameters/accept_partial'
@@ -469,6 +478,38 @@ paths:
           description: Request entity too large.
         '422':
           description: Unprocessable entity.
+      x-codeSamples:
+        - label: cURL - Basic write
+          lang: Shell
+          source: |
+            curl --request POST "http://localhost:8181/api/v3/write_lp?db=sensors" \
+              --header "Authorization: Bearer DATABASE_TOKEN" \
+              --header "Content-Type: text/plain" \
+              --data-raw "cpu,host=server01 usage=85.2 1638360000000000000"
+        - label: cURL - Write with millisecond precision
+          lang: Shell
+          source: |
+            curl --request POST "http://localhost:8181/api/v3/write_lp?db=sensors&precision=ms" \
+              --header "Authorization: Bearer DATABASE_TOKEN" \
+              --header "Content-Type: text/plain" \
+              --data-raw "cpu,host=server01 usage=85.2 1638360000000"
+        - label: cURL - Asynchronous write with partial acceptance
+          lang: Shell
+          source: |
+            curl --request POST "http://localhost:8181/api/v3/write_lp?db=sensors&accept_partial=true&no_sync=true&precision=auto" \
+              --header "Authorization: Bearer DATABASE_TOKEN" \
+              --header "Content-Type: text/plain" \
+              --data-raw "cpu,host=server01 usage=85.2
+            memory,host=server01 used=4096"
+        - label: cURL - Multiple measurements with tags
+          lang: Shell
+          source: |
+            curl --request POST "http://localhost:8181/api/v3/write_lp?db=sensors&precision=ns" \
+              --header "Authorization: Bearer DATABASE_TOKEN" \
+              --header "Content-Type: text/plain" \
+              --data-raw "cpu,host=server01,region=us-west usage=85.2,load=0.75 1638360000000000000
+            memory,host=server01,region=us-west used=4096,free=12288 1638360000000000000
+            disk,host=server01,region=us-west,device=/dev/sda1 used=50.5,free=49.5 1638360000000000000"
       tags:
         - Write data
   /api/v3/query_sql:

--- a/api-docs/influxdb3/core/v3/ref.yml
+++ b/api-docs/influxdb3/core/v3/ref.yml
@@ -429,11 +429,15 @@ paths:
         Use this endpoint to send data in [line protocol](/influxdb3/core/reference/syntax/line-protocol/) format to InfluxDB.
         Use query parameters to specify options for writing data.
         
-        ## Features
+        #### Features
         
         - **Partial writes**: Use `accept_partial=true` to allow partial success when some lines in a batch fail
         - **Asynchronous writes**: Use `no_sync=true` to skip waiting for WAL synchronization, allowing faster response times but sacrificing durability guarantees  
         - **Flexible precision**: Automatic timestamp precision detection with `precision=auto` (default)
+
+        #### Related
+        
+        - [Use the InfluxDB v3 write_lp API to write data](/influxdb3/core/write-data/http-api/v3-write-lp/)
       parameters:
         - $ref: '#/components/parameters/dbWriteParam'
         - $ref: '#/components/parameters/accept_partial'

--- a/api-docs/influxdb3/enterprise/v3/ref.yml
+++ b/api-docs/influxdb3/enterprise/v3/ref.yml
@@ -422,9 +422,18 @@ paths:
       summary: Write line protocol
       description: |
         Writes line protocol to the specified database.
+        
+        This is the native InfluxDB 3 Enterprise write endpoint that provides enhanced control 
+        over write behavior with advanced parameters for high-performance and fault-tolerant operations.
 
         Use this endpoint to send data in [line protocol](/influxdb3/enterprise/reference/syntax/line-protocol/) format to InfluxDB.
         Use query parameters to specify options for writing data.
+        
+        ## Features
+        
+        - **Partial writes**: Use `accept_partial=true` to allow partial success when some lines in a batch fail
+        - **Asynchronous writes**: Use `no_sync=true` to skip waiting for WAL synchronization, allowing faster response times but sacrificing durability guarantees  
+        - **Flexible precision**: Automatic timestamp precision detection with `precision=auto` (default)
       parameters:
         - $ref: '#/components/parameters/dbWriteParam'
         - $ref: '#/components/parameters/accept_partial'
@@ -469,6 +478,38 @@ paths:
           description: Request entity too large.
         '422':
           description: Unprocessable entity.
+      x-codeSamples:
+        - label: cURL - Basic write
+          lang: Shell
+          source: |
+            curl --request POST "http://localhost:8181/api/v3/write_lp?db=sensors" \
+              --header "Authorization: Bearer DATABASE_TOKEN" \
+              --header "Content-Type: text/plain" \
+              --data-raw "cpu,host=server01 usage=85.2 1638360000000000000"
+        - label: cURL - Write with millisecond precision
+          lang: Shell
+          source: |
+            curl --request POST "http://localhost:8181/api/v3/write_lp?db=sensors&precision=ms" \
+              --header "Authorization: Bearer DATABASE_TOKEN" \
+              --header "Content-Type: text/plain" \
+              --data-raw "cpu,host=server01 usage=85.2 1638360000000"
+        - label: cURL - Asynchronous write with partial acceptance
+          lang: Shell
+          source: |
+            curl --request POST "http://localhost:8181/api/v3/write_lp?db=sensors&accept_partial=true&no_sync=true&precision=auto" \
+              --header "Authorization: Bearer DATABASE_TOKEN" \
+              --header "Content-Type: text/plain" \
+              --data-raw "cpu,host=server01 usage=85.2
+            memory,host=server01 used=4096"
+        - label: cURL - Multiple measurements with tags
+          lang: Shell
+          source: |
+            curl --request POST "http://localhost:8181/api/v3/write_lp?db=sensors&precision=ns" \
+              --header "Authorization: Bearer DATABASE_TOKEN" \
+              --header "Content-Type: text/plain" \
+              --data-raw "cpu,host=server01,region=us-west usage=85.2,load=0.75 1638360000000000000
+            memory,host=server01,region=us-west used=4096,free=12288 1638360000000000000
+            disk,host=server01,region=us-west,device=/dev/sda1 used=50.5,free=49.5 1638360000000000000"
       tags:
         - Write data
   /api/v3/query_sql:

--- a/api-docs/influxdb3/enterprise/v3/ref.yml
+++ b/api-docs/influxdb3/enterprise/v3/ref.yml
@@ -429,11 +429,15 @@ paths:
         Use this endpoint to send data in [line protocol](/influxdb3/enterprise/reference/syntax/line-protocol/) format to InfluxDB.
         Use query parameters to specify options for writing data.
         
-        ## Features
+        #### Features
         
         - **Partial writes**: Use `accept_partial=true` to allow partial success when some lines in a batch fail
         - **Asynchronous writes**: Use `no_sync=true` to skip waiting for WAL synchronization, allowing faster response times but sacrificing durability guarantees  
         - **Flexible precision**: Automatic timestamp precision detection with `precision=auto` (default)
+
+        #### Related
+        
+        - [Use the InfluxDB v3 write_lp API to write data](/influxdb3/enterprise/write-data/http-api/v3-write-lp/)
       parameters:
         - $ref: '#/components/parameters/dbWriteParam'
         - $ref: '#/components/parameters/accept_partial'

--- a/content/influxdb3/core/write-data/http-api/v3-write-lp.md
+++ b/content/influxdb3/core/write-data/http-api/v3-write-lp.md
@@ -1,10 +1,10 @@
 ---
-title: Use the v3 write API to write data
+title: Use the v3 write_lp API to write data
 description: >
   Use the `/api/v3/write_lp` HTTP API endpoint to write data to {{% product-name %}}.
 menu:
   influxdb3_core:
-    name: Use the v3 write API
+    name: Use the v3 write_lp API
     parent: write-http-api
 weight: 201
 related:

--- a/content/influxdb3/enterprise/write-data/http-api/v3-write-lp.md
+++ b/content/influxdb3/enterprise/write-data/http-api/v3-write-lp.md
@@ -1,10 +1,10 @@
 ---
-title: Use the v3 write API to write data
+title: Use the v3 write_lp API to write data
 description: >
   Use the `/api/v3/write_lp` HTTP API endpoint to write data to {{% product-name %}}.
 menu:
   influxdb3_enterprise:
-    name: Use the v3 write API
+    name: Use the v3 write_lp API
     parent: write-http-api
 weight: 201
 related:


### PR DESCRIPTION
Closes #

- Add comprehensive description of native InfluxDB 3 write endpoint capabilities
- Document enhanced features: partial writes, asynchronous writes, flexible precision
- Add x-codeSamples with curl examples demonstrating parameter usage
- Clarify no_sync parameter behavior: faster response times vs durability trade-offs
- Update both Core and Enterprise API specifications consistently
- Closes https://github.com/influxdata/docs-v2/issues/5775
