### PR TITLE
docs(influxdb3): publish parameterized queries and add HTTP API examples

### DIFF
--- a/content/influxdb3/cloud-dedicated/query-data/sql/parameterized-queries.md
+++ b/content/influxdb3/cloud-dedicated/query-data/sql/parameterized-queries.md
@@ -10,27 +10,11 @@ menu:
     identifier: parameterized-queries-sql
 influxdb3/cloud-dedicated/tags: [query, security, sql]
 list_code_example: |
-  ##### Using Go and the influxdb3-go client
-
-  ```go
-  // Use the $parameter syntax to reference parameters in a query.
-  // The following SQL query contains $room and $min_temp placeholders.
-  query := `
-    SELECT * FROM home
-    WHERE time >= $min_time
-      AND temp >= $min_temp
-      AND room = $room`
-
-  // Assign parameter names to input values.
-  parameters := influxdb3.QueryParameters{
-          "room": "Kitchen",
-          "min_temp": 20.0,
-          "min_time": "2024-03-18 00:00:00.00",
-
-    }
-
-  // Call the client's function to query InfluxDB with parameters.
-  iterator, err := client.QueryWithParameters(context.Background(), query, parameters)
+  ```sql
+  SELECT * FROM home
+  WHERE time >= $min_time
+    AND temp >= $min_temp
+    AND room = $room
   ```
 ---
 

--- a/content/influxdb3/cloud-serverless/query-data/sql/parameterized-queries.md
+++ b/content/influxdb3/cloud-serverless/query-data/sql/parameterized-queries.md
@@ -10,27 +10,11 @@ menu:
     identifier: parameterized-queries-sql
 influxdb3/cloud-serverless/tags: [query, security, sql]
 list_code_example: |
-  ##### Using Go and the influxdb3-go client
-
-  ```go
-  // Use the $parameter syntax to reference parameters in a query.
-  // The following SQL query contains $room and $min_temp placeholders.
-  query := `
-    SELECT * FROM home
-    WHERE time >= $min_time
-      AND temp >= $min_temp
-      AND room = $room`
-
-  // Assign parameter names to input values.
-  parameters := influxdb3.QueryParameters{
-          "room": "Kitchen",
-          "min_temp": 20.0,
-          "min_time": "2024-03-18 00:00:00.00",
-
-    }
-
-  // Call the client's function to query InfluxDB with parameters.
-  iterator, err := client.QueryWithParameters(context.Background(), query, parameters)
+  ```sql
+  SELECT * FROM home
+  WHERE time >= $min_time
+    AND temp >= $min_temp
+    AND room = $room
   ```
 ---
 

--- a/content/influxdb3/clustered/query-data/sql/parameterized-queries.md
+++ b/content/influxdb3/clustered/query-data/sql/parameterized-queries.md
@@ -10,27 +10,11 @@ menu:
     identifier: parameterized-queries-sql
 influxdb3/clustered/tags: [query, security, sql]
 list_code_example: |
-  ##### Using Go and the influxdb3-go client
-
-  ```go
-  // Use the $parameter syntax to reference parameters in a query.
-  // The following SQL query contains $room and $min_temp placeholders.
-  query := `
-    SELECT * FROM home
-    WHERE time >= $min_time
-      AND temp >= $min_temp
-      AND room = $room`
-
-  // Assign parameter names to input values.
-  parameters := influxdb3.QueryParameters{
-          "room": "Kitchen",
-          "min_temp": 20.0,
-          "min_time": "2024-03-18 00:00:00.00",
-
-    }
-
-  // Call the client's function to query InfluxDB with parameters.
-  iterator, err := client.QueryWithParameters(context.Background(), query, parameters)
+  ```sql
+  SELECT * FROM home
+  WHERE time >= $min_time
+    AND temp >= $min_temp
+    AND room = $room
   ```
 ---
 

--- a/content/influxdb3/core/query-data/influxql/parameterized-queries.md
+++ b/content/influxdb3/core/query-data/influxql/parameterized-queries.md
@@ -10,36 +10,15 @@ menu:
     identifier: parameterized-queries-influxql
 influxdb3/core/tags: [query, security, influxql]
 list_code_example: |
-  ##### Using Go and the influxdb3-go client
-
-  ```go
-  // Use the $parameter syntax to reference parameters in a query.
-  // The following InfluxQL query contains $room and $min_time parameters.
-  query := `
-      SELECT * FROM home
-      WHERE time >= $min_time
-        AND temp >= $min_temp
-        AND room = $room`
-
-  // Assign parameter names to input values.
-  parameters := influxdb3.QueryParameters{
-          "room": "Kitchen",
-          "min_temp": 20.0,
-          "min_time": "2024-03-18 00:00:00.00",
-  }
-
-  // Call the client's function to query InfluxDB with parameters and the
-  // the InfluxQL QueryType.
-  iterator, err := client.QueryWithParameters(context.Background(),
-    query,
-    parameters,
-    influxdb3.WithQueryType(influxdb3.InfluxQL))
+  ```sql
+  SELECT * FROM home
+  WHERE time >= $min_time
+    AND temp >= $min_temp
+    AND room = $room
   ```
