### PR TITLE
chore: update to working kubit and kubectl versions

### DIFF
--- a/content/influxdb3/clustered/install/set-up-cluster/configure-cluster/use-helm.md
+++ b/content/influxdb3/clustered/install/set-up-cluster/configure-cluster/use-helm.md
@@ -284,9 +284,8 @@ In addition to the InfluxDB images, copy the kubit operator images:
 ```bash
 # Create a list of kubit-related images
 cat > /tmp/kubit-images.txt << EOF
-ghcr.io/kubecfg/kubit:v0.0.20
+ghcr.io/kubecfg/kubit:v0.0.22
 ghcr.io/kubecfg/kubecfg/kubecfg:latest
-bitnami/kubectl:1.27.5
 registry.k8s.io/kubectl:v1.28.0
 EOF
 
@@ -307,8 +306,8 @@ images:
 # Configure kubit operator images
 kubit:
   controller:
-    image: REGISTRY_HOSTNAME/ghcr.io/kubecfg/kubit:v0.0.20
-  apply_step_image: REGISTRY_HOSTNAME/bitnami/kubectl:1.27.5
+    image: REGISTRY_HOSTNAME/ghcr.io/kubecfg/kubit:v0.0.22
+  apply_step_image: REGISTRY_HOSTNAME/registry.k8s.io/kubectl:v1.28.0
   render_step_image: REGISTRY_HOSTNAME/registry.k8s.io/kubectl:v1.28.0
   kubecfg_image: REGISTRY_HOSTNAME/ghcr.io/kubecfg/kubecfg/kubecfg:latest
 

--- a/content/influxdb3/clustered/install/set-up-cluster/deploy.md
+++ b/content/influxdb3/clustered/install/set-up-cluster/deploy.md
@@ -76,11 +76,11 @@ making it ideal for air-gapped clusters._
 1. On a machine with internet access, download the [`kubit` CLI](https://github.com/kubecfg/kubit#cli-tool)--for example:
 
    ```bash
-   curl -L -o kubit https://github.com/kubecfg/kubit/archive/refs/tags/v0.0.20.tar.gz
+   curl -L -o kubit https://github.com/kubecfg/kubit/archive/refs/tags/v0.0.22.tar.gz
    chmod +x kubit
    ```
 
-   Replace {{% code-placeholder-key %}}`v0.0.20`{{% /code-placeholder-key%}} with the [latest release version](https://github.com/kubecfg/kubit/releases/latest).
+   Replace {{% code-placeholder-key %}}`v0.0.22`{{% /code-placeholder-key%}} with the [latest release version](https://github.com/kubecfg/kubit/releases/latest).
 
 2. If deploying InfluxDB in an air-gapped environment (without internet access),
     transfer the binary to your air-gapped environment.

--- a/content/influxdb3/clustered/install/set-up-cluster/prerequisites.md
+++ b/content/influxdb3/clustered/install/set-up-cluster/prerequisites.md
@@ -189,12 +189,12 @@ update an InfluxDB cluster.
 > separately. The Helm chart installs the kubit operator.
 
 Use `kubectl` to install the [kubecfg kubit](https://github.com/kubecfg/kubit)
-operator **v0.0.18 or later**.
+operator **v0.0.22 or later**.
 
 <!-- pytest.mark.skip -->
 
 ```bash
-kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.19'
+kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.22'
 ```
 
 ### Set up a Kubernetes ingress controller


### PR DESCRIPTION
This updates Clustered to use the latest version of kubit, which includes a fix for the bitnami kubectl image no longer being valid. It also updates a direct reference to the bitnami kubectl image to match what kubit is using in the latest release.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
