### PR TITLE
test(lint-codeblocks): shared JSON break (attribution expected) — DO NOT MERGE

### DIFF
--- a/content/shared/influxdb3-admin/tables/list.md
+++ b/content/shared/influxdb3-admin/tables/list.md
@@ -89,7 +89,7 @@ Replace the following:
       "series": [
         {
           "name": "tables",
-          "columns": ["table_catalog", "table_schema", "table_name", "table_type"],
+          "columns": ["table_catalog", "table_schema", "table_name", "table_type",],
           "values": [
             ["public", "iox", "home", "BASE TABLE"],
             ["public", "iox", "sensors", "BASE TABLE"]

--- a/scripts/lib/codeblock-validators/bash.mjs
+++ b/scripts/lib/codeblock-validators/bash.mjs
@@ -12,7 +12,15 @@ export function validate(code) {
       resolve(result);
     };
 
-    const proc = spawn('bash', ['-n', '/dev/stdin'], { stdio: ['pipe', 'ignore', 'pipe'] });
+    // Use `-s` to read the script from stdin rather than the `/dev/stdin`
+    // path. The `/dev/stdin` form is unreliable in some Linux CI
+    // environments (notably the GitHub Actions Ubuntu runner), where it
+    // errors with `bash: /dev/stdin: No such device or address` —
+    // masking the real syntax-error output and producing a misleading
+    // ::warning:: annotation on every bash block. `-ns` is the portable
+    // equivalent: `-s` reads the script from stdin, `-n` parses without
+    // executing. Works identically on macOS and Linux.
+    const proc = spawn('bash', ['-ns'], { stdio: ['pipe', 'ignore', 'pipe'] });
     let stderr = '';
     let timedOut = false;
     const timer = setTimeout(() => {


### PR DESCRIPTION
## Purpose

Verify the `lint-codeblocks` CI job correctly attributes errors in shared content files back to their consumer pages via canonical-source deduplication.

## Status: ✅ Verified

- `Lint code blocks` job: ❌ FAILURE (exit 1)
- Annotation: `failure` at `content/shared/influxdb3-admin/tables/list.md:86` — `json: Unexpected token ']'... (referenced by 2 pages: influxdb3/enterprise/admin/tables/list.md, influxdb3/core/admin/tables/list.md)`

The attribution suffix names both consumer pages that include the shared file, confirming the canonical-source dedup + cross-page attribution feature.

> Based on #7157 (`fix/bash-validator-stdin`).

## Cleanup

Close without merging once #7157 lands.