### PR TITLE
fix(influxdb3): add retention_period to CreateDatabaseRequest

### DIFF
--- a/api-docs/influxdb3/core/v3/ref.yml
+++ b/api-docs/influxdb3/core/v3/ref.yml
@@ -2115,6 +2115,12 @@ components:
       properties:
         db:
           type: string
+        retention_period:
+          type: string
+          description: |
+            The retention period for the database. Specifies how long data should be retained.
+            Use duration format (for example, "1d", "1h", "30m", "7d").
+          example: 7d
       required:
         - db
     CreateTableRequest:


### PR DESCRIPTION
## Summary

Add the undocumented `retention_period` parameter to the database creation API for InfluxDB 3 Core.

- Adds `retention_period` field to `CreateDatabaseRequest` schema
- Specifies duration format (e.g., "1d", "1h", "30m", "7d")

## Test plan

- [x] Verify API spec renders correctly in Redoc
- [x] Verify parameter appears in generated API docs

closes #6610