### PR TITLE
Release influxctl v2.10.3

### DIFF
--- a/.husky/_/pre-commit
+++ b/.husky/_/pre-commit
@@ -33,9 +33,6 @@ call_lefthook()
     then
       "$dir/node_modules/lefthook/bin/index.js" "$@"
     
-    elif go tool lefthook -h >/dev/null 2>&1
-    then
-      go tool lefthook "$@"
     elif bundle exec lefthook -h >/dev/null 2>&1
     then
       bundle exec lefthook "$@"
@@ -45,21 +42,12 @@ call_lefthook()
     elif pnpm lefthook -h >/dev/null 2>&1
     then
       pnpm lefthook "$@"
-    elif swift package lefthook >/dev/null 2>&1
+    elif swift package plugin lefthook >/dev/null 2>&1
     then
-      swift package --build-path .build/lefthook --disable-sandbox lefthook "$@"
+      swift package --disable-sandbox plugin lefthook "$@"
     elif command -v mint >/dev/null 2>&1
     then
       mint run csjones/lefthook-plugin "$@"
-    elif uv run lefthook -h >/dev/null 2>&1
-    then
-      uv run lefthook "$@"
-    elif mise exec -- lefthook -h >/dev/null 2>&1
-    then
-      mise exec -- lefthook "$@"
-    elif devbox run lefthook -h >/dev/null 2>&1
-    then
-      devbox run lefthook "$@"
     else
       echo "Can't find lefthook in PATH"
     fi

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -33,9 +33,6 @@ call_lefthook()
     then
       "$dir/node_modules/lefthook/bin/index.js" "$@"
     
-    elif go tool lefthook -h >/dev/null 2>&1
-    then
-      go tool lefthook "$@"
     elif bundle exec lefthook -h >/dev/null 2>&1
     then
       bundle exec lefthook "$@"
@@ -45,21 +42,12 @@ call_lefthook()
     elif pnpm lefthook -h >/dev/null 2>&1
     then
       pnpm lefthook "$@"
-    elif swift package lefthook >/dev/null 2>&1
+    elif swift package plugin lefthook >/dev/null 2>&1
     then
-      swift package --build-path .build/lefthook --disable-sandbox lefthook "$@"
+      swift package --disable-sandbox plugin lefthook "$@"
     elif command -v mint >/dev/null 2>&1
     then
       mint run csjones/lefthook-plugin "$@"
-    elif uv run lefthook -h >/dev/null 2>&1
-    then
-      uv run lefthook "$@"
-    elif mise exec -- lefthook -h >/dev/null 2>&1
-    then
-      mise exec -- lefthook "$@"
-    elif devbox run lefthook -h >/dev/null 2>&1
-    then
-      devbox run lefthook "$@"
     else
       echo "Can't find lefthook in PATH"
     fi

--- a/.husky/_/prepare-commit-msg
+++ b/.husky/_/prepare-commit-msg
@@ -33,9 +33,6 @@ call_lefthook()
     then
       "$dir/node_modules/lefthook/bin/index.js" "$@"
     
-    elif go tool lefthook -h >/dev/null 2>&1
-    then
-      go tool lefthook "$@"
     elif bundle exec lefthook -h >/dev/null 2>&1
     then
       bundle exec lefthook "$@"
@@ -45,21 +42,12 @@ call_lefthook()
     elif pnpm lefthook -h >/dev/null 2>&1
     then
       pnpm lefthook "$@"
-    elif swift package lefthook >/dev/null 2>&1
+    elif swift package plugin lefthook >/dev/null 2>&1
     then
-      swift package --build-path .build/lefthook --disable-sandbox lefthook "$@"
+      swift package --disable-sandbox plugin lefthook "$@"
     elif command -v mint >/dev/null 2>&1
     then
       mint run csjones/lefthook-plugin "$@"
-    elif uv run lefthook -h >/dev/null 2>&1
-    then
-      uv run lefthook "$@"
-    elif mise exec -- lefthook -h >/dev/null 2>&1
-    then
-      mise exec -- lefthook "$@"
-    elif devbox run lefthook -h >/dev/null 2>&1
-    then
-      devbox run lefthook "$@"
     else
       echo "Can't find lefthook in PATH"
     fi

