### PR TITLE
feat(api): add missing endpoints for InfluxDB 3.7 API

### DIFF
--- a/api-docs/influxdb3/core/v3/content/info.yml
+++ b/api-docs/influxdb3/core/v3/content/info.yml
@@ -17,8 +17,8 @@ description: |
   - Perform administrative tasks and access system information
 
   The API includes endpoints under the following paths:
-  - `/api/v3`: InfluxDB 3 Core native endpoints 
-  - `/`: Compatibility endpoints for InfluxDB v1 workloads and clients 
+  - `/api/v3`: InfluxDB 3 Core native endpoints
+  - `/`: Compatibility endpoints for InfluxDB v1 workloads and clients
   - `/api/v2/write`: Compatibility endpoint for InfluxDB v2 workloads and clients
 
   <!-- TODO: verify where to host the spec that users can download.

--- a/api-docs/influxdb3/core/v3/ref.yml
+++ b/api-docs/influxdb3/core/v3/ref.yml
@@ -346,8 +346,8 @@ paths:
         - Compatibility endpoints
         - Write data
       x-influxdata-guides:
-        - title: "Use compatibility APIs to write data"
-          href: "/influxdb3/core/write-data/http-api/compatibility-apis/"
+        - title: Use compatibility APIs to write data
+          href: /influxdb3/core/write-data/http-api/compatibility-apis/
   /api/v2/write:
     post:
       operationId: PostV2Write
@@ -439,21 +439,21 @@ paths:
         - Compatibility endpoints
         - Write data
       x-influxdata-guides:
-        - title: "Use compatibility APIs to write data"
-          href: "/influxdb3/core/write-data/http-api/compatibility-apis/"
+        - title: Use compatibility APIs to write data
+          href: /influxdb3/core/write-data/http-api/compatibility-apis/
   /api/v3/write_lp:
     post:
       operationId: PostWriteLP
       summary: Write line protocol
       description: |
         Writes line protocol to the specified database.
-        
+
         This is the native InfluxDB 3 Core write endpoint that provides enhanced control 
         over write behavior with advanced parameters for high-performance and fault-tolerant operations.
 
         Use this endpoint to send data in [line protocol](/influxdb3/core/reference/syntax/line-protocol/) format to InfluxDB.
         Use query parameters to specify options for writing data.
-        
+
         #### Features
 
         - **Partial writes**: Use `accept_partial=true` to allow partial success when some lines in a batch fail
@@ -471,7 +471,7 @@ paths:
         - Larger timestamps → Nanosecond precision (no conversion needed)
 
         #### Related
-        
+
         - [Use the InfluxDB v3 write_lp API to write data](/influxdb3/core/write-data/http-api/v3-write-lp/)
       parameters:
         - $ref: '#/components/parameters/dbWriteParam'
@@ -863,8 +863,8 @@ paths:
         - Query data
         - Compatibility endpoints
       x-influxdata-guides:
-        - title: "Use the InfluxDB v1 HTTP query API and InfluxQL to query data"
-          href: "/influxdb3/core/query-data/execute-queries/influxdb-v1-api/"
+        - title: Use the InfluxDB v1 HTTP query API and InfluxQL to query data
+          href: /influxdb3/core/query-data/execute-queries/influxdb-v1-api/
     post:
       operationId: PostExecuteV1Query
       summary: Execute InfluxQL query (v1-compatible)
@@ -982,8 +982,8 @@ paths:
         - Query data
         - Compatibility endpoints
       x-influxdata-guides:
-        - title: "Use the InfluxDB v1 HTTP query API and InfluxQL to query data"
-          href: "/influxdb3/core/query-data/execute-queries/influxdb-v1-api/"
+        - title: Use the InfluxDB v1 HTTP query API and InfluxQL to query data
+          href: /influxdb3/core/query-data/execute-queries/influxdb-v1-api/
   /health:
     get:
       operationId: GetHealth
