### PR TITLE
feat(lint-codeblocks): add pretty summary wrapper (yarn lint-codeblocks:pretty)

### DIFF
--- a/DOCS-TESTING.md
+++ b/DOCS-TESTING.md
@@ -327,6 +327,19 @@ Exit code is 1 if any JSON/YAML/TOML block fails to parse. The step log
 groups output per file; every block's status is reported so you can see
 the full picture.
 
+**Pretty summary (large runs):**
+
+For a condensed report — counts by severity, failures by language, and
+the top files with blocking errors — use the pretty wrapper. Output is
+GitHub-flavored Markdown so it pastes cleanly into PRs and issues.
+
+```sh
+yarn lint-codeblocks:pretty content/**/*.md
+```
+
+Exit code matches `lint-codeblocks` (0 if no parse errors, 1 otherwise),
+so the wrapper can stand in for the raw command in scripts.
+
 **Normalization:** The linter handles some common docs patterns:
 
 - Fence attributes like `{ placeholders="TOKEN_NAME|DURATION" }` —

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "test:cache:list": "./test/scripts/manage-test-cache.sh list",
     "test:lint-codeblocks": "node --test 'scripts/ci/__tests__/**/*.test.mjs'",
     "lint-codeblocks": "node scripts/ci/lint-codeblocks.mjs",
+    "lint-codeblocks:pretty": "scripts/ci/lint-codeblocks-pretty.sh",
     "test:e2e": "node cypress/support/run-e2e-specs.js",
     "test:render-regression": "node cypress/support/run-e2e-specs.js --spec \"cypress/e2e/content/render-regression.cy.js\" --no-mapping",
     "test:render-artifacts": ".ci/scripts/check-render-artifacts.sh public",

--- a/scripts/ci/lint-codeblocks-pretty.sh
+++ b/scripts/ci/lint-codeblocks-pretty.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Run lint-codeblocks and emit a human-readable summary instead of the
+# full per-file ::group:: log.
+#
+# Usage:
+#   scripts/ci/lint-codeblocks-pretty.sh content/**/*.md
+#
+# Exit status mirrors lint-codeblocks: 0 if no parse errors, 1 if any
+# JSON / YAML / TOML block fails. Non-blocking warnings (bash, python,
+# javascript) appear in the summary but don't change the exit code.
+
+set -uo pipefail
+
+DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(cd -- "$DIR/../.." && pwd)
+
+LOG=$(mktemp -t lint-codeblocks.XXXXXX)
+trap 'rm -f "$LOG"' EXIT
+
+node "$ROOT/scripts/ci/lint-codeblocks.mjs" "$@" > "$LOG" 2>&1
+LINT_EXIT=$?
+
+"$DIR/lint-codeblocks-summary.sh" "$LOG"
+
+# Lint exit code is authoritative — the summary just reports it.
+exit "$LINT_EXIT"