--- a/content/influxdb3/cloud-dedicated/admin/tables/rename.md
+++ b/content/influxdb3/cloud-dedicated/admin/tables/rename.md
@@ -1,0 +1,44 @@
+---
+title: Rename a table
+description: >
+  Use the [`influxctl table rename` command](/influxdb3/cloud-dedicated/reference/cli/influxctl/table/rename/)
+  to rename a table in your {{< product-name omit=" Cluster" >}} cluster.
+menu:
+  influxdb3_cloud_dedicated:
+    parent: Manage tables
+weight: 202
+list_code_example: |
+  ##### CLI
+  ```sh
+  influxctl table rename <DATABASE_NAME> <CURRENT_TABLE_NAME> <NEW_TABLE_NAME>
+  ```
+related:
+  - /influxdb3/cloud-dedicated/reference/cli/influxctl/table/rename/
+---
+
+Use the [`influxctl table rename` command](/influxdb3/cloud-dedicated/reference/cli/influxctl/table/rename/)
+to rename a table in your {{< product-name omit=" Clustered" >}} cluster.
+
+> [!Note]
+> After renaming a table, write and query requests using the old table name
+> are routed to the same table.
+
+## Rename a database using the influxctl CLI
+
+<!-- pytest.mark.skip -->
+
+```bash { placeholders="DATABASE_NAME|CURRENT_TABLE_NAME|NEW_TABLE_NAME" }
+influxctl table rename DATABASE_NAME CURRENT_TABLE_NAME NEW_TABLE_NAME
+```
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}: Name of the database the table is in
+- {{% code-placeholder-key %}}`CURRENT_TABLE_NAME`{{% /code-placeholder-key %}}: Name of the table to change
+- {{% code-placeholder-key %}}`NEW_TABLE_NAME`{{% /code-placeholder-key %}}: New name for the table
+
+> [!Note]
+> #### Renamed table retains its ID
+> 
+> The table ID remains the same after renaming. When you list tables,
+> you'll see the new name associated with the original table ID.

--- a/content/influxdb3/cloud-dedicated/reference/cli/influxctl/table/rename.md
+++ b/content/influxdb3/cloud-dedicated/reference/cli/influxctl/table/rename.md
@@ -1,0 +1,14 @@
+---
+title: influxctl table rename
+description: >
+  The `influxctl table rename` command renames a table in an
+  {{% product-name omit=" Clustered" %}} cluster.
+menu:
+  influxdb3_cloud_dedicated:
+    parent: influxctl table
+weight: 301
+metadata: [influxctl 2.10.3+]
+source: /shared/influxctl/table/rename.md
+---
+
+<!-- //SOURCE content/shared/influxctl/table/rename.md -->

--- a/content/influxdb3/clustered/admin/tables/rename.md
+++ b/content/influxdb3/clustered/admin/tables/rename.md
@@ -1,0 +1,44 @@
+---
+title: Rename a table
+description: >
+  Use the [`influxctl table rename` command](/influxdb3/clustered/reference/cli/influxctl/table/rename/)
+  to rename a table in your {{< product-name omit=" Cluster" >}} cluster.
+menu:
+  influxdb3_clustered:
+    parent: Manage tables
+weight: 202
+list_code_example: |
+  ##### CLI
+  ```sh
+  influxctl table rename <DATABASE_NAME> <CURRENT_TABLE_NAME> <NEW_TABLE_NAME>
+  ```
+related:
+  - /influxdb3/clustered/reference/cli/influxctl/table/rename/
+---
+
+Use the [`influxctl table rename` command](/influxdb3/clustered/reference/cli/influxctl/table/rename/)
+to rename a table in your {{< product-name omit=" Clustered" >}} cluster.
+
+> [!Note]
+> After renaming a table, write and query requests using the old table name
+> are routed to the same table.
+
+## Rename a database using the influxctl CLI
+
+<!-- pytest.mark.skip -->
+
+```bash { placeholders="DATABASE_NAME|CURRENT_TABLE_NAME|NEW_TABLE_NAME" }
+influxctl table rename DATABASE_NAME CURRENT_TABLE_NAME NEW_TABLE_NAME
+```
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}: Name of the database the table is in
+- {{% code-placeholder-key %}}`CURRENT_TABLE_NAME`{{% /code-placeholder-key %}}: Name of the table to change
+- {{% code-placeholder-key %}}`NEW_TABLE_NAME`{{% /code-placeholder-key %}}: New name for the table
+
+> [!Note]
+> #### Renamed table retains its ID
+> 
+> The table ID remains the same after renaming. When you list tables,
+> you'll see the new name associated with the original table ID.

