### PR TITLE
docs: add CLAUDE.md files for generated content directories

### DIFF
--- a/content/shared/influxdb3-plugins/plugins-library/official/CLAUDE.md
+++ b/content/shared/influxdb3-plugins/plugins-library/official/CLAUDE.md
@@ -1,0 +1,35 @@
+# Generated Content - Do Not Edit Directly
+
+The plugin documentation files in this directory are **generated from source READMEs** in the [influxdata/influxdb3_plugins](https://github.com/influxdata/influxdb3_plugins) repository.
+
+## Workflow
+
+1. **Source of truth**: `influxdb3_plugins/influxdata/<plugin>/README.md`
+2. **Sync script**: `yarn sync-plugins` transforms and ports content to this directory
+3. **Transformations**: The sync applies shortcodes, formatting, and docs-specific sections
+
+## To Make Changes
+
+1. Edit the source README in `influxdb3_plugins/influxdata/<plugin>/README.md`
+2. Run `yarn sync-plugins` from the docs-v2 root to port changes
+3. Commit changes in both repositories
+
+## Documentation
+
+See [helper-scripts/influxdb3-plugins/README.md](/helper-scripts/influxdb3-plugins/README.md) for the complete sync workflow documentation.
+
+## Files in This Directory
+
+| File | Source |
+|------|--------|
+| `basic-transformation.md` | `influxdb3_plugins/influxdata/basic_transformation/README.md` |
+| `downsampler.md` | `influxdb3_plugins/influxdata/downsampler/README.md` |
+| `forecast-error-evaluator.md` | `influxdb3_plugins/influxdata/forecast_error_evaluator/README.md` |
+| `influxdb-to-iceberg.md` | `influxdb3_plugins/influxdata/influxdb_to_iceberg/README.md` |
+| `mad-check.md` | `influxdb3_plugins/influxdata/mad_check/README.md` |
+| `notifier.md` | `influxdb3_plugins/influxdata/notifier/README.md` |
+| `prophet-forecasting.md` | `influxdb3_plugins/influxdata/prophet_forecasting/README.md` |
+| `state-change.md` | `influxdb3_plugins/influxdata/state_change/README.md` |
+| `stateless-adtk-detector.md` | `influxdb3_plugins/influxdata/stateless_adtk_detector/README.md` |
+| `system-metrics.md` | `influxdb3_plugins/influxdata/system_metrics/README.md` |
+| `threshold-deadman-checks.md` | `influxdb3_plugins/influxdata/threshold_deadman_checks/README.md` |

--- a/content/telegraf/CLAUDE.md
+++ b/content/telegraf/CLAUDE.md
@@ -1,0 +1,40 @@
+# Telegraf Plugin Documentation - Edit in Source Repository
+
+The Telegraf plugin documentation in subdirectories (`input-plugins/`, `output-plugins/`, `aggregator-plugins/`, `processor-plugins/`) is **generated from plugin READMEs** in the [influxdata/telegraf](https://github.com/influxdata/telegraf) repository.
+
+## Workflow
+
+1. **Source of truth**: Plugin READMEs in `telegraf/plugins/<type>/<plugin>/README.md`
+2. **Automated sync**: The `telegraf-internal` repository generates documentation PRs from plugin READMEs
+3. **Release process**: Telegraf releases automatically trigger documentation updates
+
+## To Make Changes
+
+1. Edit the source README in the `telegraf` repository: `plugins/<type>/<plugin>/README.md`
+2. Submit a PR to `influxdata/telegraf`
+3. After merge, the sync process will create a PR to docs-v2
+
+## Plugin Types and Locations
+
+| Directory | Source Location |
+|-----------|-----------------|
+| `input-plugins/` | `telegraf/plugins/inputs/<plugin>/README.md` |
+| `output-plugins/` | `telegraf/plugins/outputs/<plugin>/README.md` |
+| `aggregator-plugins/` | `telegraf/plugins/aggregators/<plugin>/README.md` |
+| `processor-plugins/` | `telegraf/plugins/processors/<plugin>/README.md` |
+
+## Documentation
+
+- **Telegraf repository**: https://github.com/influxdata/telegraf
+- **Contributing guide**: https://github.com/influxdata/telegraf/blob/master/CONTRIBUTING.md
+
+## Non-Generated Content
+
+The following files in `content/telegraf/` are **not generated** and can be edited directly:
+- `_index.md`
+- `configuration.md`
+- `install.md`
+- `get-started.md`
+- `metrics.md`
+- `release-notes.md`
+- Other top-level documentation files


### PR DESCRIPTION
## Summary

Add CLAUDE.md guidance files for AI tools to understand which documentation is generated from source repositories.

### New Files

- `content/shared/influxdb3-plugins/plugins-library/official/CLAUDE.md` - Documents the `yarn sync-plugins` workflow
- `content/telegraf/CLAUDE.md` - Documents the Telegraf plugin sync from influxdata/telegraf

### Purpose

These files serve as "guardrails" for AI tools (Claude, Copilot, etc.) to:
- Prevent direct edits to generated content
- Redirect changes to source repositories
- Document the sync workflows

## Related

- Part of DAR-558 work
- Companion PR: https://github.com/influxdata/influxdb3_plugins/pull/37

## Test Plan

- [ ] Verify files don't interfere with Hugo build
- [ ] Test that AI tools recognize and follow the guidance