### PR TITLE
feat(telegraf): add related links to plugin directory pages

### DIFF
--- a/content/telegraf/v1/configure_plugins/aggregator_processor/_index.md
+++ b/content/telegraf/v1/configure_plugins/aggregator_processor/_index.md
@@ -7,6 +7,9 @@ menu:
      name: Aggregator and processor plugins
      weight: 50
      parent: Configure plugins
+related:
+  - /telegraf/v1/aggregator-plugins/
+  - /telegraf/v1/processor-plugins/
 ---
 
 

--- a/content/telegraf/v1/configure_plugins/input_plugins/_index.md
+++ b/content/telegraf/v1/configure_plugins/input_plugins/_index.md
@@ -8,6 +8,8 @@ menu:
      name: Input plugins
      weight: 10
      parent: Configure plugins
+related:
+  - /telegraf/v1/input-plugins/
 ---
 
 Telegraf input plugins are used with the InfluxData time series platform to collect metrics from the system, services, or third-party APIs. All metrics are gathered from the inputs you enable and configure in the [Telegraf configuration file](/telegraf/v1/configuration/).

--- a/content/telegraf/v1/configure_plugins/output_plugins/_index.md
+++ b/content/telegraf/v1/configure_plugins/output_plugins/_index.md
@@ -1,13 +1,15 @@
 ---
 title: Write data with output plugins
 description: |
-  Output plugins define where Telegraf will deliver the collected metrics. 
+  Output plugins define where Telegraf will deliver the collected metrics.
 menu:
   telegraf_v1:
 
      name: Output plugins
      weight: 20
      parent: Configure plugins
+related:
+  - /telegraf/v1/output-plugins/
 ---
 Output plugins define where Telegraf will deliver the collected metrics. Send metrics to InfluxDB or to a variety of other datastores, services, and message queues, including Graphite, OpenTSDB, Datadog, Librato, Kafka, MQTT, and NSQ.
 


### PR DESCRIPTION
## Summary
- Add `related` frontmatter links from configure_plugins pages to dedicated plugin directory pages
- Enables direct navigation from configuration guides to plugin reference documentation

Closes #6415

## Test plan
- [ ] Verify Hugo builds successfully
- [ ] Check related links render at bottom of each page:
  - `/telegraf/v1/configure_plugins/input_plugins/`
  - `/telegraf/v1/configure_plugins/output_plugins/`
  - `/telegraf/v1/configure_plugins/aggregator_processor/`