### PR TITLE
fix(layouts): use File.Dir for baseURL-independent product detection

### DIFF
--- a/layouts/partials/product-info.html
+++ b/layouts/partials/product-info.html
@@ -1,0 +1,74 @@
+{{- /*
+  Returns a dict with product path information extracted from the page.
+
+  Uses .File.Dir when available (baseURL-independent) with fallback to .RelPermalink.
+  This ensures product detection works correctly regardless of baseURL configuration,
+  including PR preview deployments at subdirectory paths.
+
+  Usage:
+    {{ $productInfo := partial "product-info.html" . }}
+    {{ $productInfo.product }}      - e.g., "influxdb3", "influxdb", "flux"
+    {{ $productInfo.version }}      - e.g., "core", "enterprise", "v2", "cloud"
+    {{ $productInfo.isOSS }}        - true if version matches ^v[0-9] (OSS versioned product)
+    {{ $productInfo.productKey }}   - normalized key for product aliases
+    {{ $productInfo.productRef }}   - key for .Site.Data.products lookup
+    {{ $productInfo.productData }}  - product data from .Site.Data.products (may be nil)
+*/ -}}
+
+{{- /* Extract path from .File.Dir or fall back to .RelPermalink */ -}}
+{{- $path := "" -}}
+{{- if .File -}}
+  {{- /* .File.Dir returns the directory path relative to content/, e.g., "influxdb3/core/get-started/" */ -}}
+  {{- $path := .File.Dir -}}
+  {{- $.Scratch.Set "productPath" $path -}}
+{{- else -}}
+  {{- /* Fallback: strip site base path from RelPermalink */ -}}
+  {{- $.Scratch.Set "productPath" .RelPermalink -}}
+{{- end -}}
+{{- $path = $.Scratch.Get "productPath" -}}
+
+{{- /* Parse path segments - handles both File.Dir (no leading slash) and RelPermalink (leading slash) */ -}}
+{{- $pathSegments := findRE "[^/]+" $path -}}
+{{- $product := index $pathSegments 0 | default "" -}}
+{{- $version := index $pathSegments 1 | default "" -}}
+
+{{- /* Determine if this is an OSS version (matches v1, v2, etc.) */ -}}
+{{- $isOSS := ne (len (findRE `^v[0-9]` $version)) 0 -}}
+
+{{- /* Calculate product key - use "oss" for versioned products, otherwise use the version */ -}}
+{{- $productKey := cond $isOSS "oss" $version -}}
+
+{{- /* Product aliases map version/product keys to .Site.Data.products keys */ -}}
+{{- $productAliases := dict
+    "oss" "influxdb"
+    "cloud" "influxdb_cloud"
+    "cloud-tsm" "influxdb_cloud"
+    "core" "influxdb3_core"
+    "enterprise" "influxdb3_enterprise"
+    "cloud-serverless" "influxdb3_cloud_serverless"
+    "serverless" "influxdb3_cloud_serverless"
+    "cloud-dedicated" "influxdb3_cloud_dedicated"
+    "dedicated" "influxdb3_cloud_dedicated"
+    "clustered" "influxdb3_clustered"
+    "explorer" "influxdb3_explorer"
+-}}
+
+{{- /* Look up the product reference */ -}}
+{{- $productRef := index $productAliases $productKey -}}
+
+{{- /* Get product data (may be nil if productRef is not found) */ -}}
+{{- $productData := dict -}}
+{{- if $productRef -}}
+  {{- $productData = index .Site.Data.products $productRef | default dict -}}
+{{- end -}}
+
+{{- /* Return the product info dict */ -}}
+{{- return dict
+    "product" $product
+    "version" $version
+    "isOSS" $isOSS
+    "productKey" $productKey
+    "productRef" $productRef
+    "productData" $productData
+    "pathSegments" $pathSegments
+-}}

