### PR TITLE
Fix dar 524

### DIFF
--- a/content/influxdb3/clustered/reference/release-notes/clustered.md
+++ b/content/influxdb3/clustered/reference/release-notes/clustered.md
@@ -390,6 +390,43 @@ spec:
 # ...[remaining configuration]
 ```
 
+### `clustered-auth` service routes to removed `gateway` service instead of `core` service
+
+If you have the `clusteredAuth` feature flag enabled, the `clustered-auth` service will be deployed.
+The service currently routes to the recently removed `gateway` service instead of the new `core` service.
+
+#### Temporary workaround for service routing
+
+Until you upgrade to release `20250805-1812019`, you will need to override the `clustered-auth`
+service to point to the new `core` service by adding the following `env` overrides to your `AppInstance`:
+
+```yaml
+apiVersion: kubecfg.dev/v1alpha1
+kind: AppInstance
+metadata:
+  name: influxdb
+  namespace: influxdb
+spec:
+  package:
+    image: us-docker.pkg.dev/influxdb2-artifacts/clustered/influxdb:20241024-1354148
+    apiVersion: influxdata.com/v1alpha1
+    spec:
+      components:
+        querier:
+          template:
+            containers:
+              clustered-auth:
+                env:
+                  AUTHZ_TOKEN_SVC_ADDRESS: 'http://core:8091/'
+        router:
+          template:
+            containers:
+              clustered-auth:
+                env:
+                  AUTHZ_TOKEN_SVC_ADDRESS: 'http://core:8091/'
+# ...remaining configuration...
+```
+
 ### Highlights
 
 #### AppInstance image override bug fix

--- a/content/influxdb3/clustered/reference/release-notes/clustered.md
+++ b/content/influxdb3/clustered/reference/release-notes/clustered.md
@@ -1278,7 +1278,7 @@ We now expose a `google` object within the `objectStore` configuration, which
 enables support for using Google Cloud's GCS as a backing object store for IOx
 components. This supports both
 [GKE workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
-and [IAM Service Account](https://cloud.google.com/kubernetes-engine/docs/tutorials/authenticating-to-cloud-platform#step_3_create_service_account_credentials)
+and [IAM Service Account](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#kubernetes-sa-to-iam)
 authentication methods.
 
 #### Support for bypassing identity provider configuration for database/token management

--- a/content/influxdb3/clustered/reference/release-notes/clustered.md
+++ b/content/influxdb3/clustered/reference/release-notes/clustered.md
@@ -397,7 +397,7 @@ The service currently routes to the recently removed `gateway` service instead o
 
 #### Temporary workaround for service routing
 
-Until you upgrade to release `20250805-1812019`, you will need to override the `clustered-auth`
+Until you upgrade to release `20250805-1812019`, you need to override the `clustered-auth`
 service to point to the new `core` service by adding the following `env` overrides to your `AppInstance`:
 
 ```yaml


### PR DESCRIPTION
Closes influxdata/DAR/issues/524

Trying to close the loop on influxdata/DAR/issues/524--the release notes were updated in https://github.com/influxdata/k8s-idpe/pull/67034, but never ported to docs.
I'm a little confused about Clustered release notes script - I assumed it would port the change to the release notes page in docs.
