### PR TITLE
feat(enterprise): InfluxDB Enterprise v1.12.3 release

### DIFF
--- a/content/enterprise_influxdb/v1/about-the-project/release-notes.md
+++ b/content/enterprise_influxdb/v1/about-the-project/release-notes.md
@@ -13,6 +13,63 @@ alt_links:
 
 <span id="v1.12.x"></span>
 
+## v1.12.3 {date="2026-01-12"}
+
+> [!Important]
+> #### Upgrade meta nodes first
+>
+> When upgrading to InfluxDB Enterprise 1.12.1+, upgrade meta nodes before
+> upgrading data nodes.
+
+### Features
+
+- Add [`https-insecure-certificate` configuration option](/enterprise_influxdb/v1/administration/configure/config-meta-nodes/#https-insecure-certificate)
+  to meta nodes to skip file permission checking for TLS certificate and private key files.
+  Also available for data node
+  [`[cluster]`](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#https-insecure-certificate)
+  and [`[http]`](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#https-insecure-certificate-1)
+  sections.
+- Add [`advanced-expiration` TLS configuration option](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#advanced-expiration)
+  to configure how far in advance to log warnings about TLS certificate expiration.
+- Add [backup compression options](/enterprise_influxdb/v1/tools/influxd-ctl/backup/#backup-compression)
+  (`-gzipCompressionLevel`, `-gzipBlockCount`, `-gzipBlockSize`) to
+  [`influxd-ctl backup`](/enterprise_influxdb/v1/tools/influxd-ctl/backup/).
+- Add TLS certificate reloading on `SIGHUP`.
+- Add `config` and `cq` (continuous query) diagnostics to the `/debug/vars` endpoint.
+- Improve dropped point logging.
+- Show user when displaying or logging queries.
+- Add `time_format` parameter for the HTTP API.
+- Use dynamic logging levels (`zap.AtomicLevel`).
+- Report user query bytes.
+
+### Bug fixes
+
+- Fix `FUTURE LIMIT` and `PAST LIMIT`
+  [clause order](/enterprise_influxdb/v1/query_language/manage-database/#future-limit)
+  in retention policy statements.
+- Add locking in `ClearBadShardList`.
+- Stop noisy logging about phantom shards that do not belong to a node.
+- Resolve `RLock()` leakage in `Store.DeleteSeries()`.
+- Fix condition check for optimization of array cursor (tsm1).
+- Run `init.sh` `buildtsi` as `influxdb` user.
+- Reduce unnecessary purger operations and logging.
+- Sort files for adjacency testing.
+- Fix operator in host detection (systemd).
+- Use correct path in open WAL error message.
+- Handle nested low-level files in compaction.
+- Correct error logic for writing empty index files.
+- Reduce lock contention and races in purger.
+- Fix bug with authorizer leakage in `SHOW QUERIES`.
+- Rename compact throughput logging keys.
+- Fix `https-insecure-certificate` not handled properly in httpd.
+- Prevent level regression when compacting mixed-level TSM files.
+
+### Other
+
+- Update Go to 1.24.13.
+
+---
+
 ## v1.12.2 {date="2025-09-15"}
 
 > [!Important]
@@ -43,8 +100,8 @@ alt_links:
 - Add a warning if the TLS certificate is expired.
 - Add authentication to the Raft portal and add the following related _data_
   node configuration options:
-  - [`[meta].raft-portal-auth-required`](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#raft-portal-auth-required)
-  - [`[meta].raft-dialer-auth-required`](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#raft-dialer-auth-required)
+  - [`[meta].raft-portal-auth-required`](/enterprise_influxdb/v1/administration/configure/config-meta-nodes/#raft-portal-auth-required)
+  - [`[meta].raft-dialer-auth-required`](/enterprise_influxdb/v1/administration/configure/config-meta-nodes/#raft-dialer-auth-required)
 - Improve error handling.
 - InfluxQL updates:
   - Delete series by retention policy.
@@ -407,7 +464,7 @@ alt_links:
 - Add [/api/v2/delete](/enterprise_influxdb/v1/tools/api/#apiv2delete-http-endpoint) support.
 - Add  wildcard support for retention policies in `SHOW MEASUREMENTS`.
 - Log slow queries even when query logging is not enabled.
-- Add  `--start` and `--end` [backup options](/enterprise_influxdb/v1/administration/backup-and-restore/#backup-options) to specify the time to include in backup.
+- Add  `--start` and `--end` [backup flags](/enterprise_influxdb/v1/administration/backup-and-restore/#backup-flags) to specify the time to include in backup.
 - Add Raft Status output to `inflxud-ctl show`.
 
 #### Flux updates
@@ -531,7 +588,7 @@ An edge case regression was introduced into this version that may cause a consta
 
 - **Log active queries when a process is terminated**: Add the [`termination-query-log`](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#termination-query-log--false) configuration option. When set to `true` all running queries are printed to the log when a data node process receives a `SIGTERM` (for example, a Kubernetes process exceeds the container memory limit or the process is terminated).
 
-- **Log details of HTTP calls to meta nodes**. When [`cluster-tracing`](/enterprise_influxdb/v1/administration/configure/config-meta-nodes/#cluster-tracing--false) is enabled, all API calls to meta nodes are now logged with details providing an audit trail including IP address of caller, specific API being invoked, action being invoked, and more.
+- **Log details of HTTP calls to meta nodes**. When [`cluster-tracing`](/enterprise_influxdb/v1/administration/configure/config-meta-nodes/#cluster-tracing) is enabled, all API calls to meta nodes are now logged with details providing an audit trail including IP address of caller, specific API being invoked, action being invoked, and more.
 
 ### Maintenance updates
 
@@ -797,14 +854,14 @@ For details on changes incorporated from the InfluxDB OSS release, see
 
 #### Hinted handoff improvements
 
-- Allow out-of-order writes. This change adds a configuration option `allow-out-of-order-writes` to the `[cluster]` section of the data node configuration file. This setting defaults to `false` to match the existing behavior. There are some important operational considerations to review before turning this on. But, the result is enabling this option reduces the time required to drain the hinted handoff queue and increase throughput during recovery. See [`allow-out-of-order-writes`](/enterprise_influxdb/v1/administration/config-data-nodes#allow-out-of-order-writes--false) for more detail.
-- Make the number of pending writes configurable. This change adds a configuration option in the `[hinted-handoff]` section called `max-pending-writes`, which defaults to `1024`. See [max-pending-writes](/enterprise_influxdb/v1/administration/config-data-nodes#max-pending-writes-1024) for more detail.
+- Allow out-of-order writes. This change adds a configuration option `allow-out-of-order-writes` to the `[cluster]` section of the data node configuration file. This setting defaults to `false` to match the existing behavior. There are some important operational considerations to review before turning this on. But, the result is enabling this option reduces the time required to drain the hinted handoff queue and increase throughput during recovery. See [`allow-out-of-order-writes`](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#allow-out-of-order-writes) for more detail.
+- Make the number of pending writes configurable. This change adds a configuration option in the `[hinted-handoff]` section called `max-pending-writes`, which defaults to `1024`. See [`max-writes-pending`](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#max-writes-pending) for more detail.
 - Update the hinted handoff queue to ensure various entries to segment files occur atomically. Prior to this change, entries were written to disk in three separate writes (len, data, offset). If the process stopped in the middle of any of those writes, the hinted handoff segment file was left in an invalid state.
 - In certain scenarios, the hinted-handoff queue would fail to drain. Upon node startup, the queue segment files are now verified and truncated if any are corrupted. Some additional logging has been added when a node starts writing to the hinted handoff queue as well.
 
 #### `influxd-ctl` CLI improvements
 
-- Add a verbose flag to [`influxd-ctl show-shards`](/enterprise_influxdb/v1/administration/cluster-commands/#show-shards). This option provides more information about each shard owner, including the state (hot/cold), last modified date and time, and size on disk.
+- Add a verbose flag to [`influxd-ctl show-shards`](/enterprise_influxdb/v1/tools/influxd-ctl/show-shards/). This option provides more information about each shard owner, including the state (hot/cold), last modified date and time, and size on disk.
 
 ### Bug fixes
 
@@ -832,7 +889,7 @@ For details on changes incorporated from the InfluxDB OSS release, see
   > To restore a meta data backup, use the `restore -full` command and specify
   > your backup manifest: `influxd-ctl restore -full </backup-directory/backup.manifest>`.
 
-For more information, see [Perform a metastore only backup](/enterprise_influxdb/v1/administration/backup-and-restore/#perform-a-metastore-only-backup).
+For more information, see [Perform a metadata only backup](/enterprise_influxdb/v1/administration/backup-and-restore/#perform-a-metadata-only-backup).
 
 #### **Incremental and full backups**
 
@@ -900,7 +957,7 @@ For details on changes incorporated from the InfluxDB OSS release, see [InfluxDB
 - Added logging when data nodes connect to meta service.
 
 ### Features
-- The Flux Technical Preview has advanced to version [0.36.2](/flux/v0.36/).
+- The Flux Technical Preview has advanced to version 0.36.2.
 
 ---
 
@@ -1159,7 +1216,7 @@ Please see the [InfluxDB OSS release notes](/influxdb/v1/about_the_project/relea
 > This release builds off of the 1.5 release of InfluxDB OSS. Please see the [InfluxDB OSS release
 > notes](/influxdb/v1/about_the_project/release-notes/) for more information about the InfluxDB OSS release.
 
-For highlights of the InfluxDB 1.5 release, see [What's new in InfluxDB 1.5](/influxdb/v1/about_the_project/whats_new/).
+For highlights of the InfluxDB 1.5 release, see [InfluxDB 1.5 release notes](/influxdb/v1/about_the_project/release-notes/).
 
 ### Breaking changes
 
@@ -1397,7 +1454,7 @@ The following configuration changes may need to changed before [upgrading](/ente
 
 We've removed the data node's `shard-writer-timeout` configuration option from the `[cluster]` section.
 As of version 1.2.2, the system sets `shard-writer-timeout` internally.
-The configuration option can be removed from the [data node configuration file](/enterprise_influxdb/v1/administration/configuration/#data-node-configuration).
+The configuration option can be removed from the [data node configuration file](/enterprise_influxdb/v1/administration/configure/config-data-nodes/).
 
 #### retention-autocreate
 
@@ -1415,8 +1472,8 @@ This change only affects users who have disabled the `retention-autocreate` opti
 ##### Backup and Restore
 <br>
 
-- Prevent the `shard not found` error by making [backups](/enterprise_influxdb/v1/administration/backup-and-restore/#backup) skip empty shards
-- Prevent the `shard not found` error by making [restore](/enterprise_influxdb/v1/administration/backup-and-restore/#restore) handle empty shards
+- Prevent the `shard not found` error by making [backups](/enterprise_influxdb/v1/tools/influxd-ctl/backup/) skip empty shards
+- Prevent the `shard not found` error by making [restore](/enterprise_influxdb/v1/tools/influxd-ctl/restore/) handle empty shards
 - Ensure that restores from an incremental backup correctly handle file paths
 - Allow incremental backups with restrictions (for example, they use the `-db` or `rp` flags) to be stores in the same directory
 - Support restores on meta nodes that are not the raft leader
@@ -1436,8 +1493,8 @@ This change only affects users who have disabled the `retention-autocreate` opti
 - Serialize access to the meta client and meta store to prevent raft log buildup
 - Remove sysvinit package dependency for RPM packages
 - Make the default retention policy creation an atomic process instead of a two-step process
-- Prevent `influxd-ctl`'s [`join` argument](/enterprise_influxdb/v1/features/cluster-commands/#join) from completing a join when the command also specifies the help flag (`-h`)
-- Fix the `influxd-ctl`'s [force removal](/enterprise_influxdb/v1/features/cluster-commands/#remove-meta) of meta nodes
+- Prevent `influxd-ctl`'s [`join` argument](/enterprise_influxdb/v1/tools/influxd-ctl/join/) from completing a join when the command also specifies the help flag (`-h`)
+- Fix the `influxd-ctl`'s [force removal](/enterprise_influxdb/v1/tools/influxd-ctl/remove-meta/) of meta nodes
 - Update the meta node and data node sample configuration files
 
 ---
@@ -1459,7 +1516,7 @@ Please see the OSS [release notes](https://github.com/influxdata/influxdb/blob/1
 
 ### Upgrading
 
-* The `retention-autocreate` configuration option has moved from the meta node configuration file to the [data node configuration file](/enterprise_influxdb/v1/administration/configuration/#retention-autocreate-true).
+* The `retention-autocreate` configuration option has moved from the meta node configuration file to the [data node configuration file](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#retention-autocreate).
 To disable the auto-creation of retention policies, set `retention-autocreate` to `false` in your data node configuration files.
 * The previously deprecated `influxd-ctl force-leave` command has been removed. The replacement command to remove a meta node which is never coming back online is [`influxd-ctl remove-meta -force`](/enterprise_influxdb/v1/features/cluster-commands/).
 
@@ -1468,7 +1525,7 @@ To disable the auto-creation of retention policies, set `retention-autocreate` t
 - Improve the meta store: any meta store changes are done via a compare and swap
 - Add support for [incremental backups](/enterprise_influxdb/v1/administration/backup-and-restore/)
 - Automatically remove any deleted shard groups from the data store
-- Uncomment the section headers in the default [configuration file](/enterprise_influxdb/v1/administration/configuration/)
+- Uncomment the section headers in the default [configuration file](/enterprise_influxdb/v1/administration/configure/)
 - Add InfluxQL support for [subqueries](/influxdb/v1/query_language/data_exploration/#subqueries)
 
 #### Cluster-specific Bugfixes
@@ -1476,13 +1533,13 @@ To disable the auto-creation of retention policies, set `retention-autocreate` t
 - Update dependencies with Godeps
 - Fix a data race in meta client
 - Ensure that the system removes the relevant [user permissions and roles](/enterprise_influxdb/v1/features/users/) when a database is dropped
-- Fix a couple typos in demo [configuration file](/enterprise_influxdb/v1/administration/configuration/)
+- Fix a couple typos in demo [configuration file](/enterprise_influxdb/v1/administration/configure/)
 - Make optional the version protobuf field for the meta store
 - Remove the override of GOMAXPROCS
 - Remove an unused configuration option (`dir`) from the backend
 - Fix a panic around processing remote writes
 - Return an error if a remote write has a field conflict
-- Drop points in the hinted handoff that (1) have field conflict errors (2) have [`max-values-per-tag`](/influxdb/v1/administration/config/#max-values-per-tag-100000) errors
+- Drop points in the hinted handoff that (1) have field conflict errors (2) have [`max-values-per-tag`](/influxdb/v1/administration/config/#max-values-per-tag) errors
 - Remove the deprecated `influxd-ctl force-leave` command
 - Fix issue where CQs would stop running if the first meta node in the cluster stops
 - Fix logging in the meta httpd handler service
@@ -1572,8 +1629,8 @@ Switches to journald logging for on systemd systems. Logs are no longer sent to 
 
 - Return an error if getting latest snapshot takes longer than 30 seconds
 - Remove any expired shards from the `/show-shards` output
-- Respect the [`pprof-enabled` configuration setting](/enterprise_influxdb/v1/administration/configuration/#pprof-enabled-true) and enable it by default on meta nodes
-- Respect the [`pprof-enabled` configuration setting](/enterprise_influxdb/v1/administration/configuration/#pprof-enabled-true-1) on data nodes
+- Respect the [`pprof-enabled` configuration setting](/enterprise_influxdb/v1/administration/configure/config-meta-nodes/#pprof-enabled) and enable it by default on meta nodes
+- Respect the [`pprof-enabled` configuration setting](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#pprof-enabled) on data nodes
 - Use the data reference instead of `Clone()` during read-only operations for performance purposes
 - Prevent the system from double-collecting cluster statistics
 - Ensure that the Meta API redirects to the cluster leader when it gets the `ErrNotLeader` error
@@ -1589,7 +1646,7 @@ Switches to journald logging for on systemd systems. Logs are no longer sent to 
 
 #### Cluster-specific bug fixes
 
-- Respect the [Hinted Handoff settings](/enterprise_influxdb/v1/administration/configuration/#hinted-handoff) in the configuration file
+- Respect the [Hinted Handoff settings](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#hinted-handoff) in the configuration file
 - Fix expanding regular expressions when all shards do not exist on node that's handling the request
 
 ---

--- a/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
@@ -624,6 +624,14 @@ Use a separate private key location.
 
 Environment variable: `INFLUXDB_CLUSTER_HTTPS_PRIVATE_KEY`
 
+#### https-insecure-certificate {metadata="v1.12.3+"}
+
+Default is `false`.
+
+Skips file permission checking for `https-certificate` and `https-private-key` when `true`.
+
+Environment variable: `INFLUXDB_CLUSTER_HTTPS_INSECURE_CERTIFICATE`
+
 #### https-insecure-tls
 
 Default is `false`.
@@ -1171,6 +1179,14 @@ The location of the separate private key.
 
 Environment variable: `INFLUXDB_HTTP_HTTPS_PRIVATE_KEY`
 
+#### https-insecure-certificate {metadata="v1.12.3+"}
+
+Default is `false`.
+
+Skips file permission checking for `https-certificate` and `https-private-key` when `true`.
+
+Environment variable: `INFLUXDB_HTTP_HTTPS_INSECURE_CERTIFICATE`
+
 #### shared-secret
 
 Default is `""`.
@@ -1691,6 +1707,14 @@ If not specified, `max-version` is the maximum TLS version specified in the [Go 
 In the preceding example, `max-version = "tls1.3"` specifies the maximum version as TLS 1.3.
 
 Environment variable: `INFLUXDB_TLS_MAX_VERSION`
+
+#### advanced-expiration {metadata="v1.12.3+"}
+
+Default is `5d`.
+
+Sets how far in advance to log warnings about TLS certificate expiration.
+
+Environment variable: `INFLUXDB_TLS_ADVANCED_EXPIRATION`
 
 ## Flux query management settings
 

--- a/content/enterprise_influxdb/v1/administration/configure/config-meta-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/configure/config-meta-nodes.md
@@ -170,6 +170,14 @@ Use either:
 
 Environment variable: `INFLUXDB_META_HTTPS_PRIVATE_KEY`
 
+#### https-insecure-certificate {metadata="v1.12.3+"}
+
+Default is `false`.
+
+Skips file permission checking for `https-certificate` and `https-private-key` when `true`.
+
+Environment variable: `INFLUXDB_META_HTTPS_INSECURE_CERTIFICATE`
+
 #### https-insecure-tls
 
 Default is `false`.
@@ -341,7 +349,7 @@ The shared secret used by the internal API for JWT authentication for
 inter-node communication within the cluster.
 Set this to a long pass phrase.
 This value must be the same value as the
-[`[meta] meta-internal-shared-secret`](/enterprise_influxdb/v1/administration/config-data-nodes#meta-internal-shared-secret) in the data node configuration file.
+[`[meta] meta-internal-shared-secret`](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#meta-internal-shared-secret) in the data node configuration file.
 To use this option, set [`auth-enabled`](#auth-enabled) to `true`.
 
 Environment variable: `INFLUXDB_META_INTERNAL_SHARED_SECRET`
@@ -452,7 +460,7 @@ Environment variable: `INFLUXDB_META_ENSURE_FIPS`
 Default is `false`.
 
 Require Raft clients to authenticate with server using the
-[`meta-internal-shared-secret`](#meta-internal-shared-secret).
+[`meta-internal-shared-secret`](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#meta-internal-shared-secret).
 This requires that all meta nodes are running InfluxDB Enterprise v1.12.0+ and
 are configured with the correct `meta-internal-shared-secret`.
 
@@ -465,7 +473,7 @@ Environment variable: `INFLUXDB_META_RAFT_PORTAL_AUTH_REQUIRED`
 Default is `false`.
 
 Require Raft servers to authenticate Raft clients using the
-[`meta-internal-shared-secret`](#meta-internal-shared-secret).
+[`meta-internal-shared-secret`](/enterprise_influxdb/v1/administration/configure/config-data-nodes/#meta-internal-shared-secret).
 This requires that all meta nodes are running InfluxDB Enterprise v1.12.0+, have
 `raft-portal-auth-required=true`, and are configured with the correct
 `meta-internal-shared-secret`. For existing clusters, it is recommended to enable `raft-portal-auth-required` and restart

--- a/content/enterprise_influxdb/v1/query_language/manage-database.md
+++ b/content/enterprise_influxdb/v1/query_language/manage-database.md
@@ -62,15 +62,15 @@ Creates a new database.
 #### Syntax
 
 ```sql
-CREATE DATABASE <database_name> [WITH [DURATION <duration>] [REPLICATION <n>] [SHARD DURATION <duration>] [PAST LIMIT <duration>] [FUTURE LIMIT <duration>] [NAME <retention-policy-name>]]
+CREATE DATABASE <database_name> [WITH [DURATION <duration>] [REPLICATION <n>] [SHARD DURATION <duration>] [FUTURE LIMIT <duration>] [PAST LIMIT <duration>] [NAME <retention-policy-name>]]
 ```
 
 #### Description of syntax
 
 `CREATE DATABASE` requires a database [name](/enterprise_influxdb/v1/troubleshooting/frequently-asked-questions/#what-words-and-characters-should-i-avoid-when-writing-data-to-influxdb).
 
-The `WITH`, `DURATION`, `REPLICATION`, `SHARD DURATION`, `PAST LIMIT`,
-`FUTURE LIMIT, and `NAME` clauses are optional and create a single
+The `WITH`, `DURATION`, `REPLICATION`, `SHARD DURATION`, `FUTURE LIMIT`,
+`PAST LIMIT`, and `NAME` clauses are optional and create a single
 [retention policy](/enterprise_influxdb/v1/concepts/glossary/#retention-policy-rp)
 associated with the created database.
 If you do not specify one of the clauses after `WITH`, the relevant behavior
@@ -102,7 +102,7 @@ The query creates a database called `NOAA_water_database`.
 ```
 
 The query creates a database called `NOAA_water_database`.
-It also creates a default retention policy for `NOAA_water_database` with a `DURATION` of three days, a [replication factor](/enterprise_influxdb/v1/concepts/glossary/#replication-factor) of one, a [shard group](/enterprise_influxdb/v1/concepts/glossary/#shard-group) duration of one hour, and with the name `liquid`.
+It also creates a default retention policy for `NOAA_water_database` with a `DURATION` of three days, a [replication factor](/enterprise_influxdb/v1/concepts/glossary/#replication-factor-rf) of one, a [shard group](/enterprise_influxdb/v1/concepts/glossary/#shard-group) duration of one hour, and with the name `liquid`.
 
 ### Delete a database with DROP DATABASE
 
@@ -258,7 +258,7 @@ You may disable its auto-creation in the [configuration file](/enterprise_influx
 #### Syntax
 
 ```sql
-CREATE RETENTION POLICY <retention_policy_name> ON <database_name> DURATION <duration> REPLICATION <n> [SHARD DURATION <duration>] [PAST LIMIT <duration>] [FUTURE LIMIT <duration>] [DEFAULT]
+CREATE RETENTION POLICY <retention_policy_name> ON <database_name> DURATION <duration> REPLICATION <n> [SHARD DURATION <duration>] [FUTURE LIMIT <duration>] [PAST LIMIT <duration>] [DEFAULT]
 ```
 
 #### Description of syntax
@@ -306,6 +306,17 @@ See
 [Shard group duration management](/enterprise_influxdb/v1/concepts/schema_and_data_layout/#shard-group-duration-management)
 for recommended configurations.
 
+##### `FUTURE LIMIT` {metadata="v1.12.0+"}
+
+The `FUTURE LIMIT` clause defines a time boundary after and relative to _now_
+in which points written to the retention policy are accepted. If a point has a
+timestamp after the specified boundary, the point is rejected and the write
+request returns a partial write error.
+
+For example, if a write request tries to write data to a retention policy with a
+`FUTURE LIMIT 6h` and there are points in the request with future timestamps
+greater than 6 hours from now, those points are rejected.
+
 ##### `PAST LIMIT` {metadata="v1.12.0+"}
 
 The `PAST LIMIT` clause defines a time boundary before and relative to _now_
@@ -316,25 +327,6 @@ request returns a partial write error.
 For example, if a write request tries to write data to a retention policy with a
 `PAST LIMIT 6h` and there are points in the request with timestamps older than
 6 hours, those points are rejected.
-
-> [!Important]
-> `PAST LIMIT` cannot be changed after it is set.
-> This will be fixed in a future release.
-
-##### `FUTURE LIMIT` {metadata="v1.12.0+"}
-
-The `FUTURE LIMIT` clause defines a time boundary after and relative to _now_
-in which points written to the retention policy are accepted. If a point has a
-timestamp after the specified boundary, the point is rejected and the write
-request returns a partial write error.
-
-For example, if a write request tries to write data to a retention policy with a
-`FUTURE LIMIT 6h` and there are points in the request with future timestamps 
-greater than 6 hours from now, those points are rejected.
-
-> [!Important]
-> `FUTURE LIMIT` cannot be changed after it is set.
-> This will be fixed in a future release.
 
 ##### `DEFAULT`
 
@@ -371,13 +363,16 @@ See [Create a database with CREATE DATABASE](/enterprise_influxdb/v1/query_langu
 
 ### Modify retention policies with ALTER RETENTION POLICY
 
-The `ALTER RETENTION POLICY` query takes the following form, where you must declare at least one of the retention policy attributes `DURATION`, `REPLICATION`, `SHARD DURATION`, or `DEFAULT`:
+The `ALTER RETENTION POLICY` query takes the following form, where you must declare at least one of the retention policy attributes `DURATION`, `REPLICATION`, `SHARD DURATION`, `FUTURE LIMIT`, `PAST LIMIT`, or `DEFAULT`:
 ```sql
-ALTER RETENTION POLICY <retention_policy_name> ON <database_name> [DURATION <duration>] [REPLICATION <n>] [SHARD DURATION <duration>] [DEFAULT]
+ALTER RETENTION POLICY <retention_policy_name> ON <database_name> [DURATION <duration>] [REPLICATION <n>] [SHARD DURATION <duration>] [FUTURE LIMIT <duration>] [PAST LIMIT <duration>] [DEFAULT]
 ```
 
 {{% warn %}} Replication factors do not serve a purpose with single node instances.
 {{% /warn %}}
+
+For information about the `FUTURE LIMIT` and `PAST LIMIT` clauses, see
+[CREATE RETENTION POLICY](#create-retention-policies-with-create-retention-policy).
 
 First, create the retention policy `what_is_time` with a `DURATION` of two days:
 ```sql

--- a/content/enterprise_influxdb/v1/query_language/spec.md
+++ b/content/enterprise_influxdb/v1/query_language/spec.md
@@ -1,49 +1,39 @@
 ---
 title: Influx Query Language (InfluxQL) reference
-description: Reference for Influx Query Language (InfluxQL).
+description: InfluxQL is a SQL-like query language for interacting with InfluxDB and providing features specific to storing and analyzing time series data.
 menu:
   enterprise_influxdb_v1:
     name: InfluxQL reference
     weight: 90
     parent: InfluxQL
-aliases:
-  - /influxdb/v2/query_language/spec/
+related:
+  - /enterprise_influxdb/v1/query_language/internals/
+  - /enterprise_influxdb/v1/query_language/explore-data/
+  - /enterprise_influxdb/v1/query_language/explore-schema/
+  - /enterprise_influxdb/v1/query_language/manage-database/
 ---
-
-## Introduction
 
 InfluxQL is a SQL-like query language for interacting with InfluxDB
 and providing features specific to storing and analyzing time series data.
 
-Find Influx Query Language (InfluxQL) definitions and details, including:
-
-* [Notation](/enterprise_influxdb/v1/query_language/spec/#notation)
-* [Query representation](/enterprise_influxdb/v1/query_language/spec/#query-representation)
-  * [Characters](/enterprise_influxdb/v1/query_language/spec/#characters)
-  * [Letters and digits](/enterprise_influxdb/v1/query_language/spec/#letters-and-digits)
-  * [Identifiers](/enterprise_influxdb/v1/query_language/spec/#identifiers)
-  * [Keywords](/enterprise_influxdb/v1/query_language/spec/#keywords)
-  * [Literals](/enterprise_influxdb/v1/query_language/spec/#literals)
-* [Queries](/enterprise_influxdb/v1/query_language/spec/#queries)
-* [Statements](/enterprise_influxdb/v1/query_language/spec/#statements)
-* [Clauses](/enterprise_influxdb/v1/query_language/spec/#clauses)
-* [Expressions](/enterprise_influxdb/v1/query_language/spec/#expressions)
-* [Comments](/enterprise_influxdb/v1/query_language/spec/#comments)
-* [Other](/enterprise_influxdb/v1/query_language/spec/#other)
-
-To learn more about InfluxQL, browse the following topics:
-
-* [Explore your data with InfluxQL](/enterprise_influxdb/v1/query_language/explore-data/)
-* [Explore your schema with InfluxQL](/enterprise_influxdb/v1/query_language/explore-schema/)
-* [Database management](/enterprise_influxdb/v1/query_language/manage-database/)
-* [Authentication and authorization](/enterprise_influxdb/v1/administration/authentication_and_authorization/).
-* [Query engine internals](/enterprise_influxdb/v1/query_language/spec/#query-engine-internals)
+- [Notation](#notation)
+- [Query representation](#query-representation)
+  - [Characters](#characters)
+  - [Letters and digits](#letters-and-digits)
+  - [Identifiers](#identifiers)
+  - [Keywords](#keywords)
+  - [Literals](#literals)
+- [Queries](#queries)
+- [Statements](#statements)
+- [Clauses](#clauses)
+- [Expressions](#expressions)
+- [Comments](#comments)
+- [Other](#other)
 
 ## Notation
 
 The syntax is specified using Extended Backus-Naur Form ("EBNF").
-EBNF is the same notation used in the [Go](http://golang.org) programming language specification,
-which can be found [here](https://golang.org/ref/spec).
+EBNF is the same notation used in the [Go programming language specification](https://golang.org/ref/spec).
 
 ```
 Production  = production_name "=" [ Expression ] "." .
@@ -95,7 +85,7 @@ The rules:
 
 - double quoted identifiers can contain any unicode character other than a new line
 - double quoted identifiers can contain escaped `"` characters (i.e., `\"`)
-- double quoted identifiers can contain InfluxQL [keywords](/enterprise_influxdb/v1/query_language/spec/#keywords)
+- double quoted identifiers can contain InfluxQL [keywords](#keywords)
 - unquoted identifiers must start with an upper or lowercase ASCII character or "_"
 - unquoted identifiers may contain only ASCII letters, decimal digits, and "_"
 
@@ -133,7 +123,7 @@ SUBSCRIPTIONS TAG           TO            USER          USERS         VALUES
 WHERE         WITH          WRITE
 ```
 
-If you use an InfluxQL keywords as an
+If you use an InfluxQL keyword as an
 [identifier](/enterprise_influxdb/v1/concepts/glossary/#identifier) you will need to
 double quote that identifier in every query.
 
@@ -149,7 +139,7 @@ In those cases, `time` does not require double quotes in queries.
 `time` cannot be a [field key](/enterprise_influxdb/v1/concepts/glossary/#field-key) or
 [tag key](/enterprise_influxdb/v1/concepts/glossary/#tag-key);
 InfluxDB rejects writes with `time` as a field key or tag key and returns an error.
-See [Frequently Asked Questions](/enterprise_influxdb/v1/troubleshooting/frequently-asked-questions/#time) for more information.
+For more information, see [Frequently Asked Questions](/enterprise_influxdb/v1/troubleshooting/frequently-asked-questions/#time).
 
 ### Literals
 
@@ -199,6 +189,7 @@ Durations can be specified with mixed units.
 | d      | day                                     |
 | w      | week                                    |
 
+
 ```
 duration_lit        = int_lit duration_unit .
 duration_unit       = "ns" | "u" | "µ" | "ms" | "s" | "m" | "h" | "d" | "w" .
@@ -232,18 +223,22 @@ regex_lit           = "/" { unicode_char } "/" .
 `=~` matches against
 `!~` doesn't match against
 
-> **Note:** InfluxQL supports using regular expressions when specifying:
+
+InfluxQL supports using regular expressions when specifying:
+
+- [field keys](/enterprise_influxdb/v1/concepts/glossary/#field-key) and [tag keys](/enterprise_influxdb/v1/concepts/glossary/#tag-key) in the [`SELECT` clause](/enterprise_influxdb/v1/query_language/explore-data/#the-basic-select-statement)
+- [measurements](/enterprise_influxdb/v1/concepts/glossary/#measurement) in the [`FROM` clause](/enterprise_influxdb/v1/query_language/explore-data/#the-basic-select-statement)
+- [tag values](/enterprise_influxdb/v1/concepts/glossary/#tag-value) and string [field values](/enterprise_influxdb/v1/concepts/glossary/#field-value) in the [`WHERE` clause](/enterprise_influxdb/v1/query_language/explore-data/#the-where-clause).
+- [tag keys](/enterprise_influxdb/v1/concepts/glossary/#tag-key) in the [`GROUP BY` clause](/enterprise_influxdb/v1/query_language/explore-data/#group-by-tags)
+
+> [!Note]
+> #### Regular expressions and non-string field values
 >
-* [field keys](/enterprise_influxdb/v1/concepts/glossary/#field-key) and [tag keys](/enterprise_influxdb/v1/concepts/glossary/#tag-key) in the [`SELECT` clause](/enterprise_influxdb/v1/query_language/explore-data/#the-basic-select-statement)
-* [measurements](/enterprise_influxdb/v1/concepts/glossary/#measurement) in the [`FROM` clause](/enterprise_influxdb/v1/query_language/explore-data/#the-basic-select-statement)
-* [tag values](/enterprise_influxdb/v1/concepts/glossary/#tag-value) and string [field values](/enterprise_influxdb/v1/concepts/glossary/#field-value) in the [`WHERE` clause](/enterprise_influxdb/v1/query_language/explore-data/#the-where-clause).
-* [tag keys](/enterprise_influxdb/v1/concepts/glossary/#tag-key) in the [`GROUP BY` clause](/enterprise_influxdb/v1/query_language/explore-data/#group-by-tags)
->
->Currently, InfluxQL does not support using regular expressions to match
->non-string field values in the
->`WHERE` clause,
->[databases](/enterprise_influxdb/v1/concepts/glossary/#database), and
->[retention polices](/enterprise_influxdb/v1/concepts/glossary/#retention-policy-rp).
+> Currently, InfluxQL does not support using regular expressions to match
+> non-string field values in the
+> `WHERE` clause,
+> [databases](/enterprise_influxdb/v1/concepts/glossary/#database), and
+> [retention policies](/enterprise_influxdb/v1/concepts/glossary/#retention-policy-rp).
 
 ## Queries
 
@@ -308,6 +303,8 @@ alter_retention_policy_stmt  = "ALTER RETENTION POLICY" policy_name on_clause
                                retention_policy_option
                                [ retention_policy_option ]
                                [ retention_policy_option ]
+                               [ retention_policy_option ]
+                               [ retention_policy_option ]
                                [ retention_policy_option ] .
 ```
 
@@ -320,6 +317,9 @@ ALTER RETENTION POLICY "1h.cpu" ON "mydb" DEFAULT
 -- Change duration and replication factor.
 -- REPLICATION (replication factor) not valid for OSS instances.
 ALTER RETENTION POLICY "policy1" ON "somedb" DURATION 1h REPLICATION 4
+
+-- Change future and past limits.
+ALTER RETENTION POLICY "policy1" ON "somedb" FUTURE LIMIT 6h PAST LIMIT 6h
 ```
 
 ### CREATE CONTINUOUS QUERY
@@ -379,12 +379,19 @@ create_database_stmt = "CREATE DATABASE" db_name
                        [ WITH
                            [ retention_policy_duration ]
                            [ retention_policy_replication ]
-                           [ retention_past_limit ]
-                           [ retention_future_limit ]
                            [ retention_policy_shard_group_duration ]
+                           [ retention_future_limit ]
+                           [ retention_past_limit ]
                            [ retention_policy_name ]
                        ] .
 ```
+
+> [!Note]
+> When using both `FUTURE LIMIT` and `PAST LIMIT` clauses, `FUTURE LIMIT` must appear before `PAST LIMIT`.
+
+> [!Caution]
+> **Prior to InfluxDB Enterprise v1.12.3**, when using both `FUTURE LIMIT` and `PAST LIMIT` clauses,
+> `PAST LIMIT` must appear before `FUTURE LIMIT`.
 
 > [!Warning]
 > Replication factors do not serve a purpose with single node instances.
@@ -404,8 +411,8 @@ CREATE DATABASE "bar" WITH DURATION 1d REPLICATION 1 SHARD DURATION 30m NAME "my
 CREATE DATABASE "mydb" WITH NAME "myrp"
 
 -- Create a database called bar with a new retention policy named "myrp", and
--- specify the duration, past and future limits, and name of that retention policy
-CREATE DATABASE "bar" WITH DURATION 1d PAST LIMIT 6h FUTURE LIMIT 6h NAME "myrp"
+-- specify the duration, future and past limits, and name of that retention policy
+CREATE DATABASE "bar" WITH DURATION 1d FUTURE LIMIT 6h PAST LIMIT 6h NAME "myrp"
 ```
 
 ### CREATE RETENTION POLICY
@@ -415,10 +422,17 @@ create_retention_policy_stmt = "CREATE RETENTION POLICY" policy_name on_clause
                                retention_policy_duration
                                retention_policy_replication
                                [ retention_policy_shard_group_duration ]
-                               [ retention_past_limit ]
                                [ retention_future_limit ]
+                               [ retention_past_limit ]
                                [ "DEFAULT" ] .
 ```
+
+> [!Note]
+> When using both `FUTURE LIMIT` and `PAST LIMIT` clauses, `FUTURE LIMIT` must appear before `PAST LIMIT`.
+
+> [!Caution]
+> **Prior to InfluxDB Enterprise v1.12.3**, when using both `FUTURE LIMIT` and `PAST LIMIT` clauses,
+> `PAST LIMIT` must appear before `FUTURE LIMIT`.
 
 > [!Warning]
 > Replication factors do not serve a purpose with single node instances.
@@ -435,8 +449,8 @@ CREATE RETENTION POLICY "10m.events" ON "somedb" DURATION 60m REPLICATION 2 DEFA
 -- Create a retention policy and specify the shard group duration.
 CREATE RETENTION POLICY "10m.events" ON "somedb" DURATION 60m REPLICATION 2 SHARD DURATION 30m
 
--- Create a retention policy and specify past and future limits.
-CREATE RETENTION POLICY "10m.events" ON "somedb" DURATION 12h PAST LIMIT 6h FUTURE LIMIT 6h
+-- Create a retention policy and specify future and past limits.
+CREATE RETENTION POLICY "10m.events" ON "somedb" DURATION 12h FUTURE LIMIT 6h PAST LIMIT 6h
 ```
 
 ### CREATE SUBSCRIPTION
@@ -631,7 +645,7 @@ SIZE OF BLOCKS: 931
 
 ### EXPLAIN ANALYZE
 
-Executes the specified SELECT statement and returns data on the query performance and storage during runtime, visualized as a tree. Use this statement to analyze query performance and storage, including [execution time](#execution-time) and [planning time](#planning-time), and the [iterator type](#iterator-type) and [cursor type](#cursor-type).
+Executes the specified SELECT statement and returns data on the query performance and storage during runtime, visualized as a tree. Use this statement to analyze query performance and storage, including [execution time](#execution_time) and [planning time](#planning_time), and the [iterator type](#iterator-type) and [cursor type](#cursor-type).
 
 For example, executing the following statement:
 
@@ -677,11 +691,11 @@ EXPLAIN ANALYZE
 
 > Note: EXPLAIN ANALYZE ignores query output, so the cost of serialization to JSON or CSV is not accounted for.
 
-##### execution_time
+#### execution_time
 
 Shows the amount of time the query took to execute, including reading the time series data, performing operations as data flows through iterators, and draining processed data from iterators. Execution time doesn't include the time taken to serialize the output into JSON or other formats.
 
-##### planning_time
+#### planning_time
 
 Shows the amount of time the query took to plan.
 Planning a query in InfluxDB requires a number of steps. Depending on the complexity of the query, planning can require more work and consume more CPU and memory resources than the executing the query. For example, the number of series keys required to execute a query affects how quickly the query is planned and the required memory.
@@ -694,16 +708,16 @@ Next, for each shard and each measurement, InfluxDB performs the following steps
 3. Enumerate each tag set and create a cursor and iterator for each series key.
 4. Merge iterators and return the merged result to the query executor.
 
-##### iterator type
+#### iterator type
 
 EXPLAIN ANALYZE supports the following iterator types:
 
 - `create_iterator` node represents work done by the local influxd instance──a complex composition of nested iterators combined and merged to produce the final query output.
 - (InfluxDB Enterprise only) `remote_iterator` node represents work done on remote machines.
 
-For more information about iterators, see [Understanding iterators](#understanding-iterators).
+For more information about iterators, see [Understanding iterators](/influxdb/v1/query_language/spec/#understanding-iterators).
 
-##### cursor type
+#### cursor type
 
 EXPLAIN ANALYZE distinguishes 3 cursor types. While the cursor types have the same data structures and equal CPU and I/O costs, each cursor type is constructed for a different reason and separated in the final output. Consider the following cursor types when tuning a statement:
 
@@ -711,9 +725,9 @@ EXPLAIN ANALYZE distinguishes 3 cursor types. While the cursor types have the sa
 - cursor_aux:	Auxiliary cursor created for simple expression projections (not selectors or an aggregation). For example, `SELECT foo FROM m` or `SELECT foo+bar FROM m`, where `foo` and `bar` are fields.
 - cursor_cond: Condition cursor created for fields referenced in a WHERE clause.
 
-For more information about cursors, see [Understanding cursors](#understanding-cursors).
+For more information about cursors, see [Understanding cursors](/influxdb/v1/query_language/spec/#understanding-cursors).
 
-##### block types
+#### block types
 
 EXPLAIN ANALYZE separates storage block types, and reports the total number of blocks decoded and their size (in bytes) on disk. The following block types are supported:
 
@@ -727,7 +741,8 @@ For more information about storage blocks, see [TSM files](/enterprise_influxdb/
 
 ### GRANT
 
-> **NOTE:** Users can be granted privileges on databases that do not yet exist.
+> [!Note]
+> Users can be granted privileges on databases that do not yet exist.
 
 ```
 grant_stmt = "GRANT" privilege [ on_clause ] to_clause .
@@ -745,29 +760,27 @@ GRANT READ ON "mydb" TO "jdoe"
 
 ### KILL QUERY
 
-Stop currently-running query.
+Stop a currently-running query.
 
-```
-kill_query_statement = "KILL QUERY" query_id .
+#### Syntax
+
+```text
+KILL QUERY <query_id> [ON "<host>"]
 ```
 
-Where `query_id` is the query ID, displayed in the [`SHOW QUERIES`](/enterprise_influxdb/v1/troubleshooting/query_management/#list-currently-running-queries-with-show-queries) output as `qid`.
+Replace the following:
 
-> ***InfluxDB Enterprise clusters:*** To kill queries on a cluster, you need to specify the query ID (qid) and the TCP host (for example, `myhost:8088`),
-> available in the `SHOW QUERIES` output.
->
-> ```sql
-KILL QUERY <qid> ON "<host>"
-```
+- `query_id`: your query ID (`qid`) from [`SHOW QUERIES`](/influxdb/v1/troubleshooting/query_management/#list-currently-running-queries-with-show-queries)
+- `host`: your TCP host (for example, `myhost:8088`) from [`SHOW QUERIES`](/influxdb/v1/troubleshooting/query_management/#list-currently-running-queries-with-show-queries)
+
+To kill queries on a cluster, specify both the query ID and the TCP host.
 
 #### Examples
 
 ```sql
 -- kill query with qid of 36 on the local host
 KILL QUERY 36
-```
 
-```sql
 -- kill query on InfluxDB Enterprise cluster
 KILL QUERY 53 ON "myhost:8088"
 ```
@@ -1004,7 +1017,8 @@ Estimates or counts exactly the cardinality of the series for the current databa
 - [When do I need more RAM?](/enterprise_influxdb/v1/guides/hardware_sizing/#when-do-i-need-more-ram) in [Hardware Sizing Guidelines](/enterprise_influxdb/v1/guides/hardware_sizing/)
 - [Don't have too many series](/enterprise_influxdb/v1/concepts/schema_and_data_layout/#avoid-too-many-series)
 
-> **Note:** `ON <database>`, `FROM <sources>`, `WITH KEY = <key>`, `WHERE <condition>`, `GROUP BY <dimensions>`, and `LIMIT/OFFSET` clauses are optional.
+> [!Note]
+> `ON <database>`, `FROM <sources>`, `WITH KEY = <key>`, `WHERE <condition>`, `GROUP BY <dimensions>`, and `LIMIT/OFFSET` clauses are optional.
 > When using these query clauses, the query falls back to an exact count.
 > Filtering by `time` is not supported in the `WHERE` clause.
 
@@ -1066,7 +1080,7 @@ id  database   retention_policy shard_group start_time           end_time       
 - `id` column: Shard IDs that belong to the specified `database` and `retention policy`.
 - `shard_group` column: Group number that a shard belongs to. Shards in the same shard group have the same `start_time` and `end_time`. This interval indicates how long the shard is active, and the `expiry_time` columns shows when the shard group expires. No timestamps will show under `expiry_time` if the retention policy duration is set to infinite.
 - `owners` column: Shows the data nodes that own a shard. The number of nodes that own a shard is equal to the replication factor. In this example, the replication factor is 3, so 3 nodes own each shard.
-  
+
 ### SHOW STATS
 
 Returns detailed statistics on available components of an InfluxDB node and available (enabled) components.
@@ -1099,17 +1113,16 @@ batches_tx      bytes_rx        connections_active      connections_handled     
 159             3999750         0                       1                       158110          158110
 ```
 
-### `SHOW STATS FOR <component>`
+### SHOW STATS FOR <component>
 
 For the specified component (\<component\>), the command returns available statistics.
 For the `runtime` component, the command returns an overview of memory usage by the InfluxDB system,
 using the [Go runtime](https://golang.org/pkg/runtime/) package.
 
-### `SHOW STATS FOR 'indexes'`
+### SHOW STATS FOR 'indexes'
 
 Returns an estimate of memory use of all indexes.
 Index memory use is not reported with `SHOW STATS` because it is a potentially expensive operation.
-
 
 ### SHOW SUBSCRIPTIONS
 
@@ -1127,7 +1140,8 @@ SHOW SUBSCRIPTIONS
 
 Estimates or counts exactly the cardinality of tag key set on the current database unless a database is specified using the `ON <database>` option.
 
-> **Note:** `ON <database>`, `FROM <sources>`, `WITH KEY = <key>`, `WHERE <condition>`, `GROUP BY <dimensions>`, and `LIMIT/OFFSET` clauses are optional.
+> [!Note]
+> `ON <database>`, `FROM <sources>`, `WITH KEY = <key>`, `WHERE <condition>`, `GROUP BY <dimensions>`, and `LIMIT/OFFSET` clauses are optional.
 > When using these query clauses, the query falls back to an exact count.
 > Filtering by `time` is only supported when TSI (Time Series Index) is enabled and `time` is not supported in the `WHERE` clause.
 
@@ -1149,7 +1163,7 @@ SHOW TAG KEY EXACT CARDINALITY
 ### SHOW TAG KEYS
 
 ```
-show_tag_keys_stmt = "SHOW TAG KEYS" [on_clause] [ from_clause ] [ where_clause ]
+show_tag_keys_stmt = "SHOW TAG KEYS" [on_clause] [with_key_clause] [ from_clause ] [ where_clause ]
                      [ limit_clause ] [ offset_clause ] .
 ```
 
@@ -1167,6 +1181,9 @@ SHOW TAG KEYS FROM "cpu" WHERE "region" = 'uswest'
 
 -- show all tag keys where the host key = 'serverA'
 SHOW TAG KEYS WHERE "host" = 'serverA'
+
+-- show specific tag keys
+SHOW TAG KEYS WITH KEY IN ("region", "host")
 ```
 
 ### SHOW TAG VALUES
@@ -1196,7 +1213,8 @@ SHOW TAG VALUES FROM "cpu" WITH KEY IN ("region", "host") WHERE "service" = 'red
 
 Estimates or counts exactly the cardinality of tag key values for the specified tag key on the current database unless a database is specified using the `ON <database>` option.
 
-> **Note:** `ON <database>`, `FROM <sources>`, `WITH KEY = <key>`, `WHERE <condition>`, `GROUP BY <dimensions>`, and `LIMIT/OFFSET` clauses are optional.
+> [!Note]
+> `ON <database>`, `FROM <sources>`, `WITH KEY = <key>`, `WHERE <condition>`, `GROUP BY <dimensions>`, and `LIMIT/OFFSET` clauses are optional.
 > When using these query clauses, the query falls back to an exact count.
 > Filtering by `time` is only supported when TSI (Time Series Index) is enabled.
 
@@ -1332,6 +1350,8 @@ retention_policy = identifier .
 retention_policy_option      = retention_policy_duration |
                                retention_policy_replication |
                                retention_policy_shard_group_duration |
+                               retention_future_limit |
+                               retention_past_limit |
                                "DEFAULT" .
 
 retention_policy_duration    = "DURATION" duration_lit .
@@ -1339,6 +1359,10 @@ retention_policy_duration    = "DURATION" duration_lit .
 retention_policy_replication = "REPLICATION" int_lit .
 
 retention_policy_shard_group_duration = "SHARD DURATION" duration_lit .
+
+retention_future_limit       = "FUTURE LIMIT" duration_lit .
+
+retention_past_limit         = "PAST LIMIT" duration_lit .
 
 retention_policy_name = "NAME" identifier .
 

--- a/content/enterprise_influxdb/v1/tools/influxd-ctl/backup.md
+++ b/content/enterprise_influxdb/v1/tools/influxd-ctl/backup.md
@@ -48,21 +48,48 @@ influxd-ctl backup [flags] <backup-dir>
 
 ## Flags
 
-| Flag        | Description                                                         |
-| :---------- | :------------------------------------------------------------------ |
-| `-db`       | Database to backup                                                  |
-| `-end`      | End date for backup _(RFC3339 timestamp)_                           |
-| `-estimate` | Estimate the size of the requested backup                           |
-| `-from`     | Data node TCP address to prefer when backing up                     |
-| `-full`     | Perform an full backup _(deprecated in favour of `-strategy full`)_ |
-| `-rp`       | Retention policy to backup                                          |
-| `-shard`    | Shard ID to backup                                                  |
-| `-start`    | Start date for backup _(RFC3339 timestamp)_                         |
-| `-strategy` | Backup strategy to use (`only-meta`, `full`, or `incremental`)      |
+| Flag                    | Description                                                         |
+| :---------------------- | :------------------------------------------------------------------ |
+| `-db`                   | Database to backup                                                  |
+| `-end`                  | End date for backup _(RFC3339 timestamp)_                           |
+| `-estimate`             | Estimate the size of the requested backup                           |
+| `-from`                 | Data node TCP address to prefer when backing up                     |
+| `-full`                 | Perform a full backup _(deprecated in favor of `-strategy full`)_  |
+| `-rp`                   | Retention policy to backup                                          |
+| `-shard`                | Shard ID to backup                                                  |
+| `-start`                | Start date for backup _(RFC3339 timestamp)_                         |
+| `-strategy`             | Backup strategy to use (`only-meta`, `full`, or `incremental`)      |
+| `-gzipCompressionLevel` | Level of compression to use (`default`, `full`, `speedy`, `none`)   |
+| `-cpuprofile`           | Write backup execution to a cpu profile (`true` or `false`)         |
+| `-gzipBlockCount`       | Change the blocks processed concurrently during backup compression  |
+| `-gzipBlockSize`        | Change the size of compressed blocks during backup compression      |
 
 {{% caption %}}
 _Also see [`influxd-ctl` global flags](/enterprise_influxdb/v1/tools/influxd-ctl/#influxd-ctl-global-flags)._
 {{% /caption %}}
+
+## Backup compression {metadata="v1.12.3+"}
+
+You can adjust `-gzipCompressionLevel` to allow for faster backups with the tradeoff that data is less compressed.
+
+| Value   | Description                        | Use Case                                    |
+| :------ | :--------------------------------- | :------------------------------------------ |
+| default | Standard gzip compression          | General purpose, balanced                   |
+| full    | Best compression ratio             | Minimize storage when time isn't critical   |
+| speedy  | Prioritizes speed over compression | Faster backups with moderate space increase |
+| none    | No compression                     | Maximum speed when storage isn't a concern  |
+
+Running backups with different compression settings on ~5.3 GB of data:
+
+| Compression Level | Backup Time | Size on Disk | Notes                         |
+| :---------------- | :---------: | :----------: | :---------------------------- |
+| default           |     51s     |   ~3.0 GB    | ~50% compression ratio        |
+| full              |     95s     |   ~2.7 GB    | ~2x slower, ~10% less space   |
+| speedy            |     23s     |   ~3.3 GB    | ~2.2x faster, ~10% more space |
+| none              |     10s     |   ~5.3 GB    | ~5x faster, ~77% more space   |
+
+We do not recommend changing the values for `-gzipBlockCount` and `-gzipBlockSize`.
+These are set to sensible defaults (block size is `1048576` bytes (`1024*1024`)) per the [pgzip library](https://github.com/klauspost/pgzip).
 
 ## Examples
 
@@ -71,6 +98,7 @@ _Also see [`influxd-ctl` global flags](/enterprise_influxdb/v1/tools/influxd-ctl
 - [Estimate the size of a backup](#estimate-the-size-of-a-backup)
 - [Backup data from a specific time range](#backup-data-from-a-specific-time-range)
 - [Backup a specific shard](#backup-a-specific-shard)
+- [Backup data with configured compression](#backup-data-with-configured-compression)
 
 ### Perform an incremental backup
 
@@ -103,4 +131,12 @@ influxd-ctl backup \
 
 ```sh
 influxd-ctl backup -shard 00 /path/to/backup-dir
+```
+
+### Backup data with configured compression
+
+The following example uses the fastest possible compression speeds for backup:
+
+```sh
+influxd-ctl backup -strategy full -gzipBlockSize 10485760 -gzipBlockCount 28 -gzipCompressionLevel none .
 ```

--- a/data/products.yml
+++ b/data/products.yml
@@ -349,7 +349,7 @@ enterprise_influxdb:
   versions: [v1]
   latest: v1.12
   latest_patches:
-    v1: 1.12.2
+    v1: 1.12.3
   detector_config:
     query_languages:
       InfluxQL:


### PR DESCRIPTION
## Summary

InfluxDB Enterprise v1.12.3 release documentation. **Merge when Enterprise v1.12.3 is GA in the InfluxData portal.**

Stacked on #6945 (OSS v1.12.3). Will auto-retarget to `master` when the OSS PR merges.

## Pre-merge Gate
- [ ] **Release artifact is GA in the InfluxData portal**
- [ ] **v1 codeowner has signaled readiness** (e.g., applied `release:ready` label)

## Changes (Enterprise v1 only)
- `content/enterprise_influxdb/v1/about-the-project/release-notes.md` — v1.12.3 release notes
- `content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md` — `https-insecure-certificate`, `advanced-expiration`
- `content/enterprise_influxdb/v1/administration/configure/config-meta-nodes.md` — `https-insecure-certificate`
- `content/enterprise_influxdb/v1/query_language/manage-database.md` — FUTURE/PAST LIMIT clause order fix
- `content/enterprise_influxdb/v1/query_language/spec.md` — InfluxQL spec cleanup + pre-v1.12.3 ordering caution
- `content/enterprise_influxdb/v1/tools/influxd-ctl/backup.md` — backup compression flags
- `data/products.yml` — Enterprise version bump (1.12.2 → 1.12.3)

## Test plan
- [ ] Hugo build succeeds (`npx hugo --quiet`)
- [ ] No OSS v1 content changes in diff
- [ ] `data/products.yml` shows Enterprise at 1.12.3
- [ ] Link validation passes for Enterprise v1 content