### PR TITLE
docs(grafana): integrate feature flag setup into installation workflow

### DIFF
--- a/content/enterprise_influxdb/v1/tools/grafana.md
+++ b/content/enterprise_influxdb/v1/tools/grafana.md
@@ -43,7 +43,73 @@ to visualize data from your **InfluxDB Enterprise** cluster.
 1. [Set up an InfluxDB Enterprise cluster](/enterprise_influxdb/v1/introduction/installation/).
 2. [Sign up for Grafana Cloud](https://grafana.com/products/cloud/) or
    [download and install Grafana](https://grafana.com/grafana/download).
-3. Visit your **Grafana Cloud user interface** (UI) or, if running Grafana locally,
+3. If running Grafana locally, enable the `newInfluxDSConfigPageDesign` feature flag to use the latest InfluxDB data source plugin.
+
+   {{< expand-wrapper >}}
+   {{% expand "Option 1: Configuration file (recommended)" %}}
+
+   Add the following to your `grafana.ini` configuration file:
+
+   ```ini
+   [feature_toggles]
+   enable = newInfluxDSConfigPageDesign
+   ```
+
+   Configuration file locations:
+   - **Linux**: `/etc/grafana/grafana.ini`
+   - **macOS (Homebrew)**: `/opt/homebrew/etc/grafana/grafana.ini`
+   - **Windows**: `<GRAFANA_INSTALL_DIR>\conf\grafana.ini`
+
+   {{% /expand %}}
+
+   {{% expand "Option 2: Command line" %}}
+
+   Enable the feature flag when starting Grafana:
+
+   {{< code-tabs-wrapper >}}
+   {{% code-tabs %}}
+   [Linux](#)
+   [macOS (Homebrew)](#)
+   [Windows](#)
+   {{% /code-tabs %}}
+   {{% code-tab-content %}}
+
+   ```sh
+   grafana-server --config /etc/grafana/grafana.ini \
+     cfg:default.feature_toggles.enable=newInfluxDSConfigPageDesign
+   ```
+
+   {{% /code-tab-content %}}
+   {{% code-tab-content %}}
+
+   ```sh
+   /opt/homebrew/opt/grafana/bin/grafana server \
+     --config /opt/homebrew/etc/grafana/grafana.ini \
+     --homepath /opt/homebrew/opt/grafana/share/grafana \
+     --packaging=brew \
+     cfg:default.paths.logs=/opt/homebrew/var/log/grafana \
+     cfg:default.paths.data=/opt/homebrew/var/lib/grafana \
+     cfg:default.paths.plugins=/opt/homebrew/var/lib/grafana/plugins \
+     cfg:default.feature_toggles.enable=newInfluxDSConfigPageDesign
+   ```
+
+   {{% /code-tab-content %}}
+   {{% code-tab-content %}}
+
+   ```powershell
+   grafana-server.exe --config <GRAFANA_INSTALL_DIR>\conf\grafana.ini `
+     cfg:default.feature_toggles.enable=newInfluxDSConfigPageDesign
+   ```
+
+   {{% /code-tab-content %}}
+   {{< /code-tabs-wrapper >}}
+
+   {{% /expand %}}
+   {{< /expand-wrapper >}}
+
+   For more information, see [Configure feature toggles](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/) in the Grafana documentation.
+
+4. Visit your **Grafana Cloud user interface** (UI) or, if running Grafana locally,
    [start Grafana](https://grafana.com/docs/grafana/latest/installation/) and visit
    <http://localhost:3000> in your browser.
 
@@ -53,10 +119,8 @@ to visualize data from your **InfluxDB Enterprise** cluster.
 > If you need to keep your database local, consider running Grafana locally instead of using Grafana Cloud,
 > as this avoids the need to expose your database to the internet.
 >
-> To use InfluxDB running on your private network with Grafana Cloud, you must
-> [configure a private data source](https://grafana.com/docs/grafana-cloud/data-sources/private-data-sources/).
-> See the Grafana documentation for instructions on configuring a Grafana Cloud private data source
-> with {{% product-name %}} running on `http://localhost:8086`.
+> To use InfluxDB running on your private network with Grafana Cloud, you must configure a
+> [private data source for Grafana Cloud](https://grafana.com/docs/grafana-cloud/data-sources/private-data-sources/).
 
 > [!Note]
 > #### Query language support
@@ -66,20 +130,24 @@ to visualize data from your **InfluxDB Enterprise** cluster.
 
 ## Create an InfluxDB data source
 
-1. In your Grafana interface, click **Connections** in the left sidebar
-2. Click **Data sources**
-3. Click **Add new connection**
+1. In your Grafana interface, click **Connections** in the left sidebar.
+2. Click **Data sources**.
+3. Click **Add new connection**.
 4. Search for and select **InfluxDB**. The InfluxDB data source configuration page displays.
-5. In the **Settings** tab, configure the following:
- 
-   - **Name**: A descriptive name for your data source
-   - **URL**: Your server or load balancer URL--for example, `https://{{< influxdb/host >}}`
-   - **Product**: From the dropdown, select **InfluxDB Enterprise 1.x**
-   - **Query Language**: Select **InfluxQL** or **Flux**
+5. In the **Settings** tab, enter a **Name** for your data source.
+
+### Configure URL and authentication
+
+In the **URL and authentication** section, configure the following:
+
+- **URL**: Your server or load balancer URL--for example, `https://{{< influxdb/host >}}`
+- **Product**: From the dropdown, select **InfluxDB Enterprise 1.x**
+- **Query Language**: Select **InfluxQL** or **Flux**
+- _(Optional)_ **Advanced HTTP Settings**, **Auth**, and **TLS/SSL Settings** as needed for your environment
 
 ### Configure database settings
 
-The fields in this section change based on your query language selection.
+The fields in this section change based on your query language selection in [URL and authentication](#configure-url-authentication).
 
 {{< tabs-wrapper >}}
 {{% tabs %}}

--- a/content/influxdb/v1/tools/grafana.md
+++ b/content/influxdb/v1/tools/grafana.md
@@ -43,7 +43,73 @@ to visualize data from your {{% product-name %}} instance.
 1. [Start InfluxDB](/influxdb/v1/introduction/get-started/).
 2. [Sign up for Grafana Cloud](https://grafana.com/products/cloud/) or
    [download and install Grafana](https://grafana.com/grafana/download).
-3. Visit your **Grafana Cloud user interface** (UI) or, if running Grafana locally,
+3. If running Grafana locally, enable the `newInfluxDSConfigPageDesign` feature flag to use the latest InfluxDB data source plugin.
+
+   {{< expand-wrapper >}}
+   {{% expand "Option 1: Configuration file (recommended)" %}}
+
+   Add the following to your `grafana.ini` configuration file:
+
+   ```ini
+   [feature_toggles]
+   enable = newInfluxDSConfigPageDesign
+   ```
+
+   Configuration file locations:
+   - **Linux**: `/etc/grafana/grafana.ini`
+   - **macOS (Homebrew)**: `/opt/homebrew/etc/grafana/grafana.ini`
+   - **Windows**: `<GRAFANA_INSTALL_DIR>\conf\grafana.ini`
+
+   {{% /expand %}}
+
+   {{% expand "Option 2: Command line" %}}
+
+   Enable the feature flag when starting Grafana:
+
+   {{< code-tabs-wrapper >}}
+   {{% code-tabs %}}
+   [Linux](#)
+   [macOS (Homebrew)](#)
+   [Windows](#)
+   {{% /code-tabs %}}
+   {{% code-tab-content %}}
+
+   ```sh
+   grafana-server --config /etc/grafana/grafana.ini \
+     cfg:default.feature_toggles.enable=newInfluxDSConfigPageDesign
+   ```
+
+   {{% /code-tab-content %}}
+   {{% code-tab-content %}}
+
+   ```sh
+   /opt/homebrew/opt/grafana/bin/grafana server \
+     --config /opt/homebrew/etc/grafana/grafana.ini \
+     --homepath /opt/homebrew/opt/grafana/share/grafana \
+     --packaging=brew \
+     cfg:default.paths.logs=/opt/homebrew/var/log/grafana \
+     cfg:default.paths.data=/opt/homebrew/var/lib/grafana \
+     cfg:default.paths.plugins=/opt/homebrew/var/lib/grafana/plugins \
+     cfg:default.feature_toggles.enable=newInfluxDSConfigPageDesign
+   ```
+
+   {{% /code-tab-content %}}
+   {{% code-tab-content %}}
+
+   ```powershell
+   grafana-server.exe --config <GRAFANA_INSTALL_DIR>\conf\grafana.ini `
+     cfg:default.feature_toggles.enable=newInfluxDSConfigPageDesign
+   ```
+
+   {{% /code-tab-content %}}
+   {{< /code-tabs-wrapper >}}
+
+   {{% /expand %}}
+   {{< /expand-wrapper >}}
+
+   For more information, see [Configure feature toggles](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/) in the Grafana documentation.
+
+4. Visit your **Grafana Cloud user interface** (UI) or, if running Grafana locally,
    [start Grafana](https://grafana.com/docs/grafana/latest/installation/) and visit
    <http://localhost:3000> in your browser.
 
@@ -53,10 +119,8 @@ to visualize data from your {{% product-name %}} instance.
 > If you need to keep your database local, consider running Grafana locally instead of using Grafana Cloud,
 > as this avoids the need to expose your database to the internet.
 >
-> To use InfluxDB running on your private network with Grafana Cloud, you must
-> [configure a private data source](https://grafana.com/docs/grafana-cloud/data-sources/private-data-sources/).
-> See the Grafana documentation for instructions on configuring a Grafana Cloud private data source
-> with {{% product-name %}} running on `http://localhost:8086`.
+> To use InfluxDB running on your private network with Grafana Cloud, you must configure a
+> [private data source for Grafana Cloud](https://grafana.com/docs/grafana-cloud/data-sources/private-data-sources/).
 
 > [!Note]
 > SQL is only supported in InfluxDB 3.
@@ -64,20 +128,24 @@ to visualize data from your {{% product-name %}} instance.
 
 ## Create an InfluxDB data source
 
-1. In your Grafana interface, click **Connections** in the left sidebar
-2. Click **Data sources**
-3. Click **Add new connection**
+1. In your Grafana interface, click **Connections** in the left sidebar.
+2. Click **Data sources**.
+3. Click **Add new connection**.
 4. Search for and select **InfluxDB**. The InfluxDB data source configuration page displays.
-5. In the **Settings** tab, configure the following:
+5. In the **Settings** tab, enter a **Name** for your data source.
 
-   - **Name**: A descriptive name for your data source
-   - **URL**: Your server URL--for example, `https://{{< influxdb/host >}}`
-   - **Product**: From the dropdown, select **InfluxDB OSS 1.x**
-   - **Query Language**: Select **InfluxQL** or **Flux**
+### Configure URL and authentication
+
+In the **URL and authentication** section, configure the following:
+
+- **URL**: Your server URL--for example, `https://{{< influxdb/host >}}`
+- **Product**: From the dropdown, select **InfluxDB OSS 1.x**
+- **Query Language**: Select **InfluxQL** or **Flux**
+- _(Optional)_ **Advanced HTTP Settings**, **Auth**, and **TLS/SSL Settings** as needed for your environment
 
 ### Configure database settings
 
-The fields in this section change based on your query language selection.
+The fields in this section change based on your query language selection in [URL and authentication](#configure-url-authentication).
 
 {{< tabs-wrapper >}}
 {{% tabs %}}

--- a/content/shared/influxdb-v2/tools/grafana.md
+++ b/content/shared/influxdb-v2/tools/grafana.md
@@ -16,7 +16,73 @@ to visualize data from your **InfluxDB {{< current-version >}}** instance.
 1. [Start InfluxDB OSS 2.x](/influxdb/v2/install/#configure-and-start-influxdb).
 2. [Sign up for Grafana Cloud](https://grafana.com/products/cloud/) or
    [download and install Grafana](https://grafana.com/grafana/download).
-3. Visit your **Grafana Cloud user interface** (UI) or, if running Grafana locally,
+3. If running Grafana locally, enable the `newInfluxDSConfigPageDesign` feature flag to use the latest InfluxDB data source plugin.
+
+   {{< expand-wrapper >}}
+   {{% expand "Option 1: Configuration file (recommended)" %}}
+
+   Add the following to your `grafana.ini` configuration file:
+
+   ```ini
+   [feature_toggles]
+   enable = newInfluxDSConfigPageDesign
+   ```
+
+   Configuration file locations:
+   - **Linux**: `/etc/grafana/grafana.ini`
+   - **macOS (Homebrew)**: `/opt/homebrew/etc/grafana/grafana.ini`
+   - **Windows**: `<GRAFANA_INSTALL_DIR>\conf\grafana.ini`
+
+   {{% /expand %}}
+
+   {{% expand "Option 2: Command line" %}}
+
+   Enable the feature flag when starting Grafana:
+
+   {{< code-tabs-wrapper >}}
+   {{% code-tabs %}}
+   [Linux](#)
+   [macOS (Homebrew)](#)
+   [Windows](#)
+   {{% /code-tabs %}}
+   {{% code-tab-content %}}
+
+   ```sh
+   grafana-server --config /etc/grafana/grafana.ini \
+     cfg:default.feature_toggles.enable=newInfluxDSConfigPageDesign
+   ```
+
+   {{% /code-tab-content %}}
+   {{% code-tab-content %}}
+
+   ```sh
+   /opt/homebrew/opt/grafana/bin/grafana server \
+     --config /opt/homebrew/etc/grafana/grafana.ini \
+     --homepath /opt/homebrew/opt/grafana/share/grafana \
+     --packaging=brew \
+     cfg:default.paths.logs=/opt/homebrew/var/log/grafana \
+     cfg:default.paths.data=/opt/homebrew/var/lib/grafana \
+     cfg:default.paths.plugins=/opt/homebrew/var/lib/grafana/plugins \
+     cfg:default.feature_toggles.enable=newInfluxDSConfigPageDesign
+   ```
+
+   {{% /code-tab-content %}}
+   {{% code-tab-content %}}
+
+   ```powershell
+   grafana-server.exe --config <GRAFANA_INSTALL_DIR>\conf\grafana.ini `
+     cfg:default.feature_toggles.enable=newInfluxDSConfigPageDesign
+   ```
+
+   {{% /code-tab-content %}}
+   {{< /code-tabs-wrapper >}}
+
+   {{% /expand %}}
+   {{< /expand-wrapper >}}
+
+   For more information, see [Configure feature toggles](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/) in the Grafana documentation.
+
+4. Visit your **Grafana Cloud user interface** (UI) or, if running Grafana locally,
    [start Grafana](https://grafana.com/docs/grafana/latest/installation/) and visit
    <http://localhost:3000> in your browser.
 
@@ -27,15 +93,13 @@ to visualize data from your **InfluxDB {{< current-version >}}** instance.
 > If you need to keep your database local, consider running Grafana locally instead of using Grafana Cloud,
 > as this avoids the need to expose your database to the internet.
 >
-> To use InfluxDB running on your private network with Grafana Cloud, you must
-> [configure a private data source](https://grafana.com/docs/grafana-cloud/data-sources/private-data-sources/).
-> See the Grafana documentation for instructions on configuring a Grafana Cloud private data source
-> with {{% product-name %}} running on `http://localhost:8086`.
+> To use InfluxDB running on your private network with Grafana Cloud, you must configure a
+> [private data source for Grafana Cloud](https://grafana.com/docs/grafana-cloud/data-sources/private-data-sources/).
 {{% /show-in %}}
 
 > [!Note]
 > SQL is only supported in InfluxDB 3.
-> {{% show-in "v2" %}}For more information, see how to [get-started with InfluxDB 3 Core](/influxdb3/core/get-started/).{{% /show-in %}}{{% show-in "cloud" %}}For more information, see how to upgrade to [InfluxDB Cloud Serverless](/influxdb/cloud/upgrade/v2-to-cloud/).{{% /show-in %}}
+> {{% show-in "v2" %}}For more information, see how to [get started with InfluxDB 3 Core](/influxdb3/core/get-started/).{{% /show-in %}}{{% show-in "cloud" %}}For more information, see how to upgrade to [InfluxDB Cloud Serverless](/influxdb/cloud/upgrade/v2-to-cloud/).{{% /show-in %}}
 
 ## Quick reference
 
@@ -51,20 +115,24 @@ to visualize data from your **InfluxDB {{< current-version >}}** instance.
 
 ## Create an InfluxDB data source
 
-1. In your Grafana interface, click **Connections** in the left sidebar
-2. Click **Data sources**
-3. Click **Add new connection**
+1. In your Grafana interface, click **Connections** in the left sidebar.
+2. Click **Data sources**.
+3. Click **Add new connection**.
 4. Search for and select **InfluxDB**. The InfluxDB data source configuration page displays.
-5. In the **Settings** tab, configure the following:
+5. In the **Settings** tab, enter a **Name** for your data source.
 
-   - **Name**: A descriptive name for your data source
-   - **URL**: Your {{% show-in "v2" %}}[server URL](/influxdb/v2/reference/urls/)--for example, `https://{{< influxdb/host >}}`{{% /show-in %}}{{% show-in "cloud" %}}[region URL](/influxdb/cloud/reference/regions/)--for example, `https://us-east-2-1.aws.cloud2.influxdata.com`{{% /show-in %}}
-   - **Product**: From the dropdown, select {{% show-in "v2" %}}**InfluxDB OSS 2.x**{{% /show-in %}}{{% show-in "cloud" %}}**InfluxDB Cloud (TSM)**{{% /show-in %}}
-   - **Query Language**: Select **Flux** or **InfluxQL**
+### Configure URL and authentication
+
+In the **URL and authentication** section, configure the following:
+
+- **URL**: Your {{% show-in "v2" %}}[server URL](/influxdb/v2/reference/urls/)--for example, `https://{{< influxdb/host >}}`{{% /show-in %}}{{% show-in "cloud" %}}[region URL](/influxdb/cloud/reference/regions/)--for example, `https://us-east-2-1.aws.cloud2.influxdata.com`{{% /show-in %}}
+- **Product**: From the dropdown, select {{% show-in "v2" %}}**InfluxDB OSS 2.x**{{% /show-in %}}{{% show-in "cloud" %}}**InfluxDB Cloud (TSM)**{{% /show-in %}}
+- **Query Language**: Select **Flux** or **InfluxQL**
+- _(Optional)_ **Advanced HTTP Settings**, **Auth**, and **TLS/SSL Settings** as needed for your environment
 
 ### Configure database settings
 
-The fields in this section change based on your query language selection.
+The fields in this section change based on your query language selection in [URL and authentication](#configure-url-authentication).
 
 {{< tabs-wrapper >}}
 {{% tabs %}}

--- a/content/shared/v3-process-data/visualize/grafana.md
+++ b/content/shared/v3-process-data/visualize/grafana.md
@@ -19,50 +19,103 @@ to query and visualize data from {{% product-name %}}.
 
 ## Install Grafana or log in to Grafana Cloud
 
-If using the open source version of **Grafana**, follow the
-[Grafana installation instructions](https://grafana.com/docs/grafana/latest/setup-grafana/installation/)
-to install Grafana for your operating system.
-If using **Grafana Cloud**, log in to your Grafana Cloud instance.
+1. [Sign up for Grafana Cloud](https://grafana.com/products/cloud/) or follow the
+   [Grafana installation instructions](https://grafana.com/docs/grafana/latest/setup-grafana/installation/)
+   to install Grafana for your operating system.
+2. If running Grafana locally, enable the `newInfluxDSConfigPageDesign` feature flag to use the latest InfluxDB data source plugin.
 
-{{% show-in "core,enterprise" %}}
+   {{< expand-wrapper >}}
+   {{% expand "Option 1: Configuration file (recommended)" %}}
+
+   Add the following to your `grafana.ini` configuration file:
+
+   ```ini
+   [feature_toggles]
+   enable = newInfluxDSConfigPageDesign
+   ```
+
+   Configuration file locations:
+   - **Linux**: `/etc/grafana/grafana.ini`
+   - **macOS (Homebrew)**: `/opt/homebrew/etc/grafana/grafana.ini`
+   - **Windows**: `<GRAFANA_INSTALL_DIR>\conf\grafana.ini`
+
+   {{% /expand %}}
+
+   {{% expand "Option 2: Command line" %}}
+
+   Enable the feature flag when starting Grafana:
+
+   {{< code-tabs-wrapper >}}
+   {{% code-tabs %}}
+   [Linux](#)
+   [macOS (Homebrew)](#)
+   [Windows](#)
+   {{% /code-tabs %}}
+   {{% code-tab-content %}}
+
+   ```sh
+   grafana-server --config /etc/grafana/grafana.ini \
+     cfg:default.feature_toggles.enable=newInfluxDSConfigPageDesign
+   ```
+
+   {{% /code-tab-content %}}
+   {{% code-tab-content %}}
+
+   ```sh
+   /opt/homebrew/opt/grafana/bin/grafana server \
+     --config /opt/homebrew/etc/grafana/grafana.ini \
+     --homepath /opt/homebrew/opt/grafana/share/grafana \
+     --packaging=brew \
+     cfg:default.paths.logs=/opt/homebrew/var/log/grafana \
+     cfg:default.paths.data=/opt/homebrew/var/lib/grafana \
+     cfg:default.paths.plugins=/opt/homebrew/var/lib/grafana/plugins \
+     cfg:default.feature_toggles.enable=newInfluxDSConfigPageDesign
+   ```
+
+   {{% /code-tab-content %}}
+   {{% code-tab-content %}}
+
+   ```powershell
+   grafana-server.exe --config <GRAFANA_INSTALL_DIR>\conf\grafana.ini `
+     cfg:default.feature_toggles.enable=newInfluxDSConfigPageDesign
+   ```
+
+   {{% /code-tab-content %}}
+   {{< /code-tabs-wrapper >}}
+
+   {{% /expand %}}
+   {{< /expand-wrapper >}}
+
+   For more information, see [Configure feature toggles](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/) in the Grafana documentation.
+
+3. Visit your **Grafana Cloud user interface** (UI) or, if running Grafana locally,
+   [start Grafana](https://grafana.com/docs/grafana/latest/installation/) and visit
+   <http://localhost:3000> in your browser.
+
+{{% show-in "core,enterprise,clustered" %}}
 > [!Note]
 > #### Using Grafana Cloud with a local InfluxDB instance
 >
 > If you need to keep your database local, consider running Grafana locally instead of using Grafana Cloud,
 > as this avoids the need to expose your database to the internet.
 >
-> To use InfluxDB running on your private network with Grafana Cloud, you must
-> [configure a private data source](https://grafana.com/docs/grafana-cloud/data-sources/private-data-sources/).
-> See the Grafana documentation for instructions on configuring a Grafana Cloud private data source
-> with {{% product-name %}} running on `http://localhost:8181`.
-{{% /show-in %}}
-
-{{% show-in "clustered" %}}
-> [!Note]
-> #### Using Grafana Cloud with a local InfluxDB instance
->
-> If you need to keep your database local, consider running Grafana locally instead of using Grafana Cloud,
-> as this avoids the need to expose your database to the internet.
->
-> To use InfluxDB running on your private network with Grafana Cloud, you must
-> [configure a private data source](https://grafana.com/docs/grafana-cloud/data-sources/private-data-sources/).
-> See the Grafana documentation for instructions on configuring a Grafana Cloud private data source
-> with {{% product-name %}} running on `http://localhost`.
+> To use InfluxDB running on your private network with Grafana Cloud, you must configure a
+> [private data source for Grafana Cloud](https://grafana.com/docs/grafana-cloud/data-sources/private-data-sources/).
 {{% /show-in %}}
 
 ## InfluxDB data source
 
 The InfluxDB data source plugin is included in the Grafana core distribution.
 Use the plugin to query and visualize data from {{< product-name >}} with
-both SQL and InfluxQL. 
+both SQL and InfluxQL.
 
 > [!Note]
 > #### Grafana 10.3+
-> 
+>
 > The instructions below are for **Grafana 10.3+** which introduced the newest
 > version of the InfluxDB core plugin.
 > The updated plugin includes **SQL support** for InfluxDB 3-based products such
-> as {{< product-name >}}, and the interface dynamically adapts based on your product and query language selections.
+> as {{< product-name >}}, and the interface dynamically adapts based on your product and query language selection in [URL and authentication](#configure-url-authentication)s.
 
 ## Before you begin
 
@@ -87,16 +140,20 @@ both SQL and InfluxQL.
 2. Click **Data sources**.
 3. Click **Add new data source**.
 4. Search for and select **InfluxDB**. The InfluxDB data source configuration page displays.
-5. In the **Settings** tab, configure the following:
+5. In the **Settings** tab, enter a **Name** for your data source.
 
-   - **Name**: A descriptive name for your data source
-   - **URL**: Your {{% product-name %}}{{% show-in "cloud-dedicated,clustered" %}} cluster URL{{% /show-in %}}{{% show-in "cloud-serverless" %}} [region URL](/influxdb3/cloud-serverless/reference/regions/)--for example, `https://us-west-2-1.aws.cloud2.influxdata.com`{{% /show-in %}}{{% show-in "core,enterprise" %}} server URL{{% /show-in %}}{{% hide-in "cloud-serverless" %}}--for example, `https://{{< influxdb/host >}}`{{% /hide-in %}}
-   - **Product**: From the dropdown, select {{% hide-in "core,enterprise" %}}**{{% product-name %}}**{{% /hide-in %}}{{% show-in "core" %}}**InfluxDB Enterprise 3.x** _(currently, no **Core** menu option)_{{% /show-in %}}{{% show-in "core,enterprise" %}}**InfluxDB Enterprise 3.x**{{% /show-in %}}
-   - **Query Language**: Select **SQL** or **InfluxQL**
+### Configure URL and authentication
+
+In the **URL and authentication** section, configure the following:
+
+- **URL**: Your {{% product-name %}}{{% show-in "cloud-dedicated,clustered" %}} cluster URL{{% /show-in %}}{{% show-in "cloud-serverless" %}} [region URL](/influxdb3/cloud-serverless/reference/regions/)--for example, `https://us-west-2-1.aws.cloud2.influxdata.com`{{% /show-in %}}{{% show-in "core,enterprise" %}} server URL{{% /show-in %}}{{% hide-in "cloud-serverless" %}}--for example, `https://{{< influxdb/host >}}`{{% /hide-in %}}
+- **Product**: From the dropdown, select {{% hide-in "core,enterprise" %}}**{{% product-name %}}**{{% /hide-in %}}{{% show-in "core" %}}**InfluxDB Enterprise 3.x** _(currently, no **Core** menu option)_{{% /show-in %}}{{% show-in "core,enterprise" %}}**InfluxDB Enterprise 3.x**{{% /show-in %}}
+- **Query Language**: Select **SQL** or **InfluxQL**
+- _(Optional)_ **Advanced HTTP Settings**, **Auth**, and **TLS/SSL Settings** as needed for your environment
 
 ### Configure database settings
 
-The fields in this section change based on your query language selection.
+The fields in this section change based on your query language selection in [URL and authentication](#configure-url-authentication).
 
 {{< tabs-wrapper >}}
 {{% tabs %}}
@@ -253,7 +310,7 @@ With your InfluxDB connection configured, use Grafana to query and visualize tim
 For a comprehensive walk-through of creating visualizations with
 Grafana, see the [Grafana documentation](https://grafana.com/docs/grafana/latest/).
 
-### Query inspection in Grafana 
+### Query inspection in Grafana
 
 To learn more about query management and inspection in Grafana, see the
 [Grafana Explore documentation](https://grafana.com/docs/grafana/latest/explore/).


### PR DESCRIPTION
- Move feature flag configuration from Advanced section into Step 3 of installation
- Update terminology from "Grafana OSS" to "running Grafana locally" to include both OSS and Enterprise
- Consolidate "Using Grafana Cloud with local InfluxDB" guidance into single note with direct link
- Remove redundant Advanced configuration section

Changes apply to all Grafana documentation pages:
- InfluxDB 3 products (Core, Enterprise, Cloud Serverless, Cloud Dedicated, Clustered)
- InfluxDB v2 and Cloud TSM
- InfluxDB v1 OSS and Enterprise

The feature flag requirement is now integrated directly into the installation workflow, making it more discoverable for users setting up Grafana locally.

