### PR TITLE
Fix POST query endpoint request body property names in Enterprise API…

### DIFF
--- a/api-docs/influxdb3/enterprise/v3/ref.yml
+++ b/api-docs/influxdb3/enterprise/v3/ref.yml
@@ -1976,12 +1976,12 @@ components:
     QueryRequestObject:
       type: object
       properties:
-        database:
+        db:
           description: |
             The name of the database to query.
-            Required if the query (`query_str`) doesn't specify the database.
+            Required if the query (`q`) doesn't specify the database.
           type: string
-        query_str:
+        q:
           description: The query to execute.
           type: string
         format:
@@ -2000,11 +2000,11 @@ components:
           type: object
           additionalProperties: true
       required:
-        - database
-        - query_str
+        - db
+        - q
       example:
-        database: mydb
-        query_str: SELECT * FROM mytable
+        db: mydb
+        q: SELECT * FROM mytable
         format: json
         params: {}
     CreateDatabaseRequest:


### PR DESCRIPTION
… spec

fix: align POST /api/v3/query_sql property names with GET params in Enterprise 

Update QueryRequestObject schema to use 'db' and 'q' instead of
'database' and 'query_str' for consistency with GET endpoint.