### PR TITLE
fix(ci): add --public-dir argument to build-llm-markdown.js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: yarn hugo --environment production --logLevel info --gc --destination workspace/public
       - run:
           name: Generate LLM-friendly Markdown
-          command: yarn build:md
+          command: yarn build:md --public-dir workspace/public
       - persist_to_workspace:
           root: workspace
           paths:


### PR DESCRIPTION
CircleCI builds Hugo to workspace/public, but the markdown generator was hardcoded to look in public/. Added --public-dir argument:

- Default: public (for local dev and staging)
- CI: --public-dir workspace/public

Staging deployment (deploy-staging.sh) uses default public/ and continues to work unchanged.

