### PR TITLE
chore:  upgrade guidance for non-root container change

### DIFF
--- a/content/influxdb3/explorer/install.md
+++ b/content/influxdb3/explorer/install.md
@@ -218,6 +218,7 @@ docker-compose up -d
 > With v1.7.0+, the Explorer container runs as a non-root user.
 > If you're upgrading from v1.6.x or earlier with mounted volumes, update file
 > ownership before you start the container.
+> The container exits with an error if mounted volumes have incorrect ownership.
 >
 ### Set file permissions for upgrades
 

--- a/content/influxdb3/explorer/install.md
+++ b/content/influxdb3/explorer/install.md
@@ -100,6 +100,7 @@ docker-compose up -d
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
 
+
 ### Production setup
 
 For production deployments with persistence, admin mode, and automatic image updates:
@@ -214,30 +215,34 @@ docker-compose up -d
 > Without a mounted `./db` directory, application data is lost when the container is deleted.
 
 > [!Warning]
-> #### Upgrade from Explorer v1.6.x or earlier
+> With v1.7.0+, the Explorer container runs as a non-root user.
+> If you're upgrading from v1.6.x or earlier with mounted volumes, update file
+> ownership before you start the container.
 >
-> In v1.7.0+, the Explorer container runs as a non-root user
-> (`influxui`, uid 1500) for improved security. Because earlier versions
-> ran as root, existing mounted volumes are owned by root — and the new
-> non-root process can't access them.
->
-> If you start the upgraded container without updating file ownership,
-> it exits with the following error:
->
-> ```
-> ERROR: Directory '/db' is owned by root and not accessible to the 'influxui' user.
-> ```
->
-> To prevent or resolve this error, change ownership of your mounted
-> directories to uid 1500 before you start the container:
->
-> ```bash
-> sudo chown -R 1500:1500 /path/to/your/db
-> sudo chown -R 1500:1500 /path/to/your/config
-> ```
->
-> After you update ownership, restart the container.
-> Fresh installations are unaffected.
+### Set file permissions for upgrades
+
+In v1.7.0+, the Explorer container runs as a non-root user (`influxui`, uid
+1500) for improved security.
+Because earlier versions ran as root, existing mounted volumes are owned by
+root and the new non-root process can't access them.
+
+If you start the upgraded container without updating file ownership, it exits
+with the following error:
+
+```txt
+ERROR: Directory '/db' is owned by root and not accessible to the 'influxui' user.
+```
+
+To prevent or resolve this error, change ownership of your mounted directories
+to uid 1500 before you start the container--for example:
+
+```bash
+sudo chown -R 1500:1500 /path/to/your/db
+sudo chown -R 1500:1500 /path/to/your/config
+```
+
+After you update ownership, restart the container.
+Fresh installations are unaffected.
 
 ### Pre-configure InfluxDB connections
 
@@ -674,4 +679,3 @@ services:
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
-

--- a/content/influxdb3/explorer/install.md
+++ b/content/influxdb3/explorer/install.md
@@ -36,7 +36,7 @@ Get {{% product-name %}} running in minutes:
    ```bash
    docker run --detach \
      --name influxdb3-explorer \
-     --publish 8888:80 \
+     --publish 8888:8080 \
      influxdata/influxdb3-ui:{{% latest-patch %}}
    ```
 