@@ -1099,12 +1099,30 @@ paths:
             Use ISO 8601 date-time format (for example, "2025-12-31T23:59:59Z").
 
             #### Deleting a database cannot be undone
-            
+
             Deleting a database is a destructive action.
             Once a database is deleted, data stored in that database cannot be recovered.
       responses:
         '200':
           description: Success. Database deleted.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Database not found.
+      tags:
+        - Database
+  /api/v3/configure/database/retention_period:
+    delete:
+      operationId: DeleteDatabaseRetentionPeriod
+      summary: Remove database retention period
+      description: |
+        Removes the retention period from a database, setting it to infinite retention.
+        Data in the database will not expire based on time.
+      parameters:
+        - $ref: '#/components/parameters/db'
+      responses:
+        '200':
+          description: Success. Retention period removed from database.
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -1142,7 +1160,7 @@ paths:
         Use the `hard_delete_at` parameter to schedule a hard deletion.
 
         #### Deleting a table cannot be undone
-        
+
         Deleting a table is a destructive action.
         Once a table is deleted, data stored in that table cannot be recovered.
       parameters:
@@ -1224,7 +1242,7 @@ paths:
           description: Cache not found.
       tags:
         - Cache data
-        - Table  
+        - Table
   /api/v3/configure/last_cache:
     post:
       operationId: PostConfigureLastCache
@@ -1714,6 +1732,93 @@ paths:
       tags:
         - Authentication
         - Token
+  /api/v3/configure/token:
+    delete:
+      operationId: DeleteToken
+      summary: Delete token
+      description: |
+        Deletes a token.
+      parameters:
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+          description: |
+            The ID of the token to delete.
+      responses:
+        '204':
+          description: Success. The token has been deleted.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Token not found.
+      tags:
+        - Authentication
+        - Token
+  /api/v3/configure/token/named_admin:
+    post:
+      operationId: PostCreateNamedAdminToken
+      summary: Create named admin token
+      description: |
+        Creates a named admin token.
+        A named admin token is an admin token with a specific name identifier.
+      parameters:
+        - name: name
+          in: query
+          required: true
+          schema:
+            type: string
+          description: |
+            The name for the admin token.
+      responses:
+        '201':
+          description: |
+            Success. The named admin token has been created.
+            The response body contains the token string and metadata.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminTokenObject'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: A token with this name already exists.
+      tags:
+        - Authentication
+        - Token
+  /api/v3/plugins/files:
+    put:
+      operationId: PutPluginFile
+      summary: Update plugin file
+      description: |
+        Updates a plugin file in the plugin directory.
+      x-security-note: Requires an admin token
+      responses:
+        '204':
+          description: Success. The plugin file has been updated.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Forbidden. Admin token required.
+      tags:
+        - Processing engine
+  /api/v3/plugins/directory:
+    put:
+      operationId: PutPluginDirectory
+      summary: Update plugin directory
+      description: |
+        Updates the plugin directory configuration.
+      x-security-note: Requires an admin token
+      responses:
+        '204':
+          description: Success. The plugin directory has been updated.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Forbidden. Admin token required.
+      tags:
+        - Processing engine
 components:
   parameters:
     AcceptQueryHeader:
@@ -2167,7 +2272,7 @@ components:
             - `every:1w` - Every week
             - `every:1M` - Every month
             - `every:1y` - Every year
-            
+
             **Maximum interval**: 1 year
 
             ### Table-based triggers
@@ -2285,7 +2390,7 @@ components:
           description: |
             The retention period for the database. Specifies how long data should be retained.
             Use duration format (for example, "1d", "1h", "30m", "7d").
-          example: "7d"
+          example: 7d
       description: Request schema for updating database configuration.
     UpdateTableRequest:
       type: object
@@ -2301,7 +2406,7 @@ components:
           description: |
             The retention period for the table. Specifies how long data in this table should be retained.
             Use duration format (for example, "1d", "1h", "30m", "7d").
