### PR TITLE
feat(influxdb3): add 3.9.1 release notes

### DIFF
--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -10,9 +10,7 @@
 
 ### Core
 
-Maintenance release. v3.9.1 Core contains only build and dependency
-updates; no user-facing changes.
-
+Maintenance release: v3.9.1 Core includes only build and dependency updates—no user-facing changes.
 ### Enterprise
 
 All Core updates are included in Enterprise.

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -6,6 +6,28 @@
 > All updates to Core are automatically included in Enterprise.
 > The Enterprise sections below only list updates exclusive to Enterprise.
 
+## v3.9.1 {date="2026-04-09"}
+
+### Core
+
+Maintenance release. v3.9.1 Core contains only build and dependency
+updates; no user-facing changes.
+
+### Enterprise
+
+All Core updates are included in Enterprise.
+Additional Enterprise-specific updates:
+
+#### Features
+
+- **Configurable compactor snapshot loading**: The number of snapshots the Parquet compactor loads at startup is now externally configurable, making it easier to tune recovery behavior for large deployments.
+
+#### Bug Fixes and Performance Improvements
+
+- **Performance Improvements**: This release features faster multi-source query merges and improved retention scheduling with the new Performance Update Preview.
+
+- **Bug Fixes**: New updates fix issues where duplicate rows could be returned, Gen0 pruning safety, invalid status codes, and more.
+
 ## v3.9.0 {date="2026-04-02"}
 
 ### Core

--- a/data/products.yml
+++ b/data/products.yml
@@ -8,7 +8,7 @@ influxdb3_core:
   versions: [core]
   list_order: 2
   latest: core
-  latest_patch: 3.9.0
+  latest_patch: 3.9.1
   placeholder_host: localhost:8181
   limits:
     database: 5
@@ -46,7 +46,7 @@ influxdb3_enterprise:
   versions: [enterprise]
   list_order: 2
   latest: enterprise
-  latest_patch: 3.9.0
+  latest_patch: 3.9.1
   placeholder_host: localhost:8181
   limits:
     database: 100


### PR DESCRIPTION
Document Enterprise v3.9.1 updates (configurable compactor snapshot loading, query merge perf, retention scheduling, and bug fixes). Core v3.9.1 is a maintenance release. Bump latest_patch to 3.9.1 for Core and Enterprise.