### PR TITLE
feat(docs): add /mcp/server/ aliases to MCP server pages

### DIFF
--- a/content/chronograf/v1/tools/mcp-server.md
+++ b/content/chronograf/v1/tools/mcp-server.md
@@ -1,5 +1,6 @@
 ---
 title: Use the InfluxDB documentation MCP server
+seotitle: InfluxDB docs Model Context Protocol (MCP) server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
   Model Context Protocol (MCP) server.

--- a/content/chronograf/v1/tools/mcp-server.md
+++ b/content/chronograf/v1/tools/mcp-server.md
@@ -15,6 +15,8 @@ alt_links:
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/mcp-server/
   cloud-serverless: /influxdb3/cloud-serverless/reference/mcp-server/
 source: /shared/influxdb3-admin/mcp-server-docs-only.md
+aliases:
+  - /chronograf/v1/mcp/server/
 ---
 
 <!-- //SOURCE content/shared/influxdb3-admin/mcp-server-docs-only.md -->

--- a/content/chronograf/v1/tools/mcp-server.md
+++ b/content/chronograf/v1/tools/mcp-server.md
@@ -2,7 +2,7 @@
 title: Use the InfluxDB documentation MCP server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
-  MCP server.
+  Model Context Protocol (MCP) server.
 menu:
   chronograf_v1:
     name: Documentation MCP server

--- a/content/enterprise_influxdb/v1/tools/mcp-server.md
+++ b/content/enterprise_influxdb/v1/tools/mcp-server.md
@@ -15,6 +15,8 @@ alt_links:
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/mcp-server/
   cloud-serverless: /influxdb3/cloud-serverless/reference/mcp-server/
 source: /shared/influxdb3-admin/mcp-server-docs-only.md
+aliases:
+  - /enterprise_influxdb/v1/mcp/server/
 ---
 
 <!-- //SOURCE content/shared/influxdb3-admin/mcp-server-docs-only.md -->

--- a/content/enterprise_influxdb/v1/tools/mcp-server.md
+++ b/content/enterprise_influxdb/v1/tools/mcp-server.md
@@ -1,5 +1,6 @@
 ---
 title: Use the InfluxDB documentation MCP server
+seotitle: InfluxDB docs Model Context Protocol (MCP) server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
   Model Context Protocol (MCP) server.

--- a/content/enterprise_influxdb/v1/tools/mcp-server.md
+++ b/content/enterprise_influxdb/v1/tools/mcp-server.md
@@ -2,7 +2,7 @@
 title: Use the InfluxDB documentation MCP server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
-  MCP server.
+  Model Context Protocol (MCP) server.
 menu:
   enterprise_influxdb_v1:
     name: Documentation MCP server

--- a/content/flux/v0/mcp-server.md
+++ b/content/flux/v0/mcp-server.md
@@ -2,7 +2,7 @@
 title: Use the InfluxDB documentation MCP server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
-  MCP server.
+  Model Context Protocol (MCP) server.
 menu:
   flux_v0_ref:
     name: Documentation MCP server

--- a/content/flux/v0/mcp-server.md
+++ b/content/flux/v0/mcp-server.md
@@ -14,6 +14,8 @@ alt_links:
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/mcp-server/
   cloud-serverless: /influxdb3/cloud-serverless/reference/mcp-server/
 source: /shared/influxdb3-admin/mcp-server-docs-only.md
+aliases:
+  - /flux/v0/mcp/server/
 ---
 
 <!-- //SOURCE content/shared/influxdb3-admin/mcp-server-docs-only.md -->

--- a/content/flux/v0/mcp-server.md
+++ b/content/flux/v0/mcp-server.md
@@ -1,5 +1,6 @@
 ---
 title: Use the InfluxDB documentation MCP server
+seotitle: InfluxDB docs Model Context Protocol (MCP) server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
   Model Context Protocol (MCP) server.