-# Leaving in draft until tested
-draft: true
 source: /shared/influxdb3-query-guides/influxql/parameterized-queries.md
 ---
 
 <!--
-The content for this page is at content/shared/influxdb3-query-guides/influxql/parameterized-queries.md
+//SOURCE content/shared/influxdb3-query-guides/influxql/parameterized-queries.md
 -->

--- a/content/influxdb3/core/query-data/sql/parameterized-queries.md
+++ b/content/influxdb3/core/query-data/sql/parameterized-queries.md
@@ -10,32 +10,15 @@ menu:
     identifier: parameterized-queries-sql
 influxdb3/core/tags: [query, security, sql]
 list_code_example: |
-  ##### Using Go and the influxdb3-go client
-
-  ```go
-  // Use the $parameter syntax to reference parameters in a query.
-  // The following SQL query contains $room and $min_temp placeholders.
-  query := `
-    SELECT * FROM home
-    WHERE time >= $min_time
-      AND temp >= $min_temp
-      AND room = $room`
-
-  // Assign parameter names to input values.
-  parameters := influxdb3.QueryParameters{
-          "room": "Kitchen",
-          "min_temp": 20.0,
-          "min_time": "2024-03-18 00:00:00.00",
-
-    }
-
-  // Call the client's function to query InfluxDB with parameters.
-  iterator, err := client.QueryWithParameters(context.Background(), query, parameters)
+  ```sql
+  SELECT * FROM home
+  WHERE time >= $min_time
+    AND temp >= $min_temp
+    AND room = $room
   ```
 source: /shared/influxdb3-query-guides/sql/parameterized-queries.md
 ---
 
 <!--
-The content for this page is at
 //SOURCE content/shared/influxdb3-query-guides/sql/parameterized-queries.md
 -->

--- a/content/influxdb3/enterprise/query-data/influxql/parameterized-queries.md
+++ b/content/influxdb3/enterprise/query-data/influxql/parameterized-queries.md
@@ -10,36 +10,15 @@ menu:
     identifier: parameterized-queries-influxql
 influxdb3/enterprise/tags: [query, security, influxql]
 list_code_example: |
-  ##### Using Go and the influxdb3-go client
-
-  ```go
-  // Use the $parameter syntax to reference parameters in a query.
-  // The following InfluxQL query contains $room and $min_time parameters.
-  query := `
-      SELECT * FROM home
-      WHERE time >= $min_time
-        AND temp >= $min_temp
-        AND room = $room`
-
-  // Assign parameter names to input values.
-  parameters := influxdb3.QueryParameters{
-          "room": "Kitchen",
-          "min_temp": 20.0,
-          "min_time": "2024-03-18 00:00:00.00",
-  }
-
-  // Call the client's function to query InfluxDB with parameters and the
-  // the InfluxQL QueryType.
-  iterator, err := client.QueryWithParameters(context.Background(),
-    query,
-    parameters,
-    influxdb3.WithQueryType(influxdb3.InfluxQL))
+  ```sql
+  SELECT * FROM home
+  WHERE time >= $min_time
+    AND temp >= $min_temp
+    AND room = $room
   ```
-# Leaving in draft until tested
-draft: true
 source: /shared/influxdb3-query-guides/influxql/parameterized-queries.md
 ---
 
 <!--
-The content for this page is at content/shared/influxdb3-query-guides/influxql/parameterized-queries.md
+//SOURCE content/shared/influxdb3-query-guides/influxql/parameterized-queries.md
 -->

--- a/content/influxdb3/enterprise/query-data/sql/parameterized-queries.md
+++ b/content/influxdb3/enterprise/query-data/sql/parameterized-queries.md
@@ -10,32 +10,15 @@ menu:
     identifier: parameterized-queries-sql
 influxdb3/enterprise/tags: [query, security, sql]
 list_code_example: |
