### PR TITLE
hotfix(influxdb3): fix duplicate menu entry for Enterprise security page

### DIFF
--- a/content/influxdb3/enterprise/admin/security.md
+++ b/content/influxdb3/enterprise/admin/security.md
@@ -5,7 +5,7 @@ description: >
   Tune {{% product-name %}} security for local requirements.
 weight: 205
 menu:
-  influxdb3_core:
+  influxdb3_enterprise:
     parent: Administer InfluxDB
     name: Security
 related:


### PR DESCRIPTION
## Summary

- Fix duplicate menu entry warning by changing menu key from `influxdb3_core` to `influxdb3_enterprise` in Enterprise security.md

## Test plan

- [x] Hugo build completes without "duplicate menu entry" warning