### PR TITLE
feat(tc-settings): add settings page for telegraf controller

### DIFF
--- a/content/telegraf/controller/settings.md
+++ b/content/telegraf/controller/settings.md
@@ -119,7 +119,7 @@ and invite completion.
 | **High**   |     12     |    Yes     |    Yes     |   Yes   |         Yes         |
 
 {{% caption %}}
-\* Passwords require at least one of the defined character types
+\* Passwords require at least one of the defined character types.
 {{% /caption %}}
 
 To change the password complexity level:


### PR DESCRIPTION
## Summary

- Adds the "Manage settings" page to Telegraf Controller documentation

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
