### PR TITLE
fix(vale): reduce false positives in Google.Quotes and Vale.Terms rules

### DIFF
--- a/.ci/vale/styles/Google/Quotes.yml
+++ b/.ci/vale/styles/Google/Quotes.yml
@@ -1,7 +1,8 @@
 extends: existence
-message: "Commas and periods go inside quotation marks."
+message: "Commas and periods go inside quotation marks (unless in code examples or technical values)."
 link: 'https://developers.google.com/style/quotation-marks'
-level: error
+# Changed to warning due to false positives with code examples
+level: warning
 nonword: true
 tokens:
   - '"[^"]+"[.,?]'

--- a/.ci/vale/styles/config/vocabularies/InfluxDataDocs/accept.txt
+++ b/.ci/vale/styles/config/vocabularies/InfluxDataDocs/accept.txt
@@ -42,7 +42,7 @@ System.Data.Odbc
 TBs?
 \bUI\b
 URL
-\w*-?\w*url\w*-\w*
+(?i)\w*-?\w*url\w*-\w*
 US (East|West|Central|North|South|Northeast|Northwest|Southeast|Southwest)
 Unix
 WALs?


### PR DESCRIPTION
- Change Google.Quotes from error to warning to prevent blocking on code examples
- Update message to clarify exceptions for technical values and code examples
- Add case-insensitive flag to URL pattern in Vale.Terms vocabulary
- Fixes false positive on 'URL-encoded' and similar hyphenated URL terms

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
