### PR TITLE
docs(influxdb3): Update token documentation for Docker Compose and CI/CD

### DIFF
--- a/content/shared/influxdb3-admin/tokens/admin/preconfigured.md
+++ b/content/shared/influxdb3-admin/tokens/admin/preconfigured.md
@@ -65,13 +65,14 @@ object with the following fields:
 
 - **token**: The raw token string (must begin with `apiv3_`)
 - **name**: The token name (default is `_admin`)
-- **expiry_millis**: <em class="op50">(Optional)</em> Token expiration time as a
-  millisecond Unix timestamp
+- **description**: <em class="op50">(Optional)</em> A description of the token
+- **expiry_millis**: <em class="op50">(Optional)</em> Token expiration time as a millisecond Unix timestamp
 
 ```json
 {
   "token": "apiv3_0XXXX-xxxXxXxxxXX_OxxxX...",
   "name": "_admin",
+  "description": "Admin token for InfluxDB 3",
   "expiry_millis": 1756400061529
 }
 ```


### PR DESCRIPTION
## Summary

This PR updates InfluxDB 3 Core and Enterprise documentation to better support Docker Compose deployments and CI/CD workflows with preconfigured admin tokens.



### Token Format Verification

Both Core and Enterprise tokens are in the correct JSON format:
```json
{
  "token": "apiv3_...",
  "name": "admin",
  "description": "Admin token for InfluxDB 3 Core/Enterprise"
}
```

### Docker Secrets Verification

Both services correctly mount tokens as Docker secrets:
- Core: `/run/secrets/influxdb3-core-token` ✅
- Enterprise: `/run/secrets/influxdb3-enterprise-admin-token` ✅


## Changes

### 1. Updated Offline Admin Token Schema
**File**: `content/shared/influxdb3-admin/tokens/admin/preconfigured.md`

- Added `description` field as an optional field alongside `expiry_millis`
- Both fields are optional and supported by the InfluxDB 3 server
- Updated example to show both fields

### 2. Added Docker Compose Setup Documentation
**File**: `content/shared/influxdb3-get-started/setup.md`

New expandable section: "Docker Compose with preconfigured admin tokens"

- Instructions for creating admin token JSON files
- Docker Compose configuration using Docker secrets for secure token management
- CI/CD setup instructions using environment variables
- Security benefits of Docker secrets over bind mounts

## Rationale

### Token File Format Flexibility
The InfluxDB 3 server accepts offline token files with either:
- `expiry_millis` (generated by CLI `--offline` option)
- `description` (manually created for documentation/reference)
- Both fields (comprehensive setup)

### Docker Secrets Benefits
- Secrets stored encrypted in memory
- Not visible in `docker inspect` output
- Not exposed in environment variables or logs
- Follows Docker and Kubernetes best practices

### CI/CD Support
Enables automated deployments by:
- Creating token files from environment variables
- Using secure secret injection
- Supporting both local development and CI/CD pipelines


## Related

- Complements PR #6750 (Docker Compose test setup improvements)
- Uses `INFLUXDB3_AUTH_TOKEN` environment variable (already documented)
- Compatible with existing CLI and API documentation