### PR TITLE
chore: remove extra code block syntax from influxctl release notes

### DIFF
--- a/content/shared/influxctl/release-notes.md
+++ b/content/shared/influxctl/release-notes.md
@@ -49,7 +49,6 @@ $ ./influxctl query --perf-debug --format json --token REDACTED --database testd
   "queue_duration_secs": 0
 }
 ```
-```
 
 ### Dependency updates
 


### PR DESCRIPTION
Closes #

This removes some extra code block syntax from the influxctl release notes to resolve rendering issues.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
