### PR TITLE
fix(ci): update link-checker to v1.2.3 to fix false positives for new…

### DIFF
--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -95,7 +95,7 @@ jobs:
           curl -L -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -o link-checker-info.json \
-            "https://api.github.com/repos/influxdata/docs-v2/releases/tags/link-checker-v1.2.2"
+            "https://api.github.com/repos/influxdata/docs-v2/releases/tags/link-checker-v1.2.3"
           
           # Extract download URL for linux binary
           DOWNLOAD_URL=$(jq -r '.assets[] | select(.name | test("link-checker.*linux")) | .url' link-checker-info.json)


### PR DESCRIPTION
… content

- Use link-checker-v1.2.3 which includes fix for base URL detection
- Prevents false positives when checking local files for new pages
- Resolves broken link errors for pages that exist locally but not in production yet

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
