### PR TITLE
fix(ci): run Test Code Blocks workflow on every PR (required-check fix)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,13 @@
 name: Test Code Blocks
 
 on:
-  # Pull requests: detection only (informational, non-blocking)
-  # Detects changed content and suggests which products to test
+  # Pull requests: detection-only on the test-execution side, but the
+  # `Lint code blocks` job is a required status check on master. A
+  # required check that never reports blocks merge forever, so the
+  # workflow MUST run on every PR — even ones that touch no content.
+  # The lint job's own `if:` gate skips it when there are no canonical
+  # sources to lint; GitHub treats a skipped required check as success.
   pull_request:
-    paths:
-      - 'content/**/*.md'
-      - 'test/**'
-      - 'Dockerfile.pytest'
-      - 'compose.yaml'
     types: [opened, synchronize, reopened]
   # Manual dispatch: actually runs tests
   workflow_dispatch:

--- a/scripts/lib/codeblock-validators/bash.mjs
+++ b/scripts/lib/codeblock-validators/bash.mjs
@@ -12,7 +12,15 @@ export function validate(code) {
       resolve(result);
     };
 
-    const proc = spawn('bash', ['-n', '/dev/stdin'], { stdio: ['pipe', 'ignore', 'pipe'] });
+    // Use `-s` to read the script from stdin rather than the `/dev/stdin`
+    // path. The `/dev/stdin` form is unreliable in some Linux CI
+    // environments (notably the GitHub Actions Ubuntu runner), where it
+    // errors with `bash: /dev/stdin: No such device or address` —
+    // masking the real syntax-error output and producing a misleading
+    // ::warning:: annotation on every bash block. `-ns` is the portable
+    // equivalent: `-s` reads the script from stdin, `-n` parses without
+    // executing. Works identically on macOS and Linux.
+    const proc = spawn('bash', ['-ns'], { stdio: ['pipe', 'ignore', 'pipe'] });
     let stderr = '';
     let timedOut = false;
     const timer = setTimeout(() => {


### PR DESCRIPTION
## Problem

\`Lint code blocks\` was just added as a required status check on master. The workflow's \`pull_request\` trigger had a \`paths:\` filter that only matched content/test/docker files — so a PR touching only e.g. \`scripts/\`, \`layouts/\`, \`assets/\`, etc. produces **no** \`Lint code blocks\` check at all, and GitHub blocks merge when a required check never reports.

This means any PR unrelated to content/test/docker is currently un-mergeable. Fix is urgent.

## Fix

Drop the \`paths:\` filter so the workflow runs on every PR. The \`lint-codeblocks\` job's own \`if:\` already skips when there are no canonical sources to lint:

\`\`\`yaml
if: github.event_name == 'pull_request' && needs.detect-changes.outputs.canonical-sources != '' && needs.detect-changes.outputs.canonical-sources != '[]'
\`\`\`

GitHub treats a skipped required check as success, so PRs unrelated to content still merge cleanly. The \`detect-changes\` job is cheap (one GitHub API call to list PR files), so running it on every PR is fine.

## Test plan

- [ ] CI passes on this PR (which touches no content — proves \`Lint code blocks\` is skipped + counted as success)
- [ ] After merge, sanity check on a non-content PR (e.g. lockfile bump) — should show \`Lint code blocks: skipped\` and not block merge