--- a/layouts/shortcodes/api-endpoint.html
+++ b/layouts/shortcodes/api-endpoint.html
@@ -1,13 +1,17 @@
-{{- $productPathData := findRE "[^/]+.*?" .Page.RelPermalink -}}
-{{- $currentVersion := index $productPathData 1 -}}
+{{- /* Get product info using baseURL-independent path detection */ -}}
+{{- $productInfo := partial "product-info.html" .Page -}}
 {{- $endpoint := .Get "endpoint" -}}
-{{- $isOSS := ne (len (findRE `^v[0-9]` $currentVersion)) 0 -}}
-{{- $parsedProductKey := cond $isOSS "oss" $currentVersion -}}
-{{- $productKey := .Get "influxdb_host" | default $parsedProductKey -}}
-{{- $productAliases := dict "oss" "influxdb" "cloud" "influxdb_cloud" "cloud-tsm" "influxdb_cloud" "core" "influxdb3_core" "enterprise" "influxdb3_enterprise" "cloud-serverless" "influxdb3_cloud_serverless" "serverless" "influxdb3_cloud_serverless" "cloud-dedicated" "influxdb3_cloud_dedicated" "dedicated" "influxdb3_cloud_dedicated" "clustered" "influxdb3_clustered" -}}
-{{- $productRef := index $productAliases $productKey -}}
-{{- $productData := index .Site.Data.products $productRef -}}
-{{- $placeholderHost := $productData.placeholder_host }}
+{{- /* Allow influxdb_host parameter to override auto-detected product */ -}}
+{{- $overrideKey := .Get "influxdb_host" -}}
+{{- $productData := $productInfo.productData -}}
+{{- if $overrideKey -}}
+  {{- $productAliases := dict "oss" "influxdb" "cloud" "influxdb_cloud" "cloud-tsm" "influxdb_cloud" "core" "influxdb3_core" "enterprise" "influxdb3_enterprise" "cloud-serverless" "influxdb3_cloud_serverless" "serverless" "influxdb3_cloud_serverless" "cloud-dedicated" "influxdb3_cloud_dedicated" "dedicated" "influxdb3_cloud_dedicated" "clustered" "influxdb3_clustered" -}}
+  {{- $overrideRef := index $productAliases $overrideKey -}}
+  {{- if $overrideRef -}}
+    {{- $productData = index .Site.Data.products $overrideRef | default dict -}}
+  {{- end -}}
+{{- end -}}
+{{- $placeholderHost := $productData.placeholder_host | default "localhost:8086" }}
 {{- $method := .Get "method" | upper -}}
 {{- $methodStyle := .Get "method" | lower -}}
 {{- $apiRef := .Get "api-ref" | default "" -}}

--- a/layouts/shortcodes/children.html
+++ b/layouts/shortcodes/children.html
@@ -42,14 +42,9 @@
 				{{ end }}
 			{{ end }}
 			{{ if .Params.list_code_example }}
-				{{- $productPathData := findRE "[^/]+.*?" .Page.RelPermalink -}}
-				{{- $currentVersion := index $productPathData 1 -}}
-				{{- $isOSS := ne (len (findRE `^v[0-9]` $currentVersion)) 0 -}}
-				{{- $productKey := cond $isOSS "oss" $currentVersion -}}
-				{{- $productAliases := dict "oss" "influxdb" "core" "influxdb3_core" "enterprise" "influxdb3_enterprise" "cloud" "influxdb_cloud" "cloud-tsm" "influxdb_cloud" "cloud-serverless" "influxdb3_cloud_serverless" "serverless" "influxdb3_cloud_serverless" "cloud-dedicated" "influxdb3_cloud_dedicated" "dedicated" "influxdb3_cloud_dedicated" "clustered" "influxdb3_clustered" -}}
-				{{- $productRef := index $productAliases $productKey -}}
-				{{- $productData := index .Site.Data.products $productRef -}}
-				{{- $placeholderHost := $productData.placeholder_host }}
+				{{- /* Get product info using baseURL-independent path detection */ -}}
+				{{- $productInfo := partial "product-info.html" $.Page -}}
+				{{- $placeholderHost := $productInfo.productData.placeholder_host | default "localhost:8086" }}
 				{{ .Params.list_code_example | replaceRE `\{\{[<\%] influxdb/host [>%]\}\}` $placeholderHost | .RenderString }}
 			{{ end }}
 

