### PR TITLE
feat(influxdb3): discovery — cross-links and llms.txt entry for decision page

### DIFF
--- a/content/influxdb3/cloud-dedicated/_index.md
+++ b/content/influxdb3/cloud-dedicated/_index.md
@@ -15,6 +15,11 @@ cascade:
   version: cloud-dedicated
 ---
 
+> [!Tip]
+> Comparing InfluxDB Cloud Dedicated to other InfluxDB 3 products?
+> See [Which InfluxDB 3 should I use?](/influxdb3/which-influxdb-3/) for a
+> full decision guide.
+
 InfluxDB Cloud Dedicated is a hosted and managed InfluxDB Cloud cluster
 dedicated to a single tenant.
 The InfluxDB time series platform is designed to handle high write and query loads.

--- a/content/influxdb3/cloud-serverless/_index.md
+++ b/content/influxdb3/cloud-serverless/_index.md
@@ -24,6 +24,11 @@ cascade:
 > To see which storage engine your organization is using,
 > find the **InfluxDB Cloud powered by** link in your
 > [InfluxDB Cloud organization homepage](https://cloud2.influxdata.com) version information.
+
+> [!Tip]
+> Comparing InfluxDB 3 Cloud Serverless to other InfluxDB 3 products?
+> See [Which InfluxDB 3 should I use?](/influxdb3/which-influxdb-3/) —
+> Cloud Serverless has a different API surface than InfluxDB 3 Enterprise.
 > If your organization is using InfluxDB 3, you'll see
 > **InfluxDB Cloud Serverless** followed by the version number.
 

--- a/content/influxdb3/clustered/_index.md
+++ b/content/influxdb3/clustered/_index.md
@@ -15,6 +15,11 @@ cascade:
   version: clustered
 ---
 
+> [!Tip]
+> Comparing InfluxDB Clustered to other InfluxDB 3 products?
+> See [Which InfluxDB 3 should I use?](/influxdb3/which-influxdb-3/) for a
+> full decision guide.
+
 InfluxDB Clustered is a highly available InfluxDB 3 cluster hosted and
 managed on your own infrastructure.
 The InfluxDB time series platform is designed to handle high write and query loads.

--- a/content/platform/faq.md
+++ b/content/platform/faq.md
@@ -9,6 +9,7 @@ menu:
 
 [What is time series data?](#what-is-time-series-data)  
 [Why shouldn't I just use a relational database?](#why-shouldn-t-i-just-use-a-relational-database)  
+[Which version of InfluxDB should I use?](#which-version-of-influxdb-should-i-use)  
 
 ## What is time series data?
 Time series data is a series of data points each associated with a specific time.
@@ -24,3 +25,9 @@ on the precision of your data, a query can involve potentially millions of rows.
 InfluxDB is purpose-built to store and query data by time, providing out-of-the-box
 functionality that optionally downsamples data after a specific age and a query
 engine optimized for time-based data.
+
+## Which version of InfluxDB should I use?
+For new projects, use InfluxDB 3.
+See [Which InfluxDB 3 should I use?](/influxdb3/which-influxdb-3/)
+for a decision guide across InfluxDB 3 products and migration
+from InfluxDB 1 or InfluxDB 2.

--- a/content/platform/faq.md
+++ b/content/platform/faq.md
@@ -8,7 +8,7 @@ menu:
 ---
 
 [What is time series data?](#what-is-time-series-data)  
-[Why shouldn't I just use a relational database?](#why-shouldn-t-i-just-use-a-relational-database)  
+[Why shouldn't I just use a relational database?](#why-shouldnt-i-just-use-a-relational-database)  
 [Which version of InfluxDB should I use?](#which-version-of-influxdb-should-i-use)  
 
 ## What is time series data?

--- a/content/shared/influxdb3/_index.md
+++ b/content/shared/influxdb3/_index.md
@@ -1,4 +1,9 @@
 <!-- Allow leading shortcode -->
+> [!Tip]
+> Comparing InfluxDB 3 products or planning a migration from InfluxDB 1 or 2?
+> See [Which InfluxDB 3 should I use?](/influxdb3/which-influxdb-3/) for a
+> full decision guide.
+
 {{% product-name %}} is a database built to collect, process, transform, and store event and time series data, and is ideal for use cases that require real-time ingest and fast query response times to build user interfaces, monitoring, and automation solutions.
 
 Common use cases include:

--- a/cypress/e2e/content/which-influxdb-3.cy.js
+++ b/cypress/e2e/content/which-influxdb-3.cy.js
@@ -2,8 +2,9 @@
 
 // PR 1 scope: the canonical decision page renders correctly.
 // PR 2 scope: FAQPage JSON-LD emitted on the canonical URL (see final it()).
-// Hub-landing assertions live with PR 3.
-// Cross-link / llms.txt assertions live with PR 4.
+// PR 3 scope: /influxdb3/ hub landing.
+// PR 4 scope: cross-link callouts on v3 product index pages + platform FAQ
+//             cross-link Q&A (see the "Cross-link callouts" describe block).
 
 describe('Which InfluxDB 3 decision page (canonical)', function () {
   const url = '/influxdb3/which-influxdb-3/';
@@ -121,4 +122,27 @@ describe('Which InfluxDB 3 decision page (canonical)', function () {
     });
   });
 
+});
+
+describe('Cross-link callouts to the decision page', function () {
+  const productPages = [
+    '/influxdb3/core/',
+    '/influxdb3/enterprise/',
+    '/influxdb3/cloud-dedicated/',
+    '/influxdb3/cloud-serverless/',
+    '/influxdb3/clustered/',
+  ];
+
+  productPages.forEach((url) => {
+    it(`${url} links to the decision page`, function () {
+      cy.visit(url);
+      cy.get('a[href="/influxdb3/which-influxdb-3/"]').should('exist');
+    });
+  });
+
+  it('/platform/faq/ has a "Which version of InfluxDB should I use?" Q&A', function () {
+    cy.visit('/platform/faq/');
+    cy.get('h2#which-version-of-influxdb-should-i-use').should('exist');
+    cy.get('a[href="/influxdb3/which-influxdb-3/"]').should('exist');
+  });
 });

--- a/layouts/index.llmstxt.txt
+++ b/layouts/index.llmstxt.txt
@@ -16,6 +16,10 @@
 
 This documentation covers all InfluxDB versions and ecosystem tools. Each section provides comprehensive guides, API references, and tutorials.
 
+## Choosing InfluxDB
+
+- [Which InfluxDB 3 should I use?](influxdb3/which-influxdb-3/index.md): Decision guide for choosing between InfluxDB 3 Core, Enterprise, Cloud Serverless, Cloud Dedicated, Clustered, and Explorer, and for migrating from InfluxDB 1 or InfluxDB 2.
+
 ## InfluxDB 3
 
 - [InfluxDB 3 Core](influxdb3/core/index.section.md): Open source time series database optimized for real-time data


### PR DESCRIPTION
## Summary

PR 4 of the Phase 0 decision-page rollout. Adds discovery surfaces so users (and AI agents) landing on a v3 product page or the platform FAQ can find [Which InfluxDB 3 should I use?](https://docs.influxdata.com/influxdb3/which-influxdb-3/).

- **llms.txt** — new `## Choosing InfluxDB` section above `## InfluxDB 3`, listing the decision page as a top-level reference for LLM-aware tooling
- **Per-product cross-link callouts** — tailored tip callouts on the 5 v3 product index pages:
  - Core + Enterprise (shared via `content/shared/influxdb3/_index.md`)
  - Cloud Dedicated, Cloud Serverless, Clustered
  - Cloud Serverless's callout notes the different API surface vs. Enterprise
- **`content/platform/faq.md`** — new "Which version of InfluxDB should I use?" Q&A with a stable anchor and a pointer to the decision page

Tracking issue: #7219 · PR 4 in `PLAN.md`

## Test plan

- [x] `npx hugo --quiet` builds clean
- [x] `public/llms.txt` shows the new "Choosing InfluxDB" section above "InfluxDB 3"
- [x] Each of `core/`, `enterprise/`, `cloud-dedicated/`, `cloud-serverless/`, `clustered/` index pages renders exactly one `/influxdb3/which-influxdb-3/` link
- [x] `/platform/faq/` has the `#which-version-of-influxdb-should-i-use` H2 with a link to the decision page
- [x] Cypress: 15/15 pass (9 canonical-page + 6 new cross-link assertions)

## Pages to preview

| URL | Expected |
| --- | --- |
| /llms.txt | `## Choosing InfluxDB` section appears immediately above `## InfluxDB 3` |
| /influxdb3/core/ | Tip callout at top of body linking to `/influxdb3/which-influxdb-3/` |
| /influxdb3/enterprise/ | Same callout (shares the Core+Enterprise source body) |
| /influxdb3/cloud-dedicated/ | "Comparing InfluxDB Cloud Dedicated..." tip callout |
| /influxdb3/cloud-serverless/ | Callout notes the different API surface vs. Enterprise |
| /influxdb3/clustered/ | "Comparing InfluxDB Clustered..." tip callout |
| /platform/faq/ | "Which version of InfluxDB should I use?" Q&A at bottom, with `#which-version-of-influxdb-should-i-use` anchor and link list entry at top |

## Coordination notes

- Independent of PR #7228 (PR 3 / hub landing). Both branches edit `cypress/e2e/content/which-influxdb-3.cy.js` by appending new describe blocks; if PR 3 merges first, this branch needs a trivial rebase to keep both describe blocks.