--- a/scripts/ci/lint-codeblocks-summary.sh
+++ b/scripts/ci/lint-codeblocks-summary.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Summarize a lint-codeblocks log into a human-readable report.
+#
+# Usage:
+#   # Summarize an existing log
+#   scripts/ci/lint-codeblocks-summary.sh /tmp/lint.log
+#
+#   # Pipe lint output through the summarizer
+#   node scripts/ci/lint-codeblocks.mjs content/**/*.md 2>&1 \
+#     | scripts/ci/lint-codeblocks-summary.sh
+#
+# The full lint log is consumed (stdin or file path); the summary is
+# written to stdout. Exit status is 0 if no ::error annotations, 1 if
+# any are present — matching the lint script's own contract so this
+# wrapper can stand in for the raw command in CI when only the summary
+# is wanted.
+
+set -uo pipefail
+
+if [[ $# -gt 1 ]]; then
+  echo "Usage: $0 [log-file]" >&2
+  echo "  Reads from stdin if no file is given." >&2
+  exit 2
+fi
+
+# Buffer to a temp file so we can grep/awk over it multiple times.
+TMP=$(mktemp -t lint-summary.XXXXXX)
+trap 'rm -f "$TMP"' EXIT
+
+if [[ $# -eq 1 ]]; then
+  cat -- "$1" > "$TMP"
+else
+  cat > "$TMP"
+fi
+
+# --- Counts ---------------------------------------------------------------
+err_count=$(grep -c '^::error' "$TMP" || true)
+warn_count=$(grep -c '^::warning' "$TMP" || true)
+notice_count=$(grep -c '^::notice' "$TMP" || true)
+
+passed=$(grep -c '✓' "$TMP" || true)
+failed=$(grep -c '✗' "$TMP" || true)
+skipped=$(grep -cE 'skipped \(out of scope\)' "$TMP" || true)
+
+files_processed=$(grep -c '^::group::' "$TMP" || true)
+files_with_annotations=$(grep -E '^::error|^::warning' "$TMP" \
+  | sed 's/.*file=//' \
+  | sed 's/,line=.*//' \
+  | sort -u \
+  | wc -l \
+  | tr -d ' ')
+
+# --- Output ---------------------------------------------------------------
+printf '## Lint code blocks — summary\n\n'
+
+printf '| Category | Count |\n'
+printf '|---|---|\n'
+printf '| Files processed | %s |\n' "$files_processed"
+printf '| Files with annotations | %s |\n' "$files_with_annotations"
+printf '| Blocks passed | %s |\n' "$passed"
+printf '| Blocks failed | %s |\n' "$failed"
+printf '| Blocks skipped (out of scope) | %s |\n' "$skipped"
+printf '\n'
+
+printf '### Annotations\n\n'
+printf '| Severity | Count | Effect on PR |\n'
+printf '|---|---|---|\n'
+# shellcheck disable=SC2016 # `::error::` etc. are GitHub workflow command
+# literals, not shell expansions — single quotes are intentional.
+printf '| `::error::` (JSON / YAML / TOML) | **%s** | Blocks CI |\n' "$err_count"
+# shellcheck disable=SC2016
+printf '| `::warning::` (bash / python / javascript) | %s | Informational |\n' "$warn_count"
+# shellcheck disable=SC2016
+printf '| `::notice::` (normalization fired) | %s | Informational |\n' "$notice_count"
+printf '\n'
+
+# Failures by language: column 4 of "  ✗ line N  LANG  failed: ..." lines.
+printf '### Failures by language\n\n'
+printf '| Language | Failed |\n'
+printf '|---|---|\n'
+grep '^  ✗' "$TMP" \
+  | awk '{print $4}' \
+  | sort \
+  | uniq -c \
+  | sort -rn \
+  | awk '{ printf "| %s | %s |\n", $2, $1 }'
+printf '\n'
+
+# Top files with ::error annotations (the blocking ones).
+top_err_files=$(grep '^::error' "$TMP" \
+  | sed 's/.*file=//' \
+  | sed 's/,line=.*//' \
+  | sort | uniq -c | sort -rn | head -15)
+
+if [[ -n "$top_err_files" ]]; then
+  printf '### Top files with blocking errors\n\n'
+  printf '| Errors | File |\n'
+  printf '|---|---|\n'
+  echo "$top_err_files" | awk '{ count=$1; $1=""; sub(/^ /, ""); printf "| %s | %s |\n", count, $0 }'
+  printf '\n'
+
+  printf '### First 10 ::error samples\n\n'
+  grep '^::error' "$TMP" | head -10 | sed 's/^/    /'
+  printf '\n'
+fi
+
+# Notice samples (normalization rules that fired).
+if [[ "$notice_count" -gt 0 ]]; then
+  printf '### Notice samples (first 10)\n\n'
+  grep '^::notice' "$TMP" | head -10 | sed 's/^/    /'
+  printf '\n'
+fi
+
+# Match the lint script's exit contract so this can wrap the raw command.
+[[ "$err_count" -eq 0 ]]


### PR DESCRIPTION
## Summary

Adds a Markdown-formatted summary mode for \`lint-codeblocks\` runs over many files. Use when you want a condensed report instead of the per-block \`::group::\` log:

\`\`\`sh
yarn lint-codeblocks:pretty content/**/*.md
\`\`\`

Output is GitHub-flavored Markdown — pastes cleanly into PRs/issues. Exit code matches \`lint-codeblocks\` (0 if no parse errors, 1 otherwise) so the wrapper can stand in for the raw command in scripts.

## What you get

- File / block / annotation counts
- Annotation breakdown by severity (with the \"Blocks CI\" vs \"Informational\" distinction)
- Failures by language
- Top files with blocking errors
- First 10 \`::error\` samples and \`::notice\` samples

Example output (from running on the full \`content/\` tree):

| Severity | Count | Effect on PR |
|---|---|---|
| \`::error::\` (JSON / YAML / TOML) | **112** | Blocks CI |
| \`::warning::\` (bash / python / javascript) | 4135 | Informational |
| \`::notice::\` (normalization fired) | 12 | Informational |

## Files

- \`scripts/ci/lint-codeblocks-summary.sh\` — consumes a lint log (file or stdin), emits the Markdown report
- \`scripts/ci/lint-codeblocks-pretty.sh\` — wraps the linter and pipes through the summarizer (handles yarn's arg-substitution position)
- \`package.json\` — new \`lint-codeblocks:pretty\` script
- \`DOCS-TESTING.md\` — documents the new mode

## Test plan

- [x] Both shell scripts pass shellcheck
- [x] \`yarn lint-codeblocks:pretty\` on a clean file → exit 0
- [x] \`yarn lint-codeblocks:pretty\` on a file with errors → exit 1
- [x] CI passes