### PR TITLE
chore(skills): add Cypress E2E testing skill and update related skills

### DIFF
--- a/.claude/skills/cypress-e2e-testing/SKILL.md
+++ b/.claude/skills/cypress-e2e-testing/SKILL.md
@@ -1,0 +1,329 @@
+---
+name: cypress-e2e-testing
+description: Run, validate, and analyze Cypress E2E tests for the InfluxData documentation site. Covers Hugo server management, test execution modes, and failure analysis.
+author: InfluxData
+version: "1.0"
+---
+
+# Cypress E2E Testing Skill
+
+## Purpose
+
+This skill guides agents through running Cypress end-to-end tests for the documentation site, including understanding when Hugo starts automatically vs. manually, interpreting test results, and debugging failures.
+
+For comprehensive testing documentation, see **[DOCS-TESTING.md](../../../DOCS-TESTING.md)**.
+
+## Key Insight: Hugo Server Management
+
+**The test runner (`run-e2e-specs.js`) automatically manages Hugo.**
+
+- **Port 1315** is used for testing (not 1313)
+- If port 1315 is free → starts Hugo automatically
+- If port 1315 is in use → checks if it's a working Hugo server and reuses it
+- Hugo logs written to `/tmp/hugo_server.log`
+
+**You do NOT need to start Hugo separately** unless you want to keep it running between test runs for faster iteration.
+
+## Quick Reference
+
+| Task                            | Command                                                                                                 |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Test content file               | `node cypress/support/run-e2e-specs.js content/path/to/file.md`                                         |
+| Test with specific spec         | `node cypress/support/run-e2e-specs.js --spec "cypress/e2e/content/spec.cy.js" content/path/to/file.md` |
+| Functionality test (no content) | `node cypress/support/run-e2e-specs.js --spec "cypress/e2e/page-context.cy.js" --no-mapping`            |
+| Test shortcode examples         | `yarn test:shortcode-examples`                                                                          |
+
+## Prerequisites
+
+```bash
+# Install dependencies (required)
+yarn install
+
+# Verify Cypress is available
+yarn cypress --version
+```
+
+### API Reference Tests: Additional Prerequisites
+
+**API reference pages require generation before testing.** The pages don't exist until you run:
+
+```bash
+# Generate API documentation content from OpenAPI specs
+yarn build:api-docs
+```
+
+This step:
+
+- Processes OpenAPI specs in `api-docs/` directories
+- Generates Hugo content pages in `content/*/api/`
+- Creates operation pages, tag pages, and index pages
+
+**Without this step**, all API reference tests will fail with 404 errors.
+
+**Quick check** - verify API content exists:
+
+```bash
+# Should list generated API content directories
+ls content/influxdb3/core/api/
+
+# If "No such file or directory", run: yarn build:api-docs
+```
+
+### Markdown Validation Tests: Additional Prerequisites
+
+**Markdown validation tests require generated markdown files.** Run:
+
+```bash
+# Build Hugo site first (generates HTML in public/)
+npx hugo --quiet
+
+# Generate LLM-friendly markdown from HTML
+yarn build:md
+```
+
+This creates `.md` files in the `public/` directory that the markdown validation tests check.
+
+**Without this step**, markdown validation tests will fail with missing file errors.
+
+## Test Execution Modes
+
+### Mode 1: Content-Specific Tests (Default)
+
+Tests specific content files by mapping them to URLs.
+
+```bash
+# Single file
+node cypress/support/run-e2e-specs.js content/influxdb3/core/_index.md
+
+# Multiple files
+node cypress/support/run-e2e-specs.js content/influxdb3/core/_index.md content/influxdb3/enterprise/_index.md
+
+# With specific test spec
+node cypress/support/run-e2e-specs.js \
+  --spec "cypress/e2e/content/api-reference.cy.js" \
+  content/influxdb3/core/reference/api/_index.md
+```
+
+**What happens:**
+
+1. Maps content files to URLs (e.g., `content/influxdb3/core/_index.md` → `/influxdb3/core/`)
+2. Starts Hugo on port 1315 (if not running)
+3. Runs Cypress tests against mapped URLs
+4. Stops Hugo when done
+
+### Mode 2: Functionality Tests (`--no-mapping`)
+
+Tests UI functionality without requiring content file paths.
+
+```bash
+# Run functionality test
+node cypress/support/run-e2e-specs.js \
+  --spec "cypress/e2e/page-context.cy.js" \
+  --no-mapping
+```
+
+**Use when:** Testing JavaScript components, theme switching, navigation, or other UI behavior not tied to specific content.
+
+### Mode 3: Reusing an Existing Hugo Server
+
+For faster iteration during development:
+
+```bash
+# Terminal 1: Start Hugo manually on port 1315
+npx hugo server --port 1315 --environment testing --noHTTPCache
+
+# Terminal 2: Run tests (will detect and reuse existing server)
+node cypress/support/run-e2e-specs.js \
+  --spec "cypress/e2e/content/api-reference.cy.js" \
+  content/influxdb3/core/reference/api/_index.md
+```
+
+## Available Test Specs
+
+| Spec File                                               | Purpose                                       |
+| ------------------------------------------------------- | --------------------------------------------- |
+| `cypress/e2e/content/api-reference.cy.js`               | API reference pages (RapiDoc, layouts, links) |
+| `cypress/e2e/content/index.cy.js`                       | General content validation                    |
+| `cypress/e2e/content/markdown-content-validation.cy.js` | LLM markdown generation                       |
+| `cypress/e2e/page-context.cy.js`                        | Page context and navigation                   |
+
+## Understanding Test Output
+
+### Success Output
+
+```
+✅ e2e tests completed successfully
+📊 Detailed Test Results:
+   • Total Tests: 25
+   • Tests Passed: 25
+   • Tests Failed: 0
+```
+
+### Failure Output
+
+```
+ℹ️ Note: 3 test(s) failed.
+📊 Detailed Test Results:
+   • Total Tests: 25
+   • Tests Passed: 22
+   • Tests Failed: 3
+
+📋 Failed Spec Files:
+   • cypress/e2e/content/api-reference.cy.js
+     - Failures: 3
+     - Failed Tests:
+       * has API info
+         Error: Expected to find element '.article--description'
+```
+
+### Common Failure Patterns
+
+| Error                               | Likely Cause                        | Solution                         |
+| ----------------------------------- | ----------------------------------- | -------------------------------- |
+| All API tests fail with 404         | API content not generated           | Run `yarn build:api-docs` first  |
+| `Expected to find element 'X'`      | Selector changed or element removed | Update test or fix template      |
+| `Timed out waiting for element`     | Page load issue or JS error         | Check Hugo logs, browser console |
+| `cy.request() failed`               | Broken link or 404                  | Fix the link in content          |
+| `Hugo server died during execution` | Build error or memory issue         | Check `/tmp/hugo_server.log`     |
+
+## Debugging Failures
+
+### Step 1: Check Hugo Logs
+
+```bash
+cat /tmp/hugo_server.log | tail -50
+```
+
+Look for:
+
+- Template errors (`error calling partial`)
+- Build failures
+- Missing data files
+
+### Step 2: Run Test in Interactive Mode
+
+```bash
+# Start Hugo manually
+npx hugo server --port 1315 --environment testing
+
+# In another terminal, open Cypress interactively
+yarn cypress open
+```
+
+### Step 3: Inspect the Page
+
+Visit `http://localhost:1315/path/to/page/` in a browser and:
+
+- Open DevTools Console for JavaScript errors
+- Inspect elements to verify selectors
+- Check Network tab for failed requests
+
+### Step 4: Run Single Test with Verbose Output
+
+```bash
+DEBUG=cypress:* node cypress/support/run-e2e-specs.js \
+  --spec "cypress/e2e/content/api-reference.cy.js" \
+  content/influxdb3/core/reference/api/_index.md
+```
+
+## Test Configuration
+
+The test runner uses these settings:
+
+```javascript
+{
+  browser: 'chrome',
+  baseUrl: 'http://localhost:1315',
+  video: false,  // Disabled in CI
+  defaultCommandTimeout: 10000,  // 15000 in CI
+  pageLoadTimeout: 30000,  // 45000 in CI
+}
+```
+
+## Writing New Tests
+
+### Basic Test Structure
+
+```javascript
+describe('Feature Name', () => {
+  beforeEach(() => {
+    cy.visit('/path/to/page/');
+  });
+
+  it('validates expected behavior', () => {
+    cy.get('.selector').should('exist');
+    cy.get('.selector').should('be.visible');
+    cy.get('.selector').contains('Expected text');
+  });
+});
+```
+
+### Testing Components
+
+```javascript
+describe('Component Name', () => {
+  it('initializes correctly', () => {
+    cy.visit('/path/with/component/');
+
+    // Wait for component initialization
+    cy.get('[data-component="my-component"]', { timeout: 5000 })
+      .should('be.visible');
+
+    // Verify component rendered expected elements
+    cy.get('[data-component="my-component"] .child-element')
+      .should('have.length.at.least', 1);
+  });
+});
+```
+
+### Testing Links
+
+```javascript
+it('contains valid internal links', () => {
+  cy.get('body').then(($body) => {
+    if ($body.find('a[href^="/"]').length === 0) {
+      cy.log('No internal links found');
+      return;
+    }
+
+    cy.get('a[href^="/"]').each(($a) => {
+      cy.request($a.attr('href')).its('status').should('eq', 200);
+    });
+  });
+});
+```
+
+## CI/CD Considerations
+
+In CI environments:
+
+- Video recording is disabled to save resources
+- Timeouts are increased (15s command, 45s page load)
+- Memory management is enabled
+- Only 1 test kept in memory at a time
+
+## Related Files
+
+- **Test runner**: `cypress/support/run-e2e-specs.js`
+- **Hugo server helper**: `cypress/support/hugo-server.js`
+- **URL mapper**: `cypress/support/map-files-to-urls.js`
+- **Config**: `cypress.config.js`
+- **Comprehensive docs**: `DOCS-TESTING.md`
+
+## Checklist for Test Validation
+
+Before concluding test analysis:
+
+- [ ] For API tests: Verify `yarn build:api-docs` was run (check `ls content/*/api/`)
+- [ ] All tests passed, or failures are understood
+- [ ] Hugo logs checked for build errors
+- [ ] Failed selectors verified against current templates
+- [ ] Broken links identified and reported
+- [ ] JavaScript console errors investigated (if relevant)
+
+## Related Skills
+
+- **hugo-template-dev** - For Hugo template syntax, data access patterns, and runtime testing
+- **docs-cli-workflow** - For creating/editing documentation content with CLI tools
+- **ts-component-dev** (agent) - TypeScript component behavior and interactivity
+- **hugo-ui-dev** (agent) - Hugo templates and SASS/CSS styling

