### PR TITLE
chore(ci): temporarily disable link validation workflow

### DIFF
--- a/.github/workflows/pr-link-validation.yml
+++ b/.github/workflows/pr-link-validation.yml
@@ -13,9 +13,16 @@ on:
       - 'layouts/**/*.html'
 
 jobs:
+  # TEMPORARILY DISABLED - Remove this condition to re-enable link validation
+  disabled-check:
+    if: false  # Set to true to re-enable the workflow
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Link validation is temporarily disabled"
   setup:
     name: Setup and Strategy Detection
     runs-on: ubuntu-latest
+    if: false  # TEMPORARILY DISABLED - Remove this condition to re-enable
     outputs:
       strategy: ${{ steps.determine-strategy.outputs.strategy }}
       has-changes: ${{ steps.determine-strategy.outputs.has-changes }}
@@ -99,7 +106,7 @@ jobs:
   validate:
     name: ${{ matrix.name }}
     needs: setup
-    if: needs.setup.outputs.has-changes == 'true'
+    if: false  # TEMPORARILY DISABLED - Original condition: needs.setup.outputs.has-changes == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -125,7 +132,7 @@ jobs:
   report:
     name: Report Results
     needs: [setup, validate]
-    if: always() && needs.setup.outputs.has-changes == 'true'
+    if: false  # TEMPORARILY DISABLED - Original condition: always() && needs.setup.outputs.has-changes == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
- Add if: false conditions to all jobs to prevent execution
- Add disabled-check job to indicate the workflow is disabled
- Preserves original conditions in comments for easy re-enabling

To re-enable: Remove the 'if: false' conditions and disabled-check job

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
