### PR TITLE
feat(v1): add InfluxDB v1.12.4 release notes for OSS and Enterprise

### DIFF
--- a/content/enterprise_influxdb/v1/about-the-project/release-notes.md
+++ b/content/enterprise_influxdb/v1/about-the-project/release-notes.md
@@ -20,8 +20,6 @@ alt_links:
 - Fixed `fatal error: concurrent map iteration and map write` panic in the TSI
   index that could crash InfluxDB during concurrent read and write operations.
   This was a regression introduced in v1.12.3. The fix restores the original locking behavior.
-  [#27344](https://github.com/influxdata/influxdb/pull/27344),
-  [#27343](https://github.com/influxdata/influxdb/issues/27343)
 
 ---
 

--- a/content/enterprise_influxdb/v1/about-the-project/release-notes.md
+++ b/content/enterprise_influxdb/v1/about-the-project/release-notes.md
@@ -13,6 +13,20 @@ alt_links:
 
 <span id="v1.12.x"></span>
 
+## v1.12.4 {date="2026-04-13"}
+
+### Bug Fixes
+
+- Fixed `fatal error: concurrent map iteration and map write` panic in the TSI
+  index that could crash InfluxDB during concurrent read and write operations.
+  This was a regression introduced in v1.12.3 by an unnecessary backport from
+  the 2.x branch that released a read lock before the underlying map was fully
+  iterated. The fix restores the original locking behavior.
+  [#27344](https://github.com/influxdata/influxdb/pull/27344),
+  [#27343](https://github.com/influxdata/influxdb/issues/27343)
+
+---
+
 ## v1.12.3 {date="2026-03-31"}
 
 InfluxDB Enterprise 1.12.3 delivers substantial efficiency gains in CPU, memory,

--- a/content/enterprise_influxdb/v1/about-the-project/release-notes.md
+++ b/content/enterprise_influxdb/v1/about-the-project/release-notes.md
@@ -19,9 +19,7 @@ alt_links:
 
 - Fixed `fatal error: concurrent map iteration and map write` panic in the TSI
   index that could crash InfluxDB during concurrent read and write operations.
-  This was a regression introduced in v1.12.3 by an unnecessary backport from
-  the 2.x branch that released a read lock before the underlying map was fully
-  iterated. The fix restores the original locking behavior.
+  This was a regression introduced in v1.12.3. The fix restores the original locking behavior.
   [#27344](https://github.com/influxdata/influxdb/pull/27344),
   [#27343](https://github.com/influxdata/influxdb/issues/27343)
 

--- a/content/influxdb/v1/about_the_project/release-notes.md
+++ b/content/influxdb/v1/about_the_project/release-notes.md
@@ -14,6 +14,20 @@ alt_links:
 ---
 
 
+## v1.12.4 {date="2026-04-13"}
+
+### Bug Fixes
+
+- Fixed `fatal error: concurrent map iteration and map write` panic in the TSI
+  index that could crash InfluxDB during concurrent read and write operations.
+  This was a regression introduced in v1.12.3 by an unnecessary backport from
+  the 2.x branch that released a read lock before the underlying map was fully
+  iterated. The fix restores the original locking behavior.
+  [#27344](https://github.com/influxdata/influxdb/pull/27344),
+  [#27343](https://github.com/influxdata/influxdb/issues/27343)
+
+---
+
 ## v1.12.3 {date="2026-01-12"}
 
 ### Features

--- a/data/products.yml
+++ b/data/products.yml
@@ -216,7 +216,7 @@ influxdb:
   latest: v2.8
   latest_patches:
     v2: 2.8.0
-    v1: 1.12.3
+    v1: 1.12.4
   latest_cli:
     v2: 2.7.5
   detector_config:
@@ -349,7 +349,7 @@ enterprise_influxdb:
   versions: [v1]
   latest: v1.12
   latest_patches:
-    v1: 1.12.3
+    v1: 1.12.4
   detector_config:
     query_languages:
       InfluxQL:


### PR DESCRIPTION
Bump latest_patches to 1.12.4 in products.yml and add release notes
documenting the TSI index concurrent map panic fix.

https://claude.ai/code/session_01HAkj89Z8q341L8hoDYQwCD