### PR TITLE
feat: [meta] https-insecure-certificate configuration

### DIFF
--- a/content/enterprise_influxdb/v1/administration/configure/config-meta-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/configure/config-meta-nodes.md
@@ -170,6 +170,14 @@ Use either:
 
 Environment variable: `INFLUXDB_META_HTTPS_PRIVATE_KEY`
 
+#### https-insecure-certificate
+
+Default is `false`.
+
+Skips file permission checking for `https-certificate` and `https-private-key` when true.
+
+Environment variable: `INFLUXDB_META_HTTPS_INSECURE_CERTIFICATE`
+
 #### https-insecure-tls
 
 Default is `false`.


### PR DESCRIPTION
Add documentation for meta node's `[meta] https-insecure-certificate` configuration.

This configuration is available in >=  1.12.3.