### PR TITLE
Update from InfluxDB 2.7 to 2.8

### DIFF
--- a/content/influxdb/v2/install/upgrade/v1-to-v2/automatic-upgrade.md
+++ b/content/influxdb/v2/install/upgrade/v1-to-v2/automatic-upgrade.md
@@ -1,11 +1,11 @@
 ---
-title: Automatically upgrade from InfluxDB 1.x to 2.7
-list_title: Automatically upgrade from 1.x to 2.7
+title: Automatically upgrade from InfluxDB 1.x to {{< current-version >}}
+list_title: Automatically upgrade from 1.x to {{< current-version >}}
 description: >
-  Use the `influx upgrade` tool to automatically upgrade from InfluxDB 1.x to InfluxDB 2.7.
+  Use the `influx upgrade` tool to automatically upgrade from InfluxDB 1.x to InfluxDB {{< current-version >}}.
 menu:
   influxdb_v2:
-    parent: InfluxDB 1.x to 2.7
+    parent: InfluxDB 1.x to 2.8
     name: Automatically upgrade
 weight: 10
 aliases:

--- a/content/influxdb/v2/install/upgrade/v1-to-v2/docker.md
+++ b/content/influxdb/v2/install/upgrade/v1-to-v2/docker.md
@@ -1,12 +1,12 @@
 ---
-title: Upgrade from InfluxDB 1.x to 2.7 with Docker
-list_title: Upgrade from 1.x to 2.7 with Docker
+title: Upgrade from InfluxDB 1.x to {{< current-version >}} with Docker
+list_title: Upgrade from 1.x to {{< current-version >}} with Docker
 description: >
   Use the automated upgrade process built into the InfluxDB 2.x Docker image to
   update InfluxDB 1.x Docker deployments to InfluxDB 2.x.
 menu:
   influxdb_v2:
-    parent: InfluxDB 1.x to 2.7
+    parent: InfluxDB 1.x to 2.8
     name: Upgrade with Docker
 weight: 101
 aliases:

--- a/content/influxdb/v2/install/upgrade/v1-to-v2/manual-upgrade.md
+++ b/content/influxdb/v2/install/upgrade/v1-to-v2/manual-upgrade.md
@@ -1,13 +1,13 @@
 ---
-title: Manually upgrade from InfluxDB 1.x to 2.7
-list_title: Manually upgrade from 1.x to 2.7
+title: Manually upgrade from InfluxDB 1.x to {{< current-version >}}
+list_title: Manually upgrade from 1.x to {{< current-version >}}
 description: >
-  To manually upgrade from InfluxDB 1.x to InfluxDB 2.7, migrate data, create
+  To manually upgrade from InfluxDB 1.x to InfluxDB {{< current-version >}}, migrate data, create
   v1-compatible authorizations, and create database and retention policy
   (DBRP) mappings.
 menu:
   influxdb_v2:
-    parent: InfluxDB 1.x to 2.7
+    parent: InfluxDB 1.x to 2.8
     name: Manually upgrade
 weight: 11
 aliases:

--- a/content/influxdb/v2/install/upgrade/v1-to-v2/migrate-cqs.md
+++ b/content/influxdb/v2/install/upgrade/v1-to-v2/migrate-cqs.md
@@ -6,7 +6,7 @@ description: >
   InfluxDB 2.x tasks.
 menu:
   influxdb_v2:
-    parent: InfluxDB 1.x to 2.7
+    parent: InfluxDB 1.x to 2.8
     name: Migrate CQs
 weight: 102
 aliases:
@@ -123,7 +123,7 @@ See [other resources available to help](#other-helpful-resources).
 
 #### INTO clause
 The `INTO` clause defines the measurement to write results to.
-`INTO` also supports fully-qualified measurements that include the database and retention policy.
+`INTO` also supports fully qualified measurements that include the database and retention policy.
 In InfluxDB OSS {{< current-version >}}, database and retention policy combinations are mapped to specific buckets
 (for more information, see [Database and retention policy mapping](/influxdb/v2/reference/api/influxdb-1x/dbrp/)).
 

--- a/content/influxdb/v2/install/upgrade/v2-beta-to-v2.md
+++ b/content/influxdb/v2/install/upgrade/v2-beta-to-v2.md
@@ -1,13 +1,13 @@
 ---
 title: Upgrade from InfluxDB 2.0 beta to InfluxDB 2.0
 description: >
-  To upgrade from InfluxDB 2.0 beta 16 or earlier to InfluxDB 2.x, first
+  To upgrade from InfluxDB 2.0 beta 16 or earlier to {{< current-version >}}, first
   follow these steps to upgrade your InfluxDB beta instance, data, and resources
   to InfluxDB 2.0.
 menu:
   influxdb_v2:
     parent: Upgrade InfluxDB
-    name: InfluxDB 2.0 beta to 2.0
+    name: InfluxDB 2.0 beta to 2.8
 aliases:
   - /influxdb/v2.0/reference/rc0-upgrade-guide/
   - /influxdb/v2.0/reference/rc1-upgrade-guide/

--- a/content/influxdb/v2/install/upgrade/v2-to-v2.md
+++ b/content/influxdb/v2/install/upgrade/v2-to-v2.md
@@ -1,12 +1,12 @@
 ---
-title: Upgrade from InfluxDB 2.x to InfluxDB 2.7
+title: Upgrade from InfluxDB 2.x to {{< current-version >}}
 description: >
-  To upgrade from InfluxDB 2.0 beta 16 or earlier to InfluxDB 2.7 (stable),
+  To upgrade from InfluxDB 2.0 beta 16 or earlier to {{< current-version >}},
   manually upgrade all resources and data to the latest version by completing these steps.
 menu:
   influxdb_v2:
     parent: Upgrade InfluxDB
-    name: InfluxDB 2.x to 2.7
+    name: InfluxDB 2.x to 2.8
 weight: 9
 aliases:
   - /influxdb/v2/upgrade/v2-to-v2/


### PR DESCRIPTION
Replaces 2.7 with `current-version` shortcode where allowed, otherwise replaces 2.7 with 2.8 (in menus).
