### PR TITLE
test(lint-codeblocks): bash break (warning expected) — DO NOT MERGE

### DIFF
--- a/content/influxdb3/core/reference/cli/influxdb3/_index.md
+++ b/content/influxdb3/core/reference/cli/influxdb3/_index.md
@@ -18,6 +18,7 @@ The `influxdb3` CLI runs and interacts with the {{< product-name >}} server.
 
 ```bash
 influxdb3 [GLOBAL-OPTIONS] [COMMAND]
+if [ -z "$unclosed
 ```
 
 ## Commands

--- a/scripts/lib/codeblock-validators/bash.mjs
+++ b/scripts/lib/codeblock-validators/bash.mjs
@@ -12,7 +12,15 @@ export function validate(code) {
       resolve(result);
     };
 
-    const proc = spawn('bash', ['-n', '/dev/stdin'], { stdio: ['pipe', 'ignore', 'pipe'] });
+    // Use `-s` to read the script from stdin rather than the `/dev/stdin`
+    // path. The `/dev/stdin` form is unreliable in some Linux CI
+    // environments (notably the GitHub Actions Ubuntu runner), where it
+    // errors with `bash: /dev/stdin: No such device or address` —
+    // masking the real syntax-error output and producing a misleading
+    // ::warning:: annotation on every bash block. `-ns` is the portable
+    // equivalent: `-s` reads the script from stdin, `-n` parses without
+    // executing. Works identically on macOS and Linux.
+    const proc = spawn('bash', ['-ns'], { stdio: ['pipe', 'ignore', 'pipe'] });
     let stderr = '';
     let timedOut = false;
     const timer = setTimeout(() => {


### PR DESCRIPTION
## Purpose

Verify the `lint-codeblocks` CI job emits a `::warning::` annotation for a bash syntax error **without** failing the PR check (per the documented blocking policy: bash/python/javascript = warning, JSON/YAML/TOML = error).

## Status: ✅ Verified

- `Lint code blocks` job: ✅ SUCCESS (exit 0)
- Annotation: `warning` at `content/influxdb3/core/reference/cli/influxdb3/_index.md:21` — `bash: line 2: unexpected EOF while looking for matching `"'`

> Based on #7157 (`fix/bash-validator-stdin`) so the CI bash validator actually reports real syntax errors. Without that fix the validator emits `/dev/stdin: No such device or address` for every bash block.

## Cleanup

Close without merging once #7157 lands.