-          example: "30d"
+          example: 30d
       required:
         - db
         - table
@@ -2312,29 +2417,29 @@ components:
         license_type:
           type: string
           description: The type of license (for example, "enterprise", "trial").
-          example: "enterprise"
+          example: enterprise
         expires_at:
           type: string
           format: date-time
           description: The expiration date of the license in ISO 8601 format.
-          example: "2025-12-31T23:59:59Z"
+          example: '2025-12-31T23:59:59Z'
         features:
           type: array
           items:
             type: string
           description: List of features enabled by the license.
           example:
-            - "clustering"
-            - "processing_engine"
-            - "advanced_auth"
+            - clustering
+            - processing_engine
+            - advanced_auth
         status:
           type: string
           enum:
-            - "active"
-            - "expired"
-            - "invalid"
+            - active
+            - expired
+            - invalid
           description: The current status of the license.
-          example: "active"
+          example: active
       description: Response schema for license information.
   responses:
     Unauthorized:
@@ -2377,7 +2482,7 @@ components:
       schema:
         type: string
         format: uuid
-      example: "01234567-89ab-cdef-0123-456789abcdef"
+      example: 01234567-89ab-cdef-0123-456789abcdef
   securitySchemes:
     BasicAuthentication:
       type: http

--- a/api-docs/influxdb3/enterprise/v3/content/info.yml
+++ b/api-docs/influxdb3/enterprise/v3/content/info.yml
@@ -17,8 +17,8 @@ description: |
   - Perform administrative tasks and access system information
 
   The API includes endpoints under the following paths:
-  - `/api/v3`: InfluxDB 3 Enterprise native endpoints 
-  - `/`: Compatibility endpoints for InfluxDB v1 workloads and clients 
+  - `/api/v3`: InfluxDB 3 Enterprise native endpoints
+  - `/`: Compatibility endpoints for InfluxDB v1 workloads and clients
   - `/api/v2/write`: Compatibility endpoint for InfluxDB v2 workloads and clients
 
   <!-- TODO: verify where to host the spec that users can download.

--- a/api-docs/influxdb3/enterprise/v3/ref.yml
+++ b/api-docs/influxdb3/enterprise/v3/ref.yml
@@ -13,8 +13,8 @@ info:
     - Perform administrative tasks and access system information
 
     The API includes endpoints under the following paths:
-    - `/api/v3`: InfluxDB 3 Enterprise native endpoints 
-    - `/`: Compatibility endpoints for InfluxDB v1 workloads and clients 
+    - `/api/v3`: InfluxDB 3 Enterprise native endpoints
+    - `/`: Compatibility endpoints for InfluxDB v1 workloads and clients
     - `/api/v2/write`: Compatibility endpoint for InfluxDB v2 workloads and clients
 
     <!-- TODO: verify where to host the spec that users can download.
@@ -346,8 +346,8 @@ paths:
         - Compatibility endpoints
         - Write data
       x-influxdata-guides:
-        - title: "Use compatibility APIs to write data"
-          href: "/influxdb3/enterprise/write-data/http-api/compatibility-apis/"
+        - title: Use compatibility APIs to write data
+          href: /influxdb3/enterprise/write-data/http-api/compatibility-apis/
   /api/v2/write:
     post:
       operationId: PostV2Write
@@ -439,21 +439,21 @@ paths:
         - Compatibility endpoints
         - Write data
       x-influxdata-guides:
-        - title: "Use compatibility APIs to write data"
-          href: "/influxdb3/enterprise/write-data/http-api/compatibility-apis/"
+        - title: Use compatibility APIs to write data
+          href: /influxdb3/enterprise/write-data/http-api/compatibility-apis/
   /api/v3/write_lp:
     post:
       operationId: PostWriteLP
       summary: Write line protocol
       description: |
         Writes line protocol to the specified database.
