### PR TITLE
Fix documentation links for CLI and Power BI visualization

### DIFF
--- a/content/influxdb3/cloud-dedicated/admin/clusters/list.md
+++ b/content/influxdb3/cloud-dedicated/admin/clusters/list.md
@@ -15,7 +15,7 @@ aliases:
   - /influxdb3/cloud-dedicated/admin/clusters/list/
 ---
 
-Use the Admin UI or the [`influxctl cluster list` CLI command](/influxdb3/cloud-dedicated/reference/cli/influxctl/list/)
+Use the Admin UI or the [`influxctl cluster list` CLI command](/influxdb3/cloud-dedicated/reference/cli/influxctl/cluster/list/)
 to view information about all {{< product-name omit=" Clustered" >}} clusters associated with your account ID.
 
 {{< tabs-wrapper >}}

--- a/content/influxdb3/cloud-dedicated/query-data/execute-queries/visualization-tools.md
+++ b/content/influxdb3/cloud-dedicated/query-data/execute-queries/visualization-tools.md
@@ -27,7 +27,7 @@ Use visualization tools to query data stored in {{% product-name %}} with SQL.
 The following visualization tools support querying InfluxDB with SQL:
 
 - [Grafana](/influxdb3/cloud-dedicated/process-data/visualize/grafana/)
-- [Power BI](/influxdb3/cloud-dedicated/process-data/visualize/powerbi/)
+- [Power BI](/influxdb3/cloud-dedicated/visualize-data/powerbi/)
 - [Superset](/influxdb3/cloud-dedicated/process-data/visualize/superset/)
 - [Tableau](/influxdb3/cloud-dedicated/process-data/visualize/tableau/)
 

--- a/content/influxdb3/cloud-serverless/query-data/execute-queries/visualization-tools.md
+++ b/content/influxdb3/cloud-serverless/query-data/execute-queries/visualization-tools.md
@@ -27,7 +27,7 @@ Use visualization tools to query data stored in {{% product-name %}}.
 The following visualization tools support querying InfluxDB with SQL:
 
 - [Grafana](/influxdb3/cloud-serverless/process-data/visualize/grafana/)
-- [Power BI](/influxdb3/cloud-serverless/process-data/visualize/powerbi/)
+- [Power BI](/influxdb3/cloud-serverless/visualize-data/powerbi/)
 - [Superset](/influxdb3/cloud-serverless/process-data/visualize/superset/)
 - [Tableau](/influxdb3/cloud-serverless/process-data/visualize/tableau/)
 

--- a/content/influxdb3/clustered/query-data/execute-queries/visualization-tools.md
+++ b/content/influxdb3/clustered/query-data/execute-queries/visualization-tools.md
@@ -27,7 +27,7 @@ Use visualization tools to query data stored in {{% product-name %}} with SQL.
 The following visualization tools support querying InfluxDB with SQL:
 
 - [Grafana](/influxdb3/clustered/process-data/visualize/grafana/)
-- [Power BI](/influxdb3/clustered/process-data/visualize/powerbi/)
+- [Power BI](/influxdb3/clustered/visualize-data/powerbi/)
 - [Superset](/influxdb3/clustered/process-data/visualize/superset/)
 - [Tableau](/influxdb3/clustered/process-data/visualize/tableau/)
 


### PR DESCRIPTION
## Summary

Corrects broken documentation links across multiple InfluxDB 3 product variants:

1. **CLI reference link**: Updates the `influxctl cluster list` command reference link from `/reference/cli/influxctl/list/` to `/reference/cli/influxctl/cluster/list/` to match the correct documentation structure.

2. **Power BI visualization links**: Updates Power BI visualization tool links from `/process-data/visualize/powerbi/` to `/visualize-data/powerbi/` across Cloud Dedicated, Cloud Serverless, and Clustered documentation to reflect the correct URL path.

These changes ensure users are directed to the correct documentation pages when following links in the guides.

## Checklist

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
- [ ] Local build passes (`npx hugo --quiet`)

https://claude.ai/code/session_01SV14CdHN4GGVuATt9n7STn