### PR TITLE
docs(influxdb3): document three undocumented object-store options

### DIFF
--- a/content/shared/influxdb3-cli/config-options.md
+++ b/content/shared/influxdb3-cli/config-options.md
@@ -767,9 +767,12 @@ to Azure Blob Storage.
 - [object-store-connection-limit](#object-store-connection-limit)
 - [object-store-http2-only](#object-store-http2-only)
 - [object-store-http2-max-frame-size](#object-store-http2-max-frame-size)
+- [object-store-request-timeout](#object-store-request-timeout)
 - [object-store-max-retries](#object-store-max-retries)
 - [object-store-retry-timeout](#object-store-retry-timeout)
 - [object-store-cache-endpoint](#object-store-cache-endpoint)
+- [object-store-tls-allow-insecure](#object-store-tls-allow-insecure)
+- [object-store-tls-ca](#object-store-tls-ca)
 
 #### bucket
 
@@ -815,6 +818,18 @@ Sets the maximum frame size (in bytes/octets) for HTTP/2 connections.
 
 ***
 
+#### object-store-request-timeout
+
+Sets the HTTP request timeout for object store requests.
+
+**Default:** `30s`
+
+| influxdb3 serve option           | Environment variables           |
+| :------------------------------- | :----------------------------- |
+| `--object-store-request-timeout` | `INFLUXDB3_OBJECT_STORE_REQUEST_TIMEOUT` (preferred)<br>`OBJECT_STORE_REQUEST_TIMEOUT` (deprecated; supported for backward compatibility) |
+
+***
+
 #### object-store-max-retries
 
 Defines the maximum number of times to retry a request.
@@ -843,6 +858,32 @@ Sets the endpoint of an S3-compatible, HTTP/2-enabled object store cache.
 | influxdb3 serve option          | Environment variables          |
 | :------------------------------ | :---------------------------- |
 | `--object-store-cache-endpoint` | `INFLUXDB3_OBJECT_STORE_CACHE_ENDPOINT` (preferred)<br>`OBJECT_STORE_CACHE_ENDPOINT` (deprecated; supported for backward compatibility) |
+
+***
+
+#### object-store-tls-allow-insecure
+
+Allows invalid TLS certificates when connecting to object storage.
+
+{{% warn %}}
+This disables TLS certificate verification and should only be used for testing.
+{{% /warn %}}
+
+| influxdb3 serve option              | Environment variables              |
+| :---------------------------------- | :-------------------------------- |
+| `--object-store-tls-allow-insecure` | `INFLUXDB3_OBJECT_STORE_TLS_ALLOW_INSECURE` (preferred)<br>`OBJECT_STORE_TLS_ALLOW_INSECURE` (deprecated; supported for backward compatibility) |
+
+***
+
+#### object-store-tls-ca
+
+Specifies the path to a custom CA certificate file (PEM format) for verifying
+object store connections. Use this when your object store uses a certificate
+signed by a private CA.
+
+| influxdb3 serve option  | Environment variables  |
+| :---------------------- | :-------------------- |
+| `--object-store-tls-ca` | `INFLUXDB3_OBJECT_STORE_TLS_CA` (preferred)<br>`OBJECT_STORE_TLS_CA` (deprecated; supported for backward compatibility) |
 
 ***
 


### PR DESCRIPTION
## Summary
Adds documentation for three `--object-store-*` flags that are present in the InfluxDB 3 server but missing from this page. Each has both an `INFLUXDB3_`-prefixed env name and a deprecated unprefixed alias that the server still accepts.

| flag | preferred env | deprecated env |
| --- | --- | --- |
| `--object-store-request-timeout` | `INFLUXDB3_OBJECT_STORE_REQUEST_TIMEOUT` | `OBJECT_STORE_REQUEST_TIMEOUT` |
| `--object-store-tls-allow-insecure` | `INFLUXDB3_OBJECT_STORE_TLS_ALLOW_INSECURE` | `OBJECT_STORE_TLS_ALLOW_INSECURE` |
| `--object-store-tls-ca` | `INFLUXDB3_OBJECT_STORE_TLS_CA` | `OBJECT_STORE_TLS_CA` |

Also updates the section's link list.

## Verification
Verified at `influxdata/influxdb` tag `v3.9.2` (latest non-RC). The aliases come from `influxdb3_startup::env_compat::ENV_ALIASES`; the help strings come from the clap definitions in `influxdb3_clap_blocks::object_store`.

## Relationship to other PRs
Follow-up to #7182 (which closes influxdata/DAR#686 with a minimum two-row fix). Splitting this off keeps that PR small and unblocks the downstream Helm-chart change.

Refs influxdata/DAR#686

## Test plan
- [ ] `npx hugo server` renders the three new sections and the updated nav list
- [ ] No anchor changes to existing rows; existing inbound links remain valid