### PR TITLE
Update config-options.md

### DIFF
--- a/content/shared/influxdb3-cli/config-options.md
+++ b/content/shared/influxdb3-cli/config-options.md
@@ -939,6 +939,11 @@ Sets the filter directive for logs.
 
 Specifies the destination for logs.
 
+This option supports the following values:
+
+- `stdout` _(default)_
+- `stderr`
+
 **Default:** `stdout`
 
 | influxdb3 serve option | Environment variable |


### PR DESCRIPTION
Provide both available options for "log-destination" to make it more obvious that no filesystem logs are supported.