--- a/.claude/skills/docs-cli-workflow/SKILL.md
+++ b/.claude/skills/docs-cli-workflow/SKILL.md
@@ -131,3 +131,9 @@ npx docs edit --list <url>  # List files without opening
 ```
 
 For full CLI documentation, run `npx docs --help`.
+
+## Related Skills
+
+- **hugo-template-dev** - For Hugo template syntax, data access patterns, and runtime testing
+- **cypress-e2e-testing** - For running and debugging Cypress E2E tests
+- **ts-component-dev** (agent) - TypeScript component behavior and interactivity

--- a/.claude/skills/hugo-template-dev/SKILL.md
+++ b/.claude/skills/hugo-template-dev/SKILL.md
@@ -2,7 +2,7 @@
 name: hugo-template-dev
 description: Hugo template development skill for InfluxData docs-v2. Enforces proper build and runtime testing to catch template errors that build-only validation misses.
 author: InfluxData
-version: "1.0"
+version: "1.1"
 ---
 
 # Hugo Template Development Skill
@@ -23,9 +23,10 @@ Template errors like accessing undefined fields, nil values, or incorrect type a
 
 After modifying files in `layouts/`, `layouts/partials/`, or `layouts/shortcodes/`:
 
+**Step 1: Start Hugo server and capture output**
+
 ```bash
