### PR TITLE
Restore v1.11.8 as latest v1, prepare for 1.12.x

### DIFF
--- a/content/enterprise_influxdb/v1/about-the-project/release-notes.md
+++ b/content/enterprise_influxdb/v1/about-the-project/release-notes.md
@@ -1,5 +1,5 @@
 ---
-title: InfluxDB Enterprise 1.11 release notes
+title: InfluxDB Enterprise v1 release notes
 description: >
   Important changes and what's new in each version InfluxDB Enterprise.
 menu:
@@ -7,9 +7,16 @@ menu:
     name: Release notes
     weight: 10
     parent: About the project
+alt_links:
+  v1: /influxdb/v1/about_the_project/release-notes/
 ---
 
-## v1.12.1 {date="2025-06-26"}
+## v1.12.x {date="TBD"}
+
+> [!Important]
+> #### Pre-release documentation
+>
+> This release is not yet available. [**v{{% latest-patch %}}**](#v1118) is the latest InfluxDB Enterprise v1 release.
 
 > [!Important]
 > #### Upgrade meta nodes first
@@ -22,31 +29,53 @@ menu:
 - Add additional log output when using
   [`influx_inspect buildtsi`](/enterprise_influxdb/v1/tools/influx_inspect/#buildtsi) to
   rebuild the TSI index.
+<!-- TODO: Uncomment with 1.12.x release:
 - Use [`influx_inspect export`](/enterprise_influxdb/v1/tools/influx_inspect/#export) with
   [`-tsmfile` option](/enterprise_influxdb/v1/tools/influx_inspect/#--tsmfile-tsm_file-) to
+  export a single TSM file.
+-->
+<!-- TODO: Remove with 1.12.x release: -->
+- Use [`influx_inspect export`](/enterprise_influxdb/v1/tools/influx_inspect/#export) with
+  `-tsmfile` option to
   export a single TSM file.
 - Add `-m` flag to the [`influxd-ctl show-shards` command](/enterprise_influxdb/v1/tools/influxd-ctl/show-shards/)
   to output inconsistent shards.
 - Allow the specification of a write window for retention policies.
 - Add `fluxQueryRespBytes` metric to the `/debug/vars` metrics endpoint.
 - Log whenever meta gossip times exceed expiration.
+<!-- TODO: Uncomment with 1.12.x release:
 - Add [`query-log-path` configuration option](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#query-log-path)
   to data nodes.
 - Add [`aggressive-points-per-block` configuration option](/influxdb/v1/administration/config/#aggressive-points-per-block)
   to prevent TSM files from not getting fully compacted.
+-->
+<!-- TODO: Remove with 1.12.x release: -->
+- Add `query-log-path` configuration option  to data nodes.
+- Add `aggressive-points-per-block` configuration option to prevent TSM files from not getting fully compacted.
 - Log TLS configuration settings on startup.
 - Check for TLS certificate and private key permissions.
 - Add a warning if the TLS certificate is expired.
 - Add authentication to the Raft portal and add the following related _data_
   node configuration options:
+  <!-- Uncomment with 1.12.x release
   - [`[meta].raft-portal-auth-required`](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#raft-portal-auth-required)
   - [`[meta].raft-dialer-auth-required`](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#raft-dialer-auth-required)
+  -->
+  <!-- TODO: Remove with 1.12.x release: -->
+  - `[meta].raft-portal-auth-required`
+  - `[meta].raft-dialer-auth-required`
 - Improve error handling.
 - InfluxQL updates:
   - Delete series by retention policy.
+
+  <!-- TODO: Uncomment with 1.12.x release:
   - Allow retention policies to discard writes that fall within their range, but
     outside of [`FUTURE LIMIT`](/enterprise_influxdb/v1/query_language/manage-database/#future-limit)
     and [`PAST LIMIT`](/enterprise_influxdb/v1/query_language/manage-database/#past-limit).
+  -->
+  <!-- TODO: Remove with 1.12.x release: -->
+  - Allow retention policies to discard writes that fall within their range, but
+    outside of `FUTURE LIMIT` and `PAST LIMIT`.
 
 ## Bug fixes
 

--- a/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
@@ -326,7 +326,7 @@ Very useful for troubleshooting, but will log any sensitive data contained withi
 
 Environment variable: `INFLUXDB_DATA_QUERY_LOG_ENABLED`
 
-#### query-log-path
+#### query-log-path {metadata="v1.12.0+"}
 
 Default is `""`.
 
@@ -352,7 +352,7 @@ The following is an example of a `logrotate` configuration:
 ```
 
 Environment variable: `INFLUXDB_DATA_QUERY_LOG_PATH`
-
+-->
 #### wal-fsync-delay
 
 Default is `"0s"`.

--- a/content/enterprise_influxdb/v1/query_language/manage-database.md
+++ b/content/enterprise_influxdb/v1/query_language/manage-database.md
@@ -306,7 +306,7 @@ See
 [Shard group duration management](/enterprise_influxdb/v1/concepts/schema_and_data_layout/#shard-group-duration-management)
 for recommended configurations.
 
-##### `PAST LIMIT`
+##### `PAST LIMIT` {metadata="v1.12.0+"}
 
 The `PAST LIMIT` clause defines a time boundary before and relative to _now_
 in which points written to the retention policy are accepted. If a point has a
@@ -317,7 +317,7 @@ For example, if a write request tries to write data to a retention policy with a
 `PAST LIMIT 6h` and there are points in the request with timestamps older than
 6 hours, those points are rejected.
 
-##### `FUTURE LIMIT`
+##### `FUTURE LIMIT` {metadata="v1.12.0+"}
 
 The `FUTURE LIMIT` clause defines a time boundary after and relative to _now_
 in which points written to the retention policy are accepted. If a point has a

--- a/content/enterprise_influxdb/v1/tools/influx_inspect.md
+++ b/content/enterprise_influxdb/v1/tools/influx_inspect.md
@@ -453,7 +453,7 @@ Default value is `$HOME/.influxdb/wal`.
 See the [file system layout](/enterprise_influxdb/v1/concepts/file-system-layout/#file-system-layout)
 for InfluxDB on your system.
 
-##### [ `-tsmfile <tsm_file>` ]
+##### [ `-tsmfile <tsm_file>` ] {metadata="v1.12.0+"}
 
 Path to a single tsm file to export. This requires both `-database` and
 `-retention` to be specified.
@@ -472,7 +472,7 @@ influx_inspect export -compress
 influx_inspect export -database DATABASE_NAME -retention RETENTION_POLICY 
 ```
 
-##### Export data from a single TSM file
+##### Export data from a single TSM file {metadata="v1.12.0+"}
 
 ```bash
 influx_inspect export \

--- a/content/enterprise_influxdb/v1/tools/influxd-ctl/show-shards.md
+++ b/content/enterprise_influxdb/v1/tools/influxd-ctl/show-shards.md
@@ -44,6 +44,8 @@ ID  Database    Retention Policy  Desired Replicas  Shard Group  Start          
 {{% /expand %}}
 {{< /expand-wrapper >}}
 
+#### Show inconsistent shards {metadata="v1.12.0+"}
+
 You can also use the `-m` flag to output "inconsistent" shards which are shards
 that are either in metadata but not on disk or on disk but not in metadata.
 
@@ -52,10 +54,8 @@ that are either in metadata but not on disk or on disk but not in metadata.
 | Flag | Description                       |
 | :--- | :-------------------------------- |
 | `-v` | Return detailed shard information |
-| `-m` | Return inconsistent shards        |
+| `-m` | Return inconsistent shards |
 
 {{% caption %}}
 _Also see [`influxd-ctl` global flags](/enterprise_influxdb/v1/tools/influxd-ctl/#influxd-ctl-global-flags)._
 {{% /caption %}}
-
-## Examples

--- a/content/influxdb/v1/about_the_project/release-notes.md
+++ b/content/influxdb/v1/about_the_project/release-notes.md
@@ -10,27 +10,50 @@ aliases:
   - /influxdb/v1/about_the_project/releasenotes-changelog/
 alt_links:
   v2: /influxdb/v2/reference/release-notes/influxdb/
+  enterprise_v1: /enterprise_influxdb/v1/about-the-project/release-notes/
 ---
 
-## v1.12.1 {date="2025-06-26"}
+## v1.12.x {date="TBD"}
+
+> [!Important]
+> #### Pre-release documentation
+>
+> This release is not yet available. [**v{{% latest-patch %}}**](#v1118) is the latest InfluxDB v1 release.
 
 ## Features
 
 - Add additional log output when using
   [`influx_inspect buildtsi`](/influxdb/v1/tools/influx_inspect/#buildtsi) to
   rebuild the TSI index.
+<!-- TODO: Uncomment with 1.12.x release:
 - Use [`influx_inspect export`](/influxdb/v1/tools/influx_inspect/#export) with
   [`-tsmfile` option](/influxdb/v1/tools/influx_inspect/#--tsmfile-tsm_file-) to
   export a single TSM file.
+-->
+<!-- TODO: Remove with 1.12.x release: -->
+- Use [`influx_inspect export`](/influxdb/v1/tools/influx_inspect/#export) with
+  `-tsmfile` option to
+  export a single TSM file.
+
 - Add `fluxQueryRespBytes` metric to the `/debug/vars` metrics endpoint.
+<!-- TODO: Uncomment with 1.12.x release:
 - Add [`aggressive-points-per-block` configuration option](/influxdb/v1/administration/config/#aggressive-points-per-block)
+  to prevent TSM files from not getting fully compacted.
+-->
+<!-- TODO: Remove with 1.12.x release: -->
+- Add `aggressive-points-per-block` configuration option
   to prevent TSM files from not getting fully compacted.
 - Improve error handling.
 - InfluxQL updates:
   - Delete series by retention policy.
+  <!-- TODO: Uncomment with 1.12.x release:
   - Allow retention policies to discard writes that fall within their range, but
     outside of [`FUTURE LIMIT`](/influxdb/v1/query_language/manage-database/#future-limit)
     and [`PAST LIMIT`](/influxdb/v1/query_language/manage-database/#past-limit).
+  -->
+  <!-- TODO: Remove with 1.12.x release: -->
+  - Allow retention policies to discard writes that fall within their range, but
+    outside of `FUTURE LIMIT` and `PAST LIMIT`.
 
 ## Bug fixes
 

--- a/content/influxdb/v1/query_language/manage-database.md
+++ b/content/influxdb/v1/query_language/manage-database.md
@@ -307,7 +307,7 @@ See
 [Shard group duration management](/influxdb/v1/concepts/schema_and_data_layout/#shard-group-duration-management)
 for recommended configurations.
 
-##### `PAST LIMIT`
+##### `PAST LIMIT` {metadata="v1.12.0+"}
 
 The `PAST LIMIT` clause defines a time boundary before and relative to _now_
 in which points written to the retention policy are accepted. If a point has a
@@ -318,7 +318,7 @@ For example, if a write request tries to write data to a retention policy with a
 `PAST LIMIT 6h` and there are points in the request with timestamps older than
 6 hours, those points are rejected.
 
-##### `FUTURE LIMIT`
+##### `FUTURE LIMIT` {metadata="v1.12.0+"}
 
 The `FUTURE LIMIT` clause defines a time boundary after and relative to _now_
 in which points written to the retention policy are accepted. If a point has a

--- a/content/influxdb/v1/tools/influx_inspect.md
+++ b/content/influxdb/v1/tools/influx_inspect.md
@@ -449,7 +449,7 @@ Default value is `$HOME/.influxdb/wal`.
 See the [file system layout](/influxdb/v1/concepts/file-system-layout/#file-system-layout)
 for InfluxDB on your system.
 
-##### [ `-tsmfile <tsm_file>` ]
+##### [ `-tsmfile <tsm_file>` ] {metadata="v1.12.0+"}
 
 Path to a single tsm file to export. This requires both `-database` and
 `-retention` to be specified.
@@ -468,7 +468,7 @@ influx_inspect export -compress
 influx_inspect export -database DATABASE_NAME -retention RETENTION_POLICY 
 ```
 
-##### Export data from a single TSM file
+##### Export data from a single TSM file {metadata="v1.12.0+"}
 
 ```bash
 influx_inspect export \

--- a/data/products.yml
+++ b/data/products.yml
@@ -100,7 +100,7 @@ influxdb:
   latest: v2.7
   latest_patches:
     v2: 2.7.12
-    v1: 1.12.1
+    v1: 1.11.8
   latest_cli:
     v2: 2.7.5
   ai_sample_questions:
@@ -183,9 +183,9 @@ enterprise_influxdb:
   menu_category: self-managed
   list_order: 5
   versions: [v1]
-  latest: v1.12
+  latest: v1.11
   latest_patches:
-    v1: 1.12.1
+    v1: 1.11.8
   ai_sample_questions:
   - How can I configure my InfluxDB v1 Enterprise server?
   - How do I replicate data between InfluxDB v1 Enterprise and OSS?


### PR DESCRIPTION
v1.11.8 is the latest available release of InfluxDB v1 OSS and Enterprise, but the release notes show v1.12.1.
1. Partially undo the changes where it isn't disruptive.
2. Clearly show that 1.11.8 is the latest release and 1.12 is pre-release

- Remove links from release notes to upcoming 1.12.x features
- Add callout to explain that v1.12 isn't yet available

- Label upcoming features as v1.12.0+:
    
      - Update configuration documentation for data nodes
      - Update database management documentation
      - Update influx_inspect tool documentation
      - Update show-shards documentation
    
- Revert product version references to 1.11.8 in products.yml

Closes #6309
Prepares for #6310