### PR TITLE
docs(enterprise): add cross-references to performance preview

### DIFF
--- a/content/influxdb3/enterprise/performance-preview/_index.md
+++ b/content/influxdb3/enterprise/performance-preview/_index.md
@@ -38,13 +38,13 @@ manages resources.
 
 ## Why these upgrades
 
-The default InfluxDB 3 storage layer uses [Apache Parquet](https://parquet.apache.org/) and
-is optimized for analytical workloads.
+The existing InfluxDB 3 storage layer uses [Apache Parquet](https://parquet.apache.org/)
+and is optimized for analytical workloads.
 Customers running high-cardinality, wide-schema, and query-intensive workloads
 need better single-series query performance, more predictable resource usage,
 and the schema flexibility that made InfluxDB v1 and v2 popular.
-These upgrades address those gaps while maintaining full compatibility with
-InfluxDB 3's data model and query languages.
+These upgrades extend the storage layer to support those workloads while
+maintaining full compatibility with InfluxDB 3's data model and query languages.
 
 Key improvements include:
 


### PR DESCRIPTION
## Summary
- Link key terms in the performance preview overview to glossary entries and reference pages (Apache Parquet, series key, line protocol, Gen0, compaction levels L1–L4)
- Add WAL→snapshot→Gen0 pipeline summary in the bounded compaction section
- Clarify wording around the default storage layer vs. performance preview

## Test plan
- [ ] Verify all cross-reference links resolve correctly in local Hugo build
- [ ] Check rendered page for readability of new links and added sentence