--- a/content/influxdb3/clustered/reference/cli/influxctl/table/rename.md
+++ b/content/influxdb3/clustered/reference/cli/influxctl/table/rename.md
@@ -1,0 +1,14 @@
+---
+title: influxctl table rename
+description: >
+  The `influxctl table rename` command renames a table in an
+  {{% product-name omit=" Clustered" %}} cluster.
+menu:
+  influxdb3_clustered:
+    parent: influxctl table
+weight: 301
+metadata: [influxctl 2.10.3+]
+source: /shared/influxctl/table/rename.md
+---
+
+<!-- //SOURCE content/shared/influxctl/table/rename.md -->

--- a/content/shared/influxctl/release-notes.md
+++ b/content/shared/influxctl/release-notes.md
@@ -1,3 +1,31 @@
+## 2.10.3 {date="2025-07-30"}
+
+### Features
+
+- Add `id` column to the output of the
+  [`influxctl database list` command](/influxdb3/version/reference/cli/influxctl/database/list/).
+- Add [`influxctl table rename` command](/influxdb3/version/reference/cli/influxctl/table/rename/).
+- Add user-agent to Granite gRPC requests.
+
+### Bug Fixes
+
+- Require the `--template-timeformat` option when the `--template-tags` option
+  is included when creating a database or table with custom partitions.
+- Fix table iceberg enable/disable description.
+
+### Dependency updates
+
+- Update `github.com/apache/arrow-go/v18` from 18.3.1 to 18.4.0.
+- Update `github.com/docker/docker` from 28.2.2+incompatible to 28.3.3+incompatible.
+- Update `github.com/golang-jwt/jwt/v5` from 5.2.2 to 5.2.3.
+- Update `github.com/jedib0t/go-pretty/v6` from 6.6.7 to 6.6.8.
+- Update `golang.org/x/mod` from 0.25.0 to 0.26.0.
+- Update `google.golang.org/grpc` from 1.73.0 to 1.74.2.
+- Update `helm.sh/helm/v3` from 3.17.3 to 3.18.4.
+- Update Go 1.24.5.
+
+---
+
 ## v2.10.2 {date="2025-06-30"}
 
 ### Features

--- a/content/shared/influxctl/table/rename.md
+++ b/content/shared/influxctl/table/rename.md
@@ -1,0 +1,39 @@
+
+The `influxctl table rename` command renames a table in the specified database in
+an {{< product-name omit=" Clustered" >}} cluster.
+
+## Usage
+
+<!-- pytest.mark.skip -->
+
+```bash
+influxctl table rename [flags] <DATABASE_NAME> <CURRENT_TABLE_NAME> <NEW_TABLE_NAME>
+```
+
+## Arguments
+
+| Argument               | Description                          |
+| :--------------------- | :----------------------------------- |
+| **DATABASE_NAME**      | Name of the database the table is in |
+| **CURRENT_TABLE_NAME** | Current name of the table            |
+| **NEW_TABLE_NAME**     | New name for the table               |
+
+## Flags
+
+| Flag |            | Description                                   |
+| :--- | :--------- | :-------------------------------------------- |
+|      | `--format` | Output format (`table` _(default)_ or `json`) |
+| `-h` | `--help`   | Output command help                           |
+
+{{% caption %}}
+_Also see [`influxctl` global flags](/influxdb3/version/reference/cli/influxctl/#global-flags)._
+{{% /caption %}}
+
+## Examples
+
+<!-- pytest.mark.skip -->
+
+```bash
+# Rename the "example-tb" table to "example_tb"
+influxctl table rename mydb example-tb example_tb
+```

--- a/data/products.yml
+++ b/data/products.yml
@@ -64,7 +64,7 @@ influxdb3_cloud_dedicated:
   list_order: 3
   latest: cloud-dedicated
   link: "https://www.influxdata.com/contact-sales-cloud-dedicated/"
-  latest_cli: 2.10.2
+  latest_cli: 2.10.3
   placeholder_host: cluster-id.a.influxdb.io
   ai_sample_questions:
     - How do I migrate from InfluxDB v1 to InfluxDB Cloud Dedicated?


### PR DESCRIPTION
A few small changes to call out in this release:
- A new command for renaming tables `influxctl table rename <databaseName> <tableName> <newTableName>`
- Added the database ID column when calling `influxctl database list`
- Bugfix for when `--template-timeformat` is missing with `--template-tags` included

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
