### PR TITLE
fix(layouts): trim whitespace in render-codeblock placeholder/callout branch

### DIFF
--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -1,16 +1,16 @@
 {{ $result := transform.HighlightCodeBlock . }}
 {{- if or .Attributes.placeholders .Attributes.callout -}}
-  {{ $code := highlight .Inner .Type }}
+  {{- $code := highlight .Inner .Type -}}
   {{- if .Attributes.placeholders -}}
-    {{ $placeholderReplace := print "<div data-component='code-placeholder' class='code-placeholder-wrapper'><var title='Edit $0' class='code-placeholder' data-code-var='$0' data-code-var-value='$0' data-code-var-escaped=\"$0\">$0<span class='code-placeholder-edit-icon cf-icon Pencil'></span></var></div>" }}
-    {{ $code = replaceRE .Attributes.placeholders $placeholderReplace $code }}
+    {{- $placeholderReplace := print "<div data-component='code-placeholder' class='code-placeholder-wrapper'><var title='Edit $0' class='code-placeholder' data-code-var='$0' data-code-var-value='$0' data-code-var-escaped=\"$0\">$0<span class='code-placeholder-edit-icon cf-icon Pencil'></span></var></div>" -}}
+    {{- $code = replaceRE .Attributes.placeholders $placeholderReplace $code -}}
   {{- end -}}
   {{- if .Attributes.callout -}}
-    {{ $color := index .Attributes "callout-color" | default "green" }}
-    {{ $calloutReplace := print "<span class='code-callout " $color "'>$0</span>" }}
-    {{ $code = replaceRE .Attributes.callout $calloutReplace $code }}
+    {{- $color := index .Attributes "callout-color" | default "green" -}}
+    {{- $calloutReplace := print "<span class='code-callout " $color "'>$0</span>" -}}
+    {{- $code = replaceRE .Attributes.callout $calloutReplace $code -}}
   {{- end -}}
-  {{ $code | safeHTML }}
+  {{- $code | safeHTML -}}
 {{- else -}}
   {{- $wrapped := string $result.Wrapped -}}
   {{- if in $wrapped "tc-dynamic-values" -}}


### PR DESCRIPTION
## Summary

Fixes the root cause of the site-wide broken-code-block regression reported in influxdata/docs-v2#7079. The merged PR #7083 collapsed two wrapper shortcode templates as a band-aid that worked around the visible symptom on sample-data pages, but the same bug was still affecting ~18 other admin/install pages with placeholder code blocks (e.g. `/influxdb3/enterprise/admin/backup-restore/`, `/influxdb3/clustered/admin/users/add/`, `/influxdb3/enterprise/admin/upgrade/`). This PR fixes the underlying cause in `layouts/_default/_markup/render-codeblock.html`.

## Root cause

Commit d80eb2f from influxdata/docs-v2#7069 (Apr 8) refactored `render-codeblock.html` to support the new `callout` fence attribute alongside `placeholders`. The refactor introduced a new conditional branch:

```gotemplate
{{- if or .Attributes.placeholders .Attributes.callout -}}
  {{ $code := highlight .Inner .Type }}
  {{- if .Attributes.placeholders -}}
    {{ $placeholderReplace := print "<div data-component='code-placeholder'..." }}
    {{ $code = replaceRE .Attributes.placeholders $placeholderReplace $code }}
  {{- end -}}
  ...
  {{ $code | safeHTML }}
```

The outer `{{- if -}}` trims its own surrounding whitespace, but the inner action tags use bare `{{ ... }}` instead of `{{- ... -}}`. Each bare assignment leaks its leading indent (2 or 4 spaces) and trailing newline into the rendered output. For a placeholder code block the final render-hook output looks like:

```
  
    
    
  <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash"...
```

Goldmark sees a run of indented whitespace-only lines followed by an indented HTML block, interprets the leading portion as an indented code block, wraps it in `<pre><code>`, and HTML-escapes every `<` → `&lt;`. Users see a wall of escaped `<span class="line">` fragments instead of a code block.

The `else` branch (non-placeholder/non-callout code blocks) already uses `{{- ... -}}` on every action, which is why ordinary code blocks were unaffected. The regression only hit pages that use either the `placeholders` or `callout` fence attribute — i.e. almost every admin CLI / install / backup / sample-data page.

## Fix

Apply `{{- ... -}}` whitespace trimming to every action inside the `if or .Attributes.placeholders .Attributes.callout` branch, matching the pattern the `else` branch already uses. No content files change, no shortcode templates change.

```diff
-  {{ $code := highlight .Inner .Type }}
+  {{- $code := highlight .Inner .Type -}}
-    {{ $placeholderReplace := print "..." }}
-    {{ $code = replaceRE .Attributes.placeholders $placeholderReplace $code }}
+    {{- $placeholderReplace := print "..." -}}
+    {{- $code = replaceRE .Attributes.placeholders $placeholderReplace $code -}}
...
-  {{ $code | safeHTML }}
+  {{- $code | safeHTML -}}
```

## Why not keep the collapse band-aid from #7083

The collapses in `layouts/shortcodes/influxdb/custom-timestamps.html` and `layouts/shortcodes/code-tab-content.html` fixed the sample-data pages only. They didn't help pages that wrap placeholder code blocks in other shortcodes (`tab-content`, `expand`, plain bullet lists, etc.), which is why backup-restore, users/add, upgrade, and ~15 others were still broken. Fixing `render-codeblock.html` itself eliminates the class of bug everywhere in one place, so any wrapper shortcode works correctly regardless of whether its template has indented `.Inner`.

## Verification

Built locally with Hugo 0.149.0 extended against `origin/master` plus this commit.

Site-wide count of pages containing the escaped-highlight pattern (`&lt;div class=&quot;highlight`):

| State | Count |
| --- | --- |
| master (before #7083) | 23 pages |
| master (with #7083 band-aid) | 18 pages |
| **this branch** | **0 pages** |

Specific pages spot-checked:

- `/influxdb3/enterprise/admin/backup-restore/` ✅
- `/influxdb3/enterprise/admin/upgrade/` ✅
- `/influxdb3/enterprise/admin/mcp-server/` ✅
- `/influxdb3/enterprise/admin/backup-restore/` ✅
- `/influxdb3/enterprise/admin/upgrade-from-core/` ✅
- `/influxdb3/enterprise/reference/cli/influxdb3/write/` ✅
- `/influxdb3/enterprise/write-data/best-practices/optimize-writes/` ✅
- `/influxdb3/clustered/admin/users/add/` ✅
- `/influxdb3/clustered/install/secure-cluster/auth/` ✅
- `/influxdb3/clustered/write-data/best-practices/optimize-writes/` ✅
- `/influxdb3/explorer/install/` ✅
- All 5 sample-data pages (core, enterprise, cloud-dedicated, clustered, cloud-serverless) ✅
- `/influxdb3/core/get-started/write/` and `/query/` — no regressions ✅

## Follow-ups (not in this PR)

- The two shortcode template collapses from PR #7083 are no longer needed but don't hurt anything; leaving them in place.
- Worth adding a Cypress test that asserts no rendered page contains the literal string `&lt;div class=&quot;highlight` to catch any future regression of this class.

## Test plan

- [x] Local Hugo 0.149 build succeeds
- [x] Site-wide escaped-highlight count drops to 0
- [x] Sample-data pages render correctly
- [x] Backup-restore, upgrade, users/add pages render correctly
- [ ] PR preview visual check on `/influxdb3/enterprise/admin/backup-restore/`
- [ ] CI checks pass

Closes influxdata/docs-v2#7079