-        
+
         This is the native InfluxDB 3 Enterprise write endpoint that provides enhanced control 
         over write behavior with advanced parameters for high-performance and fault-tolerant operations.
 
         Use this endpoint to send data in [line protocol](/influxdb3/enterprise/reference/syntax/line-protocol/) format to InfluxDB.
         Use query parameters to specify options for writing data.
-        
+
         #### Features
 
         - **Partial writes**: Use `accept_partial=true` to allow partial success when some lines in a batch fail
@@ -471,7 +471,7 @@ paths:
         - Larger timestamps → Nanosecond precision (no conversion needed)
 
         #### Related
-        
+
         - [Use the InfluxDB v3 write_lp API to write data](/influxdb3/enterprise/write-data/http-api/v3-write-lp/)
       parameters:
         - $ref: '#/components/parameters/dbWriteParam'
@@ -863,8 +863,8 @@ paths:
         - Query data
         - Compatibility endpoints
       x-influxdata-guides:
-        - title: "Use the InfluxDB v1 HTTP query API and InfluxQL to query data"
-          href: "/influxdb3/enterprise/query-data/execute-queries/influxdb-v1-api/"
+        - title: Use the InfluxDB v1 HTTP query API and InfluxQL to query data
+          href: /influxdb3/enterprise/query-data/execute-queries/influxdb-v1-api/
     post:
       operationId: PostExecuteV1Query
       summary: Execute InfluxQL query (v1-compatible)
@@ -982,8 +982,8 @@ paths:
         - Query data
         - Compatibility endpoints
       x-influxdata-guides:
-        - title: "Use the InfluxDB v1 HTTP query API and InfluxQL to query data"
-          href: "/influxdb3/enterprise/query-data/execute-queries/influxdb-v1-api/"
+        - title: Use the InfluxDB v1 HTTP query API and InfluxQL to query data
+          href: /influxdb3/enterprise/query-data/execute-queries/influxdb-v1-api/
   /health:
     get:
       operationId: GetHealth
@@ -1099,12 +1099,29 @@ paths:
             Use ISO 8601 date-time format (for example, "2025-12-31T23:59:59Z").
 
             #### Deleting a database cannot be undone
-            
+
             Deleting a database is a destructive action.
             Once a database is deleted, data stored in that database cannot be recovered.
       responses:
         '200':
           description: Success. Database deleted.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Database not found.
+      tags:
+        - Database
+  /api/v3/configure/database/retention_period:
+    delete:
+      operationId: DeleteDatabaseRetentionPeriod
+      summary: Remove database retention period
+      description: |
+        Removes the retention period from a database, setting it to infinite retention.
+      parameters:
+        - $ref: '#/components/parameters/db'
+      responses:
+        '204':
+          description: Success. The database retention period has been removed.
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -1142,7 +1159,7 @@ paths:
         Use the `hard_delete_at` parameter to schedule a hard deletion.
 
         #### Deleting a table cannot be undone
-        
+
         Deleting a table is a destructive action.
         Once a table is deleted, data stored in that table cannot be recovered.
       parameters:
@@ -1295,7 +1312,7 @@ paths:
           description: Cache not found.
       tags:
         - Cache data
-        - Table      
+        - Table
   /api/v3/configure/last_cache:
     post:
       operationId: PostConfigureLastCache
@@ -1808,6 +1825,91 @@ paths:
       tags:
         - Authentication
         - Token