-# Step 1: Start Hugo server and capture output
-npx hugo server --port 1314 2>&1 | head -50
+npx hugo server --port 1315 2>&1 | head -50
 ```
 
 **Success criteria:**
@@ -33,20 +34,37 @@ npx hugo server --port 1314 2>&1 | head -50
 - No `error calling partial` messages
 - No `can't evaluate field` errors
 - No `template: ... failed` messages
-- Server shows "Web Server is available at <http://localhost:1314/>"
+- Server shows "Web Server is available at <http://localhost:1315/>"
 
 **If errors appear:** Fix the template and repeat Step 1 before proceeding.
 
+**Step 2: Verify the page renders**
+
 ```bash
-# Step 2: Verify the page renders (only after Step 1 passes)
-curl -s -o /dev/null -w "%{http_code}" http://localhost:1314/PATH/TO/PAGE/
+curl -s -o /dev/null -w "%{http_code}" http://localhost:1315/PATH/TO/PAGE/
 ```
 
 **Expected:** HTTP 200 status code
 
+**Step 3: Browser testing (if MCP browser tools available)**
+
+If `mcp__claude-in-chrome__*` tools are available, use them for visual inspection:
+
+```
+# Navigate and screenshot
+mcp__claude-in-chrome__navigate({ url: "http://localhost:1315/PATH/", tabId: ... })
+mcp__claude-in-chrome__computer({ action: "screenshot", tabId: ... })
+
+# Check for JavaScript errors
+mcp__claude-in-chrome__read_console_messages({ tabId: ..., onlyErrors: true })
+```
+
+This catches runtime JavaScript errors that template changes may introduce.
+
+**Step 4: Stop the test server**
+
 ```bash
-# Step 3: Stop the test server
-pkill -f "hugo server --port 1314"
+pkill -f "hugo server --port 1315"
 ```
 
 ### Quick Test Command
