### PR TITLE
fix(ci): fetch fresh PR body for preview URL detection

### DIFF
--- a/.github/scripts/detect-preview-pages.js
+++ b/.github/scripts/detect-preview-pages.js
@@ -10,7 +10,7 @@
  */
 
 import { execSync } from 'child_process';
-import { appendFileSync, existsSync } from 'fs';
+import { appendFileSync, existsSync, readFileSync } from 'fs';
 import { extractDocsUrls } from './parse-pr-urls.js';
 import {
   getChangedContentFiles,
@@ -18,7 +18,12 @@ import {
 } from '../../scripts/lib/content-utils.js';
 
 const GITHUB_OUTPUT = process.env.GITHUB_OUTPUT || '/dev/stdout';
-const PR_BODY = process.env.PR_BODY || '';
+// Read PR body from file (fetched fresh from API) or fall back to env var
+const PR_BODY_FILE = process.env.PR_BODY_FILE;
+const PR_BODY =
+  PR_BODY_FILE && existsSync(PR_BODY_FILE)
+    ? readFileSync(PR_BODY_FILE, 'utf-8')
+    : process.env.PR_BODY || '';
 const BASE_REF = process.env.BASE_REF || 'origin/master';
 const MAX_PAGES = 50; // Limit to prevent storage bloat
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -2,7 +2,7 @@ name: PR Preview
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, closed, ready_for_review]
+    types: [opened, reopened, synchronize, closed, ready_for_review, edited]
     paths:
       - 'content/**'
       - 'layouts/**'
@@ -39,6 +39,13 @@ jobs:
             // Check for draft PR
             if (pr?.draft) {
               core.info('Skipping draft PR');
+              core.setOutput('should-run', 'false');
+              return;
+            }
+
+            // For 'edited' events, skip if only the title changed (body unchanged)
+            if (context.payload.action === 'edited' && !context.payload.changes?.body) {
+              core.info('PR title edited (body unchanged) - skipping');
               core.setOutput('should-run', 'false');
               return;
             }
@@ -155,10 +162,24 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Fetch current PR body
+        id: fetch-pr-body
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const fs = require('fs');
+            const bodyFile = `${process.env.RUNNER_TEMP}/pr-body.txt`;
+            fs.writeFileSync(bodyFile, pr.body || '');
+            core.exportVariable('PR_BODY_FILE', bodyFile);
+
       - name: Detect preview pages
         id: detect
         env:
-          PR_BODY: ${{ github.event.pull_request.body }}
           BASE_REF: origin/${{ github.base_ref }}
         run: node .github/scripts/detect-preview-pages.js
 


### PR DESCRIPTION
The PR preview workflow used the event payload's PR body, which is a
snapshot from when the workflow was triggered. On re-runs or edited
events, this stale body meant newly added URLs were never detected.

Fetch the current PR body from the GitHub API instead and add the
'edited' trigger type so the workflow re-runs automatically when the
PR description changes.

closes #7089

https://claude.ai/code/session_01AK8bDp6pnny5UiE2yzTbtZ