--- a/layouts/shortcodes/influxdb/host.html
+++ b/layouts/shortcodes/influxdb/host.html
@@ -1,9 +1,13 @@
-{{- $productPathData := findRE "[^/]+.*?" .Page.RelPermalink -}}
-{{- $currentVersion := index $productPathData 1 -}}
-{{- $isOSS := ne (len (findRE `^v[0-9]` $currentVersion)) 0 -}}
-{{- $parsedProductKey := cond $isOSS "oss" $currentVersion -}}
-{{- $productKey := .Get 0 | default $parsedProductKey -}}
-{{- $productAliases := dict "oss" "influxdb" "cloud" "influxdb_cloud" "cloud-tsm" "influxdb_cloud" "core" "influxdb3_core" "enterprise" "influxdb3_enterprise" "cloud-serverless" "influxdb3_cloud_serverless" "serverless" "influxdb3_cloud_serverless" "cloud-dedicated" "influxdb3_cloud_dedicated" "dedicated" "influxdb3_cloud_dedicated" "clustered" "influxdb3_clustered" -}}
-{{- $productRef := index $productAliases $productKey -}}
-{{- $productData := index .Site.Data.products $productRef -}}
-{{ $productData.placeholder_host }}
+{{- /* Get product info using baseURL-independent path detection */ -}}
+{{- $productInfo := partial "product-info.html" .Page -}}
+{{- /* Allow positional parameter to override auto-detected product */ -}}
+{{- $overrideKey := .Get 0 -}}
+{{- $productData := $productInfo.productData -}}
+{{- if $overrideKey -}}
+  {{- $productAliases := dict "oss" "influxdb" "cloud" "influxdb_cloud" "cloud-tsm" "influxdb_cloud" "core" "influxdb3_core" "enterprise" "influxdb3_enterprise" "cloud-serverless" "influxdb3_cloud_serverless" "serverless" "influxdb3_cloud_serverless" "cloud-dedicated" "influxdb3_cloud_dedicated" "dedicated" "influxdb3_cloud_dedicated" "clustered" "influxdb3_clustered" -}}
+  {{- $overrideRef := index $productAliases $overrideKey -}}
+  {{- if $overrideRef -}}
+    {{- $productData = index .Site.Data.products $overrideRef | default dict -}}
+  {{- end -}}
+{{- end -}}
+{{ $productData.placeholder_host | default "localhost:8086" }}


### PR DESCRIPTION
## Summary

Architectural fix for product detection in shortcodes - uses `.File.Dir` instead of `.RelPermalink` to make product detection independent of baseURL configuration.

## Problem

Shortcodes parse `.RelPermalink` to determine product context, but when `baseURL` includes a path (e.g., for PR previews at `/docs-v2/pr-preview/pr-XXXX/`), the path segments shift and product detection fails.

## Solution

Creates a centralized `product-info.html` partial that extracts product/version from `.File.Dir` (the content file's directory path), which is unaffected by baseURL configuration.

## Changes

- **`layouts/partials/product-info.html`** - New partial for baseURL-independent product detection
- **`layouts/shortcodes/api-endpoint.html`** - Uses new partial
- **`layouts/shortcodes/influxdb/host.html`** - Uses new partial
- **`layouts/shortcodes/children.html`** - Uses new partial

## Benefits

- Works regardless of baseURL configuration
- Centralized logic (DRY)
- Could be extended to fix ~20+ other templates using the same vulnerable pattern

## Test plan

- [ ] Full site build passes
- [ ] PR preview builds work
- [ ] Product detection works correctly across all products
- [ ] Review impact on other templates that use `.RelPermalink` for product detection

---

**Note**: This is the broader architectural fix for later testing. A localized workaround for PR previews is in the `ci-pr-preview` branch.