@@ -54,7 +72,7 @@ pkill -f "hugo server --port 1314"
 Use this one-liner to test and get immediate feedback:
 
 ```bash
-timeout 15 npx hugo server --port 1314 2>&1 | grep -E "(error|Error|ERROR|fail|FAIL)" | head -20; pkill -f "hugo server --port 1314" 2>/dev/null
+timeout 15 npx hugo server --port 1315 2>&1 | grep -E "(error|Error|ERROR|fail|FAIL)" | head -20; pkill -f "hugo server --port 1315" 2>/dev/null
 ```
 
 If output is empty, no errors were detected.
@@ -335,24 +353,6 @@ The **only** acceptable inline scripts are minimal initialization that MUST run 
 
 Everything else belongs in `assets/js/`.
 
-### File Organization for Components
-
-```
-assets/
-├── js/
-│   ├── main.js                    # Entry point, component registry
-│   ├── components/
-│   │   ├── api-nav.ts             # API navigation behavior
-│   │   ├── api-toc.ts             # Table of contents
-│   │   ├── api-tabs.ts            # Tab switching (if needed beyond CSS)
-│   │   └── api-scalar.ts          # Scalar/RapiDoc integration
-│   └── utils/
-│       └── dom-helpers.ts         # Shared DOM utilities
-└── styles/
-    └── layouts/
-        └── _api-layout.scss       # API-specific styles
-```
-
 ### TypeScript Component Checklist
 
 When creating a new interactive feature:
@@ -363,15 +363,14 @@ When creating a new interactive feature:
 4. [ ] Register in `main.js` componentRegistry
 5. [ ] Add `data-component` attribute to HTML element
 6. [ ] Pass data via `data-*` attributes (not inline JS)