--- a/content/influxdb/cloud/tools/mcp-server.md
+++ b/content/influxdb/cloud/tools/mcp-server.md
@@ -2,7 +2,7 @@
 title: Use the InfluxDB documentation MCP server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
-  MCP server.
+  Model Context Protocol (MCP) server.
 menu:
   influxdb_cloud:
     name: Documentation MCP server

--- a/content/influxdb/cloud/tools/mcp-server.md
+++ b/content/influxdb/cloud/tools/mcp-server.md
@@ -15,6 +15,8 @@ alt_links:
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/mcp-server/
   cloud-serverless: /influxdb3/cloud-serverless/reference/mcp-server/
 source: /shared/influxdb3-admin/mcp-server-docs-only.md
+aliases:
+  - /influxdb/cloud/mcp/server/
 ---
 
 <!-- //SOURCE content/shared/influxdb3-admin/mcp-server-docs-only.md -->

--- a/content/influxdb/cloud/tools/mcp-server.md
+++ b/content/influxdb/cloud/tools/mcp-server.md
@@ -1,5 +1,6 @@
 ---
 title: Use the InfluxDB documentation MCP server
+seotitle: InfluxDB docs Model Context Protocol (MCP) server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
   Model Context Protocol (MCP) server.

--- a/content/influxdb/v1/tools/mcp-server.md
+++ b/content/influxdb/v1/tools/mcp-server.md
@@ -15,6 +15,8 @@ alt_links:
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/mcp-server/
   cloud-serverless: /influxdb3/cloud-serverless/reference/mcp-server/
 source: /shared/influxdb3-admin/mcp-server-docs-only.md
+aliases:
+  - /influxdb/v1/mcp/server/
 ---
 
 <!-- //SOURCE content/shared/influxdb3-admin/mcp-server-docs-only.md -->

--- a/content/influxdb/v1/tools/mcp-server.md
+++ b/content/influxdb/v1/tools/mcp-server.md
@@ -2,7 +2,7 @@
 title: Use the InfluxDB documentation MCP server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
-  MCP server.
+  Model Context Protocol (MCP) server.
 menu:
   influxdb_v1:
     name: Documentation MCP server

--- a/content/influxdb/v1/tools/mcp-server.md
+++ b/content/influxdb/v1/tools/mcp-server.md
@@ -1,5 +1,6 @@
 ---
 title: Use the InfluxDB documentation MCP server
+seotitle: InfluxDB docs Model Context Protocol (MCP) server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
   Model Context Protocol (MCP) server.

--- a/content/influxdb/v2/tools/mcp-server.md
+++ b/content/influxdb/v2/tools/mcp-server.md
@@ -2,7 +2,7 @@
 title: Use the InfluxDB documentation MCP server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
-  MCP server.
+  Model Context Protocol (MCP) server.
 menu:
   influxdb_v2:
     name: Documentation MCP server

--- a/content/influxdb/v2/tools/mcp-server.md
+++ b/content/influxdb/v2/tools/mcp-server.md
@@ -1,5 +1,6 @@
 ---
 title: Use the InfluxDB documentation MCP server
+seotitle: InfluxDB docs Model Context Protocol (MCP) server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
   Model Context Protocol (MCP) server.

--- a/content/influxdb/v2/tools/mcp-server.md
+++ b/content/influxdb/v2/tools/mcp-server.md
@@ -15,6 +15,8 @@ alt_links:
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/mcp-server/
   cloud-serverless: /influxdb3/cloud-serverless/reference/mcp-server/
 source: /shared/influxdb3-admin/mcp-server-docs-only.md
+aliases:
+  - /influxdb/v2/mcp/server/
 ---
 
 <!-- //SOURCE content/shared/influxdb3-admin/mcp-server-docs-only.md -->

