### PR TITLE
fix(ci): preview URL extractor accepts /content/<ns>/... filesystem-style paths

### DIFF
--- a/.github/scripts/parse-pr-urls.js
+++ b/.github/scripts/parse-pr-urls.js
@@ -113,14 +113,18 @@ function isValidUrlPath(path) {
  */
 function buildRelativePattern() {
   const namespaceAlternation = PRODUCT_NAMESPACES.join('|');
-  // Match relative paths starting with known product prefixes
-  // Captures paths in various contexts: markdown links, parentheses, backticks, etc.
-  // Delimiters: start of string, whitespace, ], ), (, or `
-  // Note: Backtick appears in both the delimiter list and negated character class
-  // for defense-in-depth - delimiter stops extraction, character class prevents
-  // any edge cases where backticks might slip through
+  // Match relative paths starting with known product prefixes, in either
+  // URL form (`/influxdb3/core/...`) or filesystem form
+  // (`/content/influxdb3/core/...`). The `/content/` prefix is stripped
+  // by normalizeUrlPath so both shapes resolve to the same canonical
+  // URL path.
+  // Captures paths in various contexts: markdown links, parentheses,
+  // backticks, etc. Delimiters: start of string, whitespace, ], ), (, or `.
+  // Note: Backtick appears in both the delimiter list and negated character
+  // class for defense-in-depth — delimiter stops extraction, character class
+  // prevents any edge cases where backticks might slip through.
   return new RegExp(
-    `(?:^|\\s|\\]|\\)|\\(|\`)(\\/(?:${namespaceAlternation})[^\\s)\\]>"'\`]*)`,
+    `(?:^|\\s|\\]|\\)|\\(|\`)(\\/(?:content\\/)?(?:${namespaceAlternation})[^\\s)\\]>"'\`]*)`,
     'gm'
   );
 }
@@ -188,6 +192,14 @@ function normalizeUrlPath(urlPath) {
   let normalized = urlPath.split('#')[0];
   // Remove query strings
   normalized = normalized.split('?')[0];
+  // Strip a leading `/content/` prefix when present. Authors frequently
+  // copy filesystem paths (e.g. `/content/influxdb3/core/admin/...`)
+  // into the PR description; the docs site URL for the same page is
+  // `/influxdb3/core/admin/...`. Treat the two equivalently so the
+  // extractor doesn't silently drop the path.
+  if (normalized.startsWith('/content/')) {
+    normalized = normalized.slice('/content'.length);
+  }
   // Remove wildcard characters (* is often used to indicate "all pages")
   // Do this BEFORE collapsing slashes to handle patterns like /path/*/
   normalized = normalized.replace(/\*/g, '');

--- a/.github/scripts/test-parse-pr-urls.js
+++ b/.github/scripts/test-parse-pr-urls.js
@@ -409,6 +409,36 @@ test('Home page: relative root path / in text', () => {
   );
 });
 
+test('Filesystem-style /content/ prefix is normalized to URL path', () => {
+  // Authors frequently paste filesystem paths like
+  // `/content/influxdb3/clustered/...` into the PR description; the
+  // preview should treat them equivalently to the corresponding URL
+  // `/influxdb3/clustered/...`. The leading `/content` is stripped
+  // by normalizeUrlPath.
+  const text = 'See /content/influxdb3/clustered/reference/release-notes/clustered/';
+  const result = extractDocsUrls(text);
+  assertEquals(
+    result,
+    ['/influxdb3/clustered/reference/release-notes/clustered/'],
+    'Should strip leading /content/ filesystem-path prefix'
+  );
+});
+
+test('/content/ prefix dedupes with the equivalent URL path', () => {
+  // If the description names both forms of the same page, the result
+  // set should contain it only once.
+  const text = `
+    - /content/influxdb3/core/admin/
+    - /influxdb3/core/admin/
+  `;
+  const result = extractDocsUrls(text);
+  assertEquals(
+    result,
+    ['/influxdb3/core/admin/'],
+    'Both forms should resolve to the same URL and dedupe'
+  );
+});
+
 // Print summary
 console.log('\n=== Test Summary ===');
 console.log(`Total: ${totalTests}`);


### PR DESCRIPTION
## Problem

Surfaced on #7163. The PR Preview workflow re-runs on PR description edits (#7092 fixed body staleness), but its URL extractor only matches URL paths (e.g. \`/influxdb3/clustered/...\`). Authors frequently paste filesystem-style paths from \`content/\` (e.g. \`/content/influxdb3/clustered/reference/release-notes/clustered/\`) into the description when listing pages affected by a layout/asset change. Those references were silently dropped and the workflow logged \"No URLs found in PR description — author input needed\" even though the author had listed the pages.

## Fix

- Extend \`buildRelativePattern\` to also match \`/content/<namespace>/...\` paths.
- Strip a leading \`/content\` prefix in \`normalizeUrlPath\` so both shapes canonicalize to the same URL.

The two shapes dedupe in the result set, so listing both \`/content/foo\` and \`/foo\` yields a single preview entry.

## Verification

- New regression tests pass:
  - \`Filesystem-style /content/ prefix is normalized to URL path\`
  - \`/content/ prefix dedupes with the equivalent URL path\`
- All other existing tests still pass (one pre-existing failure on master is unrelated).

## Test plan

- [ ] CI passes
- [ ] After merge, edit the description on a non-content PR (e.g. an \`assets/\` change) to add a path with \`/content/<ns>/\` prefix, confirm the preview workflow picks it up