### PR TITLE
Telegraf Controller v0.0.6-beta

### DIFF
--- a/content/telegraf/controller/reference/eula.md
+++ b/content/telegraf/controller/reference/eula.md
@@ -9,8 +9,431 @@ menu:
     name: EULA
     parent: Reference
 weight: 110
-metadata: ['Updated January 1, 2026']
+metadata: ['Updated April 8, 2026']
 ---
+
+**Early Access Software License Terms**
+
+**(Telegraf Controller)**
+
+**IMPORTANT - READ BEFORE COPYING, INSTALLING OR USING.**
+
+These Early Access Software License Terms (these “**Terms**”) contain the terms
+under which InfluxData agrees to grant Customer license rights to use certain
+“Early Access Software” (defined below). By indicating Customer’s acceptance of
+these Terms, by executing a sales order that references these Terms, or by using
+such Early Access Software or features, Customer agrees to be bound by these
+Terms. If you are entering into these Terms on behalf of an entity, such as the
+company you work for, then you represent to InfluxData that you have the legal
+authority to bind the Customer to these Terms. If you do not have that authority
+or if Customer does not agree with these Terms, then you may not indicate
+acceptance of these Terms, and neither you nor Customer may use or access the
+Early Access Software. For these purposes, “**Customer**” means the individual
+that indicated their agreement to these Terms or, if you are entering into these
+Terms on behalf of an entity, such as the company you work for, that entity.
+
+## 1. Definitions
+
+For the purposes of these Terms, the following capitalized words and phrases are
+ascribed the following meanings:
+
+“**Affiliate**” means any person, partnership, joint venture, corporation or
+other form of venture or enterprise, domestic or foreign, including
+subsidiaries, which directly or indirectly Control, are Controlled by, or are
+under common Control with a party. “**Control**” means the possession, directly
+or indirectly, of the power to direct or cause the direction of the management
+and operating policies of the entity in respect of which the determination is
+being made, through the ownership of more than fifty percent (50%) of its voting
+or equity securities, contract, voting trust or otherwise.
+
+“**Confidential Information**” has the meaning ascribed to it in Section 5.
+
+**“Documentation”** means the EA Software documentation published by InfluxData
+at or under [https://influxdata.com](https://influxdata.com/), or in files
+included with the EA Software.
+
+“**Early Access** **Software**” or “**EA Software**” means executable code
+versions of InfluxData’s InfluxDB computer software programs that are not yet
+generally available, including any software, services, or features labeled
+“alpha”, “beta”, “preview”, “pre-release”, or “experimental”.
+
+“**License Term**” means the time period described in Section 4.
+
+“**Intellectual Property Rights**” means all trade secrets, patents and patent
+applications, trademarks (whether registered or unregistered and including any
+goodwill acquired in such trademarks), service marks, trade names, copyrights,
+moral rights, database rights, design rights, rights in know-how, rights in
+confidential information, rights in inventions (whether patentable or not) and
+all other intellectual property and proprietary rights (whether registered or
+unregistered, any application for the foregoing, and all rights to enforce the
+foregoing), and all other equivalent or similar rights which may subsist
+anywhere in the world.
+
+“**Scope Limitations**” means any limitations on use of the EA Software
+specified by InfluxData (i) in the Documentation, (ii) at the location from
+which Customer accesses, downloads or launches installation of the EA Software,
+(iii) at the location at which Customer obtains a license management key, or
+(iv) in a sales order executed by both Customer and InfluxData.
+
+The following words will be interpreted as designated: (i) “or” connotes any
+combination of all or any of the items listed; (ii) where “including” is used to
+refer to an example or begins a list of items, such example or items will not be
+exclusive; (iii) “specified” requires that an express statement is contained in
+the relevant document; (iv) “will” is, unless the context requires otherwise, an
+expression of command, not merely an expression of future intent or expectation;
+and (v) “may” is, unless the context requires otherwise, an expression of
+permission, but not an obligation.
+
+## 2. Rights to Use Software; Delivery
+
+1.  **Copying, Installation and Operation.** Subject to these Terms, InfluxData
+    hereby grants Customer the following non-exclusive, non-transferable,
+    worldwide licenses, without right to sub-license, for the License Term,
+    solely for its internal purposes, subject to the Scope Limitations: (a) to
+    reproduce a reasonable number of copies of the EA Software; (b) to
+    distribute such copies to and install them on computing infrastructure owned
+    by Customer or its Affiliates or under its or their control; (c) to run the
+    EA Software on such infrastructure, and (d) to permit employees and service
+    providers of Customer or its Affiliates to use the EA Software on such
+    infrastrcture.
+2.  **Open Source Components.** The EA Software includes software components
+    provided by third parties that are subject to open-source copyright license
+    agreements (“Open Source Components”). These Open Source Components are
+    identified in the Documentation. The Open Source Components do not include
+    any open-source software licensed under the GNU General Public License, the
+    GNU Lesser General Public License, or any similar copyleft license that,
+    when Customer uses the EA Software in accordance with these Terms, would
+    require Customer to make any of its source code publicly available.
+3.  **Reservations.** All rights to the EA Software, Documentation and all
+    related and other Intellectual Property Rights of InfluxData not expressly
+    granted to Customer are reserved to InfluxData. Customer may not make the
+    EA Software or Documentation available to any third parties as part of any
+    rental, leasing, time-sharing, SaaS, or service bureau arrangement. All EA
+    Software is licensed, not sold.
+4.  **Proprietary Rights; Reverse Engineering.** As between InfluxData and
+    Customer, InfluxData will own all Intellectual Property Rights in or to the
+    EA Software and Documentation, and any derivative works of or improvements
+    or enhancements to any of the foregoing created or developed by or on behalf
+    of InfluxData, or created or developed by or on behalf of Customer in
+    violation of any of InfluxData’s Intellectual Property Rights. Customer
+    acknowledges that the EA Software (including its structure, organization and
+    code) and the Documentation constitute trade secrets and are the valuable
+    property of InfluxData. Customer will not remove, obscure or alter any
+    notice of copyright, patent, trade secret, trademark or other proprietary
+    right or disclaimer appearing in or on any EA Software or Documentation.
+    Except to the extent (if any) permitted by applicable law or required by
+    InfluxData’s licensors, Customer will not decompile, or create or attempt to
+    create, by reverse engineering or otherwise, the source code from the
+    executable code supplied under these Terms or use it to create a derivative
+    work.
+
+## 3. Early Access Terms
+
+1.  **Non-Production Use Recommended**. InfluxData strongly recommends that
+    Customer should use the EA Software solely for its internal evaluation
+    purposes, and in non-production environments. Customer acknowledges that EA
+    Software has not undergone the same performance and security reviews and
+    processes that InfluxData applies to its general release software. If
+    Customer elects to use EA Software for purposes other than internal
+    evaluation, or in production environments, then Customer assumes all of the
+    risks of doing so.
+2.  **Use Policies.** Customer must comply with all policies and guidelines
+    related to any EA Software as posted on or under
+    the [https://influxdata.com](https://influxdata.com/) site or otherwise made
+    available to Customer, including the Scope Limitations. InfluxData may add
+    or modify restrictions related to use of any EA Software as it reasonably
+    considers necessary at any time.
+3.  **Support Program.** InfluxData’s support program does not apply to any EA
+    Software.
+4.  **Observations.** Customer agrees to provide InfluxData with reasonable
+    information relating to its use, testing, or evaluation of the EA Software,
+    including observations or information regarding the performance, features
+    and functionality of the EA Software (“**Test Observations**”), when and in
+    the form reasonably requested by InfluxData. The EA Software may
+    automatically transmit Test Observations to InfluxData. If any Test
+    Observations include any personal data (such as an IP address), then
+    InfluxData will process such personal data in accordance with its privacy
+    policy published at https://influxdata.com/legal. InfluxData may use and
+    evaluate all Test Observations for its own purposes. With the exception of
+    Customer’s personal data, which InfluxData will process in accordance with
+    its privacy policy, (a) Customer hereby grants InfluxData a non-exclusive,
+    perpetual, irrevocable, paid-up, royalty-free, worldwide, transferable
+    license, with right to sublicense, to make, have made, sell, offer for sale,
+    use, import, reproduce, distribute, display, perform, and make derivative
+    works of the Test Observations; (b) Customer will not use any Test
+    Observations except for its internal evaluation purposes of the EA Software;
+    and (c) Customer will not disclose (including in a press release or public
+    statement) any Test Observations, suggestions concerning EA Software, or any
+    other information about or involving any EA Software, except as agreed by
+    InfluxData in writing.
+
+## 4. Term and Termination
+
+1.  **License Term.** Subject to earlier termination as described in this
+    Section 4, the License Term will be a period of 12 months beginning on
+    Customer’s obtaining a copy of the EA Software.
+2.  **Early Termination.** Each of InfluxData and Customer may terminate
+    Customer’s use of any EA Software or the License Term at any time and for
+    any reason, upon notice to the other. InfluxData may at any time cease
+    providing any or all of any EA Software, including any updates or error
+    corrections, in its sole discretion and without notice.
+3.  **Obligations on Termination.** Upon any termination or expiration of the
+    License Term, (i) Customer will destroy all copies of the EA Software and
+    the Documentation within its custody or control within twenty (20) days of
+    such termination and, if requested by InfluxData, immediately certify that
+    all copies of the EA Software have been destroyed and all use of the EA
+    Software has been discontinued; and (ii) each party will return or destroy
+    all copies of any Confidential Information of the other, as certified by an
+    authorized representative of the returning party.
+4.  **Survival.** The provisions of Sections 1, 2.3, 2.4, 3.4, 4.3, 4.4, and 5-8
+    of these Terms will survive any termination or expiration of these Terms.
+
+## 5. Confidential Information
+
+1.  **Restrictions on Use and Disclosure.** Neither InfluxData nor Customer will
+    disclose to any third party any information provided by the other party
+    pursuant to or in connection with these Terms that the disclosing party
+    identifies as being proprietary or confidential or that, by the nature of
+    the circumstances surrounding the disclosure, ought in good faith to be
+    treated as proprietary or confidential (such information, “**Confidential
+    Information**”), and will make no use of such Confidential Information,
+    except under and in accordance with these Terms. The receiving party will
+    take reasonable precautions (using no less than a reasonable standard of
+    care) to protect the disclosing party’s Confidential Information in its
+    possession or under its control from unauthorized access or use. Each party
+    may disclose Confidential Information to its Affiliates and service
+    providers, and its Affiliates and service providers may use such
+    information, in each case solely for purposes of these Terms. Each party
+    will be liable for any breach of its obligations under this Section 5 that
+    is caused by an act, error or omission of any such Affiliate or service
+    provider. Confidential Information includes information disclosed by the
+    disclosing party with permission from a third party, and combinations of or
+    with publicly known information where the nature of the combination is not
+    publicly known. InfluxData’s Confidential Information includes information
+    regarding the EA Software, InfluxData’s processes, methods, techniques and
+    know-how relating to time-series data and time-series databases, non-public
+    Documentation, road-maps, pricing, marketing and business plans, financial
+    information and information security information. Customer’s Confidential
+    Information includes its proprietary workflows and processes, systems
+    architecture, marketing and business plans, financial information,
+    information security information, and information pertaining to Customer’s
+    other suppliers.
+2.  **Exclusions.** Confidential Information will not include information that
+    the receiving party can establish: (i) has entered the public domain without
+    the receiving party’s breach of any obligation owed to the disclosing party;
+    (ii) has been rightfully received by the receiving party from a third party
+    without confidentiality restrictions; (iii) is known to the receiving party
+    without any restriction as to use or disclosure prior to first receipt by
+    the receiving party from the disclosing party hereunder; or (iv) has been
+    independently developed by the receiving party.
+3.  **Disclosure Required By Law.** If any applicable law, regulation or
+    judicial or administrative order requires the receiving party to disclose
+    any of the disclosing party’s Confidential Information (a “Disclosure
+    Order”) then, unless otherwise required by the Disclosure Order, the
+    receiving party will promptly notify the disclosing party in writing prior
+    to making any such disclosure, in order to facilitate the disclosing party’s
+    efforts to protect its Confidential Information. Following such
+    notification, the receiving party will cooperate with the disclosing party,
+    at the disclosing party’s reasonable expense, in seeking and obtaining
+    protection for the disclosing party’s Confidential Information. The
+    receiving party will disclose only that portion of the Confidential
+    Information that is legally required.
+4.  **Independent Development.** The terms of confidentiality under these Terms
+    will not limit either party’s right to independently develop or acquire
+    products, software or services without use of or reference to the other
+    party’s Confidential Information.
+
+## 6. WARRANTY DISCLAIMERS; EXCLUSION OF CONSEQUENTIAL DAMAGES; LIMITATION OF LIABILITY
+
+THE EA SOFTWARE IS NOT READY FOR GENERAL COMMERCIAL RELEASE AND MAY CONTAIN
+BUGS, ERRORS, DEFECTS, VULNERABILITIES OR HARMFUL COMPONENTS. ACCORDINGLY, AND
+NOTWITHSTANDING ANYTHING TO THE CONTRARY IN ANY OTHER AGREEMENT BETWEEN CUSTOMER
+OR ITS AFFILIATES AND INFLUXDATA, INFLUXDATA IS PROVIDING THE EA SOFTWARE TO
+CUSTOMER “AS IS.” INFLUXDATA AND ITS AFFILIATES AND LICENSORS PROVIDE NO
+ASSURANCES, AND MAKE NO REPRESENTATIONS OR WARRANTIES OF ANY KIND, WHETHER
+EXPRESS, IMPLIED, STATUTORY OR OTHERWISE REGARDING THE EA SOFTWARE, INCLUDING
+ANY WARRANTY THAT THE EA SOFTWARE WILL OPERATE UNINTERRUPTED, BE ERROR FREE OR
+FREE OF VULNERABILITIES OR HARMFUL COMPONENTS, OR THAT ANY DATA PROCESSED WITH
+THE EA SOFTWARE WILL BE SECURE OR NOT OTHERWISE LOST OR DAMAGED. EXCEPT TO THE
+EXTENT PROHIBITED BY LAW, INFLUXDATA AND ITS AFFILIATES AND LICENSORS DISCLAIM
+ALL WARRANTIES, INCLUDING ANY IMPLIED WARRANTIES OF MERCHANTABILITY,
+SATISFACTORY QUALITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR
+QUIET ENJOYMENT, AND ANY WARRANTIES ARISING OUT OF ANY COURSE OF DEALING OR
+USAGE OF TRADE. INFLUXDATA’S AND ITS AFFILIATES’ AND LICENSORS’ AGGREGATE
+LIABILITY FOR ANY EA SOFTWARE WILL BE LIMITED TO THE AMOUNT CUSTOMER ACTUALLY
+PAYS INFLUXDATA UNDER THESE TERMS FOR THE EA SOFTWARE THAT GAVE RISE TO THE
+CLAIM DURING THE 12 MONTHS PRECEDING FIRST ASSERTION OF THE CLAIM. NEITHER
+INFLUXDATA, ITS AFFILIATES OR ITS LICENSORS WILL BE LIABLE FOR ANY
+CONSEQUENTIAL, INDIRECT, SPECIAL, INCIDENTAL, PUNITIVE OR EXEMPLARY DAMAGES,
+WHETHER FORESEEABLE OR UNFORESEEABLE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES, ARISING OUT OF THE PERFORMANCE OR NON-PERFORMANCE OF THESE TERMS OR ANY
+RELATED AGREEMENT, OR ANY SOFTWARE OR SERVICES PROVIDED UNDER OR IN CONNECTION
+WITH THESE TERMS.
+
+## 7. Dispute Resolution
+
+1.  **Governing Law and Venue.** These Terms will be governed by and interpreted
+    in accordance with the internal laws of the states or countries specified in
+    the table below, without regard to conflicts of laws principles. In the
+    event of any controversy or claim arising out of or relating to these Terms,
+    or its breach or interpretation, the parties will submit to the jurisdiction
+    of and venue in the applicable courts or arbitration bodies specified in the
+    table below. Each party waives all defenses of lack of personal jurisdiction
+    and inconvenient forum.
+
+    If the Customer’s address is in:
+
+    The governing law is that of:
+
+    The arbitration bodies or courts having exclusive jurisdiction are:
+
+    The USA, Mexico, Canada or any country in Central or South America or the
+    Caribbean, or any country falling outside the regions listed in this table
+
+    California, USA, and controlling United States federal law
+
+    Arbitration in San Francisco, California, USA under the Commercial
+    Arbitration Rules and the Optional Rules for Emergency Measures of
+    Protection of the American Arbitration Association; those rules are
+    incorporated by reference in this clause.1
+
+    Any country in the United Kingdom, the Middle East, or Africa
+
+    England
+
+    Arbitration in London, England under the Rules of the London Court of
+    International Arbitration (LCIA); those rules are incorporated by reference
+    in this clause.1
+
+    Any country in the European Economic Area or Switzerland
+
+    Republic of Ireland
+
+    Arbitration in Dublin, Ireland under the UNCITRAL Arbitration Rules; those
+    rules are incorporated by reference in this clause.1
+
+    Any country located in Asia or the Pacific region, other than Australia and
+    New Zealand
+
+    Singapore
+
+    Arbitration in Singapore in accordance with the Arbitration Rules of the
+    Singapore International Arbitration Centre then in force; those rules are
+    incorporated by reference in this clause.1
+
+    Australia or New Zealand
+
+    New South Wales, Australia
+
+    Courts located in Sydney, New South Wales, Australia
+
+    Note 1: The Tribunal will consist of one independent, disinterested
+    arbitrator. The language of the arbitration will be English. The
+    determination of the arbitrator will be final, conclusive and binding.
+    Judgment upon the award rendered may be entered in any court of any state or
+    country having jurisdiction.
+
+2.   **Legal Expenses.** If any proceeding is brought by either party to enforce
+    or interpret any term or provision of these Terms, the substantially
+    prevailing party in such proceeding will be entitled to recover, in addition
+    to all other relief arising out of these Terms, its reasonable attorneys’
+    and other experts’ (including without limitation accountants) fees and
+    expenses.
+
+## 8. Miscellaneous Provisions
+
+1.  **Compliance with Laws – Export Control.** Each party will comply with all
+    laws and regulations applicable to it, including U.S. export control laws.
+    Each party represents and warrants to the other that neither it nor its
+    Affiliates, nor any of its or their users, officers or directors, are
+    persons, entities or organizations with whom the other party is prohibited
+    from dealing (including provision of EA Software) by virtue of any
+    applicable law, regulation, or executive order, including US export control
+    laws, and names appearing on the U.S. Department of the Treasury’s Office of
+    Foreign Assets Control’s Specially Designated Nationals and Blocked Persons
+    List.
+2.  **Equitable Relief.** Each of Customer and InfluxData acknowledges that
+    damages will be an inadequate remedy if the other violates the terms of
+    these Terms pertaining to protection of a Party’s Intellectual Property
+    Rights or Confidential Information. Accordingly, each of them will have the
+    right, in addition to any other rights each of them may have, to seek in any
+    court of competent jurisdiction, temporary, preliminary and permanent
+    injunctive relief to restrain any breach, threatened breach, or otherwise to
+    specifically enforce any of such obligations in these Terms.
+3.  **Captions and Headings.** The captions and headings are inserted in these
+    Terms for convenience only, and will not be deemed to limit or describe the
+    scope or intent of any provision of these Terms.
+4.  **Severability; Invalidity.** If any provision of these Terms is held to be
+    invalid, such invalidity will not render invalid the remainder of these
+    Terms or the remainder of which such invalid provision is a part. If any
+    provision of these Terms is so broad as to be held unenforceable, such
+    provision will be interpreted to be only so broad as is enforceable.
+5.  **Waiver.** No waiver of or with respect to any provision of these Terms,
+    nor consent by a party to the breach of or departure from any provision of
+    these Terms, will in any event be binding on or effective against such party
+    unless it be in writing and signed by such party, and then such waiver will
+    be effective only in the specific instance and for the purpose for which
+    given.
+6.  **Third Party Beneficiaries.** Except as expressly set forth in these Terms,
+    no provisions of these Terms are intended nor will be interpreted to provide
+    or create any third party beneficiary rights or any other rights of any kind
+    in any other party. If the law governing these Terms is English law, then a
+    person who is not a party to these Terms will not have any rights under the
+    Contracts (Rights of Third Parties) Act 1999) to enforce any term of these
+    Terms.
+7.  **Assignment.** Neither party may assign any of its rights or obligations
+    under these Terms without the prior written consent of the other, which will
+    not be unreasonably withheld, provided, however that either party may assign
+    all, but not some of its rights and obligations under these Terms to any of
+    its Affiliates, or to any entity into or with which it is merged, or that
+    acquires all or substantially all of its assets, upon notice to the other
+    party, but without requiring consent. Subject to the foregoing restriction
+    on assignment, these Terms will be binding upon, inure to the benefit of and
+    be enforceable by the parties and their respective successors and assigns.
+8.  **Notices.** InfluxData will provide Customer with notices that affect
+    InfluxData’s customers generally (e.g., notices that relate to updates to or
+    discontinuance of the EA Software) via e-mail or the support program
+    platform. InfluxData will provide Customer with any legal notices by
+    pre-paid first class mail, air courier or email to the mailing or email
+    address Customer provided InfluxData upon obtaining the EA Software, or to a
+    substitute, updated mailing or email address that Customer has provided to
+    InfluxData for these purposes. Customer is responsible for keeping its
+    mailing and email address current with InfluxData. Except as otherwise
+    specified in these Terms, all notices to be given to InfluxData under these
+    Terms must be in writing and sent by email
+    to [legal@influxdata.com](mailto:legal@influxdata.com), or by prepaid first
+    class mail or air courier at the address specified on the first page of
+    these Terms, or to a substitute, updated address notified by InfluxData,
+    marked “Attention: Legal Department”. Notices sent electronically will be
+    deemed received within 1 business day of dispatch. Notices sent by prepaid
+    first class mail will be deemed received within 5 business days of dispatch
+    (however, notices sent by mail to addressees in a different country from
+    that of the sender will be deemed received upon delivery). Notices sent by
+    air courier, or personally delivered, will be deemed received upon delivery.
+9.  **Governing Language.** The governing language for these Terms and its
+    related transactions, for any notices or other documents transmitted or
+    delivered under these Terms, and for the negotiation and resolution of any
+    dispute or other matter between the parties, will be the English language. 
+    If there is any conflict between the provisions of any notice or document
+    and an English version of the notice or document (including these Terms),
+    the provisions of the English version will prevail.  Customer waives any
+    rights it may have under any law in any state or country to have the
+    Agreement written in any language other than English. In transactions
+    between the parties, a decimal point will be indicated by a period, and not
+    by a comma.
+10.  **Entire Agreement; Amendments.** These Terms constitutes and embodies the
+    entire agreement and understanding between the parties with respect to the
+    subject matter hereof and supersedes all prior or contemporaneous written,
+    electronic or oral communications, representations, agreements or
+    understandings between the parties with respect thereto. These Terms may not
+    be modified or amended except by a written instrument executed by both
+    parties. Any additional, supplementary or conflicting terms supplied by
+    either party (whether in hard copy or electronic form), including those
+    contained on or within any invoice, purchase order, standard terms of
+    purchase or vendor onboarding documents, are specifically and expressly
+    rejected by each party.
+
+<!-- 
 
 **(Telegraf Controller)**
 
@@ -109,3 +532,4 @@ copyright licenses granted to the U.S. Government are coextensive with the
 technical data and computer Software licenses granted in this Agreement. The
 U.S. Government will only have the right to reproduce, distribute, perform,
 display, and prepare derivative works as needed to implement those rights.
+-->

--- a/content/telegraf/controller/reference/release-notes.md
+++ b/content/telegraf/controller/reference/release-notes.md
@@ -9,10 +9,22 @@ menu:
 weight: 101
 ---
 
-## v0.0.5-beta {date="2026-03-26"}
+## v0.0.6-beta {date="TBD"}
 
 <!-- Link only be on the latest version, update and move with new versions. -->
-[Download Telegraf Controller v0.0.5-beta](/telegraf/controller/install/#download-and-install-telegraf-controller)
+[Download Telegraf Controller v0.0.6-beta](/telegraf/controller/install/#download-and-install-telegraf-controller)
+
+> [!Important]
+> #### Updated End User License Agreement (EULA)
+>
+> This release includes an updated
+> [EULA for {{% product-name %}}](/telegraf/controller/reference/eula/). After
+> upgrading to this release, **you are required to accept the updated EULA**
+> before {{% product-name %}} starts. For information about different ways to
+> accept the updated EULA, see
+> [Install {{% product-name %}}--Review the EULA](https://docs.influxdata.com/telegraf/controller/install/#review-the-eula).
+
+## v0.0.5-beta {date="2026-03-26"}
 
 ### Important changes
 

--- a/content/telegraf/controller/reference/release-notes.md
+++ b/content/telegraf/controller/reference/release-notes.md
@@ -9,7 +9,7 @@ menu:
 weight: 101
 ---
 
-## v0.0.6-beta {date="TBD"}
+## v0.0.6-beta {date="2026-04-13"}
 
 <!-- Link only be on the latest version, update and move with new versions. -->
 [Download Telegraf Controller v0.0.6-beta](/telegraf/controller/install/#download-and-install-telegraf-controller)
@@ -23,6 +23,43 @@ weight: 101
 > before {{% product-name %}} starts. For information about different ways to
 > accept the updated EULA, see
 > [Install {{% product-name %}}--Review the EULA](https://docs.influxdata.com/telegraf/controller/install/#review-the-eula).
+
+### Features
+
+- Separate managed and external configurations on the agent detail page.
+- Enhance Heartbeat plugin with HTTP client configuration options for transport,
+  TLS, OAuth2, and Cookie Auth.
+- Add plugin support to the Telegraf Builder UI:
+  - Intel PMU (`inputs.intel_pmu`)
+  - Intel PowerStat (`inputs.intel_powerstat`)
+  - Intel RDT (`inputs.intel_rdt`)
+  - Internal (`inputs.internal`)
+  - Internet Speed (`inputs.internet_speed`)
+  - Interrupts (`inputs.interrupts`)
+  - IPMI Sensor (`inputs.ipmi_sensor`)
+  - Ipset (`inputs.ipset`)
+  - Iptables (`inputs.iptables`)
+  - Jenkins (`inputs.jenkins`)
+  - Jolokia2 Agent (`inputs.jolokia2_agent`)
+  - JTI OpenConfig Telemetry (`inputs.jti_openconfig_telemetry`)
+  - Kafka Consumer (`inputs.kafka_consumer`)
+  - Kapacitor (`inputs.kapacitor`)
+  - Kernel Vmstat (`inputs.kernel_vmstat`)
+  - IPVS (`inputs.ipvs`)
+  - Kibana (`inputs.kibana`)
+  - Kinesis Consumer (`inputs.kinesis_consumer`)
+  - KNX Listener (`inputs.knx_listener`)
+  - Kubernetes (`inputs.kubernetes`)
+  - Kubernetes Inventory (`inputs.kube_inventory`)
+  - Lanz (`inputs.lanz`)
+  - LDAP (`inputs.ldap`)
+  - LeoFS (`inputs.leofs`)
+
+### Bug fixes
+
+- Fix typo in TOML parsing rename configuration.
+
+---
 
 ## v0.0.5-beta {date="2026-03-26"}
 

--- a/data/notifications.yaml
+++ b/data/notifications.yaml
@@ -106,6 +106,17 @@
     - [Telegraf Controller Documentation](/telegraf/controller/)
     - [Download and install Telegraf Controller](/telegraf/controller/install/)
 
+- id: telegraf-controller-0.0.6-beta
+  level: note
+  scope:
+    - /telegraf/controller/
+  title: Telegraf Controller v0.0.6-beta now available
+  slug: |
+    Telegraf Controller v0.0.6-beta is now available with new features, improvements, and bug fixes.
+    
+    <a href="/telegraf/controller/reference/release-notes/#v006-beta">View the release notes</a>  
+    <a href="/telegraf/controller/install/#download-and-install-telegraf-controller">Download Telegraf Controller v0.0.6-beta</a>
+
 # - id: influxdb3.8-explorer-1.6
 #   level: note
 #   scope:

--- a/data/tc_downloads.yml
+++ b/data/tc_downloads.yml
@@ -1,24 +1,24 @@
-version: "0.0.5-beta"
+version: "0.0.6-beta"
 platforms:
   - name: Linux
     builds:
       - arch: x64
         os: linux
-        sha256: "854592b5e1f1922774074036650ed94fc278d9a666b20d35c98e75defb56d2cf"
+        sha256: "4da264cc06fc5978b92c654a61fd3ad3c7cd5bf0f26b5403d839c7c4ccd187d0"
       - arch: arm64
         os: linux
-        sha256: "15ea90cc93bc345ce77e4b7eb15efa36522efb7026433f25098280fb6577ca91"
+        sha256: "40b824377bcccbe52ab59d32380e02ef976154c0a2e8d6a6e0154afd5101cbf4"
   - name: macOS
     builds:
       - arch: x64
         os: macos
-        sha256: "3ac978da3619f396b78fe51db32cbcc6365af41b6e53ad28eec393eccf3a53a2"
+        sha256: "38fc1215d6c7f1924f081b0c37efb52f3163fd7ed3d818f0b332ddf4c6fc8a04"
       - arch: arm64
         os: macos
-        sha256: "5c64a3dd3b211cbb0fa3b1e833ca0cb88bbf32209802533b138018a939892562"
+        sha256: "85dfa4241f3e4a12e4388f18f543f593d31ee81e8b09382559a1282b9b037777"
   - name: Windows
     builds:
       - arch: x64
         os: win
         ext: .exe
-        sha256: "b98d5034d8cbeb84efeed754688906500c528a54b70fdb33a338a60f13316f94"
+        sha256: "f3eb8e095f477d7dbaa1f12c737d05dd3959147a144e4407608d07ea95505751"


### PR DESCRIPTION
## Summary

- Updates Telegraf Controller EULA to use early access software gaurantees
- Adds Telegraf Controller v0.0.6-beta release notes
- Updates Telegraf Controller binary downloads to use v0.0.6-beta
- Adds Telegraf Controller v0.0.6-beta notification that appears on Telegraf Controller pages

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
