### PR TITLE
hotfix: Revert latest_cli version from 2.8.0 to 2.7.5

### DIFF
--- a/data/products.yml
+++ b/data/products.yml
@@ -182,7 +182,7 @@ influxdb:
     v2: 2.8.0
     v1: 1.12.2
   latest_cli:
-    v2: 2.8.0
+    v2: 2.7.5
   detector_config:
     query_languages:
       InfluxQL:


### PR DESCRIPTION
Fix broken download links. Revert mistakenly updated CLI version.

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
