### PR TITLE
fix(enterprise): correct FUTURE/PAST LIMIT docs for v1.12.2

### DIFF
--- a/content/enterprise_influxdb/v1/query_language/manage-database.md
+++ b/content/enterprise_influxdb/v1/query_language/manage-database.md
@@ -62,15 +62,15 @@ Creates a new database.
 #### Syntax
 
 ```sql
-CREATE DATABASE <database_name> [WITH [DURATION <duration>] [REPLICATION <n>] [SHARD DURATION <duration>] [PAST LIMIT <duration>] [FUTURE LIMIT <duration>] [NAME <retention-policy-name>]]
+CREATE DATABASE <database_name> [WITH [DURATION <duration>] [REPLICATION <n>] [SHARD DURATION <duration>] [FUTURE LIMIT <duration>] [PAST LIMIT <duration>] [NAME <retention-policy-name>]]
 ```
 
 #### Description of syntax
 
 `CREATE DATABASE` requires a database [name](/enterprise_influxdb/v1/troubleshooting/frequently-asked-questions/#what-words-and-characters-should-i-avoid-when-writing-data-to-influxdb).
 
-The `WITH`, `DURATION`, `REPLICATION`, `SHARD DURATION`, `PAST LIMIT`,
-`FUTURE LIMIT, and `NAME` clauses are optional and create a single
+The `WITH`, `DURATION`, `REPLICATION`, `SHARD DURATION`, `FUTURE LIMIT`,
+`PAST LIMIT`, and `NAME` clauses are optional and create a single
 [retention policy](/enterprise_influxdb/v1/concepts/glossary/#retention-policy-rp)
 associated with the created database.
 If you do not specify one of the clauses after `WITH`, the relevant behavior
@@ -102,7 +102,7 @@ The query creates a database called `NOAA_water_database`.
 ```
 
 The query creates a database called `NOAA_water_database`.
-It also creates a default retention policy for `NOAA_water_database` with a `DURATION` of three days, a [replication factor](/enterprise_influxdb/v1/concepts/glossary/#replication-factor) of one, a [shard group](/enterprise_influxdb/v1/concepts/glossary/#shard-group) duration of one hour, and with the name `liquid`.
+It also creates a default retention policy for `NOAA_water_database` with a `DURATION` of three days, a [replication factor](/enterprise_influxdb/v1/concepts/glossary/#replication-factor-rf) of one, a [shard group](/enterprise_influxdb/v1/concepts/glossary/#shard-group) duration of one hour, and with the name `liquid`.
 
 ### Delete a database with DROP DATABASE
 
@@ -258,7 +258,7 @@ You may disable its auto-creation in the [configuration file](/enterprise_influx
 #### Syntax
 
 ```sql
-CREATE RETENTION POLICY <retention_policy_name> ON <database_name> DURATION <duration> REPLICATION <n> [SHARD DURATION <duration>] [PAST LIMIT <duration>] [FUTURE LIMIT <duration>] [DEFAULT]
+CREATE RETENTION POLICY <retention_policy_name> ON <database_name> DURATION <duration> REPLICATION <n> [SHARD DURATION <duration>] [FUTURE LIMIT <duration>] [PAST LIMIT <duration>] [DEFAULT]
 ```
 
 #### Description of syntax
@@ -306,6 +306,21 @@ See
 [Shard group duration management](/enterprise_influxdb/v1/concepts/schema_and_data_layout/#shard-group-duration-management)
 for recommended configurations.
 
+##### `FUTURE LIMIT` {metadata="v1.12.0+"}
+
+The `FUTURE LIMIT` clause defines a time boundary after and relative to _now_
+in which points written to the retention policy are accepted. If a point has a
+timestamp after the specified boundary, the point is rejected and the write
+request returns a partial write error.
+
+For example, if a write request tries to write data to a retention policy with a
+`FUTURE LIMIT 6h` and there are points in the request with future timestamps
+greater than 6 hours from now, those points are rejected.
+
+> [!Important]
+> `FUTURE LIMIT` cannot be changed after it is set.
+> This will be fixed in a future release.
+
 ##### `PAST LIMIT` {metadata="v1.12.0+"}
 
 The `PAST LIMIT` clause defines a time boundary before and relative to _now_
@@ -319,21 +334,6 @@ For example, if a write request tries to write data to a retention policy with a
 
 > [!Important]
 > `PAST LIMIT` cannot be changed after it is set.
-> This will be fixed in a future release.
-
-##### `FUTURE LIMIT` {metadata="v1.12.0+"}
-
-The `FUTURE LIMIT` clause defines a time boundary after and relative to _now_
-in which points written to the retention policy are accepted. If a point has a
-timestamp after the specified boundary, the point is rejected and the write
-request returns a partial write error.
-
-For example, if a write request tries to write data to a retention policy with a
-`FUTURE LIMIT 6h` and there are points in the request with future timestamps 
-greater than 6 hours from now, those points are rejected.
-
-> [!Important]
-> `FUTURE LIMIT` cannot be changed after it is set.
 > This will be fixed in a future release.
 
 ##### `DEFAULT`

--- a/content/enterprise_influxdb/v1/query_language/spec.md
+++ b/content/enterprise_influxdb/v1/query_language/spec.md
@@ -379,12 +379,15 @@ create_database_stmt = "CREATE DATABASE" db_name
                        [ WITH
                            [ retention_policy_duration ]
                            [ retention_policy_replication ]
-                           [ retention_past_limit ]
-                           [ retention_future_limit ]
                            [ retention_policy_shard_group_duration ]
+                           [ retention_future_limit ]
+                           [ retention_past_limit ]
                            [ retention_policy_name ]
                        ] .
 ```
+
+> [!Note]
+> When using both `FUTURE LIMIT` and `PAST LIMIT` clauses, `FUTURE LIMIT` must appear before `PAST LIMIT`.
 
 > [!Warning]
 > Replication factors do not serve a purpose with single node instances.
@@ -404,8 +407,8 @@ CREATE DATABASE "bar" WITH DURATION 1d REPLICATION 1 SHARD DURATION 30m NAME "my
 CREATE DATABASE "mydb" WITH NAME "myrp"
 
 -- Create a database called bar with a new retention policy named "myrp", and
--- specify the duration, past and future limits, and name of that retention policy
-CREATE DATABASE "bar" WITH DURATION 1d PAST LIMIT 6h FUTURE LIMIT 6h NAME "myrp"
+-- specify the duration, future and past limits, and name of that retention policy
+CREATE DATABASE "bar" WITH DURATION 1d FUTURE LIMIT 6h PAST LIMIT 6h NAME "myrp"
 ```
 
 ### CREATE RETENTION POLICY
@@ -415,10 +418,13 @@ create_retention_policy_stmt = "CREATE RETENTION POLICY" policy_name on_clause
                                retention_policy_duration
                                retention_policy_replication
                                [ retention_policy_shard_group_duration ]
-                               [ retention_past_limit ]
                                [ retention_future_limit ]
+                               [ retention_past_limit ]
                                [ "DEFAULT" ] .
 ```
+
+> [!Note]
+> When using both `FUTURE LIMIT` and `PAST LIMIT` clauses, `FUTURE LIMIT` must appear before `PAST LIMIT`.
 
 > [!Warning]
 > Replication factors do not serve a purpose with single node instances.
@@ -435,8 +441,8 @@ CREATE RETENTION POLICY "10m.events" ON "somedb" DURATION 60m REPLICATION 2 DEFA
 -- Create a retention policy and specify the shard group duration.
 CREATE RETENTION POLICY "10m.events" ON "somedb" DURATION 60m REPLICATION 2 SHARD DURATION 30m
 
--- Create a retention policy and specify past and future limits.
-CREATE RETENTION POLICY "10m.events" ON "somedb" DURATION 12h PAST LIMIT 6h FUTURE LIMIT 6h
+-- Create a retention policy and specify future and past limits.
+CREATE RETENTION POLICY "10m.events" ON "somedb" DURATION 12h FUTURE LIMIT 6h PAST LIMIT 6h
 ```
 
 ### CREATE SUBSCRIPTION
@@ -1339,6 +1345,10 @@ retention_policy_duration    = "DURATION" duration_lit .
 retention_policy_replication = "REPLICATION" int_lit .
 
 retention_policy_shard_group_duration = "SHARD DURATION" duration_lit .
+
+retention_future_limit       = "FUTURE LIMIT" duration_lit .
+
+retention_past_limit         = "PAST LIMIT" duration_lit .
 
 retention_policy_name = "NAME" identifier .
 


### PR DESCRIPTION
## Summary

- Fixes documentation bugs in Enterprise v1.12.2 InfluxQL docs where PAST LIMIT incorrectly appeared before FUTURE LIMIT
- The correct syntax has always been FUTURE LIMIT before PAST LIMIT — this is a doc bug, not a parser change
- Reorders grammar productions in `spec.md` (CREATE DATABASE, CREATE RETENTION POLICY) to match actual parser behavior
- Adds ordering note callouts explaining that FUTURE LIMIT must precede PAST LIMIT when both are used
- Fixes example SQL to use the correct clause order
- Adds missing `retention_future_limit` and `retention_past_limit` production rule definitions to the spec
- Reorders FUTURE/PAST LIMIT section descriptions in `manage-database.md` to match syntax order
- Fixes broken glossary anchor: `#replication-factor` → `#replication-factor-rf`

Closes #6590
Stacked on #6945