### PR TITLE
chore: updates to 3.4.1 + Explorer page updates

### DIFF
--- a/content/influxdb3/explorer/_index.md
+++ b/content/influxdb3/explorer/_index.md
@@ -11,19 +11,11 @@ weight: 1
 InfluxDB 3 Explorer is the standalone web application designed for visualizing, querying, and managing your data stored in InfluxDB 3 Core and Enterprise.
 Explorer provides an intuitive interface for interacting with your time series data, streamlining database operations and enhancing data insights.
 
-> [!Important]
-> #### InfluxDB 3 Core or Enterprise v3.1.0 or later required
->
-> InfluxDB 3 Explorer is compatible with the following:
->
-> - [InfluxDB 3 Core v3.1.0 or later](/influxdb3/core/install/)
-> - [InfluxDB 3 Enterprise v3.1.0 or later](/influxdb3/enterprise/install/)
-
 ## Key features
 
 Use InfluxDB 3 Explorer for:
 
-- **Database and query management**: Create and manage InfluxDB 3 databases, admin and resource tokens, and configure new InfluxDB 3 Enterprise instances
+- **Database management**: Create and manage InfluxDB 3 instances, databases, tokens, plugins, and more
 - **Data visualization and analysis**: Query data with a built-in visualizer for enhanced data insights  
 - **Data ingestion**: Write new data and setup Telegraf configurations
 
@@ -33,14 +25,14 @@ Run the Docker image to start InfluxDB 3 Explorer:
 
 ```sh
 # Pull the Docker image
-docker pull influxdata/influxdb3-ui:{{% latest-patch %}}
+docker pull influxdata/influxdb3-ui
 
 # Run the Docker container
 docker run --detach \
   --name influxdb3-explorer \
   --publish 8888:80 \
   --publish 8889:8888 \
-  influxdata/influxdb3-ui:{{% latest-patch %}} \
+  influxdata/influxdb3-ui \
   --mode=admin
 
 # Visit http://localhost:8888 in your browser to begin using InfluxDB 3 Explorer

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -5,6 +5,14 @@
 > All updates to Core are automatically included in Enterprise.
 > The Enterprise sections below only list updates exclusive to Enterprise.
 
+## v3.4.1 {date="2025-08-28"}
+
+### Core
+
+#### Bug Fixes
+- Upgrading from 3.3.0 to 3.4.x no longer causes possible catalog migration issues ([#26756](https://github.com/influxdata/influxdb/pull/26756))
+
+
 ## v3.4.0 {date="2025-08-27"}
 
 ### Core
@@ -68,7 +76,7 @@ All Core updates are included in Enterprise. Additional Enterprise-specific feat
 #### Bug Fixes
 
 - **Database reliability**:
-  - Fix URL encoded table name handling failures ([#26586](https://github.com/influxdata/influxdb/pull/26586))
+  - Fix url encoded table name handling failures ([#26586](https://github.com/influxdata/influxdb/pull/26586))
   - Allow hard deletion of existing soft-deleted schema ([#26574](https://github.com/influxdata/influxdb/pull/26574))
 - **Authentication**: Fix AWS S3 API error handling when tokens are expired ([#1013](https://github.com/influxdata/influxdb/pull/1013))
 - **Query processing**: Set nanosecond precision as default for V1 query API CSV output ([#26577](https://github.com/influxdata/influxdb/pull/26577))
@@ -172,8 +180,8 @@ All Core updates are included in Enterprise. Additional Enterprise-specific feat
 - **License management improvements**: 
   - New `influxdb3 show license` command to display current license information
 - **Table-level retention period support**: Add retention period support for individual tables in addition to database-level retention, providing granular data lifecycle management
-   - New CLI commands: `create table --retention-period` and `update table --retention-period`
-   - Set or clear table-specific retention policies independent of database settings
+  - New CLI commands: `create table --retention-period` and `update table --retention-period`
+  - Set or clear table-specific retention policies independent of database settings
 - **Compaction improvements**:
   - Address compactor restart issues for better reliability
   - Track compacted generation durations in catalog for monitoring

--- a/data/products.yml
+++ b/data/products.yml
@@ -6,7 +6,7 @@ influxdb3_core:
   versions: [core]
   list_order: 2
   latest: core
-  latest_patch: 3.4.0
+  latest_patch: 1
   placeholder_host: localhost:8181
   ai_sample_questions:
     - How do I install and run InfluxDB 3 Core?
@@ -21,7 +21,7 @@ influxdb3_enterprise:
   versions: [enterprise]
   list_order: 2
   latest: enterprise
-  latest_patch: 3.4.0
+  latest_patch: 3.4.1
   placeholder_host: localhost:8181
   ai_sample_questions:
     - How do I install and run InfluxDB 3 Enterprise?

--- a/data/products.yml
+++ b/data/products.yml
@@ -6,7 +6,7 @@ influxdb3_core:
   versions: [core]
   list_order: 2
   latest: core
-  latest_patch: 1
+  latest_patch: 3.4.1
   placeholder_host: localhost:8181
   ai_sample_questions:
     - How do I install and run InfluxDB 3 Core?

--- a/layouts/partials/article/feedback.html
+++ b/layouts/partials/article/feedback.html
@@ -55,8 +55,8 @@
         <li><a class="discord" href="https://discord.gg/9zaNCW2PRT" target="_blank"><strong>InfluxDB Discord Server</strong> <em style="opacity:.5">(Preferred)</em></a></li>
         <li><a class="slack" href="https://influxdata.com/slack" target="_blank">InfluxDB Community Slack</a></li>
       {{ else }}
-        <li><a class="slack" href="https://influxdata.com/slack" target="_blank">InfluxDB Community Slack  <em style="opacity:.5">(Preferred)</em></a></li>
-        <li><a class="discord" href="https://discord.gg/9zaNCW2PRT" target="_blank"><strong>InfluxDB Discord Server</strong></a></li>
+        <li><a class="slack" href="https://influxdata.com/slack" target="_blank"><strong>InfluxDB Community Slack</strong>  <em style="opacity:.5">(Preferred)</em></a></li>
+        <li><a class="discord" href="https://discord.gg/9zaNCW2PRT" target="_blank">InfluxDB Discord Server</a></li>
       {{ end }}
       <li><a class="community" href="https://community.influxdata.com/" target="_blank">InfluxData Community</a></li>
       <li><a class="reddit" href="https://reddit.com/r/influxdb" target="_blank">InfluxDB Subreddit</a></li>


### PR DESCRIPTION
Updates to 3.4.1 and adds a note (plus corrects a lint error).

Also, removes the Explorer requires 3.1 as we're well past that now. Further, it simplifies the docker command to always pull latest. 

Also, fixes a bolding issue for Discord in the feedback section when in a non-Core/Ent/Explorer product.