--- a/content/influxdb3/cloud-dedicated/admin/mcp-server.md
+++ b/content/influxdb3/cloud-dedicated/admin/mcp-server.md
@@ -19,6 +19,8 @@ alt_links:
   core: /influxdb3/core/admin/mcp-server/
   enterprise: /influxdb3/enterprise/admin/mcp-server/
 source: /shared/influxdb3-admin/mcp-server.md
+aliases:
+  - /influxdb3/cloud-dedicated/mcp/server/
 ---
 
 <!-- //SOURCE content/shared/influxdb3-admin/mcp-server.md -->

--- a/content/influxdb3/cloud-dedicated/admin/mcp-server.md
+++ b/content/influxdb3/cloud-dedicated/admin/mcp-server.md
@@ -1,10 +1,10 @@
 ---
 title: Use the InfluxDB 3 MCP server
 description: >
-  Use the **InfluxDB MCP server** to interact with and manage {{% product-name %}}
+  Use the **InfluxDB Model Context Protocol (MCP) server** to interact with and manage {{% product-name %}}
   using natural language with LLM agents to query and analyze data, manage databases
   and more. Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
-  MCP server.
+  Model Context Protocol (MCP) server.
 menu:
   influxdb3_cloud_dedicated:
     name: Use the InfluxDB MCP server

--- a/content/influxdb3/cloud-dedicated/admin/mcp-server.md
+++ b/content/influxdb3/cloud-dedicated/admin/mcp-server.md
@@ -1,5 +1,6 @@
 ---
 title: Use the InfluxDB 3 MCP server
+seotitle: InfluxDB 3 Model Context Protocol (MCP) server
 description: >
   Use the **InfluxDB Model Context Protocol (MCP) server** to interact with and manage {{% product-name %}}
   using natural language with LLM agents to query and analyze data, manage databases

--- a/content/influxdb3/cloud-serverless/reference/mcp-server.md
+++ b/content/influxdb3/cloud-serverless/reference/mcp-server.md
@@ -2,7 +2,7 @@
 title: Use the InfluxDB documentation MCP server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
-  MCP server.
+  Model Context Protocol (MCP) server.
 menu:
   influxdb3_cloud_serverless:
     name: Documentation MCP server

--- a/content/influxdb3/cloud-serverless/reference/mcp-server.md
+++ b/content/influxdb3/cloud-serverless/reference/mcp-server.md
@@ -1,5 +1,6 @@
 ---
 title: Use the InfluxDB documentation MCP server
+seotitle: InfluxDB docs Model Context Protocol (MCP) server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
   Model Context Protocol (MCP) server.

--- a/content/influxdb3/cloud-serverless/reference/mcp-server.md
+++ b/content/influxdb3/cloud-serverless/reference/mcp-server.md
@@ -15,6 +15,8 @@ alt_links:
   core: /influxdb3/core/admin/mcp-server/
   enterprise: /influxdb3/enterprise/admin/mcp-server/
 source: /shared/influxdb3-admin/mcp-server-docs-only.md
+aliases:
+  - /influxdb3/cloud-serverless/mcp/server/
 ---
 
 <!-- //SOURCE content/shared/influxdb3-admin/mcp-server-docs-only.md -->

--- a/content/influxdb3/clustered/reference/mcp-server.md
+++ b/content/influxdb3/clustered/reference/mcp-server.md
@@ -15,6 +15,8 @@ alt_links:
   core: /influxdb3/core/admin/mcp-server/
   enterprise: /influxdb3/enterprise/admin/mcp-server/
 source: /shared/influxdb3-admin/mcp-server-docs-only.md
+aliases:
+  - /influxdb3/clustered/mcp/server/
 ---
 
 <!-- //SOURCE content/shared/influxdb3-admin/mcp-server-docs-only.md -->

--- a/content/influxdb3/clustered/reference/mcp-server.md
+++ b/content/influxdb3/clustered/reference/mcp-server.md
@@ -2,7 +2,7 @@
 title: Use the InfluxDB documentation MCP server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
