### PR TITLE
fix(influxdb3): correct preferred env name for two jaeger config options

### DIFF
--- a/content/shared/influxdb3-cli/config-options.md
+++ b/content/shared/influxdb3-cli/config-options.md
@@ -767,9 +767,12 @@ to Azure Blob Storage.
 - [object-store-connection-limit](#object-store-connection-limit)
 - [object-store-http2-only](#object-store-http2-only)
 - [object-store-http2-max-frame-size](#object-store-http2-max-frame-size)
+- [object-store-request-timeout](#object-store-request-timeout)
 - [object-store-max-retries](#object-store-max-retries)
 - [object-store-retry-timeout](#object-store-retry-timeout)
 - [object-store-cache-endpoint](#object-store-cache-endpoint)
+- [object-store-tls-allow-insecure](#object-store-tls-allow-insecure)
+- [object-store-tls-ca](#object-store-tls-ca)
 
 #### bucket
 
@@ -815,6 +818,18 @@ Sets the maximum frame size (in bytes/octets) for HTTP/2 connections.
 
 ***
 
+#### object-store-request-timeout
+
+Sets the HTTP request timeout for object store requests.
+
+**Default:** `30s`
+
+| influxdb3 serve option           | Environment variables           |
+| :------------------------------- | :----------------------------- |
+| `--object-store-request-timeout` | `INFLUXDB3_OBJECT_STORE_REQUEST_TIMEOUT` (preferred)<br>`OBJECT_STORE_REQUEST_TIMEOUT` (deprecated; supported for backward compatibility) |
+
+***
+
 #### object-store-max-retries
 
 Defines the maximum number of times to retry a request.
@@ -843,6 +858,32 @@ Sets the endpoint of an S3-compatible, HTTP/2-enabled object store cache.
 | influxdb3 serve option          | Environment variables          |
 | :------------------------------ | :---------------------------- |
 | `--object-store-cache-endpoint` | `INFLUXDB3_OBJECT_STORE_CACHE_ENDPOINT` (preferred)<br>`OBJECT_STORE_CACHE_ENDPOINT` (deprecated; supported for backward compatibility) |
+
+***
+
+#### object-store-tls-allow-insecure
+
+Allows invalid TLS certificates when connecting to object storage.
+
+{{% warn %}}
+This disables TLS certificate verification and should only be used for testing.
+{{% /warn %}}
+
+| influxdb3 serve option              | Environment variables              |
+| :---------------------------------- | :-------------------------------- |
+| `--object-store-tls-allow-insecure` | `INFLUXDB3_OBJECT_STORE_TLS_ALLOW_INSECURE` (preferred)<br>`OBJECT_STORE_TLS_ALLOW_INSECURE` (deprecated; supported for backward compatibility) |
+
+***
+
+#### object-store-tls-ca
+
+Specifies the path to a custom CA certificate file (PEM format) for verifying
+object store connections. Use this when your object store uses a certificate
+signed by a private CA.
+
+| influxdb3 serve option  | Environment variables  |
+| :---------------------- | :-------------------- |
+| `--object-store-tls-ca` | `INFLUXDB3_OBJECT_STORE_TLS_CA` (preferred)<br>`OBJECT_STORE_TLS_CA` (deprecated; supported for backward compatibility) |
 
 ***
 

--- a/content/shared/influxdb3-cli/config-options.md
+++ b/content/shared/influxdb3-cli/config-options.md
@@ -1072,7 +1072,7 @@ Specifies the header name used for force sampling in tracing.
 
 | influxdb3 serve option       | Environment variables                |
 | :--------------------------- | :---------------------------------- |
-| `--traces-jaeger-debug-name` | `INFLUXDB3_TRACES_JAEGER_DEBUG_NAME` (preferred)<br>`TRACES_EXPORTER_JAEGER_DEBUG_NAME` (deprecated; supported for backward compatibility) |
+| `--traces-jaeger-debug-name` | `INFLUXDB3_TRACES_EXPORTER_JAEGER_DEBUG_NAME` (preferred)<br>`TRACES_EXPORTER_JAEGER_DEBUG_NAME` (deprecated; supported for backward compatibility) |
 
 ***
 
@@ -1082,7 +1082,7 @@ Defines a set of `key=value` pairs to annotate tracing spans with.
 
 | influxdb3 serve option | Environment variables          |
 | :--------------------- | :---------------------------- |
-| `--traces-jaeger-tags` | `INFLUXDB3_TRACES_JAEGER_TAGS` (preferred)<br>`TRACES_EXPORTER_JAEGER_TAGS` (deprecated; supported for backward compatibility) |
+| `--traces-jaeger-tags` | `INFLUXDB3_TRACES_EXPORTER_JAEGER_TAGS` (preferred)<br>`TRACES_EXPORTER_JAEGER_TAGS` (deprecated; supported for backward compatibility) |
 
 ***
 


### PR DESCRIPTION
## Summary
The `Environment variables` column for `--traces-jaeger-debug-name` and `--traces-jaeger-tags` listed the wrong "preferred" name. Both env vars include the `EXPORTER_` segment that the CLI flag itself drops.

| flag | preferred env (corrected) | deprecated env (unchanged) |
| --- | --- | --- |
| `--traces-jaeger-debug-name` | `INFLUXDB3_TRACES_EXPORTER_JAEGER_DEBUG_NAME` | `TRACES_EXPORTER_JAEGER_DEBUG_NAME` |
| `--traces-jaeger-tags` | `INFLUXDB3_TRACES_EXPORTER_JAEGER_TAGS` | `TRACES_EXPORTER_JAEGER_TAGS` |

## Verification
Verified against `influxdata/influxdb_pro` and `influxdata/influxdb` at tag `v3.9.2` (latest non-RC). The shared deprecation map in `influxdb3_startup::env_compat::ENV_ALIASES` and the clap definitions in `trace_exporters` both confirm the corrected names. The flag-vs-env divergence is intentional in source.

Closes influxdata/DAR#686

## Out of scope (follow-up PR)
Three documented-elsewhere object-store deprecations (`OBJECT_STORE_REQUEST_TIMEOUT`, `OBJECT_STORE_TLS_ALLOW_INSECURE`, `OBJECT_STORE_TLS_CA`) are not yet on this page. Tracking separately so this PR stays minimal and unblocks the downstream Helm-chart change.

## Test plan
- [ ] `npx hugo server` renders the changed table rows correctly
- [ ] No anchor or link changes; existing inbound links remain valid