-7. [ ] Write Cypress tests for the component
-8. [ ] **NO inline `<script>` tags in templates**
+7. [ ] **NO inline `<script>` tags in templates**
 
 ## Debugging Templates
 
 ### Enable Verbose Mode
 
 ```bash
-npx hugo server --port 1314 --verbose 2>&1 | head -100
+npx hugo server --port 1315 --verbose 2>&1 | head -100
 ```
 
 ### Print Variables for Debugging
@@ -400,8 +399,8 @@ pre-commit:
     hugo-template-test:
       glob: "layouts/**/*.html"
       run: |
-        timeout 20 npx hugo server --port 1314 2>&1 | grep -E "error|Error" && exit 1 || exit 0
-        pkill -f "hugo server --port 1314" 2>/dev/null
+        timeout 20 npx hugo server --port 1315 2>&1 | grep -E "error|Error" && exit 1 || exit 0
+        pkill -f "hugo server --port 1315" 2>/dev/null
 ```
 
 ### GitHub Actions Workflow
@@ -409,133 +408,20 @@ pre-commit:
 ```yaml
 - name: Test Hugo templates
   run: |
-    npx hugo server --port 1314 &
+    npx hugo server --port 1315 &
     sleep 10
-    curl -f http://localhost:1314/ || exit 1
+    curl -f http://localhost:1315/ || exit 1
     pkill -f hugo
 ```
-
-### Cypress E2E Tests for UI Features
-
-After template changes that affect UI functionality, run Cypress tests to verify:
-
-**Run a specific test file against a content page:**
-
-```bash
-node cypress/support/run-e2e-specs.js \
-  --spec "cypress/e2e/content/api-reference.cy.js" \
-  content/influxdb3/core/reference/api/_index.md
-```
-
-**Run tests against a URL (for deployed or running server):**
-
-```bash
-node cypress/support/run-e2e-specs.js \
-  --spec "cypress/e2e/content/api-reference.cy.js" \
-  http://localhost:<port>/influxdb3/core/reference/api/
-```
-
-**Example Cypress test structure for API reference:**
-
-```javascript
-// cypress/e2e/content/api-reference.cy.js
-describe('API Reference Documentation', () => {
-  beforeEach(() => {
-    cy.visit('/influxdb3/core/reference/api/');
-  });
-
-  it('displays 3-column layout with sidebar, content, and TOC', () => {
-    cy.get('.sidebar').should('be.visible');
-    cy.get('.api-content').should('be.visible');
-    cy.get('.api-toc').should('be.visible');
-  });
-
-  it('switches tabs correctly', () => {
-    cy.get('.tabs a').contains('Authentication').click();
-    cy.get('.tab-content').contains('Bearer Token').should('be.visible');
-  });
-
-  it('displays API navigation in sidebar', () => {
-    cy.get('.api-nav').should('be.visible');
-    cy.get('.api-nav').contains('API v3');
-  });
-
-  it('TOC updates highlight on scroll', () => {
-    cy.get('.api-toc-nav a').first().click();
-    cy.get('.api-toc-nav a.is-active').should('exist');
-  });
-});
-```
-
-**Check for JavaScript console errors (common pattern for feature development):**
-
-```javascript
-// cypress/e2e/content/my-component.cy.js
-describe('My Component', () => {
-  it('should not throw JavaScript console errors', () => {
-    cy.visit('/path/to/page/');
-
-    // Wait for component to initialize
-    cy.get('[data-component="my-component"]', { timeout: 5000 })
-      .should('be.visible');
-
-    cy.window().then((win) => {
-      const logs = [];
-      const originalError = win.console.error;
-
-      // Intercept console.error calls
-      win.console.error = (...args) => {
-        logs.push(args.join(' '));
-        originalError.apply(win.console, args);
-      };
-
-      // Allow time for async operations
-      cy.wait(2000);
-
-      cy.then(() => {
-        // Filter for relevant errors (customize for your component)
-        const relevantErrors = logs.filter(
-          (log) =>
-            log.includes('my-component') ||
-            log.includes('Failed to parse') ||
-            log.includes('is not a function')
-        );
-        expect(relevantErrors).to.have.length(0);
-      });
-    });
-  });
-});
-```
-
-This pattern is especially useful for catching:
-
-- TypeScript/JavaScript runtime errors in components
-- JSON parsing failures from `data-*` attributes
-- Undefined function calls from missing imports
-- Template data binding issues that only manifest at runtime
-
-**Integrate Cypress into development workflow:**
-
-1. Create test file in `cypress/e2e/content/` for your feature
-2. Run tests after template changes to verify UI behavior
-3. Include test execution in PR checklist
-
-**Quick Cypress commands:**
-
-| Purpose                | Command                                                                                     |
-| ---------------------- | ------------------------------------------------------------------------------------------- |
-| Run specific spec      | `node cypress/support/run-e2e-specs.js --spec "path/to/spec.cy.js" content/path/to/page.md` |
-| Run all E2E tests      | `yarn test:e2e`                                                                             |
-| Run shortcode examples | `yarn test:shortcode-examples`                                                              |
 
 ## Quick Reference
 
 | Action                    | Command                                                              |
 | ------------------------- | -------------------------------------------------------------------- |
-| Test templates (runtime)  | `npx hugo server --port 1314 2>&1 \| head -50`                       |
+| Test templates (runtime)  | `npx hugo server --port 1315 2>&1 \| head -50`                       |
 | Build only (insufficient) | `npx hugo --quiet`                                                   |
-| Check specific page       | `curl -s -o /dev/null -w "%{http_code}" http://localhost:1314/path/` |
-| Stop test server          | `pkill -f "hugo server --port 1314"`                                 |
+| Check specific page       | `curl -s -o /dev/null -w "%{http_code}" http://localhost:1315/path/` |
+| Stop test server          | `pkill -f "hugo server --port 1315"`                                 |
 | Debug data access         | `<pre>{{ printf "%#v" $var }}</pre>`                                 |
 
 ## Remember