-  MCP server.
+  Model Context Protocol (MCP) server.
 menu:
   influxdb3_clustered:
     name: Documentation MCP server

--- a/content/influxdb3/clustered/reference/mcp-server.md
+++ b/content/influxdb3/clustered/reference/mcp-server.md
@@ -1,5 +1,6 @@
 ---
 title: Use the InfluxDB documentation MCP server
+seotitle: InfluxDB docs Model Context Protocol (MCP) server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
   Model Context Protocol (MCP) server.

--- a/content/influxdb3/core/admin/mcp-server.md
+++ b/content/influxdb3/core/admin/mcp-server.md
@@ -1,10 +1,10 @@
 ---
 title: Use the InfluxDB 3 MCP server
 description: >
-  Use the **InfluxDB MCP server** to interact with and manage {{% product-name %}}
+  Use the **InfluxDB Model Context Protocol (MCP) server** to interact with and manage {{% product-name %}}
   using natural language with LLM agents to query and analyze data, manage databases
   and more. Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
-  MCP server.
+  Model Context Protocol (MCP) server.
 menu:
   influxdb3_core:
     name: Use the InfluxDB MCP server

--- a/content/influxdb3/core/admin/mcp-server.md
+++ b/content/influxdb3/core/admin/mcp-server.md
@@ -1,5 +1,6 @@
 ---
 title: Use the InfluxDB 3 MCP server
+seotitle: InfluxDB 3 Model Context Protocol (MCP) server
 description: >
   Use the **InfluxDB Model Context Protocol (MCP) server** to interact with and manage {{% product-name %}}
   using natural language with LLM agents to query and analyze data, manage databases

--- a/content/influxdb3/core/admin/mcp-server.md
+++ b/content/influxdb3/core/admin/mcp-server.md
@@ -19,6 +19,8 @@ alt_links:
   clustered: /influxdb3/clustered/reference/mcp-server/
   enterprise: /influxdb3/enterprise/admin/mcp-server/
 source: /shared/influxdb3-admin/mcp-server.md
+aliases:
+  - /influxdb3/core/mcp/server/
 ---
 
 <!-- //SOURCE content/shared/influxdb3-admin/mcp-server.md -->

--- a/content/influxdb3/enterprise/admin/mcp-server.md
+++ b/content/influxdb3/enterprise/admin/mcp-server.md
@@ -19,6 +19,8 @@ alt_links:
   clustered: /influxdb3/clustered/reference/mcp-server/
   core: /influxdb3/core/admin/mcp-server/
 source: /shared/influxdb3-admin/mcp-server.md
+aliases:
+  - /influxdb3/enterprise/mcp/server/
 ---
 
 <!-- //SOURCE content/shared/influxdb3-admin/mcp-server.md -->

--- a/content/influxdb3/enterprise/admin/mcp-server.md
+++ b/content/influxdb3/enterprise/admin/mcp-server.md
@@ -1,5 +1,6 @@
 ---
 title: Use the InfluxDB 3 MCP server
+seotitle: InfluxDB 3 Model Context Protocol (MCP) server
 description: >
   Use the **InfluxDB Model Context Protocol (MCP) server** to interact with and manage {{% product-name %}}
   using natural language with LLM agents to query and analyze data, manage databases

--- a/content/influxdb3/enterprise/admin/mcp-server.md
+++ b/content/influxdb3/enterprise/admin/mcp-server.md
@@ -1,10 +1,10 @@
 ---
 title: Use the InfluxDB 3 MCP server
 description: >
-  Use the **InfluxDB MCP server** to interact with and manage {{% product-name %}}
+  Use the **InfluxDB Model Context Protocol (MCP) server** to interact with and manage {{% product-name %}}
   using natural language with LLM agents to query and analyze data, manage databases
   and more. Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
-  MCP server.
+  Model Context Protocol (MCP) server.
 menu:
   influxdb3_enterprise:
     name: Use the InfluxDB MCP server