-  ##### Using Go and the influxdb3-go client
-
-  ```go
-  // Use the $parameter syntax to reference parameters in a query.
-  // The following SQL query contains $room and $min_temp placeholders.
-  query := `
-    SELECT * FROM home
-    WHERE time >= $min_time
-      AND temp >= $min_temp
-      AND room = $room`
-
-  // Assign parameter names to input values.
-  parameters := influxdb3.QueryParameters{
-          "room": "Kitchen",
-          "min_temp": 20.0,
-          "min_time": "2024-03-18 00:00:00.00",
-
-    }
-
-  // Call the client's function to query InfluxDB with parameters.
-  iterator, err := client.QueryWithParameters(context.Background(), query, parameters)
+  ```sql
+  SELECT * FROM home
+  WHERE time >= $min_time
+    AND temp >= $min_temp
+    AND room = $room
   ```
 source: /shared/influxdb3-query-guides/sql/parameterized-queries.md
 ---
 
 <!--
-The content for this page is at
 //SOURCE content/shared/influxdb3-query-guides/sql/parameterized-queries.md
 -->

--- a/content/shared/influxdb3-query-guides/influxql/parameterized-queries.md
+++ b/content/shared/influxdb3-query-guides/influxql/parameterized-queries.md
@@ -22,6 +22,9 @@ In InfluxDB 3, a parameterized query is an InfluxQL or SQL query that contains o
   - [Not compatible with parameters](#not-compatible-with-parameters)
 - [Parameterize an SQL query](#parameterize-an-sql-query)
 - [Execute parameterized InfluxQL queries](#execute-parameterized-influxql-queries)
+{{% show-in "core,enterprise" %}}
+  - [Use the HTTP API](#use-the-http-api)
+{{% /show-in %}}
   - [Use InfluxDB Flight RPC clients](#use-influxdb-flight-rpc-clients)
 - [Client support for parameterized queries](#client-support-for-parameterized-queries)
 - [Not supported](#not-supported)
@@ -182,11 +185,64 @@ AND room = 'Kitchen'
 
 > [!Note]
 > #### Sample data
-> 
+>
 > The following examples use the {{< influxdb3/home-sample-link >}}.
 > To run the example queries and return results,
 > [write the sample data](/influxdb3/version/reference/sample-data/#write-the-home-sensor-data-to-influxdb)
 > to your {{% product-name %}} database before running the example queries.
+
+{{% show-in "core,enterprise" %}}
+
+### Use the HTTP API
+
+{{% product-name %}} provides the `/api/v3/query_influxql` HTTP API endpoint for executing InfluxQL queries with parameters.
+
+{{% api-endpoint method="POST" endpoint="/api/v3/query_influxql" api-ref="/influxdb3/version/api/v3/#operation/PostExecuteQueryInfluxQL" %}}
+
+Send a JSON object that contains `db` (database), `q` (query), and `params` (parameter name-value pairs) properties in the request body.
+
+The following example sends a parameterized InfluxQL query to the `/api/v3/query_influxql` endpoint:
+
+{{% influxdb/custom-timestamps %}}
+
+```bash {placeholders="DATABASE_NAME|AUTH_TOKEN"}
+curl "http://localhost:8181/api/v3/query_influxql" \
+  --header "Authorization: Bearer AUTH_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "db": "DATABASE_NAME",
+    "q": "SELECT * FROM home WHERE time >= $min_time AND temp >= $min_temp AND room = $room",
+    "params": {
+      "min_time": "2022-01-01T08:00:00Z",
+      "min_temp": 22.0,
+      "room": "Kitchen"
+    }
+  }'
+```
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}: the name of the database to query
+- {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}}: your {{% token-link "database" %}}{{% show-in "enterprise" %}} with permission to query the specified database{{% /show-in %}}
+
+{{% /influxdb/custom-timestamps %}}
+
+The response body contains query results in JSON format:
+
+{{% influxdb/custom-timestamps %}}
+
+```json
+[
+  {"iox::measurement":"home","time":"2022-01-01T09:00:00","co":0,"hum":36.2,"room":"Kitchen","temp":23.0},
+  {"iox::measurement":"home","time":"2022-01-01T10:00:00","co":0,"hum":36.1,"room":"Kitchen","temp":22.7},
+  {"iox::measurement":"home","time":"2022-01-01T11:00:00","co":0,"hum":36.0,"room":"Kitchen","temp":22.4},
+  {"iox::measurement":"home","time":"2022-01-01T12:00:00","co":0,"hum":36.0,"room":"Kitchen","temp":22.5}
+]
+```
+
+{{% /influxdb/custom-timestamps %}}
+
+{{% /show-in %}}
 
 ### Use InfluxDB Flight RPC clients
 

--- a/content/shared/influxdb3-query-guides/sql/parameterized-queries.md
+++ b/content/shared/influxdb3-query-guides/sql/parameterized-queries.md
@@ -22,6 +22,9 @@ In InfluxDB 3, a parameterized query is an InfluxQL or SQL query that contains o
   - [Not compatible with parameters](#not-compatible-with-parameters)
 - [Parameterize an SQL query](#parameterize-an-sql-query)
 - [Execute parameterized SQL queries](#execute-parameterized-sql-queries)
+{{% show-in "core,enterprise" %}}
+  - [Use the HTTP API](#use-the-http-api)
+{{% /show-in %}}
   - [Use InfluxDB Flight RPC clients](#use-influxdb-flight-rpc-clients)
 - [Client support for parameterized queries](#client-support-for-parameterized-queries)
 - [Not supported](#not-supported)
@@ -182,11 +185,64 @@ AND room = 'Kitchen'
 
 > [!Note]
 > #### Sample data
-> 
+>
 > The following examples use the {{< influxdb3/home-sample-link >}}.
 > To run the example queries and return results,
 > [write the sample data](/influxdb3/version/reference/sample-data/#write-the-home-sensor-data-to-influxdb)
 > to your {{% product-name %}} database before running the example queries.
+
+{{% show-in "core,enterprise" %}}
+
+### Use the HTTP API
+
+{{% product-name %}} provides the `/api/v3/query_sql` HTTP API endpoint for executing SQL queries with parameters.
+
+{{% api-endpoint method="POST" endpoint="/api/v3/query_sql" api-ref="/influxdb3/version/api/v3/#operation/PostExecuteQuerySQL" %}}
+
+Send a JSON object that contains `db` (database), `q` (query), and `params` (parameter name-value pairs) properties in the request body.
+
+The following example sends a parameterized SQL query to the `/api/v3/query_sql` endpoint:
+
+{{% influxdb/custom-timestamps %}}
+
+```bash {placeholders="DATABASE_NAME|AUTH_TOKEN"}
+curl "http://localhost:8181/api/v3/query_sql" \
+  --header "Authorization: Bearer AUTH_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "db": "DATABASE_NAME",
+    "q": "SELECT * FROM home WHERE time >= $min_time AND temp >= $min_temp AND room = $room",
+    "params": {
+      "min_time": "2022-01-01T08:00:00Z",
+      "min_temp": 22.0,
+      "room": "Kitchen"
+    }
+  }'
+```
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}: the name of the database to query
+- {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}}: your {{% token-link "database" %}}{{% show-in "enterprise" %}} with permission to query the specified database{{% /show-in %}}
+
+{{% /influxdb/custom-timestamps %}}
+
+The response body contains query results in JSON format:
+
+{{% influxdb/custom-timestamps %}}
+
+```json
+[
+  {"co":0,"hum":36.2,"room":"Kitchen","temp":23.0,"time":"2022-01-01T09:00:00"},
+  {"co":0,"hum":36.1,"room":"Kitchen","temp":22.7,"time":"2022-01-01T10:00:00"},
+  {"co":0,"hum":36.0,"room":"Kitchen","temp":22.4,"time":"2022-01-01T11:00:00"},
+  {"co":0,"hum":36.0,"room":"Kitchen","temp":22.5,"time":"2022-01-01T12:00:00"}
+]
+```
+
+{{% /influxdb/custom-timestamps %}}
+
+{{% /show-in %}}
 
 ### Use InfluxDB Flight RPC clients
 

--- a/content/shared/influxql-v3-reference/time-and-timezone.md
+++ b/content/shared/influxql-v3-reference/time-and-timezone.md
@@ -351,4 +351,4 @@ provide an explicit upper bound in the `WHERE` clause.
 ### Cannot use parameters for durations
 
 Currently, InfluxDB doesn't support using parameters for durations in
-[parameterized queries](/influxdb/version/query-data/parameterized-queries/).
+[parameterized queries](/influxdb/version/query-data/influxql/parameterized-queries/).


### PR DESCRIPTION
## Summary

- Remove draft status from InfluxQL parameterized queries pages for Core and Enterprise
- Fix broken link in time-and-timezone.md to point to correct InfluxQL parameterized queries path
- Add v3 HTTP API examples for parameterized queries (Core/Enterprise only) using `/api/v3/query_influxql` and `/api/v3/query_sql` endpoints
- Include proper `code-placeholder-key` definitions and `token-link` shortcodes for placeholder documentation

## Test plan

- [x] Tested parameterized InfluxQL queries on InfluxDB 3 Core v3.8.0
- [x] Verified Hugo builds without errors
- [x] Vale linting passes
- [ ] Review rendered pages in staging

Closes #6672