### PR TITLE
feat(influxdb-3.4): added cli updates for influxdb 3.4

### DIFF
--- a/content/shared/influxdb3-cli/config-options.md
+++ b/content/shared/influxdb3-cli/config-options.md
@@ -42,9 +42,7 @@ influxdb3 serve
 - [General](#general)
 {{% show-in "enterprise" %}}  - [cluster-id](#cluster-id){{% /show-in %}}
   - [data-dir](#data-dir)
-{{% show-in "enterprise" %}}  - [license-email](#license-email)
-  - [license-file](#license-file)
-  - [mode](#mode){{% /show-in %}}
+{{% show-in "enterprise" %}}  - [mode](#mode){{% /show-in %}}
   - [node-id](#node-id)
 {{% show-in "enterprise" %}}  - [node-id-from-env](#node-id-from-env){{% /show-in %}}
   - [object-store](#object-store)
@@ -56,7 +54,11 @@ influxdb3 serve
 {{% show-in "enterprise" %}}
   - [num-database-limit](#num-database-limit)
   - [num-table-limit](#num-table-limit)
-  - [num-total-columns-per-table-limit](#num-total-columns-per-table-limit){{% /show-in %}}
+  - [num-total-columns-per-table-limit](#num-total-columns-per-table-limit)
+- [Licensing](#licensing)
+  - [license-email](#license-email)
+  - [license-file](#license-file)
+  - [license-type](#license-type){{% /show-in %}}
 - [AWS](#aws)
   - [aws-access-key-id](#aws-access-key-id)
   - [aws-secret-access-key](#aws-secret-access-key)
@@ -65,11 +67,14 @@ influxdb3 serve
   - [aws-session-token](#aws-session-token)
   - [aws-allow-http](#aws-allow-http)
   - [aws-skip-signature](#aws-skip-signature)
+  - [aws-credentials-file](#aws-credentials-file)
 - [Google Cloud Service](#google-cloud-service)
   - [google-service-account](#google-service-account)
 - [Microsoft Azure](#microsoft-azure)
   - [azure-storage-account](#azure-storage-account)
   - [azure-storage-access-key](#azure-storage-access-key)
+  - [azure-endpoint](#azure-endpoint)
+  - [azure-allow-http](#azure-allow-http)
 - [Object Storage](#object-storage)
   - [bucket](#bucket)
   - [object-store-connection-limit](#object-store-connection-limit)
@@ -182,8 +187,6 @@ influxdb3 serve
 {{% /show-in %}}
 - [data-dir](#data-dir)
 {{% show-in "enterprise" %}}
-- [license-email](#license-email)
-- [license-file](#license-file)
 - [mode](#mode)
 {{% /show-in %}}
 - [node-id](#node-id)
@@ -218,30 +221,6 @@ Required when using the `file` [object store](#object-store).
 ---
 
 {{% show-in "enterprise" %}}
-#### license-email
-
-Specifies the email address to associate with your {{< product-name >}} license
-and automatically responds to the interactive email prompt when the server starts.
-This option is mutually exclusive with [license-file](#license-file).
-
-| influxdb3 serve option | Environment variable                 |
-| :--------------------- | :----------------------------------- |
-| `--license-email`      | `INFLUXDB3_ENTERPRISE_LICENSE_EMAIL` |
-
----
-
-#### license-file
-
-Specifies the path to a license file for {{< product-name >}}. When provided, the license
-file's contents are used instead of requesting a new license.
-This option is mutually exclusive with [license-email](#license-email).
-
-| influxdb3 serve option | Environment variable                 |
-| :--------------------- | :----------------------------------- |
-| `--license-file`       | `INFLUXDB3_ENTERPRISE_LICENSE_FILE`  |
-
----
-
 #### mode
 
 Sets the mode to start the server in.
@@ -274,6 +253,8 @@ configuration--for example, the same bucket.
 | influxdb3 serve option | Environment variable               |
 | :--------------------- | :--------------------------------- |
 | `--node-id`            | `INFLUXDB3_NODE_IDENTIFIER_PREFIX` |
+
+---
 
 {{% show-in "enterprise" %}}
 #### node-id-from-env
@@ -403,7 +384,51 @@ Default is {{% influxdb3/limit "column" %}}.
 | :------------------------------------ | :------------------------------------------------------- |
 | `--num-total-columns-per-table-limit` | `INFLUXDB3_ENTERPRISE_NUM_TOTAL_COLUMNS_PER_TABLE_LIMIT` |
 {{% /show-in %}}
+
 ---
+
+{{% show-in "enterprise" %}}
+### Licensing
+
+#### license-email
+
+Specifies the email address to associate with your {{< product-name >}} license
+and automatically responds to the interactive email prompt when the server starts.
+This option is mutually exclusive with [license-file](#license-file).
+
+| influxdb3 serve option | Environment variable                 |
+| :--------------------- | :----------------------------------- |
+| `--license-email`      | `INFLUXDB3_ENTERPRISE_LICENSE_EMAIL` |
+
+---
+
+#### license-file
+
+Specifies the path to a license file for {{< product-name >}}. When provided, the license
+file's contents are used instead of requesting a new license.
+This option is mutually exclusive with [license-email](#license-email).
+
+| influxdb3 serve option | Environment variable                 |
+| :--------------------- | :----------------------------------- |
+| `--license-file`       | `INFLUXDB3_ENTERPRISE_LICENSE_FILE`  |
+
+---
+
+#### license-type
+
+Specifies the type of {{% product-name %}} license to use and bypasses the
+interactive license prompt. Provide one of the following license types:
+
+- `home`
+- `trial`
+- `commercial`
+
+| influxdb3 serve option | Environment variable                 |
+| :--------------------- | :----------------------------------- |
+| `--license-type`       | `INFLUXDB3_ENTERPRISE_LICENSE_TYPE`  |
+
+---
+{{% /show-in %}}
 
 ### AWS
 
@@ -414,6 +439,7 @@ Default is {{% influxdb3/limit "column" %}}.
 - [aws-session-token](#aws-session-token)
 - [aws-allow-http](#aws-allow-http)
 - [aws-skip-signature](#aws-skip-signature)
+- [aws-credentials-file](#aws-credentials-file)
 
 #### aws-access-key-id
 
@@ -491,6 +517,37 @@ If enabled, S3 object stores do not fetch credentials and do not sign requests.
 
 ---
 
+#### aws-credentials-file
+
+Specifies the path to your S3 credentials file.
+When using a credentials file, settings in the file override the corresponding
+CLI flags.
+
+S3 credential files are JSON-formatted and should contain the following:
+
+```json { placeholders="AWS_(ACCESS_KEY_ID|SECRET_ACCESS_KEY|SESSION_TOKEN)|UNIX_SECONDS_TIMESTAMP" }
+{
+  "aws_access_key_id": "AWS_ACCESS_KEY_ID",
+  "aws_secret_access_key": "AWS_SECRET_ACCESS_KEY",
+  "aws_session_token": "AWS_SESSION_TOKEN",
+  "expiry": "UNIX_SECONDS_TIMESTAMP"
+}
+```
+
+The `aws_session_token` and `expiry` fields are optional.
+The file is automatically checked for updates at the expiry time or at 1-hour
+intervals.
+
+If the object store returns an "Unauthenticated" error, InfluxDB will attempt to
+update its in-memory credentials from this file and then retry the object store
+request.
+
+| influxdb3 serve option   | Environment variable   |
+| :----------------------- | :--------------------- |
+| `--aws-credentials-file` | `AWS_CREDENTIALS_FILE` |
+
+---
+
 ### Google Cloud Service
 
 - [google-service-account](#google-service-account)
@@ -510,6 +567,8 @@ JSON file that contains the Google credentials.
 
 - [azure-storage-account](#azure-storage-account)
 - [azure-storage-access-key](#azure-storage-access-key)
+- [azure-endpoint](#azure-endpoint)
+- [azure-allow-http](#azure-allow-http)
 
 #### azure-storage-account
 
@@ -530,6 +589,30 @@ values in the Storage account's **Settings > Access keys**.
 | influxdb3 serve option       | Environment variable       |
 | :--------------------------- | :------------------------- |
 | `--azure-storage-access-key` | `AZURE_STORAGE_ACCESS_KEY` |
+
+---
+
+#### azure-endpoint
+
+When using Microsoft Azure as the object store, set this to the Azure Blob
+Storage endpoint.
+
+| influxdb3 serve option | Environment variable |
+| :--------------------- | :------------------- |
+| `--azure-endpoint`     | `AZURE_ENDPOINT`     |
+
+---
+
+#### azure-allow-http
+
+When using Microsoft Azure as the object store, allow unencrypted HTTP requests
+to Azure Blob Storage.
+
+**Default:** `false`
+
+| influxdb3 serve option | Environment variable |
+| :--------------------- | :------------------- |
+| `--azure-allow-http`   | `AZURE_ALLOW_HTTP`   |
 
 ---
 

--- a/content/shared/influxdb3-cli/write.md
+++ b/content/shared/influxdb3-cli/write.md
@@ -178,6 +178,7 @@ types of write errors--for example: malformed line protocol or type conflicts.
 > [!Tip]
 > Only use `--no-sync` when low write latency is more important than guaranteed data durability.
 > Avoid using this option for critical or irreplaceable data, as it increases the risk of silent data loss.
+
 ```bash { placeholders="DATABASE_NAME|AUTH_TOKEN" }
 influxdb3 write \
   --database DATABASE_NAME \

--- a/content/shared/influxdb3-cli/write.md
+++ b/content/shared/influxdb3-cli/write.md
@@ -169,12 +169,15 @@ home,room=Kitchen temp=23.0,hum=36.2,co=0i 1641027600
 ### Write line protocol and immediately return a response
 
 By default, {{% product-name %}} waits to respond to write requests until the
-written data is flush from the Write-Ahead Log (WAL) to object storage
+written data is flushed from the Write-Ahead Log (WAL) to object storage
 (every 1s by default).
 Use the `--no-sync` option to immediately return a response without waiting for
-the WAL to flush. This improves perceived write response times, but hides any
-potential write errors.
+the WAL to flush. This improves perceived write response times, but may hide certain
+types of write errors--for example: malformed line protocol or type conflicts.
 
+> [!Tip]
+> Only use `--no-sync` when low write latency is more important than guaranteed data durability.
+> Avoid using this option for critical or irreplaceable data, as it increases the risk of silent data loss.
 ```bash { placeholders="DATABASE_NAME|AUTH_TOKEN" }
 influxdb3 write \
   --database DATABASE_NAME \

--- a/content/shared/influxdb3-cli/write.md
+++ b/content/shared/influxdb3-cli/write.md
@@ -31,7 +31,8 @@ influxdb3 write [OPTIONS] --database <DATABASE_NAME> [LINE_PROTOCOL]...
 |        | `--token`          | _({{< req >}})_ Authentication token                                                     |
 | `-f`   | `--file`           | A file that contains line protocol to write                                              |
 |        | `--accept-partial` | Accept partial writes                                                                    |
-|      | `--precision`  | Precision of data timestamps (`ns`, `us`, `ms`, or `s`) |                     |
+|        | `--no-sync`        | Do not wait for WAL sync before acknowledging the write request                          |
+|        | `--precision`      | Precision of data timestamps (`ns`, `us`, `ms`, or `s`)                                  |
 |        | `--tls-ca`         | Path to a custom TLS certificate authority (for testing or self-signed certificates)     |
 | `-h`   | `--help`           | Print help information                                                                   |
 |        | `--help-all`       | Print detailed help information                                                          |
@@ -50,6 +51,8 @@ You can use the following environment variables to set command options:
 
 - [Write line protocol to your InfluxDB 3 server](#write-line-protocol-to-your-influxdb-3-server)
 - [Write line protocol and accept partial writes](#write-line-protocol-and-accept-partial-writes)
+- [Write line protocol with specific timestamp precision](#write-line-protocol-with-specific-timestamp-precision)
+- [Write line protocol and immediately return a response](#write-line-protocol-and-immediately-return-a-response)
 
 In the examples below, replace the following:
 
@@ -57,8 +60,6 @@ In the examples below, replace the following:
   the name of the database to query
 - {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}}: 
   Authentication token
-
-{{% code-placeholders "DATABASE_NAME|AUTH_TOKEN" %}}
 
 ### Write line protocol to your InfluxDB 3 server
 
@@ -72,7 +73,7 @@ In the examples below, replace the following:
 {{% influxdb/custom-timestamps %}}
 <!--pytest.mark.skip-->
 
-```bash
+```bash { placeholders="DATABASE_NAME|AUTH_TOKEN" }
 influxdb3 write \
   --database DATABASE_NAME \
   --token AUTH_TOKEN \
@@ -83,7 +84,7 @@ influxdb3 write \
 {{% code-tab-content %}}
 <!--pytest.mark.skip-->
 
-```bash
+```bash { placeholders="DATABASE_NAME|AUTH_TOKEN" }
 influxdb3 write \
   --database DATABASE_NAME \
   --token AUTH_TOKEN \
@@ -93,7 +94,7 @@ influxdb3 write \
 {{% code-tab-content %}}
 <!--pytest.mark.skip-->
 
-```bash
+```bash { placeholders="DATABASE_NAME|AUTH_TOKEN" }
 cat ./data.lp | influxdb3 write \
   --database DATABASE_NAME \
   --token AUTH_TOKEN
@@ -113,7 +114,7 @@ cat ./data.lp | influxdb3 write \
 {{% influxdb/custom-timestamps %}}
 <!--pytest.mark.skip-->
 
-```bash
+```bash { placeholders="DATABASE_NAME|AUTH_TOKEN" }
 influxdb3 write \
   --accept-partial \
   --database DATABASE_NAME \
@@ -125,7 +126,7 @@ influxdb3 write \
 {{% code-tab-content %}}
 <!--pytest.mark.skip-->
 
-```bash
+```bash { placeholders="DATABASE_NAME|AUTH_TOKEN" }
 influxdb3 write \
   --accept-partial \
   --database DATABASE_NAME \
@@ -136,7 +137,7 @@ influxdb3 write \
 {{% code-tab-content %}}
 <!--pytest.mark.skip-->
 
-```bash
+```bash { placeholders="DATABASE_NAME|AUTH_TOKEN" }
 cat ./data.lp | influxdb3 write \
   --accept-partial \
   --database DATABASE_NAME \
@@ -145,14 +146,15 @@ cat ./data.lp | influxdb3 write \
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
 
-## Write line protocol with specific timestamp precision
+### Write line protocol with specific timestamp precision
 
-By default, in CLI and HTTP API write requests, {{% product-name %}} uses the timestamp magnitude to auto-detect the precision.
+By default, in CLI and HTTP API write requests, {{% product-name %}} uses the
+timestamp magnitude to auto-detect the precision.
 To avoid any ambiguity, specify  the `--precision {ns|us|ms|s}` option:
 
 <!--pytest.mark.skip--> 
 
-```bash
+```bash { placeholders="DATABASE_NAME|AUTH_TOKEN" }
 influxdb3 write \
   --database DATABASE_NAME \
   --token AUTH_TOKEN \
@@ -163,4 +165,20 @@ home,room=Living\ Room temp=21.4,hum=35.9,co=0i 1641027600
 home,room=Kitchen temp=23.0,hum=36.2,co=0i 1641027600
 '
 ```
-{{% /code-placeholders %}}
+
+### Write line protocol and immediately return a response
+
+By default, {{% product-name %}} waits to respond to write requests until the
+written data is flush from the Write-Ahead Log (WAL) to object storage
+(every 1s by default).
+Use the `--no-sync` option to immediately return a response without waiting for
+the WAL to flush. This improves perceived write response times, but hides any
+potential write errors.
+
+```bash { placeholders="DATABASE_NAME|AUTH_TOKEN" }
+influxdb3 write \
+  --database DATABASE_NAME \
+  --token AUTH_TOKEN \
+  --no-sync \
+  'home,room=Living\ Room temp=21.1,hum=35.9,co=0i 1641024000'
+```


### PR DESCRIPTION
- Added missing configuration options for InfluxDB 3 Core and Enterprise
- Added new configuration options (`azure-endpoint`, `license-type`) for InfluxDB 3 Core and Enterprise.
- Added `--no-sync` option to `influxdb3 write`

---

- [x] Rebased/mergeable