@@ -546,10 +432,9 @@ This pattern is especially useful for catching:
 4. **Use `isset` and `index`** for safe data access
 5. **Hyphenated keys require `index` function** - dot notation fails
 
-## Related Agents
+## Related Skills
 
-This skill focuses on Hugo template development practices. For specialized tasks, use:
-
-- **hugo-ui-dev** - Hugo templates and SASS/CSS styling
-- **ts-component-dev** - TypeScript component behavior and interactivity
-- **ui-testing** - Cypress E2E testing for UI components
+- **cypress-e2e-testing** - For E2E testing of UI components and pages
+- **docs-cli-workflow** - For creating/editing documentation content
+- **ts-component-dev** (agent) - TypeScript component behavior and interactivity
+- **ui-testing** (agent) - Cypress E2E testing for UI components


### PR DESCRIPTION
## Summary

- Adds new `cypress-e2e-testing` skill for comprehensive E2E test guidance
- Updates `hugo-template-dev` skill to focus on template-specific testing (extracted E2E content to dedicated skill)
- Minor updates to `docs-cli-workflow` skill

## Changes

### New: `cypress-e2e-testing` skill
Comprehensive guide for running Cypress E2E tests, including:
- Hugo server management (auto-start on port 1315)
- Test execution commands and modes
- Failure analysis and debugging
- API reference test prerequisites

### Updated: `hugo-template-dev` skill
- Refocused on Hugo template development practices
- Removed E2E testing content (now in dedicated skill)
- Emphasizes mandatory runtime testing for template changes

### Updated: `docs-cli-workflow` skill
- Minor additions to trigger keywords

## Test plan
- [ ] Review skill content for accuracy
- [ ] Verify skills load correctly in Claude Code

Closes #6708