### PR TITLE
docs(enterprise): add --use-pacha-tree to CLI reference

### DIFF
--- a/content/influxdb3/enterprise/reference/cli/influxdb3/serve.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/serve.md
@@ -154,6 +154,8 @@ influxdb3 serve [OPTIONS]
 |                  | `--traces-jaeger-debug-name`                         | _See [configuration options](/influxdb3/enterprise/reference/config-options/#traces-jaeger-debug-name)_                         |
 |                  | `--traces-jaeger-max-msgs-per-second`                | _See [configuration options](/influxdb3/enterprise/reference/config-options/#traces-jaeger-max-msgs-per-second)_                |
 |                  | `--traces-jaeger-tags`                               | _See [configuration options](/influxdb3/enterprise/reference/config-options/#traces-jaeger-tags)_                               |
+|                  | `--use-pacha-tree`                                   | Enable the [performance upgrade preview](/influxdb3/enterprise/performance-preview/). Required for any `--pt-*` option.         |
+|                  | `--pt-*`                                             | Performance upgrade preview tuning options. Requires `--use-pacha-tree`. _See [configuration reference](/influxdb3/enterprise/performance-preview/configure/)._ |
 |                  | `--virtual-env-location`                             | _See [configuration options](/influxdb3/enterprise/reference/config-options/#virtual-env-location)_                             |
 |                  | `--wait-for-running-ingestor`                        | _See [configuration options](/influxdb3/enterprise/reference/config-options/#wait-for-running-ingestor)_                        |
 |                  | `--wal-flush-interval`                               | _See [configuration options](/influxdb3/enterprise/reference/config-options/#wal-flush-interval)_                               |


### PR DESCRIPTION
## Summary

- Add `--use-pacha-tree` entry to the `influxdb3 serve` options table, linking to the [performance upgrade preview](/influxdb3/enterprise/performance-preview/) page
- Add grouped `--pt-*` entry for all preview tuning options, linking to the [configuration reference](/influxdb3/enterprise/performance-preview/configure/)

## Test plan

- [ ] Verify links resolve to correct anchors on the performance preview pages
- [ ] Confirm table renders correctly in Hugo

---

## Enterprise v3.9.0 Documentation Audit

Extracted from `influxdb3-enterprise` v3.9.0 binary (revision `7afad402c07f2cfab59a3a3ea33d5766c881b92a`) and derive source extraction. Compared against docs-v2 branch `docs/influxdb3-enterprise-performance-upgrade-preview-v2`.

### CLI vs Docs Coverage

#### Documented (has a page — shared or enterprise-specific)

| Command | Page location |
|:--------|:-------------|
| `influxdb3` (root) | `enterprise/reference/cli/influxdb3/_index.md` |
| `serve` | `enterprise/reference/cli/influxdb3/serve.md` (enterprise-only) |
| `query` | `shared/influxdb3-cli/query.md` |
| `write` | `shared/influxdb3-cli/write.md` |
| `create` + all sub-subcommands | `shared/` + enterprise-only `create/token/permission.md` |
| `delete` + all sub-subcommands | `shared/` |
| `show` + databases, nodes, plugins, retention, tokens, system/* | `shared/` + enterprise-only `show/license.md` |
| `enable`, `disable` | `shared/` |
| `install` | `shared/` |
| `test` (wal_plugin, schedule_plugin) | `shared/` |
| `update` (database, table, trigger) | `shared/` + enterprise-only database, table overrides |
| `stop` (node) | `shared/` |

#### Not documented (no CLI reference page)

| Command | Status | Notes |
|:--------|:-------|:------|
| `export` | New in v3.9.0 | Documented in `performance-preview/_index.md` with usage examples, but no CLI reference page |
| `downgrade-to-parquet` | New in v3.9.0 | Enterprise-only, no docs at all |

The `export` command is partially covered by the performance preview docs, but `downgrade-to-parquet` has zero documentation.

### Performance Preview Flag Verification

#### Flags: docs vs v3.9.0 binary

All 40 `--pt-*` flags in the binary are documented. Discrepancies:

| Flag | Docs | `--help-all` |
|:-----|:-----|:-------------|
| `--pt-max-columns` default | ~6.5M | 10000000 |
| `--pt-compactor-input-size-budget` default | 50% of system memory at startup | 2 GB |
| `--pt-file-cache-recency` default | Mirrors `--parquet-mem-cache-query-path-duration` | 5h |
| `--pt-upgrade-poll-interval` | Documented | Not present |
| `--pt-enable-auto-dvc` | Documented | Hidden |

### API Changes (v3.8.4 → v3.9.0)

#### New endpoints (4 added, 0 removed)

All new endpoints are Enterprise-only and support the `influxdb3 export` CLI workflow:

| Method | Path | Handler | Purpose |
|:-------|:-----|:--------|:--------|
| `GET` | `/api/v3/export/databases` | `export_databases` | List databases available for export |
| `GET` | `/api/v3/export/tables` | `export_tables` | List tables in a database |
| `GET` | `/api/v3/export/windows` | `export_windows` | List compacted 24-hour windows for a table |
| `GET` | `/api/v3/export/window_data` | `export_window_data` | Download compacted data as Parquet |

The `window_data` endpoint has a corresponding client method, suggesting the CLI `influxdb3 export data` calls this endpoint.

#### Notable: `query_sql_telemetry` not flagged as Enterprise-only

`/api/v3/query_sql_telemetry` (GET + POST) is present in the extraction but not marked `enterprise_only`. It also doesn't show as "added" in the diff, meaning it existed in v3.8.4 too. Worth checking whether this is documented as Enterprise-only in the docs (the performance preview monitor page references it without that caveat).

#### Route inventory:

| Category | Count | Enterprise-only |
|:---------|:------|:----------------|
| v3 configure | 15 | 0 |
| v3 query | 6 | 0 |
| v3 export | 4 | 4 |
| v3 enterprise | 3 | 3 |
| v3 write | 1 | 0 |
| v3 engine | 2 | 0 |
| v3 plugins | 3 | 0 |
| v1/v2 compat | 4 | 0 |
| other (plugin_test) | 2 | 0 |

<details>
<summary>All routes by category</summary>

**v1 compat**

| Method | Path |
|:-------|:-----|
| `GET` | `/query` |
| `POST` | `/query` |
| `POST` | `/write` |

**v2 compat**

| Method | Path |
|:-------|:-----|
| `POST` | `/api/v2/write` |

**v3 query**

| Method | Path |
|:-------|:-----|
| `GET` | `/api/v3/query_influxql` |
| `POST` | `/api/v3/query_influxql` |
| `GET` | `/api/v3/query_sql` |
| `POST` | `/api/v3/query_sql` |
| `GET` | `/api/v3/query_sql_telemetry` |
| `POST` | `/api/v3/query_sql_telemetry` |

**v3 write**

| Method | Path |
|:-------|:-----|
| `POST` | `/api/v3/write_lp` |

**v3 configure**

| Method | Path |
|:-------|:-----|
| `DELETE` | `/api/v3/configure/database` |
| `GET` | `/api/v3/configure/database` |
| `POST` | `/api/v3/configure/database` |
| `PUT` | `/api/v3/configure/database` |
| `DELETE` | `/api/v3/configure/distinct_cache` |
| `POST` | `/api/v3/configure/distinct_cache` |
| `POST` | `/api/v3/configure/gen1_cleanup` |
| `DELETE` | `/api/v3/configure/last_cache` |
| `POST` | `/api/v3/configure/last_cache` |
| `DELETE` | `/api/v3/configure/table` |
| `POST` | `/api/v3/configure/table` |
| `PUT` | `/api/v3/configure/table` |
| `DELETE` | `/api/v3/configure/token` |
| `POST` | `/api/v3/configure/token/admin` |
| `POST` | `/api/v3/configure/token/named_admin` |

**v3 processing engine**

| Method | Path |
|:-------|:-----|
| `GET` | `/api/v3/engine/` |
| `POST` | `/api/v3/engine/` |

**v3 plugins**

| Method | Path |
|:-------|:-----|
| `PUT` | `/api/v3/plugins/directory` |
| `POST` | `/api/v3/plugins/files` |
| `PUT` | `/api/v3/plugins/files` |

**v3 export (Enterprise-only)**

| Method | Path |
|:-------|:-----|
| `GET` | `/api/v3/export/databases` |
| `GET` | `/api/v3/export/tables` |
| `GET` | `/api/v3/export/window_data` |
| `GET` | `/api/v3/export/windows` |


**Infrastructure**

| Method | Path |
|:-------|:-----|
| `GET` | `/health` |
| `GET` | `/metrics` |
| `GET` | `/ping` |
| `POST` | `/ping` |

**Other**

| Method | Path |
|:-------|:-----|
| `POST` | `/api/v3/plugin_test/schedule` |
| `POST` | `/api/v3/plugin_test/wal` |

</details>