--- a/content/influxdb3/explorer/mcp-server.md
+++ b/content/influxdb3/explorer/mcp-server.md
@@ -1,5 +1,6 @@
 ---
 title: Use the InfluxDB documentation MCP server
+seotitle: InfluxDB docs Model Context Protocol (MCP) server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
   Model Context Protocol (MCP) server.

--- a/content/influxdb3/explorer/mcp-server.md
+++ b/content/influxdb3/explorer/mcp-server.md
@@ -2,7 +2,7 @@
 title: Use the InfluxDB documentation MCP server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
-  MCP server.
+  Model Context Protocol (MCP) server.
 menu:
   influxdb3_explorer:
     name: Documentation MCP server

--- a/content/influxdb3/explorer/mcp-server.md
+++ b/content/influxdb3/explorer/mcp-server.md
@@ -15,6 +15,8 @@ alt_links:
   core: /influxdb3/core/admin/mcp-server/
   enterprise: /influxdb3/enterprise/admin/mcp-server/
 source: /shared/influxdb3-admin/mcp-server-docs-only.md
+aliases:
+  - /influxdb3/explorer/mcp/server/
 ---
 
 <!-- //SOURCE content/shared/influxdb3-admin/mcp-server-docs-only.md -->

--- a/content/kapacitor/v1/reference/mcp-server.md
+++ b/content/kapacitor/v1/reference/mcp-server.md
@@ -14,6 +14,8 @@ alt_links:
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/mcp-server/
   cloud-serverless: /influxdb3/cloud-serverless/reference/mcp-server/
 source: /shared/influxdb3-admin/mcp-server-docs-only.md
+aliases:
+  - /kapacitor/v1/mcp/server/
 ---
 
 <!-- //SOURCE content/shared/influxdb3-admin/mcp-server-docs-only.md -->

--- a/content/kapacitor/v1/reference/mcp-server.md
+++ b/content/kapacitor/v1/reference/mcp-server.md
@@ -1,5 +1,6 @@
 ---
 title: Use the InfluxDB documentation MCP server
+seotitle: InfluxDB docs Model Context Protocol (MCP) server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
   Model Context Protocol (MCP) server.

--- a/content/kapacitor/v1/reference/mcp-server.md
+++ b/content/kapacitor/v1/reference/mcp-server.md
@@ -2,7 +2,7 @@
 title: Use the InfluxDB documentation MCP server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
-  MCP server.
+  Model Context Protocol (MCP) server.
 menu:
   kapacitor_v1_ref:
     name: Documentation MCP server

--- a/content/platform/mcp/server.md
+++ b/content/platform/mcp/server.md
@@ -1,0 +1,17 @@
+---
+title: Use the InfluxDB documentation MCP server
+description: >
+  Query InfluxData product documentation from your IDE using the InfluxDB documentation
+  Model Context Protocol (MCP) server.
+menu:
+  platform:
+    name: Documentation MCP server
+weight: 10
+tags: [MCP, LLM, AI]
+aliases:
+  - /platform/mcp-server/
+  - /platform/mcp/
+source: /shared/influxdb3-admin/mcp-server-docs-only.md
+---
+
+<!-- //SOURCE content/shared/influxdb3-admin/mcp-server-docs-only.md -->

--- a/content/platform/mcp/server.md
+++ b/content/platform/mcp/server.md
@@ -1,5 +1,6 @@
 ---
 title: Use the InfluxDB documentation MCP server
+seotitle: InfluxData Model Context Protocol (MCP) server
 description: >
   Query InfluxData product documentation from your IDE using the InfluxDB documentation
   Model Context Protocol (MCP) server.

--- a/content/platform/mcp/server.md
+++ b/content/platform/mcp/server.md
@@ -11,7 +11,6 @@ weight: 10
 tags: [MCP, LLM, AI]
 aliases:
   - /platform/mcp-server/
