### PR TITLE
chore(enterprise): update enterprise 1.12.3 version and binary naming convention

### DIFF
--- a/content/enterprise_influxdb/v1/administration/upgrading.md
+++ b/content/enterprise_influxdb/v1/administration/upgrading.md
@@ -41,13 +41,13 @@ Complete the following steps to upgrade meta nodes:
 ##### Ubuntu and Debian (64-bit)
 
 ```bash
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
 ```
 
 ##### RedHat and CentOS (64-bit)
 
 ```bash
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
 ```
 
 ### Install the meta node package
@@ -55,13 +55,13 @@ wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-{{< latest-patc
 ##### Ubuntu and Debian (64-bit)
 
 ```bash
-sudo dpkg -i influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
+sudo dpkg -i influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
 ```
 
 ##### RedHat and CentOS (64-bit)
 
 ```bash
-sudo yum localinstall influxdb-meta-{{< latest-patch >}}-c{{< latest-patch >}}-1.x86_64.rpm
+sudo yum localinstall influxdb-meta-{{< latest-patch >}}-c{{< latest-patch >}}.x86_64.rpm
 ```
 
 ### Update the meta node configuration file
@@ -167,13 +167,13 @@ from other data nodes in the cluster.
 ##### Ubuntu and Debian (64-bit)
 
 ```bash
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
 ```
 
 ##### RedHat and CentOS (64-bit)
 
 ```bash
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
 ```
 
 ### Install the data node package
@@ -188,7 +188,7 @@ next procedure, [Update the data node configuration file](#update-the-data-node-
 ##### Ubuntu & Debian (64-bit)
 
 ```bash
-sudo dpkg -i influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
+sudo dpkg -i influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
 ```
 
 ##### RedHat & CentOS (64-bit)

--- a/content/enterprise_influxdb/v1/guides/migration.md
+++ b/content/enterprise_influxdb/v1/guides/migration.md
@@ -200,14 +200,14 @@ Without a backup, you'll lose custom configuration settings when updating the In
     {{% /code-tabs %}}
     {{% code-tab-content %}}
 ```bash
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
-sudo dpkg -i influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
+sudo dpkg -i influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
 ```
     {{% /code-tab-content %}}
     {{% code-tab-content %}}
 ```bash
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
-sudo yum localinstall influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
+sudo yum localinstall influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
 ```
     {{% /code-tab-content %}}
     {{< /code-tabs-wrapper >}}

--- a/content/enterprise_influxdb/v1/introduction/installation/data_node_installation.md
+++ b/content/enterprise_influxdb/v1/introduction/installation/data_node_installation.md
@@ -152,14 +152,14 @@ Instructions for both are provided below.
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
-sudo dpkg -i influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
+sudo dpkg -i influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/fips/influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
-sudo dpkg -i influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/fips/influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
+sudo dpkg -i influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
@@ -173,14 +173,14 @@ sudo dpkg -i influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.de
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
-sudo yum localinstall influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
+sudo yum localinstall influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/fips/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
-sudo yum localinstall influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/fips/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
+sudo yum localinstall influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
@@ -205,12 +205,12 @@ For added security, follow these steps to verify the signature of your InfluxDB 
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm.asc
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm.asc
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/fips/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm.asc
+wget https://dl.influxdata.com/enterprise/releases/fips/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm.asc
 ```
 {{% /code-tab-content %}}
   {{< /code-tabs-wrapper >}}
@@ -218,7 +218,7 @@ wget https://dl.influxdata.com/enterprise/releases/fips/influxdb-data-{{< latest
 3.  Verify the signature with `gpg --verify`:
    
     ```sh
-    gpg --verify influxdb-data-{{< latest-patch >}}-c{{< latest-patch >}}.x86_64.rpm.asc influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
+    gpg --verify influxdb-data-{{< latest-patch >}}-c{{< latest-patch >}}.x86_64.rpm.asc influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
     ```
     
     The output from this command should include the following:

--- a/content/enterprise_influxdb/v1/introduction/installation/meta_node_installation.md
+++ b/content/enterprise_influxdb/v1/introduction/installation/meta_node_installation.md
@@ -159,14 +159,14 @@ Instructions for both are provided below.
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
-sudo dpkg -i influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
+sudo dpkg -i influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/fips/influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
-sudo dpkg -i influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/fips/influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
+sudo dpkg -i influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
@@ -180,14 +180,14 @@ sudo dpkg -i influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.de
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
-sudo yum localinstall influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
+sudo yum localinstall influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/fips/influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
-sudo yum localinstall influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/fips/influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
+sudo yum localinstall influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
@@ -213,12 +213,12 @@ For added security, follow these steps to verify the signature of your InfluxDB 
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm.asc
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm.asc
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/fips/influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm.asc
+wget https://dl.influxdata.com/enterprise/releases/fips/influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm.asc
 ```
 {{% /code-tab-content %}}
   {{< /code-tabs-wrapper >}}
@@ -226,7 +226,7 @@ wget https://dl.influxdata.com/enterprise/releases/fips/influxdb-meta-{{< latest
 3.  Verify the signature with `gpg --verify`:
 
     ```sh
-    gpg --verify influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm.asc influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
+    gpg --verify influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm.asc influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
     ```
 
     The output from this command should include the following:

--- a/content/enterprise_influxdb/v1/introduction/installation/single-server.md
+++ b/content/enterprise_influxdb/v1/introduction/installation/single-server.md
@@ -90,14 +90,14 @@ processes running on the same server.
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
-sudo dpkg -i influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
+sudo dpkg -i influxdb-meta_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
-sudo yum localinstall influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
+sudo yum localinstall influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
 ```
 {{% /code-tab-content %}}
     {{< /code-tabs-wrapper >}}
@@ -118,13 +118,13 @@ InfluxDB Enterprise meta service download with `gpg`.
    For example:
 
     ```sh
-    wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm.asc
+    wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm.asc
     ```
 
 3. Verify the signature with `gpg --verify`:
 
     ```sh
-    gpg --verify influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm.asc influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
+    gpg --verify influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm.asc influxdb-meta-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
     ```
 
     The output from this command should include the following:
@@ -335,14 +335,14 @@ The InfluxDB Enterprise data service runs the InfluxDB storage and query engines
 {{% /code-tabs %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
-sudo dpkg -i influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}-1_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
+sudo dpkg -i influxdb-data_{{< latest-patch >}}-c{{< latest-patch >}}_amd64.deb
 ```
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 ```sh
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
-sudo yum localinstall influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
+sudo yum localinstall influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
 ```
 {{% /code-tab-content %}}
     {{< /code-tabs-wrapper >}}
@@ -363,13 +363,13 @@ InfluxDB Enterprise data service download with `gpg`.
    For example:
 
     ```sh
-    wget https://dl.influxdata.com/enterprise/releases/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm.asc
+    wget https://dl.influxdata.com/enterprise/releases/influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm.asc
     ```
 
 3. Verify the signature with `gpg --verify`:
 
     ```sh
-    gpg --verify influxdb-data-{{< latest-patch >}}-c{{< latest-patch >}}.x86_64.rpm.asc influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}-1.x86_64.rpm
+    gpg --verify influxdb-data-{{< latest-patch >}}-c{{< latest-patch >}}.x86_64.rpm.asc influxdb-data-{{< latest-patch >}}_c{{< latest-patch >}}.x86_64.rpm
     ```
 
     The output from this command should include the following:

--- a/data/products.yml
+++ b/data/products.yml
@@ -349,7 +349,7 @@ enterprise_influxdb:
   versions: [v1]
   latest: v1.12
   latest_patches:
-    v1: 1.12.2
+    v1: 1.12.3
   detector_config:
     query_languages:
       InfluxQL:


### PR DESCRIPTION
## Summary

- Updates products.yml with InfluxDB Enterprise 1.12.3 version
- Updates the filenaming convention for InfluxDB Enterprise v1 packages (removed the `-1`)

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
