### PR TITLE
chore(claude): direct superpowers skills to PLAN.md instead of docs/superpowers/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,21 @@ testing, link validation, style linting, and advanced testing procedures.
 
 See @api-docs/README.md for information about the API reference documentation, how to
 generate it, and how to contribute to it.
+
+## Design docs and implementation plans (superpowers skills)
+
+The `superpowers:brainstorming` and `superpowers:writing-plans` skills default to
+writing output under `docs/superpowers/specs/` and `docs/superpowers/plans/`.
+Do **not** use those paths in this repo. Instead:
+
+- **Implementation plan** → `PLAN.md` at the repo root. A CI workflow deletes
+  `PLAN.md` before merging to `master`, so the plan stays visible on the branch
+  during review but never lands in `master`.
+- **Design spec** → if a design doc is genuinely useful post-merge, put it in
+  an existing docs location (for example, `DOCS-*.md` or product-specific
+  `content/` frontmatter). Otherwise skip committing it; keep the spec in the
+  session only, or save it alongside `PLAN.md` on the branch so it gets
+  scrubbed by the same workflow.
+
+When a superpowers skill asks where to save a plan or spec, use `PLAN.md` (or
+ask the user) — never write to `docs/superpowers/`.


### PR DESCRIPTION
## Summary

Adds a CLAUDE.md directive telling the `superpowers:brainstorming` and `superpowers:writing-plans` skills to save implementation plans to `PLAN.md` at the repo root, not to their default `docs/superpowers/specs/` and `docs/superpowers/plans/` paths.

`PLAN.md` is scrubbed by an existing CI workflow before merge to `master`, so the plan stays readable on feature branches during review but never pollutes master. The skill default (a new top-level `docs/superpowers/` directory) bypasses that scrubbing and doesn't fit the repo's layout.

## Background

Surfaced while working on #7122 (legacy API URL redirects). That session followed the superpowers brainstorming → plan → execute workflow and the skill defaults silently created `docs/superpowers/specs/2026-04-20-...-design.md` and `docs/superpowers/plans/2026-04-20-...md`. Those files were cleaned up on the feature branch, but only after the fact. This directive prevents the same mistake on the next session.

## What changed

- `CLAUDE.md`: new section "Design docs and implementation plans (superpowers skills)" at the end, 18 lines added.

## Test plan

- [x] CLAUDE.md renders as valid markdown
- [x] No other files touched