### PR TITLE
chore(telegraf_controller): base template and layout changes for telegraf controller beta

### DIFF
--- a/assets/styles/layouts/_homepage.scss
+++ b/assets/styles/layouts/_homepage.scss
@@ -278,8 +278,8 @@
     position: relative;
     overflow: hidden;
     display: flex;
-    flex-direction: row;
-    align-items: center;
+    flex-direction: column;
+    // align-items: center;
     justify-content: space-between;
 
     .bg-overlay {
@@ -302,9 +302,6 @@
     }
 
     ul.product-links {
-      padding-left: 0;
-      margin: 0 3rem 0 2rem;
-      list-style: none;
 
       li:not(:last-child) {margin-bottom: .35rem;}
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -128,12 +128,29 @@
       <div class="bg-overlay"></div>
       <div class="product-info">
         <h2>Collect data with Telegraf</h2>
-        <p>The data collection agent that supports a large catalog of data sources and targets.</p>      
       </div>
-      <ul class="product-links">
-        <li><a href="/telegraf/v1/get-started/">Get started with Telegraf</a></li>
-        <li><a href="/telegraf/v1/plugins/">View Telegraf plugins</a></li>
-      </ul>
+      <div class="products">
+        <div class="product">
+          <div class="product-info">
+            <h3><a href="/telegraf/v1/">Telegraf <span class="version">{{ $telegrafVersion }}</span></a></h3>
+            <p>The open source data collection agent with support for a large catalog of data sources and targets.</p>
+          </div>
+          <ul class="product-links">
+            <li><a href="/telegraf/v1/get-started/">Get started with Telegraf</a></li>
+            <li><a href="/telegraf/v1/plugins/">View Telegraf plugins</a></li>
+          </ul>
+        </div>
+        <div class="product">
+          <div class="product-info">
+            <h3 state="beta"><a href="/telegraf/controller/">Telegraf Controller</a></h3>
+            <p>Centralized Telegraf configuration management and agent observability with an intuitive UI.</p>
+          </div>
+          <ul class="product-links">
+            <li><a href="/telegraf/controller/get-started/">Get started with Telegraf Controller</a></li>
+            <li><a href="/telegraf/controller/">View documentation</a></li>
+          </ul>
+        </div>
+      </div>
     </div>
   
     <div id="influxdbv2" class="product-group">
@@ -201,16 +218,6 @@
     <div id="other" class="product-group">
       <h2>Other Products</h2>
       <div class="products">
-        <div class="product">
-          <div class="product-info">
-            <h3><a href="/telegraf/v1/">Telegraf <span class="version">{{ $telegrafVersion }}</span></a></h3>
-            <p>The collection agent that gathers time series data from many different sources.</p>
-          </div>
-          <ul class="product-links">
-            <li><a href="/telegraf/v1/get-started/">Get started with Telegraf {{ $telegrafVersion }}</a></li>
-            <li><a href="/telegraf/v1/plugins/">View Telegraf plugins</a></li>
-          </ul>
-        </div>
         <div class="product">
           <div class="product-info">
             <h3><a href="/chronograf/v1/">Chronograf <span class="version">{{ $chronografVersion }}</span></a></h3>

--- a/layouts/partials/article/special-state.html
+++ b/layouts/partials/article/special-state.html
@@ -18,20 +18,49 @@
 {{ if in $productPathWhitelist (print $product "/" $version )}}
 <div class="block special-state">
   <div class="state-content">
-    <h4 id="telegraf-controller-private-alpha">{{ $displayName }} is in Private Alpha</h4>
+    <h4 id="telegraf-controller-public-beta">{{ $displayName }} is in Public Beta</h4>
     <p>
-      {{ $displayName }} is in private alpha. If you are interested in being a
-      part of the private alpha program, please sign up:
-    </p>
-    <p><a href="https://www.influxdata.com/products/telegraf-enterprise" class="btn">Sign Up for the Alpha</a></p>
-    <p>
-      While in alpha, {{ $displayName }} is <strong>not meant for production use</strong>.
+      {{ $displayName }} is in public beta.
+      While in beta, {{ $displayName }} is <strong>not meant for production use</strong>.
       The {{ $displayName}} documentation is a work in progress, and we are actively
       working to improve it. If you have any questions or suggestions, please
       <a href="https://github.com/influxdata/docs-v2/issues/new?labels=Telegraf%20Controller">submit an issue</a>.
       We welcome any and all contributions.
     </p>
     <div class="expand-wrapper">
+      <div class="expand" id="beta-expecations">
+        <p class="expand-label">
+          <span class="expand-toggle"></span><span>Beta expectations</span>
+        </p>
+        <div class="expand-content" style="display: none;" >
+          <ul>
+            <li>
+              <strong>No configuration or agent limits</strong> <br/>
+              While in beta, {{ $displayName }} doesn't place any limits on the
+              number of configurations you can store or the number of Telegraf
+              agents you can track. However, upon being generally available,
+              the free distribution of {{ $displayName }} will have limits
+              introduced, with the option to increase limits through a
+              Telegraf Enterprise license.
+            </li>
+            <li>
+              <strong>Potential breaking changes</strong> <br/>
+              While in beta, we will do our best to no longer make breaking
+              changes to {{ $displayName }}, however, they may be necessary.
+              The majority of changes we make will be additive and non-breaking,
+              and include any necessary migrations. When we do need to make
+              breaking changes, we will do our best to communicate them clearly
+              and in advance to minimize disruption.
+            </li>
+            <li>
+              <strong>Flexible release schedule</strong> <br/>
+              While in beta, we will continue to create new releases of
+              {{ $displayName }}, but likely at irregular intervals. We will
+              provide release notes to make it easy to track updates.
+            </li>
+          </ul>
+        </div>
+      </div>
       <div class="expand" id="feedback-channels">
         <p class="expand-label">
           <span class="expand-toggle"></span><span>Join our public channels</span>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -35,6 +35,8 @@
   {{ .Scratch.Set "searchPlaceholder" "Search the docs" }}
 {{ else if (eq $currentVersion nil) }}
   {{ .Scratch.Set "searchPlaceholder"  (print "Search " (index .Site.Data.products $product).name) }}
+{{ else if (eq $product "telegraf") }}
+  {{ .Scratch.Set "searchPlaceholder"  (print "Search " (cond (eq $currentVersion "v1") "Telegraf" "Telegraf Controller")) }}
 {{ else if eq $product "influxdb" }}
   {{ if eq $currentVersion "v3" }}
     {{ .Scratch.Set "searchPlaceholder"  "Search InfluxDB OSS v3" }}

--- a/layouts/partials/topnav/product-selector.html
+++ b/layouts/partials/topnav/product-selector.html
@@ -90,7 +90,7 @@ Identify products by their product path. Dictionary schema:
       <div class="group-title"><p>Telegraf</p></div>
       <ul class="item-list products">
         <li>{{ template "productLink" (merge (dict "productPath" "telegraf/v1") $templateDefaults) }}</li>
-        <li>{{ template "productLink" (merge (dict "productPath" "telegraf/controller" "state" "alpha") $templateDefaults) }}</li>
+        <li>{{ template "productLink" (merge (dict "productPath" "telegraf/controller" "state" "beta") $templateDefaults) }}</li>
       </ul>
     </div>
     <div class="product-group">


### PR DESCRIPTION
## Summary

- Updates the home page with additional options in the Telegraf block: https://docs.influxdata.com/
- Updates the state flag for Telegraf Controller to "beta" in the product dropdown
- Updates the special state partial with information about the Telegraf Controller beta
- Updates search placeholders for Telegraf and Telegraf Controller

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
