### PR TITLE
fix(v2): broken links to Grafana guides for Cloud and OSS v2.

### DIFF
--- a/content/influxdb/cloud/tools/grafana.md
+++ b/content/influxdb/cloud/tools/grafana.md
@@ -13,6 +13,8 @@ related:
   - /influxdb/cloud/query-data/get-started/
   - /influxdb/cloud/query-data/influxql/
   - /flux/v0/get-started/, Get started with Flux
+aliases:
+  - /influxdb/cloud/visualize-data/grafana/
 alt_links:
   v1: /influxdb/v1/tools/grafana/
   enterprise_v1: /enterprise_influxdb/v1/tools/grafana/

--- a/content/influxdb/v2/tools/grafana.md
+++ b/content/influxdb/v2/tools/grafana.md
@@ -10,6 +10,7 @@ weight: 120
 influxdb/v2/tags: [grafana]
 aliases:
   - /influxdb/v2/visualize-data/other-tools/grafana/
+  - /influxdb/v2/visualize-data/grafana/
 related:
   - https://grafana.com/docs/, Grafana documentation
   - /influxdb/v2/query-data/get-started/


### PR DESCRIPTION
- Add expected aliases (more descriptive URLs) for the Grafana pages

Closes #6689 

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
