### PR TITLE
fix(lint-codeblocks): use bash -ns to avoid /dev/stdin failure on Ubuntu runners

### DIFF
--- a/scripts/lib/codeblock-validators/bash.mjs
+++ b/scripts/lib/codeblock-validators/bash.mjs
@@ -12,7 +12,15 @@ export function validate(code) {
       resolve(result);
     };
 
-    const proc = spawn('bash', ['-n', '/dev/stdin'], { stdio: ['pipe', 'ignore', 'pipe'] });
+    // Use `-s` to read the script from stdin rather than the `/dev/stdin`
+    // path. The `/dev/stdin` form is unreliable in some Linux CI
+    // environments (notably the GitHub Actions Ubuntu runner), where it
+    // errors with `bash: /dev/stdin: No such device or address` —
+    // masking the real syntax-error output and producing a misleading
+    // ::warning:: annotation on every bash block. `-ns` is the portable
+    // equivalent: `-s` reads the script from stdin, `-n` parses without
+    // executing. Works identically on macOS and Linux.
+    const proc = spawn('bash', ['-ns'], { stdio: ['pipe', 'ignore', 'pipe'] });
     let stderr = '';
     let timedOut = false;
     const timer = setTimeout(() => {


### PR DESCRIPTION
## Problem

The bash validator spawns \`bash -n /dev/stdin\` and pipes the script in. On macOS this works. On the GitHub Actions Ubuntu runner it fails with:

\`\`\`
bash: /dev/stdin: No such device or address
\`\`\`

That stderr is then surfaced as the \`::warning::\` annotation, so every bash block — passing or failing — produces the same misleading output and the real syntax errors are masked.

Surfaced via test PR #7154 (intentional bash break): the expected annotation was \`bash: line 2: unexpected EOF while looking for matching \\\`"'\`; CI emitted only the \`/dev/stdin\` error.

## Fix

Use \`bash -ns\` instead. \`-s\` reads the script from stdin (no path argument needed), \`-n\` parses without executing. Portable across macOS and Linux.

## Verification

- Unit tests pass (59/59).
- After merging, re-run the test PRs (#7154, #7155, #7156) to confirm annotations contain the expected real syntax errors.

## Test plan

- [ ] CI passes on this PR
- [ ] Re-running CI on #7154 shows the expected annotation: \`bash: line 2: unexpected EOF while looking for matching \\\`"'\` at line 21 (or close)