### PR TITLE
test(lint-codeblocks): JSON break (error expected) — DO NOT MERGE

### DIFF
--- a/content/influxdb/v2/tools/influxdb-templates/create.md
+++ b/content/influxdb/v2/tools/influxdb-templates/create.md
@@ -229,7 +229,7 @@ metadata:
   "metadata": {
     "name": {
       "envRef": {
-        "key": "bucket-name-1"
+        "key": "bucket-name-1",
       }
     }
   }

--- a/scripts/lib/codeblock-validators/bash.mjs
+++ b/scripts/lib/codeblock-validators/bash.mjs
@@ -12,7 +12,15 @@ export function validate(code) {
       resolve(result);
     };
 
-    const proc = spawn('bash', ['-n', '/dev/stdin'], { stdio: ['pipe', 'ignore', 'pipe'] });
+    // Use `-s` to read the script from stdin rather than the `/dev/stdin`
+    // path. The `/dev/stdin` form is unreliable in some Linux CI
+    // environments (notably the GitHub Actions Ubuntu runner), where it
+    // errors with `bash: /dev/stdin: No such device or address` —
+    // masking the real syntax-error output and producing a misleading
+    // ::warning:: annotation on every bash block. `-ns` is the portable
+    // equivalent: `-s` reads the script from stdin, `-n` parses without
+    // executing. Works identically on macOS and Linux.
+    const proc = spawn('bash', ['-ns'], { stdio: ['pipe', 'ignore', 'pipe'] });
     let stderr = '';
     let timedOut = false;
     const timer = setTimeout(() => {


### PR DESCRIPTION
## Purpose

Verify the `lint-codeblocks` CI job emits an `::error::` annotation for a JSON syntax error and **fails** the PR check (per the documented blocking policy: JSON/YAML/TOML = error).

## Status: ✅ Verified

- `Lint code blocks` job: ❌ FAILURE (exit 1)
- Annotation: `failure` at `content/influxdb/v2/tools/influxdb-templates/create.md:233` — `json: Expected double-quoted property name in JSON at position 151 (line 8 column 7)`

(The trailing comma after `bucket-name-1` in the JSON block is the intentional break.)

> Based on #7157 (`fix/bash-validator-stdin`) so unrelated bash blocks in the same file produce real annotations rather than the masking `/dev/stdin` error.

## Cleanup

Close without merging once #7157 lands.