### PR TITLE
chore(ci): update link-checker to v1.2.4

### DIFF
--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -95,7 +95,7 @@ jobs:
           curl -L -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -o link-checker-info.json \
-            "https://api.github.com/repos/influxdata/docs-v2/releases/tags/link-checker-v1.2.3"
+            "https://api.github.com/repos/influxdata/docs-v2/releases/tags/link-checker-v1.2.4"
           
           # Extract download URL for linux binary
           DOWNLOAD_URL=$(jq -r '.assets[] | select(.name | test("link-checker.*linux")) | .url' link-checker-info.json)


### PR DESCRIPTION
- Update GitHub Actions workflow to use link-checker v1.2.4
- Ensures CI uses latest link validation tooling with improvements and bug fixes
