### PR TITLE
fix(telegraf): link to plugins docs in the docs, update plugin cards

### DIFF
--- a/assets/styles/layouts/article/_telegraf-plugins.scss
+++ b/assets/styles/layouts/article/_telegraf-plugins.scss
@@ -38,63 +38,23 @@
     }
   }
 
-  a.external {
-    position: relative;
-    margin: 0 0 0 -.25rem;
-    display: inline-block;
-    padding: .4rem .85rem;
-    background-color: rgba($article-text, .1);
-    border-radius: 1rem;
-    font-size: .9rem;
-    font-weight: $medium;
-    color: $article-text;
-
-    &:after {
-      content: "?";
-      position: absolute;
-      display: block;
-      top: -3px;
-      right: -3px;
-      padding: 0.1rem 0.3rem .04rem;
-      color: $g20-white;
-      @include gradient($article-btn-gradient);
-      border-radius: 50%;
-      font-weight: bold;
-      line-height: .8rem;
-      font-size: .7rem;
-      box-shadow: 1px 1px 4px $sidebar-search-shadow;
-      opacity: 0;
-      transition: opacity .2s;
-    }
-
-    &:hover {
-      color: $article-text;
-      &:after {opacity: 1;}
-    }
-  }
-
   & .info {
     & > p:last-child { margin-bottom: .5rem; }
     & > ul:last-child { margin-bottom: .5rem; }
     & > ol:last-child { margin-bottom: .5rem; }
   }
 
-  .github-link {
+  .plugin-link {
     position: absolute;
     top: 0;
     right: 0.5rem;
     opacity: 0.25;
     transition: opacity .2s, background .2s, color .2s;
     @include gradient($article-btn-gradient);
-
-    .icon-github {
-      font-size: 1.2rem;
-      margin: 0 .25rem 0 0;
-    }
   }
 
   &:hover {
-    .github-link {
+    .plugin-link {
       opacity: 1;
       @include gradient($article-btn-gradient);
     }
@@ -138,9 +98,9 @@
 @include media(small) {
 
   .plugin-card {
-    .github-link {
+    .plugin-link {
       opacity: 1;
-      @include gradient($article-btn-gradient)
+      @include gradient($article-btn-gradient);
       padding: .25rem .35rem .35rem;
       line-height: 0;
       .icon-github { margin: 0; }

--- a/layouts/shortcodes/telegraf/plugins.html
+++ b/layouts/shortcodes/telegraf/plugins.html
@@ -12,17 +12,14 @@
   <div class="plugin-card filter-item visible{{ if eq $minorVer $latestTelegrafVersion }} new{{ end }}" id="{{ .id }}" data-tags="{{ $type }} {{ lower $pluginTags }} {{ lower $osTags }} {{ if eq $minorVer $latestTelegrafVersion }}new{{ end }} {{ if .deprecated }}deprecated{{ end }} ">
     <div class="info">
       <h3 id="{{ $type }}-{{ .id }}">{{ .name }}</h3>
-      {{ if in .tags "external"}}
-        <a class="external" href="{{ $externalPluginLink }}">External</a>
-      {{ end }}
       <p class="meta">
         Plugin ID: <code>{{ $type }}s.{{ .id }}</code><br/>
         Telegraf {{ if not .deprecated }}{{ .introduced }}+{{ else }}{{ .introduced }} - {{ .deprecated }} <span class="deprecated">Deprecated</span>{{ end }}
       </p>
       <p>{{ .description | markdownify | safeHTML }}</p>
     </div>
-    <a class="btn github-link" href="{{ if .link }}{{ .link }}{{ else }}https://github.com/influxdata/telegraf/blob/release-{{ $latestTelegrafVersion }}/plugins/{{ $type }}s/{{ .id }}/README.md{{ end }}" target="_blank">
-      <span class="icon-github"></span> <span class="hide">View</span>
+    <a class="btn plugin-link" href="{{ if .link }}{{ .link }}{{ else }}/telegraf/v1/{{ $type }}-plugins/{{ .id }}/{{ end }}">
+      <span class="hide">View</span>
     </a>
   </div>
 {{ end }}


### PR DESCRIPTION
Updates the Telegraf plugins list shortcode and styles to point to plugin docs in the documentation rather than sending users to GitHub.

- [x] Rebased/mergeable
