### PR TITLE
fix(influxdb3): `api/v3/configure/database` requires format

### DIFF
--- a/content/shared/influxdb3-admin/databases/list.md
+++ b/content/shared/influxdb3-admin/databases/list.md
@@ -79,7 +79,7 @@ noaa
 {{% /expand %}}
 {{< /expand-wrapper >}}
 
-### Output to a Parquet file
+#### Output to Parquet
 
 To output your list of databases to a Parquet file, use the `influxdb3 query` command
 


### PR DESCRIPTION
Closes influxdata/dar/580

- `format` query param is required
- Provide examples, including parquet to output file

influxdb3 CLI doesn't support `--output` for parquet.

