### PR TITLE
fix(enterprise): clarify license binding in backup-restore docs

### DIFF
--- a/content/shared/influxdb3-admin/backup-restore.md
+++ b/content/shared/influxdb3-admin/backup-restore.md
@@ -477,8 +477,8 @@ Replace the following:
 ### License files
 
 > [!Important]
-> License files are tied to the complete object store configuration, not just the bucket or container name.
-> Changing any component of your object store configuration invalidates your license.
+> License files are tied to the complete object store configuration and the cluster ID, not just the bucket or container name.
+> Changing any component of your object store configuration or restoring to a different cluster invalidates your license.
 
 License binding varies by cloud provider:
 
@@ -492,8 +492,7 @@ License binding varies by cloud provider:
 For disaster recovery planning:
 
 - **Pre-provision a DR license**: Request a license for your DR storage configuration before an incident occurs.
-- **Use provider-native replication**: Azure GRS/ZRS or S3 Cross-Region Replication preserves the storage account or endpoint identity, so your existing license remains valid.
-- **Contact support for migrations**: If you need to restore to a different storage account, endpoint, or bucket, [contact InfluxData support](https://support.influxdata.com) to obtain a new license.
+- **Contact support for migrations**: If you need to restore to a different storage account, endpoint, bucket, or cluster, [contact InfluxData support](https://support.influxdata.com) to obtain a new license.
 {{% /show-in %}}
 
 ### Docker considerations

--- a/content/shared/influxdb3-admin/backup-restore.md
+++ b/content/shared/influxdb3-admin/backup-restore.md
@@ -477,12 +477,23 @@ Replace the following:
 ### License files
 
 > [!Important]
-> License files are tied to:
-> - The specific cloud provider (AWS, Azure, GCS)
-> - The specific bucket name
-> - For file storage: the exact file path
-> 
-> You cannot restore a license file to a different bucket or path. Contact InfluxData support if you need to migrate to a different bucket.
+> License files are tied to the complete object store configuration, not just the bucket or container name.
+> Changing any component of your object store configuration invalidates your license.
+
+License binding varies by cloud provider:
+
+| Provider | License bound to |
+| -------- | ---------------- |
+| **AWS S3** | Endpoint + bucket name + region + cluster ID |
+| **Azure Blob Storage** | Storage account name + container name + cluster ID |
+| **Google Cloud Storage** | GCS base URL + bucket name + cluster ID |
+| **File storage** | Exact file path + cluster ID |
+
+For disaster recovery planning:
+
+- **Pre-provision a DR license**: Request a license for your DR storage configuration before an incident occurs.
+- **Use provider-native replication**: Azure GRS/ZRS or S3 Cross-Region Replication preserves the storage account or endpoint identity, so your existing license remains valid.
+- **Contact support for migrations**: If you need to restore to a different storage account, endpoint, or bucket, [contact InfluxData support](https://support.influxdata.com) to obtain a new license.
 {{% /show-in %}}
 
 ### Docker considerations


### PR DESCRIPTION
## Summary

- Clarifies that InfluxDB 3 Enterprise licenses are tied to the complete object store configuration, not just the bucket/container name
- Adds a table showing exactly what each cloud provider's license binding includes
- Adds disaster recovery planning recommendations

## Context

Customer support case ([EAR#6827](https://github.com/influxdata/EAR/issues/6827)) revealed confusion about license portability during disaster recovery. The existing documentation stated licenses are "tied to the specific bucket name" which led to incorrect assumptions about DR scenarios.

Code analysis confirmed licenses are bound to:
| Provider | License bound to |
| -------- | ---------------- |
| AWS S3 | Endpoint + bucket + region + cluster ID |
| Azure | Storage account + container + cluster ID |
| GCS | Base URL + bucket + cluster ID |
| File | Exact path + cluster ID |

This means:
- ❌ Different storage account + same container = License fails
- ❌ Same storage account + different container = License fails
- ✅ Same storage account + same container = License works

## Test plan

- [ ] Verify page renders correctly at `/influxdb3/enterprise/admin/backup-restore/`
- [ ] Verify table displays properly
- [ ] Verify support link is valid