+  /api/v3/configure/token:
+    delete:
+      operationId: DeleteToken
+      summary: Delete token
+      description: |
+        Deletes a token.
+      parameters:
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+          description: The ID of the token to delete.
+      responses:
+        '204':
+          description: Success. The token has been deleted.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Token not found.
+      tags:
+        - Authentication
+        - Token
+  /api/v3/configure/token/named_admin:
+    post:
+      operationId: PostCreateNamedAdminToken
+      summary: Create named admin token
+      description: |
+        Creates a named admin token.
+        A named admin token is a special type of admin token with a custom name for identification and management.
+      parameters:
+        - name: name
+          in: query
+          required: true
+          schema:
+            type: string
+          description: The name for the admin token.
+      responses:
+        '201':
+          description: |
+            Success. The named admin token has been created.
+            The response body contains the token string and metadata.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminTokenObject'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: A token with this name already exists.
+      tags:
+        - Authentication
+        - Token
+  /api/v3/plugins/files:
+    put:
+      operationId: PutPluginFile
+      summary: Update plugin file
+      description: |
+        Updates a plugin file in the plugin directory.
+      x-security-note: Requires an admin token
+      responses:
+        '204':
+          description: Success. The plugin file has been updated.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Forbidden. Admin token required.
+      tags:
+        - Processing engine
+  /api/v3/plugins/directory:
+    put:
+      operationId: PutPluginDirectory
+      summary: Update plugin directory
+      description: |
+        Updates the plugin directory configuration.
+      x-security-note: Requires an admin token
+      responses:
+        '204':
+          description: Success. The plugin directory has been updated.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Forbidden. Admin token required.
+      tags:
+        - Processing engine
 components:
   parameters:
     AcceptQueryHeader:
@@ -2142,7 +2244,7 @@ components:
       properties:
         db:
           type: string
-          pattern: '^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$|^[a-zA-Z0-9]$'
+          pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$|^[a-zA-Z0-9]$
           description: |-
             The database name. Database names cannot contain underscores (_).
             Names must start and end with alphanumeric characters and can contain hyphens (-) in the middle.
@@ -2151,7 +2253,7 @@ components:
           description: |-
             The retention period for the database. Specifies how long data should be retained.
             Use duration format (for example, "1d", "1h", "30m", "7d").
-          example: "7d"
+          example: 7d
       required:
         - db
     CreateTableRequest:
@@ -2188,7 +2290,7 @@ components:
           description: |-
             The retention period for the table. Specifies how long data in this table should be retained.
             Use duration format (for example, "1d", "1h", "30m", "7d").
-          example: "30d"
+          example: 30d
       required:
         - db
         - table
@@ -2314,7 +2416,7 @@ components:
             - `every:1w` - Every week
             - `every:1M` - Every month
             - `every:1y` - Every year
-            
+
             **Maximum interval**: 1 year
 
             ### Table-based triggers
@@ -2432,7 +2534,7 @@ components:
           description: |
             The retention period for the database. Specifies how long data should be retained.
             Use duration format (for example, "1d", "1h", "30m", "7d").
-          example: "7d"
+          example: 7d
       description: Request schema for updating database configuration.
     UpdateTableRequest:
       type: object
@@ -2448,7 +2550,7 @@ components:
           description: |
             The retention period for the table. Specifies how long data in this table should be retained.
             Use duration format (for example, "1d", "1h", "30m", "7d").
-          example: "30d"
+          example: 30d
       required:
         - db
         - table
@@ -2459,29 +2561,29 @@ components:
         license_type:
           type: string
           description: The type of license (for example, "enterprise", "trial").
-          example: "enterprise"
+          example: enterprise
         expires_at:
           type: string
           format: date-time
           description: The expiration date of the license in ISO 8601 format.
-          example: "2025-12-31T23:59:59Z"
+          example: '2025-12-31T23:59:59Z'
         features:
           type: array
           items:
             type: string
           description: List of features enabled by the license.
           example:
-            - "clustering"
-            - "processing_engine"
-            - "advanced_auth"
+            - clustering
+            - processing_engine
+            - advanced_auth
         status:
           type: string
           enum:
-            - "active"
-            - "expired"
-            - "invalid"
+            - active
+            - expired
+            - invalid
           description: The current status of the license.
-          example: "active"
+          example: active
       description: Response schema for license information.
   responses:
     Unauthorized:
@@ -2524,7 +2626,7 @@ components:
       schema:
         type: string
         format: uuid