@@ -71,7 +71,7 @@ Install [Docker](https://docs.docker.com/engine/) or [Docker Desktop](https://do
 ```bash
 docker run --detach \
   --name influxdb3-explorer \
-  --publish 8888:80 \
+  --publish 8888:8080 \
   influxdata/influxdb3-ui:{{% latest-patch %}}
 ```
 {{% /code-tab-content %}}
@@ -86,7 +86,7 @@ services:
     image: influxdata/influxdb3-ui:{{% latest-patch %}}
     container_name: influxdb3-explorer
     ports:
-      - "8888:80"
+      - "8888:8080"
     volumes:
       - ./config:/app-root/config:ro
     restart: unless-stopped
@@ -115,7 +115,7 @@ For production deployments with persistence, admin mode, and automatic image upd
 docker run --detach \
   --name influxdb3-explorer \
   --pull always \
-  --publish 8888:80 \
+  --publish 8888:8080 \
   --volume $(pwd)/db:/db:rw \
   --volume $(pwd)/config:/app-root/config:ro \
   --env SESSION_SECRET_KEY=$(openssl rand -hex 32) \
@@ -137,7 +137,7 @@ services:
     pull_policy: always
     command: ["--mode=admin"]
     ports:
-      - "8888:80"
+      - "8888:8080"
     volumes:
       - ./db:/db:rw
       - ./config:/app-root/config:ro
@@ -187,7 +187,7 @@ docker-compose up -d
    ```bash
    docker run --detach \
      --name influxdb3-explorer \
-     --publish 8888:80 \
+     --publish 8888:8080 \
      --volume $(pwd)/db:/db:rw \
      influxdata/influxdb3-ui:{{% latest-patch %}}
    ```
@@ -202,7 +202,7 @@ docker-compose up -d
        image: influxdata/influxdb3-ui:{{% latest-patch %}}
        container_name: influxdb3-explorer
        ports:
-         - "8888:80"
+         - "8888:8080"
        volumes:
          - ./db:/db:rw
        restart: unless-stopped
@@ -295,7 +295,7 @@ Instead of configuring connections through the UI, you can pre-define connection
    ```bash
    docker run --detach \
      --name influxdb3-explorer \
-     --publish 8888:80 \
+     --publish 8888:8080 \
      --volume $(pwd)/config:/app-root/config:ro \
      influxdata/influxdb3-ui:{{% latest-patch %}}
    ```
@@ -310,7 +310,7 @@ Instead of configuring connections through the UI, you can pre-define connection
        image: influxdata/influxdb3-ui:{{% latest-patch %}}
        container_name: influxdb3-explorer
        ports:
-         - "8888:80"
+         - "8888:8080"
        volumes:
          - ./config:/app-root/config:ro
        restart: unless-stopped
@@ -347,7 +347,7 @@ To enable TLS/SSL for secure connections:
    ```bash
    docker run --detach \
      --name influxdb3-explorer \
-     --publish 8888:443 \
+     --publish 8888:8443 \
      --volume $(pwd)/ssl:/etc/nginx/ssl:ro \
      influxdata/influxdb3-ui:{{% latest-patch %}}
    ```
@@ -362,7 +362,7 @@ To enable TLS/SSL for secure connections:
        image: influxdata/influxdb3-ui:{{% latest-patch %}}
        container_name: influxdb3-explorer
        ports:
-         - "8888:443"
+         - "8888:8443"
        volumes:
          - ./ssl:/etc/nginx/ssl:ro
        restart: unless-stopped
@@ -428,7 +428,7 @@ To configure Explorer to trust self-signed or custom CA certificates when connec
 docker run --detach \
   --name influxdb3-explorer \
   --restart unless-stopped \
-  --publish 8888:443 \
+  --publish 8888:8443 \
   --volume $(pwd)/db:/db:rw \
   --volume $(pwd)/config:/app-root/config:ro \
   --volume $(pwd)/ssl:/etc/nginx/ssl:ro \
@@ -453,7 +453,7 @@ services:
     pull_policy: always
     command: ["--mode=admin"]
     ports:
-      - "8888:443"
+      - "8888:8443"
     volumes:
       - ./db:/db:rw
       - ./config:/app-root/config:ro
@@ -491,14 +491,14 @@ Set the mode using the `--mode` parameter:
 # Query mode (default)
 docker run --detach \
   --name influxdb3-explorer \
-  --publish 8888:80 \
+  --publish 8888:8080 \
   influxdata/influxdb3-ui:{{% latest-patch %}} \
   --mode=query
 
 # Admin mode
 docker run --detach \
   --name influxdb3-explorer \
-  --publish 8888:80 \
+  --publish 8888:8080 \
   influxdata/influxdb3-ui:{{% latest-patch %}} \
   --mode=admin
 ```
@@ -516,7 +516,7 @@ services:
     # For admin mode, add:
     command: ["--mode=admin"]
     ports:
-      - "8888:80"
+      - "8888:8080"
     restart: unless-stopped
 ```
 {{% /code-tab-content %}}
@@ -558,8 +558,8 @@ services:
 
 | Container Port | Protocol | Purpose | Common Host Mapping |
 |----------------|----------|---------|---------------------|
-| 80 | HTTP | Web UI (unencrypted) | 8888 |
-| 443 | HTTPS | Web UI (encrypted) | 8888 |
+| 8080 | HTTP | Web UI (unencrypted) | 8888 |
+| 8443 | HTTPS | Web UI (encrypted) | 8888 |
 
 ---
 
@@ -596,7 +596,7 @@ EOF
 docker run --detach \
   --name influxdb3-explorer \
   --pull always \
-  --publish 8888:443 \
+  --publish 8888:8443 \
   --volume $(pwd)/db:/db:rw \
   --volume $(pwd)/config:/app-root/config:ro \
   --volume $(pwd)/ssl:/etc/nginx/ssl:ro \
@@ -619,7 +619,7 @@ services:
     pull_policy: always
     command: ["--mode=admin"]
     ports:
-      - "8888:443"
+      - "8888:8443"
     volumes:
       - ./db:/db:rw
       - ./config:/app-root/config:ro
@@ -655,7 +655,7 @@ docker-compose up -d
 ```bash
 docker run --rm \
   --name influxdb3-explorer \
-  --publish 8888:80 \
+  --publish 8888:8080 \
   influxdata/influxdb3-ui:{{% latest-patch %}}
 ```
 {{% /code-tab-content %}}
@@ -670,7 +670,7 @@ services:
     image: influxdata/influxdb3-ui:{{% latest-patch %}}
     container_name: influxdb3-explorer
     ports:
-      - "8888:80"
+      - "8888:8080"
 ```
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}

--- a/content/influxdb3/explorer/install.md
+++ b/content/influxdb3/explorer/install.md
@@ -219,7 +219,6 @@ docker-compose up -d
 > If you're upgrading from v1.6.x or earlier with mounted volumes, update file
 > ownership before you start the container.
 > The container exits with an error if mounted volumes have incorrect ownership.
->
 
 ### Set file permissions for upgrades
 

--- a/content/influxdb3/explorer/install.md
+++ b/content/influxdb3/explorer/install.md
@@ -213,6 +213,32 @@ docker-compose up -d
 > [!Important]
 > Without a mounted `./db` directory, application data is lost when the container is deleted.
 
+> [!Warning]
+> #### Upgrade from Explorer v1.6.x or earlier
+>
+> Starting with v1.7.0, the Explorer container runs as a non-root user
+> (`influxui`, uid 1500) for improved security. Because earlier versions
+> ran as root, existing mounted volumes are owned by root — and the new
+> non-root process can't access them.
+>
+> If you start the upgraded container without updating file ownership,
+> it exits with the following error:
+>
+> ```
+> ERROR: Directory '/db' is owned by root and not accessible to the 'influxui' user.
+> ```
+>
+> To prevent or resolve this error, change ownership of your mounted
+> directories to uid 1500 before you start the container:
+>
+> ```bash
+> sudo chown -R 1500:1500 /path/to/your/db
+> sudo chown -R 1500:1500 /path/to/your/config
+> ```
+>
+> After you update ownership, restart the container.
+> Fresh installations are unaffected.
+
 ### Pre-configure InfluxDB connections
 
 Instead of configuring connections through the UI, you can pre-define connection settings using a `config.json` file. This is useful for:

--- a/content/influxdb3/explorer/install.md
+++ b/content/influxdb3/explorer/install.md
@@ -216,7 +216,7 @@ docker-compose up -d
 > [!Warning]
 > #### Upgrade from Explorer v1.6.x or earlier
 >
-> Starting with v1.7.0, the Explorer container runs as a non-root user
+> In v1.7.0+, the Explorer container runs as a non-root user
 > (`influxui`, uid 1500) for improved security. Because earlier versions
 > ran as root, existing mounted volumes are owned by root — and the new
 > non-root process can't access them.

--- a/content/influxdb3/explorer/install.md
+++ b/content/influxdb3/explorer/install.md
@@ -220,6 +220,7 @@ docker-compose up -d
 > ownership before you start the container.
 > The container exits with an error if mounted volumes have incorrect ownership.
 >
+
 ### Set file permissions for upgrades
 
 In v1.7.0+, the Explorer container runs as a non-root user (`influxui`, uid

--- a/content/influxdb3/explorer/install.md
+++ b/content/influxdb3/explorer/install.md
@@ -234,7 +234,8 @@ ERROR: Directory '/db' is owned by root and not accessible to the 'influxui' use
 ```
 
 To prevent or resolve this error, change ownership of your mounted directories
-to uid 1500 before you start the container--for example:
+to uid 1500 before you start the container.
+For example:
 
 ```bash
 sudo chown -R 1500:1500 /path/to/your/db

--- a/content/influxdb3/explorer/release-notes/_index.md
+++ b/content/influxdb3/explorer/release-notes/_index.md
@@ -18,6 +18,19 @@ docker pull influxdata/influxdb3-ui
 
 ## v1.7.0 {date="2026-04-14"}
 
+#### Breaking changes
+
+- **Container user change**: The Docker container now runs as non-root user `influxui` (uid 1500) instead of root for improved security.
+
+  **Action required for upgrades:** If you're upgrading from v1.6.x or earlier with mounted volumes (e.g., `/db`, `/app-root/config`), you must update file ownership before the container will start:
+
+  ```bash
+  sudo chown -R 1500:1500 /path/to/your/db
+  sudo chown -R 1500:1500 /path/to/your/config
+  ```
+
+  The container will exit with a clear error message and instructions if it detects root-owned files. Fresh installations are unaffected.
+
 #### Features
 
 - **Transform Data**: Rename tables (measurements), rename columns, transform values (such as unit conversions), and filter rows from a dedicated Transform Data page with dry-run testing.
@@ -28,6 +41,7 @@ docker pull influxdata/influxdb3-ui
 - **Line protocol validation**: Get clearer, inline validation when writing data with line protocol.
 - **TLS certificate management**: Generate and renew short-lived TLS certificates for IP-based deployments.
 - **Storage type display**: View the configured storage type for your InfluxDB instance in the metrics UI.
+- **Security**: Container now runs as non-root user (uid 1500) for improved security posture.
 
 #### Bug fixes
 

--- a/content/influxdb3/explorer/release-notes/_index.md
+++ b/content/influxdb3/explorer/release-notes/_index.md
@@ -21,20 +21,8 @@ docker pull influxdata/influxdb3-ui
 #### Breaking changes
 
 - **Container user change**: The Docker container now runs as non-root user `influxui` (uid 1500) instead of root for improved security.
-
-> [!Important]
-> #### Action required for upgrades on Linux and WSL2
->
-> If you're upgrading from v1.6.x or earlier with mounted volumes
-> (for example, `/db` or `/app-root/config`) on **Linux or Windows WSL2**,
-> update file ownership before you start the container:
->
-> ```bash
-> sudo chown -R 1500:1500 /path/to/your/db
-> sudo chown -R 1500:1500 /path/to/your/config
-> ```
->
-> The container exits with an error message if it detects root-owned files.
+- **Upgrade action**: See [Install InfluxDB 3 Explorer](/influxdb3/explorer/install/)
+  for upgrade file permission steps.
 
 #### Features
 

--- a/content/influxdb3/explorer/release-notes/_index.md
+++ b/content/influxdb3/explorer/release-notes/_index.md
@@ -22,14 +22,20 @@ docker pull influxdata/influxdb3-ui
 
 - **Container user change**: The Docker container now runs as non-root user `influxui` (uid 1500) instead of root for improved security.
 
-  **Action required for upgrades:** If you're upgrading from v1.6.x or earlier with mounted volumes (e.g., `/db`, `/app-root/config`), you must update file ownership before the container will start:
-
-  ```bash
-  sudo chown -R 1500:1500 /path/to/your/db
-  sudo chown -R 1500:1500 /path/to/your/config
-  ```
-
-  The container will exit with a clear error message and instructions if it detects root-owned files. Fresh installations are unaffected.
+> [!Important]
+> #### Action required for upgrades
+>
+> If you're upgrading from v1.6.x or earlier with mounted volumes
+> (for example, `/db` or `/app-root/config`), update file ownership
+> before you start the container:
+>
+> ```bash
+> sudo chown -R 1500:1500 /path/to/your/db
+> sudo chown -R 1500:1500 /path/to/your/config
+> ```
+>
+> The container exits with an error message if it detects root-owned
+> files. Fresh installations are unaffected.
 
 #### Features
 
@@ -41,7 +47,7 @@ docker pull influxdata/influxdb3-ui
 - **Line protocol validation**: Get clearer, inline validation when writing data with line protocol.
 - **TLS certificate management**: Generate and renew short-lived TLS certificates for IP-based deployments.
 - **Storage type display**: View the configured storage type for your InfluxDB instance in the metrics UI.
-- **Security**: Container now runs as non-root user (uid 1500) for improved security posture.
+- **Non-root container**: The container now runs as a non-root user (uid 1500) for improved security.
 
 #### Bug fixes
 

--- a/content/influxdb3/explorer/release-notes/_index.md
+++ b/content/influxdb3/explorer/release-notes/_index.md
@@ -21,7 +21,7 @@ docker pull influxdata/influxdb3-ui
 #### Breaking changes
 
 - **Container user change**: The Docker container now runs as non-root user `influxui` (uid 1500) instead of root for improved security.
-- **Upgrade action**: See [Install InfluxDB 3 Explorer](/influxdb3/explorer/install/)
+- **Upgrade action**: See [Install InfluxDB 3 Explorer](/influxdb3/explorer/install/#set-file-permissions-for-upgrades)
   for upgrade file permission steps.
 
 #### Features

--- a/content/influxdb3/explorer/release-notes/_index.md
+++ b/content/influxdb3/explorer/release-notes/_index.md
@@ -23,19 +23,18 @@ docker pull influxdata/influxdb3-ui
 - **Container user change**: The Docker container now runs as non-root user `influxui` (uid 1500) instead of root for improved security.
 
 > [!Important]
-> #### Action required for upgrades
+> #### Action required for upgrades on Linux and WSL2
 >
 > If you're upgrading from v1.6.x or earlier with mounted volumes
-> (for example, `/db` or `/app-root/config`), update file ownership
-> before you start the container:
+> (for example, `/db` or `/app-root/config`) on **Linux or Windows WSL2**,
+> update file ownership before you start the container:
 >
 > ```bash
 > sudo chown -R 1500:1500 /path/to/your/db
 > sudo chown -R 1500:1500 /path/to/your/config
 > ```
 >
-> The container exits with an error message if it detects root-owned
-> files. Fresh installations are unaffected.
+> The container exits with an error message if it detects root-owned files.
 
 #### Features
 


### PR DESCRIPTION
## Summary

Closes #

Adds documentation for the breaking change in Explorer v1.7.0 where the container now runs as non-root user (uid 1500).

Related: influxdata/influxdb3_ui#1620

## Checklist

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
- [ ] Local build passes (`npx hugo --quiet`)

***

<details>
<summary><b>Suggested reviewers</b> (click to expand)</summary>

<!--
## Tips:
- Docs team (influxdata/docs-team) is auto-assigned via CODEOWNERS
- Request additional reviewers above when ready for technical review
- Open as Draft until ready for review to avoid notification spam
- Copilot reviews automatically - address suggestions before requesting human review
-->

Based on files changed, consider requesting review from:

### InfluxDB 3

| Content          | Engineering                    | Product                     |
| ---------------- | ------------------------------ | --------------------------- |
| Core, Enterprise | influxdata/monolith-team       | peterbarnett03, garylfowler |
| Clustered        | influxdata/platform-team       | ritwika314, sanderson       |
| Cloud Dedicated  | influxdata/cloud-single-tenant | ritwika314, sanderson       |
| Cloud Serverless | —                              | mavarius, garylfowler       |
| Explorer         | —                              | mavarius, peterbarnett03    |

### InfluxDB v2 / v1 / Enterprise v1

| Content           | Engineering     | Product               |
| ----------------- | --------------- | --------------------- |
| v2, Cloud (TSM)   | influxdata/edge | sanderson, jstirnaman |
| v1, Enterprise v1 | influxdata/edge | sanderson, jstirnaman |

### Other Products

| Content    | Engineering              | Product               |
| ---------- | ------------------------ | --------------------- |
| Telegraf   | influxdata/telegraf-team | sanderson, caterryan  |
| Kapacitor  | influxdata/bonitoo       | sanderson, jstirnaman |
| Chronograf | influxdata/bonitoo       | mavarius, caterryan   |
| Flux       | —                        | sanderson, jstirnaman |

### Shared / Cross-Product

| Content            | Reviewers                   |
| ------------------ | --------------------------- |
| `/content/shared/` | influxdata/product-managers |
| API docs           | Relevant product team above |

</details>
