### PR TITLE
Docs: Update Azure Blob Storage access key parameter In documentation

### DIFF
--- a/content/influxdb3/enterprise/get-started/multi-server.md
+++ b/content/influxdb3/enterprise/get-started/multi-server.md
@@ -140,7 +140,7 @@ with your `influxdb3 serve` command:
 - `--bucket`: Your Azure Blob Storage container name
 - `--azure-storage-account`: Your Azure Blob Storage account name  
   _(can also be defined using the `AZURE_STORAGE_ACCOUNT` environment variable)_
-- `--aws-secret-access-key`: Your Azure Blob Storage access key  
+- `--azure-storage-access-key`: Your Azure Blob Storage access key  
   _(can also be defined using the `AZURE_STORAGE_ACCESS_KEY` environment variable)_
 
 {{% code-placeholders "AZURE_(CONTAINER_NAME|STORAGE_ACCOUNT|STORAGE_ACCESS_KEY)" %}}


### PR DESCRIPTION
Replaces `--aws-secret-access-key` with `--azure-storage-access-key` in the documentation:
- Create a multi-node cluster
  - Connect to your object store
    - Azure Blob Storage