-      example: "01234567-89ab-cdef-0123-456789abcdef"
+      example: 01234567-89ab-cdef-0123-456789abcdef
   securitySchemes:
     BasicAuthentication:
       type: http

--- a/api-docs/openapi/plugins/decorators/operations/remove-internal-operations.cjs
+++ b/api-docs/openapi/plugins/decorators/operations/remove-internal-operations.cjs
@@ -1,0 +1,19 @@
+module.exports = RemoveInternalOperations;
+
+/** @type {import('@redocly/openapi-cli').OasDecorator} */
+function RemoveInternalOperations() {
+  return {
+    Operation: {
+      leave(operation, ctx) {
+        // Redocly's Redoc natively respects x-internal: true
+        // Operations with x-internal: true remain in the bundled spec
+        // but are hidden from the generated documentation
+        // This decorator preserves the x-internal marker without modification
+        if (operation['x-internal'] === true) {
+          // Keep the operation in the spec with x-internal flag
+          // No deletion - Redoc will hide it automatically
+        }
+      }
+    }
+  }
+}

--- a/api-docs/openapi/plugins/docs-plugin.cjs
+++ b/api-docs/openapi/plugins/docs-plugin.cjs
@@ -2,6 +2,7 @@ const {info, servers, tagGroups} = require('./docs-content.cjs');
 const ReportTags = require('./rules/report-tags.cjs');
 const ValidateServersUrl = require('./rules/validate-servers-url.cjs');
 const RemovePrivatePaths = require('./decorators/paths/remove-private-paths.cjs');
+const RemoveInternalOperations = require('./decorators/operations/remove-internal-operations.cjs');
 const ReplaceShortcodes = require('./decorators/replace-shortcodes.cjs');
 const SetInfo = require('./decorators/set-info.cjs');
 const DeleteServers = require('./decorators/servers/delete-servers.cjs');
@@ -26,6 +27,7 @@ const decorators = {
     'set-servers': () => SetServers(servers()),
     'delete-servers': DeleteServers,
     'remove-private-paths': RemovePrivatePaths,
+    'remove-internal-operations': RemoveInternalOperations,
     'strip-version-prefix': StripVersionPrefix,
     'strip-trailing-slash': StripTrailingSlash,
     'set-info': () => SetInfo(info()),
@@ -46,6 +48,7 @@ module.exports = {
         'docs/set-servers': 'error',
         'docs/delete-servers': 'error',
       	'docs/remove-private-paths': 'error',
+      	'docs/remove-internal-operations': 'error',
       	'docs/strip-version-prefix': 'error',
         'docs/strip-trailing-slash': 'error',
       	'docs/set-info': 'error',

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "docs:create": "node scripts/docs-create.js",
     "docs:edit": "node scripts/docs-edit.js",
     "docs:add-placeholders": "node scripts/add-placeholders.js",
+    "build:api-docs": "cd api-docs && sh generate-api-docs.sh",
     "build:pytest:image": "docker build -t influxdata/docs-pytest:latest -f Dockerfile.pytest .",
     "build:agent:instructions": "node ./helper-scripts/build-agent-instructions.js",
     "build:ts": "tsc --project tsconfig.json --outDir dist",


### PR DESCRIPTION
- Add DELETE /api/v3/configure/database/retention_period
- Add DELETE /api/v3/configure/token
- Add POST /api/v3/configure/token/named_admin
- Add PUT /api/v3/plugins/files (requires admin token)
- Add PUT /api/v3/plugins/directory (requires admin token)

Apply to both influxdb3/core/v3 and influxdb3/enterprise/v3 specs.

chore(api): Add RemoveInternalOperations decorator to document Redocly's built-in behavior, hiding endpoints that have `x-internal: true`

chore(api): Add yarn build:api-docs

This command:
1. Changes to the api-docs directory
2. Executes the generate-api-docs.sh script to generate API documentation HTML from the OpenAPI specs

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