-  - /platform/mcp/
 source: /shared/influxdb3-admin/mcp-server-docs-only.md
 ---
 

--- a/content/telegraf/v1/mcp-server.md
+++ b/content/telegraf/v1/mcp-server.md
@@ -1,5 +1,6 @@
 ---
 title: Use the InfluxDB documentation MCP server
+seotitle: InfluxDB docs Model Context Protocol (MCP) server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
   Model Context Protocol (MCP) server.

--- a/content/telegraf/v1/mcp-server.md
+++ b/content/telegraf/v1/mcp-server.md
@@ -14,6 +14,8 @@ alt_links:
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/mcp-server/
   cloud-serverless: /influxdb3/cloud-serverless/reference/mcp-server/
 source: /shared/influxdb3-admin/mcp-server-docs-only.md
+aliases:
+  - /telegraf/v1/mcp/server/
 ---
 
 <!-- //SOURCE content/shared/influxdb3-admin/mcp-server-docs-only.md -->

--- a/content/telegraf/v1/mcp-server.md
+++ b/content/telegraf/v1/mcp-server.md
@@ -2,7 +2,7 @@
 title: Use the InfluxDB documentation MCP server
 description: >
   Query {{% product-name %}} documentation from your IDE using the InfluxDB documentation
-  MCP server.
+  Model Context Protocol (MCP) server.
 menu:
   telegraf_v1_ref:
     name: Documentation MCP server


### PR DESCRIPTION
## Summary

Adds Hugo `aliases:` frontmatter to all MCP server documentation pages so that `/<product>/mcp/server/` redirects to the canonical page.

Users and LLM-generated links often guess the shorter form (e.g. `/influxdb3/enterprise/mcp/server/`) instead of the deeper canonical path (`/influxdb3/enterprise/admin/mcp-server/`). This adds client-side redirect stubs at the guessable URLs — purely additive, no content moves.

## Aliases added

| New alias | Redirects to |
|---|---|
| `/telegraf/v1/mcp/server/` | `/telegraf/v1/mcp-server/` |
| `/flux/v0/mcp/server/` | `/flux/v0/mcp-server/` |
| `/kapacitor/v1/mcp/server/` | `/kapacitor/v1/reference/mcp-server/` |
| `/chronograf/v1/mcp/server/` | `/chronograf/v1/tools/mcp-server/` |
| `/influxdb/v1/mcp/server/` | `/influxdb/v1/tools/mcp-server/` |
| `/influxdb/v2/mcp/server/` | `/influxdb/v2/tools/mcp-server/` |
| `/influxdb/cloud/mcp/server/` | `/influxdb/cloud/tools/mcp-server/` |
| `/enterprise_influxdb/v1/mcp/server/` | `/enterprise_influxdb/v1/tools/mcp-server/` |
| `/influxdb3/core/mcp/server/` | `/influxdb3/core/admin/mcp-server/` |
| `/influxdb3/enterprise/mcp/server/` | `/influxdb3/enterprise/admin/mcp-server/` |
| `/influxdb3/clustered/mcp/server/` | `/influxdb3/clustered/reference/mcp-server/` |
| `/influxdb3/cloud-serverless/mcp/server/` | `/influxdb3/cloud-serverless/reference/mcp-server/` |
| `/influxdb3/cloud-dedicated/mcp/server/` | `/influxdb3/cloud-dedicated/admin/mcp-server/` |
| `/influxdb3/explorer/mcp/server/` | `/influxdb3/explorer/mcp-server/` |

## Test plan

- [x] `npx hugo --quiet` builds cleanly
- [x] Verified each `public/<product>/mcp/server/index.html` contains a `<meta http-equiv="refresh">` tag pointing to the canonical URL
- [x] Vale linting passes for all 14 modified files

## Follow-up

A follow-on PR will add an MCP server page under the `/platform/` section of the site.