### PR TITLE
chore(telegraf): Remove direct references to Telegraf version in plugins

### DIFF
--- a/content/telegraf/v1/aggregator-plugins/basicstats/_index.md
+++ b/content/telegraf/v1/aggregator-plugins/basicstats/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Basic Statistics, "aggregator-plugins", "configuration", "statistics"]
 introduced: "v1.5.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/aggregators/basicstats/README.md, Basic Statistics Plugin Source
 ---
 
 # Basic Statistics Aggregator Plugin

--- a/content/telegraf/v1/aggregator-plugins/derivative/_index.md
+++ b/content/telegraf/v1/aggregator-plugins/derivative/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Derivative, "aggregator-plugins", "configuration", "math"]
 introduced: "v1.18.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/aggregators/derivative/README.md, Derivative Plugin Source
 ---
 
 # Derivative Aggregator Plugin

--- a/content/telegraf/v1/aggregator-plugins/final/_index.md
+++ b/content/telegraf/v1/aggregator-plugins/final/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Final, "aggregator-plugins", "configuration", "sampling"]
 introduced: "v1.11.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/aggregators/final/README.md, Final Plugin Source
 ---
 
 # Final Aggregator Plugin

--- a/content/telegraf/v1/aggregator-plugins/histogram/_index.md
+++ b/content/telegraf/v1/aggregator-plugins/histogram/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Histogram, "aggregator-plugins", "configuration", "statistics"]
 introduced: "v1.4.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/aggregators/histogram/README.md, Histogram Plugin Source
 ---
 
 # Histogram Aggregator Plugin

--- a/content/telegraf/v1/aggregator-plugins/merge/_index.md
+++ b/content/telegraf/v1/aggregator-plugins/merge/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Merge, "aggregator-plugins", "configuration", "transformation"]
 introduced: "v1.13.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/aggregators/merge/README.md, Merge Plugin Source
 ---
 
 # Merge Aggregator Plugin

--- a/content/telegraf/v1/aggregator-plugins/minmax/_index.md
+++ b/content/telegraf/v1/aggregator-plugins/minmax/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Minimum-Maximum, "aggregator-plugins", "configuration", "statistics"]
 introduced: "v1.1.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/aggregators/minmax/README.md, Minimum-Maximum Plugin Source
 ---
 
 # Minimum-Maximum Aggregator Plugin

--- a/content/telegraf/v1/aggregator-plugins/quantile/_index.md
+++ b/content/telegraf/v1/aggregator-plugins/quantile/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Quantile, "aggregator-plugins", "configuration", "statistics"]
 introduced: "v1.18.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/aggregators/quantile/README.md, Quantile Plugin Source
 ---
 
 # Quantile Aggregator Plugin

--- a/content/telegraf/v1/aggregator-plugins/starlark/_index.md
+++ b/content/telegraf/v1/aggregator-plugins/starlark/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Starlark, "aggregator-plugins", "configuration", "transformation"]
 introduced: "v1.21.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/aggregators/starlark/README.md, Starlark Plugin Source
 ---
 
 # Starlark Aggregator Plugin

--- a/content/telegraf/v1/aggregator-plugins/valuecounter/_index.md
+++ b/content/telegraf/v1/aggregator-plugins/valuecounter/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Value Counter, "aggregator-plugins", "configuration", "statistics"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/aggregators/valuecounter/README.md, Value Counter Plugin Source
 ---
 
 # Value Counter Aggregator Plugin

--- a/content/telegraf/v1/input-plugins/activemq/_index.md
+++ b/content/telegraf/v1/input-plugins/activemq/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [ActiveMQ, "input-plugins", "configuration", "messaging"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/activemq/README.md, ActiveMQ Plugin Source
 ---
 
 # ActiveMQ Input Plugin

--- a/content/telegraf/v1/input-plugins/aerospike/_index.md
+++ b/content/telegraf/v1/input-plugins/aerospike/_index.md
@@ -10,9 +10,6 @@ introduced: "v0.2.0"
 deprecated: v1.30.0
 removal: v1.40.0
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/aerospike/README.md, Aerospike Plugin Source
 ---
 
 # Aerospike Input Plugin

--- a/content/telegraf/v1/input-plugins/aliyuncms/_index.md
+++ b/content/telegraf/v1/input-plugins/aliyuncms/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Alibaba Cloud Monitor Service (Aliyun), "input-plugins", "configuration", "cloud"]
 introduced: "v1.19.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/aliyuncms/README.md, Alibaba Cloud Monitor Service (Aliyun) Plugin Source
 ---
 
 # Alibaba Cloud Monitor Service (Aliyun) Input Plugin

--- a/content/telegraf/v1/input-plugins/amd_rocm_smi/_index.md
+++ b/content/telegraf/v1/input-plugins/amd_rocm_smi/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [AMD ROCm System Management Interface (SMI), "input-plugins", "configuration", "hardware", "system"]
 introduced: "v1.20.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/amd_rocm_smi/README.md, AMD ROCm System Management Interface (SMI) Plugin Source
 ---
 
 # AMD ROCm System Management Interface (SMI) Input Plugin

--- a/content/telegraf/v1/input-plugins/amqp_consumer/_index.md
+++ b/content/telegraf/v1/input-plugins/amqp_consumer/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [AMQP Consumer, "input-plugins", "configuration", "messaging"]
 introduced: "v1.3.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/amqp_consumer/README.md, AMQP Consumer Plugin Source
 ---
 
 # AMQP Consumer Input Plugin

--- a/content/telegraf/v1/input-plugins/apache/_index.md
+++ b/content/telegraf/v1/input-plugins/apache/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Apache, "input-plugins", "configuration", "server", "web"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/apache/README.md, Apache Plugin Source
 ---
 
 # Apache Input Plugin

--- a/content/telegraf/v1/input-plugins/apcupsd/_index.md
+++ b/content/telegraf/v1/input-plugins/apcupsd/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [APC UPSD, "input-plugins", "configuration", "hardware", "server"]
 introduced: "v1.12.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/apcupsd/README.md, APC UPSD Plugin Source
 ---
 
 # APC UPSD Input Plugin

--- a/content/telegraf/v1/input-plugins/aurora/_index.md
+++ b/content/telegraf/v1/input-plugins/aurora/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Apache Aurora, "input-plugins", "configuration", "applications", "server"]
 introduced: "v1.7.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/aurora/README.md, Apache Aurora Plugin Source
 ---
 
 # Apache Aurora Input Plugin

--- a/content/telegraf/v1/input-plugins/azure_monitor/_index.md
+++ b/content/telegraf/v1/input-plugins/azure_monitor/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Azure Monitor, "input-plugins", "configuration", "cloud"]
 introduced: "v1.25.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/azure_monitor/README.md, Azure Monitor Plugin Source
 ---
 
 # Azure Monitor Input Plugin

--- a/content/telegraf/v1/input-plugins/azure_storage_queue/_index.md
+++ b/content/telegraf/v1/input-plugins/azure_storage_queue/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Azure Queue Storage, "input-plugins", "configuration", "cloud"]
 introduced: "v1.13.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/azure_storage_queue/README.md, Azure Queue Storage Plugin Source
 ---
 
 # Azure Queue Storage Input Plugin

--- a/content/telegraf/v1/input-plugins/bcache/_index.md
+++ b/content/telegraf/v1/input-plugins/bcache/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Bcache, "input-plugins", "configuration", "system"]
 introduced: "v0.2.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/bcache/README.md, Bcache Plugin Source
 ---
 
 # Bcache Input Plugin

--- a/content/telegraf/v1/input-plugins/beanstalkd/_index.md
+++ b/content/telegraf/v1/input-plugins/beanstalkd/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Beanstalkd, "input-plugins", "configuration", "messaging"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/beanstalkd/README.md, Beanstalkd Plugin Source
 ---
 
 # Beanstalkd Input Plugin

--- a/content/telegraf/v1/input-plugins/beat/_index.md
+++ b/content/telegraf/v1/input-plugins/beat/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Beat, "input-plugins", "configuration", "applications"]
 introduced: "v1.18.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/beat/README.md, Beat Plugin Source
 ---
 
 # Beat Input Plugin

--- a/content/telegraf/v1/input-plugins/bind/_index.md
+++ b/content/telegraf/v1/input-plugins/bind/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [BIND 9 Nameserver, "input-plugins", "configuration", "server"]
 introduced: "v1.11.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/bind/README.md, BIND 9 Nameserver Plugin Source
 ---
 
 # BIND 9 Nameserver Input Plugin

--- a/content/telegraf/v1/input-plugins/bond/_index.md
+++ b/content/telegraf/v1/input-plugins/bond/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Bond, "input-plugins", "configuration", "system"]
 introduced: "v1.5.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/bond/README.md, Bond Plugin Source
 ---
 
 # Bond Input Plugin

--- a/content/telegraf/v1/input-plugins/burrow/_index.md
+++ b/content/telegraf/v1/input-plugins/burrow/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Burrow, "input-plugins", "configuration", "messaging"]
 introduced: "v1.7.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/burrow/README.md, Burrow Plugin Source
 ---
 
 # Burrow Input Plugin

--- a/content/telegraf/v1/input-plugins/ceph/_index.md
+++ b/content/telegraf/v1/input-plugins/ceph/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Ceph Storage, "input-plugins", "configuration", "system"]
 introduced: "v0.13.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/ceph/README.md, Ceph Storage Plugin Source
 ---
 
 # Ceph Storage Input Plugin

--- a/content/telegraf/v1/input-plugins/cgroup/_index.md
+++ b/content/telegraf/v1/input-plugins/cgroup/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Control Group, "input-plugins", "configuration", "system"]
 introduced: "v1.0.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/cgroup/README.md, Control Group Plugin Source
 ---
 
 # Control Group Input Plugin

--- a/content/telegraf/v1/input-plugins/chrony/_index.md
+++ b/content/telegraf/v1/input-plugins/chrony/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [chrony, "input-plugins", "configuration", "system"]
 introduced: "v0.13.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/chrony/README.md, chrony Plugin Source
 ---
 
 # chrony Input Plugin

--- a/content/telegraf/v1/input-plugins/cisco_telemetry_mdt/_index.md
+++ b/content/telegraf/v1/input-plugins/cisco_telemetry_mdt/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Cisco Model-Driven Telemetry (MDT), "input-plugins", "configuration", "applications"]
 introduced: "v1.11.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/cisco_telemetry_mdt/README.md, Cisco Model-Driven Telemetry (MDT) Plugin Source
 ---
 
 # Cisco Model-Driven Telemetry (MDT) Input Plugin

--- a/content/telegraf/v1/input-plugins/clickhouse/_index.md
+++ b/content/telegraf/v1/input-plugins/clickhouse/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [ClickHouse, "input-plugins", "configuration", "server"]
 introduced: "v1.14.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/clickhouse/README.md, ClickHouse Plugin Source
 ---
 
 # ClickHouse Input Plugin

--- a/content/telegraf/v1/input-plugins/cloud_pubsub/_index.md
+++ b/content/telegraf/v1/input-plugins/cloud_pubsub/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Google Cloud PubSub, "input-plugins", "configuration", "cloud", "messaging"]
 introduced: "v1.10.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/cloud_pubsub/README.md, Google Cloud PubSub Plugin Source
 ---
 
 # Google Cloud PubSub Input Plugin

--- a/content/telegraf/v1/input-plugins/cloud_pubsub_push/_index.md
+++ b/content/telegraf/v1/input-plugins/cloud_pubsub_push/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Google Cloud PubSub Push, "input-plugins", "configuration", "cloud", "messaging"]
 introduced: "v1.10.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/cloud_pubsub_push/README.md, Google Cloud PubSub Push Plugin Source
 ---
 
 # Google Cloud PubSub Push Input Plugin

--- a/content/telegraf/v1/input-plugins/cloudwatch/_index.md
+++ b/content/telegraf/v1/input-plugins/cloudwatch/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Amazon CloudWatch Statistics, "input-plugins", "configuration", "cloud"]
 introduced: "v0.12.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/cloudwatch/README.md, Amazon CloudWatch Statistics Plugin Source
 ---
 
 # Amazon CloudWatch Statistics Input Plugin

--- a/content/telegraf/v1/input-plugins/cloudwatch_metric_streams/_index.md
+++ b/content/telegraf/v1/input-plugins/cloudwatch_metric_streams/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Amazon CloudWatch Metric Streams, "input-plugins", "configuration", "cloud"]
 introduced: "v1.24.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/cloudwatch_metric_streams/README.md, Amazon CloudWatch Metric Streams Plugin Source
 ---
 
 # Amazon CloudWatch Metric Streams Input Plugin

--- a/content/telegraf/v1/input-plugins/conntrack/_index.md
+++ b/content/telegraf/v1/input-plugins/conntrack/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Netfilter Conntrack, "input-plugins", "configuration", "system"]
 introduced: "v1.0.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/conntrack/README.md, Netfilter Conntrack Plugin Source
 ---
 
 # Netfilter Conntrack Input Plugin

--- a/content/telegraf/v1/input-plugins/consul/_index.md
+++ b/content/telegraf/v1/input-plugins/consul/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Hashicorp Consul, "input-plugins", "configuration", "server"]
 introduced: "v1.0.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/consul/README.md, Hashicorp Consul Plugin Source
 ---
 
 # Hashicorp Consul Input Plugin

--- a/content/telegraf/v1/input-plugins/consul_agent/_index.md
+++ b/content/telegraf/v1/input-plugins/consul_agent/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Hashicorp Consul Agent, "input-plugins", "configuration", "server"]
 introduced: "v1.22.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/consul_agent/README.md, Hashicorp Consul Agent Plugin Source
 ---
 
 # Hashicorp Consul Agent Input Plugin

--- a/content/telegraf/v1/input-plugins/couchbase/_index.md
+++ b/content/telegraf/v1/input-plugins/couchbase/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Couchbase, "input-plugins", "configuration", "server"]
 introduced: "v0.12.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/couchbase/README.md, Couchbase Plugin Source
 ---
 
 # Couchbase Input Plugin

--- a/content/telegraf/v1/input-plugins/couchdb/_index.md
+++ b/content/telegraf/v1/input-plugins/couchdb/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Apache CouchDB, "input-plugins", "configuration", "server"]
 introduced: "v0.10.3"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/couchdb/README.md, Apache CouchDB Plugin Source
 ---
 
 # Apache CouchDB Input Plugin

--- a/content/telegraf/v1/input-plugins/cpu/_index.md
+++ b/content/telegraf/v1/input-plugins/cpu/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [CPU, "input-plugins", "configuration", "system"]
 introduced: "v0.1.5"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/cpu/README.md, CPU Plugin Source
 ---
 
 # CPU Input Plugin

--- a/content/telegraf/v1/input-plugins/csgo/_index.md
+++ b/content/telegraf/v1/input-plugins/csgo/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Counter-Strike Global Offensive (CSGO), "input-plugins", "configuration", "server"]
 introduced: "v1.18.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/csgo/README.md, Counter-Strike Global Offensive (CSGO) Plugin Source
 ---
 
 # Counter-Strike: Global Offensive (CSGO) Input Plugin

--- a/content/telegraf/v1/input-plugins/ctrlx_datalayer/_index.md
+++ b/content/telegraf/v1/input-plugins/ctrlx_datalayer/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Bosch Rexroth ctrlX Data Layer, "input-plugins", "configuration", "iot", "messaging"]
 introduced: "v1.27.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/ctrlx_datalayer/README.md, Bosch Rexroth ctrlX Data Layer Plugin Source
 ---
 
 # Bosch Rexroth ctrlX Data Layer Input Plugin

--- a/content/telegraf/v1/input-plugins/dcos/_index.md
+++ b/content/telegraf/v1/input-plugins/dcos/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Mesosphere Distributed Cloud OS, "input-plugins", "configuration", "containers"]
 introduced: "v1.5.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/dcos/README.md, Mesosphere Distributed Cloud OS Plugin Source
 ---
 
 # Mesosphere Distributed Cloud OS Input Plugin

--- a/content/telegraf/v1/input-plugins/directory_monitor/_index.md
+++ b/content/telegraf/v1/input-plugins/directory_monitor/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Directory Monitor, "input-plugins", "configuration", "system"]
 introduced: "v1.18.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/directory_monitor/README.md, Directory Monitor Plugin Source
 ---
 
 # Directory Monitor Input Plugin

--- a/content/telegraf/v1/input-plugins/disk/_index.md
+++ b/content/telegraf/v1/input-plugins/disk/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Disk, "input-plugins", "configuration", "system"]
 introduced: "v0.1.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/disk/README.md, Disk Plugin Source
 ---
 
 # Disk Input Plugin

--- a/content/telegraf/v1/input-plugins/diskio/_index.md
+++ b/content/telegraf/v1/input-plugins/diskio/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [DiskIO, "input-plugins", "configuration", "system"]
 introduced: "v0.10.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/diskio/README.md, DiskIO Plugin Source
 ---
 
 # DiskIO Input Plugin

--- a/content/telegraf/v1/input-plugins/disque/_index.md
+++ b/content/telegraf/v1/input-plugins/disque/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Disque, "input-plugins", "configuration", "messaging"]
 introduced: "v0.10.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/disque/README.md, Disque Plugin Source
 ---
 
 # Disque Input Plugin

--- a/content/telegraf/v1/input-plugins/dmcache/_index.md
+++ b/content/telegraf/v1/input-plugins/dmcache/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Device Mapper Cache, "input-plugins", "configuration", "system"]
 introduced: "v1.3.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/dmcache/README.md, Device Mapper Cache Plugin Source
 ---
 
 # Device Mapper Cache Input Plugin

--- a/content/telegraf/v1/input-plugins/dns_query/_index.md
+++ b/content/telegraf/v1/input-plugins/dns_query/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [DNS Query, "input-plugins", "configuration", "network", "system"]
 introduced: "v1.4.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/dns_query/README.md, DNS Query Plugin Source
 ---
 
 # DNS Query Input Plugin

--- a/content/telegraf/v1/input-plugins/docker/_index.md
+++ b/content/telegraf/v1/input-plugins/docker/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Docker, "input-plugins", "configuration", "containers"]
 introduced: "v0.1.9"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/docker/README.md, Docker Plugin Source
 ---
 
 # Docker Input Plugin

--- a/content/telegraf/v1/input-plugins/docker_log/_index.md
+++ b/content/telegraf/v1/input-plugins/docker_log/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Docker Log, "input-plugins", "configuration", "containers", "logging"]
 introduced: "v1.12.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/docker_log/README.md, Docker Log Plugin Source
 ---
 
 # Docker Log Input Plugin

--- a/content/telegraf/v1/input-plugins/dovecot/_index.md
+++ b/content/telegraf/v1/input-plugins/dovecot/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Dovecot, "input-plugins", "configuration", "server"]
 introduced: "v0.10.3"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/dovecot/README.md, Dovecot Plugin Source
 ---
 
 # Dovecot Input Plugin

--- a/content/telegraf/v1/input-plugins/dpdk/_index.md
+++ b/content/telegraf/v1/input-plugins/dpdk/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Data Plane Development Kit (DPDK), "input-plugins", "configuration", "applications", "network"]
 introduced: "v1.19.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/dpdk/README.md, Data Plane Development Kit (DPDK) Plugin Source
 ---
 
 # Data Plane Development Kit (DPDK) Input Plugin

--- a/content/telegraf/v1/input-plugins/ecs/_index.md
+++ b/content/telegraf/v1/input-plugins/ecs/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Amazon Elastic Container Service, "input-plugins", "configuration", "cloud"]
 introduced: "v1.11.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/ecs/README.md, Amazon Elastic Container Service Plugin Source
 ---
 
 # Amazon Elastic Container Service Input Plugin

--- a/content/telegraf/v1/input-plugins/elasticsearch/_index.md
+++ b/content/telegraf/v1/input-plugins/elasticsearch/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Elasticsearch, "input-plugins", "configuration", "server"]
 introduced: "v0.1.5"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/elasticsearch/README.md, Elasticsearch Plugin Source
 ---
 
 # Elasticsearch Input Plugin

--- a/content/telegraf/v1/input-plugins/elasticsearch_query/_index.md
+++ b/content/telegraf/v1/input-plugins/elasticsearch_query/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Elasticsearch Query, "input-plugins", "configuration", "datastore"]
 introduced: "v1.20.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/elasticsearch_query/README.md, Elasticsearch Query Plugin Source
 ---
 
 # Elasticsearch Query Input Plugin

--- a/content/telegraf/v1/input-plugins/ethtool/_index.md
+++ b/content/telegraf/v1/input-plugins/ethtool/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Ethtool, "input-plugins", "configuration", "network", "system"]
 introduced: "v1.13.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/ethtool/README.md, Ethtool Plugin Source
 ---
 
 # Ethtool Input Plugin

--- a/content/telegraf/v1/input-plugins/eventhub_consumer/_index.md
+++ b/content/telegraf/v1/input-plugins/eventhub_consumer/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Azure Event Hub Consumer, "input-plugins", "configuration", "iot", "messaging"]
 introduced: "v1.14.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/eventhub_consumer/README.md, Azure Event Hub Consumer Plugin Source
 ---
 
 # Azure Event Hub Consumer Input Plugin

--- a/content/telegraf/v1/input-plugins/exec/_index.md
+++ b/content/telegraf/v1/input-plugins/exec/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Exec, "input-plugins", "configuration", "system"]
 introduced: "v0.1.5"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/exec/README.md, Exec Plugin Source
 ---
 
 # Exec Input Plugin

--- a/content/telegraf/v1/input-plugins/execd/_index.md
+++ b/content/telegraf/v1/input-plugins/execd/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Execd, "input-plugins", "configuration", "system"]
 introduced: "v1.14.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/execd/README.md, Execd Plugin Source
 ---
 
 # Execd Input Plugin

--- a/content/telegraf/v1/input-plugins/fail2ban/_index.md
+++ b/content/telegraf/v1/input-plugins/fail2ban/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Fail2ban, "input-plugins", "configuration", "network", "system"]
 introduced: "v1.4.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/fail2ban/README.md, Fail2ban Plugin Source
 ---
 
 # Fail2ban Input Plugin

--- a/content/telegraf/v1/input-plugins/fibaro/_index.md
+++ b/content/telegraf/v1/input-plugins/fibaro/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Fibaro, "input-plugins", "configuration", "iot"]
 introduced: "v1.7.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/fibaro/README.md, Fibaro Plugin Source
 ---
 
 # Fibaro Input Plugin

--- a/content/telegraf/v1/input-plugins/file/_index.md
+++ b/content/telegraf/v1/input-plugins/file/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [File, "input-plugins", "configuration", "system"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/file/README.md, File Plugin Source
 ---
 
 # File Input Plugin

--- a/content/telegraf/v1/input-plugins/filecount/_index.md
+++ b/content/telegraf/v1/input-plugins/filecount/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Filecount, "input-plugins", "configuration", "system"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/filecount/README.md, Filecount Plugin Source
 ---
 
 # Filecount Input Plugin

--- a/content/telegraf/v1/input-plugins/filestat/_index.md
+++ b/content/telegraf/v1/input-plugins/filestat/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [File statistics, "input-plugins", "configuration", "system"]
 introduced: "v0.13.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/filestat/README.md, File statistics Plugin Source
 ---
 
 # File statistics Input Plugin

--- a/content/telegraf/v1/input-plugins/fireboard/_index.md
+++ b/content/telegraf/v1/input-plugins/fireboard/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Fireboard, "input-plugins", "configuration", "iot"]
 introduced: "v1.12.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/fireboard/README.md, Fireboard Plugin Source
 ---
 
 # Fireboard Input Plugin

--- a/content/telegraf/v1/input-plugins/firehose/_index.md
+++ b/content/telegraf/v1/input-plugins/firehose/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [AWS Data Firehose, "input-plugins", "configuration", "cloud", "messaging"]
 introduced: "v1.34.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/firehose/README.md, AWS Data Firehose Plugin Source
 ---
 
 # AWS Data Firehose Input Plugin

--- a/content/telegraf/v1/input-plugins/fluentd/_index.md
+++ b/content/telegraf/v1/input-plugins/fluentd/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Fluentd, "input-plugins", "configuration", "server"]
 introduced: "v1.4.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/fluentd/README.md, Fluentd Plugin Source
 ---
 
 # Fluentd Input Plugin

--- a/content/telegraf/v1/input-plugins/fritzbox/_index.md
+++ b/content/telegraf/v1/input-plugins/fritzbox/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Fritzbox, "input-plugins", "configuration", "iot", "network"]
 introduced: "v1.35.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/fritzbox/README.md, Fritzbox Plugin Source
 ---
 
 # Fritzbox Input Plugin

--- a/content/telegraf/v1/input-plugins/github/_index.md
+++ b/content/telegraf/v1/input-plugins/github/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [GitHub, "input-plugins", "configuration", "applications"]
 introduced: "v1.11.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/github/README.md, GitHub Plugin Source
 ---
 
 # GitHub Input Plugin

--- a/content/telegraf/v1/input-plugins/gnmi/_index.md
+++ b/content/telegraf/v1/input-plugins/gnmi/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [gNMI (gRPC Network Management Interface), "input-plugins", "configuration", "network"]
 introduced: "v1.15.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/gnmi/README.md, gNMI (gRPC Network Management Interface) Plugin Source
 ---
 
 # gNMI (gRPC Network Management Interface) Input Plugin

--- a/content/telegraf/v1/input-plugins/google_cloud_storage/_index.md
+++ b/content/telegraf/v1/input-plugins/google_cloud_storage/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Google Cloud Storage, "input-plugins", "configuration", "cloud", "datastore"]
 introduced: "v1.25.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/google_cloud_storage/README.md, Google Cloud Storage Plugin Source
 ---
 
 # Google Cloud Storage Input Plugin

--- a/content/telegraf/v1/input-plugins/graylog/_index.md
+++ b/content/telegraf/v1/input-plugins/graylog/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [GrayLog, "input-plugins", "configuration", "logging"]
 introduced: "v1.0.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/graylog/README.md, GrayLog Plugin Source
 ---
 
 # GrayLog Input Plugin

--- a/content/telegraf/v1/input-plugins/haproxy/_index.md
+++ b/content/telegraf/v1/input-plugins/haproxy/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [HAProxy, "input-plugins", "configuration", "network", "server"]
 introduced: "v0.1.5"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/haproxy/README.md, HAProxy Plugin Source
 ---
 
 # HAProxy Input Plugin

--- a/content/telegraf/v1/input-plugins/hddtemp/_index.md
+++ b/content/telegraf/v1/input-plugins/hddtemp/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [HDDtemp, "input-plugins", "configuration", "hardware", "system"]
 introduced: "v1.0.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/hddtemp/README.md, HDDtemp Plugin Source
 ---
 
 # HDDtemp Input Plugin

--- a/content/telegraf/v1/input-plugins/http/_index.md
+++ b/content/telegraf/v1/input-plugins/http/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [HTTP, "input-plugins", "configuration", "applications", "server"]
 introduced: "v1.6.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/http/README.md, HTTP Plugin Source
 ---
 
 # HTTP Input Plugin

--- a/content/telegraf/v1/input-plugins/http_listener_v2/_index.md
+++ b/content/telegraf/v1/input-plugins/http_listener_v2/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [HTTP Listener v2, "input-plugins", "configuration", "server"]
 introduced: "v1.9.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/http_listener_v2/README.md, HTTP Listener v2 Plugin Source
 ---
 
 # HTTP Listener v2 Input Plugin

--- a/content/telegraf/v1/input-plugins/http_response/_index.md
+++ b/content/telegraf/v1/input-plugins/http_response/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [HTTP Response, "input-plugins", "configuration", "server"]
 introduced: "v0.12.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/http_response/README.md, HTTP Response Plugin Source
 ---
 
 # HTTP Response Input Plugin

--- a/content/telegraf/v1/input-plugins/huebridge/_index.md
+++ b/content/telegraf/v1/input-plugins/huebridge/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [HueBridge, "input-plugins", "configuration", "iot"]
 introduced: "v1.34.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/huebridge/README.md, HueBridge Plugin Source
 ---
 
 # HueBridge Input Plugin

--- a/content/telegraf/v1/input-plugins/hugepages/_index.md
+++ b/content/telegraf/v1/input-plugins/hugepages/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Hugepages, "input-plugins", "configuration", "system"]
 introduced: "v1.22.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/hugepages/README.md, Hugepages Plugin Source
 ---
 
 # Hugepages Input Plugin

--- a/content/telegraf/v1/input-plugins/icinga2/_index.md
+++ b/content/telegraf/v1/input-plugins/icinga2/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Icinga2, "input-plugins", "configuration", "network", "server", "system"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/icinga2/README.md, Icinga2 Plugin Source
 ---
 
 # Icinga2 Input Plugin

--- a/content/telegraf/v1/input-plugins/infiniband/_index.md
+++ b/content/telegraf/v1/input-plugins/infiniband/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [InfiniBand, "input-plugins", "configuration", "network"]
 introduced: "v1.14.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/infiniband/README.md, InfiniBand Plugin Source
 ---
 
 # InfiniBand Input Plugin

--- a/content/telegraf/v1/input-plugins/influxdb/_index.md
+++ b/content/telegraf/v1/input-plugins/influxdb/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [InfluxDB, "input-plugins", "configuration", "datastore"]
 introduced: "v0.2.5"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/influxdb/README.md, InfluxDB Plugin Source
 ---
 
 # InfluxDB Input Plugin

--- a/content/telegraf/v1/input-plugins/influxdb_listener/_index.md
+++ b/content/telegraf/v1/input-plugins/influxdb_listener/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [InfluxDB Listener, "input-plugins", "configuration", "datastore"]
 introduced: "v1.9.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/influxdb_listener/README.md, InfluxDB Listener Plugin Source
 ---
 
 # InfluxDB Listener Input Plugin

--- a/content/telegraf/v1/input-plugins/influxdb_v2_listener/_index.md
+++ b/content/telegraf/v1/input-plugins/influxdb_v2_listener/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [InfluxDB V2 Listener, "input-plugins", "configuration", "datastore"]
 introduced: "v1.16.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/influxdb_v2_listener/README.md, InfluxDB V2 Listener Plugin Source
 ---
 
 # InfluxDB V2 Listener Input Plugin

--- a/content/telegraf/v1/input-plugins/intel_baseband/_index.md
+++ b/content/telegraf/v1/input-plugins/intel_baseband/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Intel Baseband Accelerator, "input-plugins", "configuration", "hardware", "network", "system"]
 introduced: "v1.27.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/intel_baseband/README.md, Intel Baseband Accelerator Plugin Source
 ---
 
 # Intel Baseband Accelerator Input Plugin

--- a/content/telegraf/v1/input-plugins/intel_dlb/_index.md
+++ b/content/telegraf/v1/input-plugins/intel_dlb/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Intel® Dynamic Load Balancer, "input-plugins", "configuration", "applications"]
 introduced: "v1.25.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/intel_dlb/README.md, Intel® Dynamic Load Balancer Plugin Source
 ---
 
 # Intel® Dynamic Load Balancer Input Plugin

--- a/content/telegraf/v1/input-plugins/intel_pmt/_index.md
+++ b/content/telegraf/v1/input-plugins/intel_pmt/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Intel® Platform Monitoring Technology, "input-plugins", "configuration", "hardware", "system"]
 introduced: "v1.28.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/intel_pmt/README.md, Intel® Platform Monitoring Technology Plugin Source
 ---
 
 # Intel® Platform Monitoring Technology Input Plugin

--- a/content/telegraf/v1/input-plugins/intel_pmu/_index.md
+++ b/content/telegraf/v1/input-plugins/intel_pmu/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Intel Performance Monitoring Unit, "input-plugins", "configuration", "hardware", "system"]
 introduced: "v1.21.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/intel_pmu/README.md, Intel Performance Monitoring Unit Plugin Source
 ---
 
 # Intel Performance Monitoring Unit Plugin

--- a/content/telegraf/v1/input-plugins/intel_powerstat/_index.md
+++ b/content/telegraf/v1/input-plugins/intel_powerstat/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Intel PowerStat, "input-plugins", "configuration", "hardware", "system"]
 introduced: "v1.17.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/intel_powerstat/README.md, Intel PowerStat Plugin Source
 ---
 
 # Intel PowerStat Input Plugin

--- a/content/telegraf/v1/input-plugins/intel_rdt/_index.md
+++ b/content/telegraf/v1/input-plugins/intel_rdt/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Intel RDT, "input-plugins", "configuration", "hardware", "system"]
 introduced: "v1.16.0"
 os_support: "freebsd, linux, macos"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/intel_rdt/README.md, Intel RDT Plugin Source
 ---
 
 # Intel RDT Input Plugin

--- a/content/telegraf/v1/input-plugins/internal/_index.md
+++ b/content/telegraf/v1/input-plugins/internal/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Telegraf Internal, "input-plugins", "configuration", "applications"]
 introduced: "v1.2.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/internal/README.md, Telegraf Internal Plugin Source
 ---
 
 # Telegraf Internal Input Plugin

--- a/content/telegraf/v1/input-plugins/internet_speed/_index.md
+++ b/content/telegraf/v1/input-plugins/internet_speed/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Internet Speed Monitor, "input-plugins", "configuration", "network"]
 introduced: "v1.20.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/internet_speed/README.md, Internet Speed Monitor Plugin Source
 ---
 
 # Internet Speed Monitor Input Plugin

--- a/content/telegraf/v1/input-plugins/interrupts/_index.md
+++ b/content/telegraf/v1/input-plugins/interrupts/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Interrupts, "input-plugins", "configuration", "system"]
 introduced: "v1.3.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/interrupts/README.md, Interrupts Plugin Source
 ---
 
 # Interrupts Input Plugin

--- a/content/telegraf/v1/input-plugins/ipmi_sensor/_index.md
+++ b/content/telegraf/v1/input-plugins/ipmi_sensor/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [IPMI Sensor, "input-plugins", "configuration", "hardware", "system"]
 introduced: "v0.12.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/ipmi_sensor/README.md, IPMI Sensor Plugin Source
 ---
 
 # IPMI Sensor Input Plugin

--- a/content/telegraf/v1/input-plugins/ipset/_index.md
+++ b/content/telegraf/v1/input-plugins/ipset/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Ipset, "input-plugins", "configuration", "network", "system"]
 introduced: "v1.6.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/ipset/README.md, Ipset Plugin Source
 ---
 
 # Ipset Input Plugin

--- a/content/telegraf/v1/input-plugins/iptables/_index.md
+++ b/content/telegraf/v1/input-plugins/iptables/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Iptables, "input-plugins", "configuration", "network", "system"]
 introduced: "v1.1.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/iptables/README.md, Iptables Plugin Source
 ---
 
 # Iptables Input Plugin

--- a/content/telegraf/v1/input-plugins/ipvs/_index.md
+++ b/content/telegraf/v1/input-plugins/ipvs/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [IPVS, "input-plugins", "configuration", "network", "system"]
 introduced: "v1.9.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/ipvs/README.md, IPVS Plugin Source
 ---
 
 # IPVS Input Plugin

--- a/content/telegraf/v1/input-plugins/jenkins/_index.md
+++ b/content/telegraf/v1/input-plugins/jenkins/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Jenkins, "input-plugins", "configuration", "applications"]
 introduced: "v1.9.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/jenkins/README.md, Jenkins Plugin Source
 ---
 
 # Jenkins Input Plugin

--- a/content/telegraf/v1/input-plugins/jolokia2_agent/_index.md
+++ b/content/telegraf/v1/input-plugins/jolokia2_agent/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Jolokia2 Agent, "input-plugins", "configuration", "applications", "network"]
 introduced: "v1.5.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/jolokia2_agent/README.md, Jolokia2 Agent Plugin Source
 ---
 
 # Jolokia2 Agent Input Plugin

--- a/content/telegraf/v1/input-plugins/jolokia2_proxy/_index.md
+++ b/content/telegraf/v1/input-plugins/jolokia2_proxy/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Jolokia2 Proxy, "input-plugins", "configuration", "applications", "network"]
 introduced: "v1.5.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/jolokia2_proxy/README.md, Jolokia2 Proxy Plugin Source
 ---
 
 # Jolokia2 Proxy Input Plugin

--- a/content/telegraf/v1/input-plugins/jti_openconfig_telemetry/_index.md
+++ b/content/telegraf/v1/input-plugins/jti_openconfig_telemetry/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Juniper Telemetry, "input-plugins", "configuration", "iot", "network"]
 introduced: "v1.7.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/jti_openconfig_telemetry/README.md, Juniper Telemetry Plugin Source
 ---
 
 # Juniper Telemetry Input Plugin

--- a/content/telegraf/v1/input-plugins/kafka_consumer/_index.md
+++ b/content/telegraf/v1/input-plugins/kafka_consumer/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Apache Kafka Consumer, "input-plugins", "configuration", "messaging"]
 introduced: "v0.2.3"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/kafka_consumer/README.md, Apache Kafka Consumer Plugin Source
 ---
 
 # Apache Kafka Consumer Input Plugin

--- a/content/telegraf/v1/input-plugins/kapacitor/_index.md
+++ b/content/telegraf/v1/input-plugins/kapacitor/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Kapacitor, "input-plugins", "configuration", "applications"]
 introduced: "v1.3.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/kapacitor/README.md, Kapacitor Plugin Source
 ---
 
 # Kapacitor Input Plugin

--- a/content/telegraf/v1/input-plugins/kernel/_index.md
+++ b/content/telegraf/v1/input-plugins/kernel/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Kernel, "input-plugins", "configuration", "system"]
 introduced: "v0.11.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/kernel/README.md, Kernel Plugin Source
 ---
 
 # Kernel Input Plugin

--- a/content/telegraf/v1/input-plugins/kernel_vmstat/_index.md
+++ b/content/telegraf/v1/input-plugins/kernel_vmstat/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Kernel VM Statistics, "input-plugins", "configuration", "system"]
 introduced: "v1.0.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/kernel_vmstat/README.md, Kernel VM Statistics Plugin Source
 ---
 
 # Kernel VM Statistics Input Plugin

--- a/content/telegraf/v1/input-plugins/kibana/_index.md
+++ b/content/telegraf/v1/input-plugins/kibana/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Kibana, "input-plugins", "configuration", "applications", "server"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/kibana/README.md, Kibana Plugin Source
 ---
 
 # Kibana Input Plugin

--- a/content/telegraf/v1/input-plugins/kinesis_consumer/_index.md
+++ b/content/telegraf/v1/input-plugins/kinesis_consumer/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Kinesis Consumer, "input-plugins", "configuration", "iot", "messaging"]
 introduced: "v1.10.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/kinesis_consumer/README.md, Kinesis Consumer Plugin Source
 ---
 
 # Kinesis Consumer Input Plugin

--- a/content/telegraf/v1/input-plugins/knx_listener/_index.md
+++ b/content/telegraf/v1/input-plugins/knx_listener/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [KNX, "input-plugins", "configuration", "iot"]
 introduced: "v1.19.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/knx_listener/README.md, KNX Plugin Source
 ---
 
 # KNX Input Plugin

--- a/content/telegraf/v1/input-plugins/kube_inventory/_index.md
+++ b/content/telegraf/v1/input-plugins/kube_inventory/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Kubernetes Inventory, "input-plugins", "configuration", "containers"]
 introduced: "v1.10.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/kube_inventory/README.md, Kubernetes Inventory Plugin Source
 ---
 
 # Kubernetes Inventory Input Plugin

--- a/content/telegraf/v1/input-plugins/kubernetes/_index.md
+++ b/content/telegraf/v1/input-plugins/kubernetes/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Kubernetes, "input-plugins", "configuration", "containers"]
 introduced: "v1.1.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/kubernetes/README.md, Kubernetes Plugin Source
 ---
 
 # Kubernetes Input Plugin

--- a/content/telegraf/v1/input-plugins/lanz/_index.md
+++ b/content/telegraf/v1/input-plugins/lanz/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Arista LANZ Consumer, "input-plugins", "configuration", "network"]
 introduced: "v1.14.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/lanz/README.md, Arista LANZ Consumer Plugin Source
 ---
 
 # Arista LANZ Consumer Input Plugin

--- a/content/telegraf/v1/input-plugins/ldap/_index.md
+++ b/content/telegraf/v1/input-plugins/ldap/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [LDAP, "input-plugins", "configuration", "network", "server"]
 introduced: "v1.29.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/ldap/README.md, LDAP Plugin Source
 ---
 
 # LDAP Input Plugin

--- a/content/telegraf/v1/input-plugins/leofs/_index.md
+++ b/content/telegraf/v1/input-plugins/leofs/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [LeoFS, "input-plugins", "configuration", "network", "server"]
 introduced: "v0.1.5"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/leofs/README.md, LeoFS Plugin Source
 ---
 
 # LeoFS Input Plugin

--- a/content/telegraf/v1/input-plugins/libvirt/_index.md
+++ b/content/telegraf/v1/input-plugins/libvirt/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Libvirt, "input-plugins", "configuration", "server"]
 introduced: "v1.25.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/libvirt/README.md, Libvirt Plugin Source
 ---
 
 # Libvirt Input Plugin

--- a/content/telegraf/v1/input-plugins/linux_cpu/_index.md
+++ b/content/telegraf/v1/input-plugins/linux_cpu/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Linux CPU, "input-plugins", "configuration", "system"]
 introduced: "v1.24.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/linux_cpu/README.md, Linux CPU Plugin Source
 ---
 
 # Linux CPU Input Plugin

--- a/content/telegraf/v1/input-plugins/linux_sysctl_fs/_index.md
+++ b/content/telegraf/v1/input-plugins/linux_sysctl_fs/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Linux Sysctl Filesystem, "input-plugins", "configuration", "system"]
 introduced: "v1.24.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/linux_sysctl_fs/README.md, Linux Sysctl Filesystem Plugin Source
 ---
 
 # Linux Sysctl Filesystem Input Plugin

--- a/content/telegraf/v1/input-plugins/logql/_index.md
+++ b/content/telegraf/v1/input-plugins/logql/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [LogQL, "input-plugins", "configuration", "datastore"]
 introduced: "v1.37.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/logql/README.md, LogQL Plugin Source
 ---
 
 # LogQL Input Plugin

--- a/content/telegraf/v1/input-plugins/logstash/_index.md
+++ b/content/telegraf/v1/input-plugins/logstash/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Logstash, "input-plugins", "configuration", "server"]
 introduced: "v1.12.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/logstash/README.md, Logstash Plugin Source
 ---
 
 # Logstash Input Plugin

--- a/content/telegraf/v1/input-plugins/lustre2/_index.md
+++ b/content/telegraf/v1/input-plugins/lustre2/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Lustre, "input-plugins", "configuration", "system"]
 introduced: "v0.1.5"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/lustre2/README.md, Lustre Plugin Source
 ---
 
 # Lustre Input Plugin

--- a/content/telegraf/v1/input-plugins/lvm/_index.md
+++ b/content/telegraf/v1/input-plugins/lvm/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Logical Volume Manager, "input-plugins", "configuration", "system"]
 introduced: "v1.21.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/lvm/README.md, Logical Volume Manager Plugin Source
 ---
 
 # Logical Volume Manager Input Plugin

--- a/content/telegraf/v1/input-plugins/mailchimp/_index.md
+++ b/content/telegraf/v1/input-plugins/mailchimp/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Mailchimp, "input-plugins", "configuration", "cloud", "web"]
 introduced: "v0.2.4"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/mailchimp/README.md, Mailchimp Plugin Source
 ---
 
 # Mailchimp Input Plugin

--- a/content/telegraf/v1/input-plugins/marklogic/_index.md
+++ b/content/telegraf/v1/input-plugins/marklogic/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [MarkLogic, "input-plugins", "configuration", "server"]
 introduced: "v1.12.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/marklogic/README.md, MarkLogic Plugin Source
 ---
 
 # MarkLogic Input Plugin

--- a/content/telegraf/v1/input-plugins/mavlink/_index.md
+++ b/content/telegraf/v1/input-plugins/mavlink/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [MavLink, "input-plugins", "configuration", "iot"]
 introduced: "v1.35.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/mavlink/README.md, MavLink Plugin Source
 ---
 
 # MavLink Input Plugin

--- a/content/telegraf/v1/input-plugins/mcrouter/_index.md
+++ b/content/telegraf/v1/input-plugins/mcrouter/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Mcrouter, "input-plugins", "configuration", "applications", "network"]
 introduced: "v1.7.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/mcrouter/README.md, Mcrouter Plugin Source
 ---
 
 # Mcrouter Input Plugin

--- a/content/telegraf/v1/input-plugins/mdstat/_index.md
+++ b/content/telegraf/v1/input-plugins/mdstat/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [MD RAID Statistics, "input-plugins", "configuration", "system"]
 introduced: "v1.20.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/mdstat/README.md, MD RAID Statistics Plugin Source
 ---
 
 # MD RAID Statistics Input Plugin

--- a/content/telegraf/v1/input-plugins/mem/_index.md
+++ b/content/telegraf/v1/input-plugins/mem/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Memory, "input-plugins", "configuration", "system"]
 introduced: "v0.1.5"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/mem/README.md, Memory Plugin Source
 ---
 
 # Memory Input Plugin

--- a/content/telegraf/v1/input-plugins/memcached/_index.md
+++ b/content/telegraf/v1/input-plugins/memcached/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Memcached, "input-plugins", "configuration", "server"]
 introduced: "v0.1.2"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/memcached/README.md, Memcached Plugin Source
 ---
 
 # Memcached Input Plugin

--- a/content/telegraf/v1/input-plugins/mesos/_index.md
+++ b/content/telegraf/v1/input-plugins/mesos/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Apache Mesos, "input-plugins", "configuration", "containers"]
 introduced: "v0.10.3"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/mesos/README.md, Apache Mesos Plugin Source
 ---
 
 # Apache Mesos Input Plugin

--- a/content/telegraf/v1/input-plugins/minecraft/_index.md
+++ b/content/telegraf/v1/input-plugins/minecraft/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Minecraft, "input-plugins", "configuration", "server"]
 introduced: "v1.4.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/minecraft/README.md, Minecraft Plugin Source
 ---
 
 # Minecraft Input Plugin

--- a/content/telegraf/v1/input-plugins/mock/_index.md
+++ b/content/telegraf/v1/input-plugins/mock/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Mock Data, "input-plugins", "configuration", "testing"]
 introduced: "v1.22.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/mock/README.md, Mock Data Plugin Source
 ---
 
 # Mock Data Input Plugin

--- a/content/telegraf/v1/input-plugins/modbus/_index.md
+++ b/content/telegraf/v1/input-plugins/modbus/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Modbus, "input-plugins", "configuration", "iot"]
 introduced: "v1.14.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/modbus/README.md, Modbus Plugin Source
 ---
 
 <!-- markdownlint-disable MD024 -->

--- a/content/telegraf/v1/input-plugins/mongodb/_index.md
+++ b/content/telegraf/v1/input-plugins/mongodb/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [MongoDB, "input-plugins", "configuration", "datastore"]
 introduced: "v0.1.5"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/mongodb/README.md, MongoDB Plugin Source
 ---
 
 # MongoDB Input Plugin

--- a/content/telegraf/v1/input-plugins/monit/_index.md
+++ b/content/telegraf/v1/input-plugins/monit/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Monit, "input-plugins", "configuration", "network"]
 introduced: "v1.14.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/monit/README.md, Monit Plugin Source
 ---
 
 # Monit Input Plugin

--- a/content/telegraf/v1/input-plugins/mqtt_consumer/_index.md
+++ b/content/telegraf/v1/input-plugins/mqtt_consumer/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [MQTT Consumer, "input-plugins", "configuration", "messaging"]
 introduced: "v0.10.3"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/mqtt_consumer/README.md, MQTT Consumer Plugin Source
 ---
 
 # MQTT Consumer Input Plugin

--- a/content/telegraf/v1/input-plugins/multifile/_index.md
+++ b/content/telegraf/v1/input-plugins/multifile/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Multifile, "input-plugins", "configuration", "system"]
 introduced: "v1.10.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/multifile/README.md, Multifile Plugin Source
 ---
 
 # Multifile Input Plugin

--- a/content/telegraf/v1/input-plugins/mysql/_index.md
+++ b/content/telegraf/v1/input-plugins/mysql/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [MySQL, "input-plugins", "configuration", "datastore"]
 introduced: "v0.1.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/mysql/README.md, MySQL Plugin Source
 ---
 
 # MySQL Input Plugin

--- a/content/telegraf/v1/input-plugins/nats/_index.md
+++ b/content/telegraf/v1/input-plugins/nats/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [NATS Server Monitoring, "input-plugins", "configuration", "server"]
 introduced: "v1.6.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nats/README.md, NATS Server Monitoring Plugin Source
 ---
 
 # NATS Server Monitoring Input Plugin

--- a/content/telegraf/v1/input-plugins/nats_consumer/_index.md
+++ b/content/telegraf/v1/input-plugins/nats_consumer/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [NATS Consumer, "input-plugins", "configuration", "messaging"]
 introduced: "v0.10.3"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nats_consumer/README.md, NATS Consumer Plugin Source
 ---
 
 # NATS Consumer Input Plugin

--- a/content/telegraf/v1/input-plugins/neoom_beaam/_index.md
+++ b/content/telegraf/v1/input-plugins/neoom_beaam/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Neoom Beaam, "input-plugins", "configuration", "iot"]
 introduced: "v1.33.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/neoom_beaam/README.md, Neoom Beaam Plugin Source
 ---
 
 # Neoom Beaam Input Plugin

--- a/content/telegraf/v1/input-plugins/neptune_apex/_index.md
+++ b/content/telegraf/v1/input-plugins/neptune_apex/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Neptune Apex, "input-plugins", "configuration", "iot"]
 introduced: "v1.10.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/neptune_apex/README.md, Neptune Apex Plugin Source
 ---
 
 # Neptune Apex Input Plugin

--- a/content/telegraf/v1/input-plugins/net/_index.md
+++ b/content/telegraf/v1/input-plugins/net/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Network, "input-plugins", "configuration", "network"]
 introduced: "v0.1.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/net/README.md, Network Plugin Source
 ---
 
 # Network Input Plugin

--- a/content/telegraf/v1/input-plugins/net_response/_index.md
+++ b/content/telegraf/v1/input-plugins/net_response/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Network Response, "input-plugins", "configuration", "network"]
 introduced: "v0.10.3"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/net_response/README.md, Network Response Plugin Source
 ---
 
 # Network Response Input Plugin

--- a/content/telegraf/v1/input-plugins/netflow/_index.md
+++ b/content/telegraf/v1/input-plugins/netflow/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Netflow, "input-plugins", "configuration", "network"]
 introduced: "v1.25.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/netflow/README.md, Netflow Plugin Source
 ---
 
 # Netflow Input Plugin

--- a/content/telegraf/v1/input-plugins/netstat/_index.md
+++ b/content/telegraf/v1/input-plugins/netstat/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Network Connection Statistics, "input-plugins", "configuration", "network"]
 introduced: "v0.2.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/netstat/README.md, Network Connection Statistics Plugin Source
 ---
 
 # Network Connection Statistics Input Plugin

--- a/content/telegraf/v1/input-plugins/nfsclient/_index.md
+++ b/content/telegraf/v1/input-plugins/nfsclient/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Network Filesystem, "input-plugins", "configuration", "network", "system"]
 introduced: "v1.18.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nfsclient/README.md, Network Filesystem Plugin Source
 ---
 
 # Network Filesystem Input Plugin

--- a/content/telegraf/v1/input-plugins/nftables/_index.md
+++ b/content/telegraf/v1/input-plugins/nftables/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Nftables, "input-plugins", "configuration", "network", "system"]
 introduced: "v1.37.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nftables/README.md, Nftables Plugin Source
 ---
 
 # Nftables Plugin

--- a/content/telegraf/v1/input-plugins/nginx/_index.md
+++ b/content/telegraf/v1/input-plugins/nginx/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Nginx, "input-plugins", "configuration", "server", "web"]
 introduced: "v0.1.5"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nginx/README.md, Nginx Plugin Source
 ---
 
 # Nginx Input Plugin

--- a/content/telegraf/v1/input-plugins/nginx_plus/_index.md
+++ b/content/telegraf/v1/input-plugins/nginx_plus/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Nginx Plus, "input-plugins", "configuration", "server", "web"]
 introduced: "v1.5.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nginx_plus/README.md, Nginx Plus Plugin Source
 ---
 
 # Nginx Plus Input Plugin

--- a/content/telegraf/v1/input-plugins/nginx_plus_api/_index.md
+++ b/content/telegraf/v1/input-plugins/nginx_plus_api/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Nginx Plus API, "input-plugins", "configuration", "server", "web"]
 introduced: "v1.9.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nginx_plus_api/README.md, Nginx Plus API Plugin Source
 ---
 
 # Nginx Plus API Input Plugin

--- a/content/telegraf/v1/input-plugins/nginx_sts/_index.md
+++ b/content/telegraf/v1/input-plugins/nginx_sts/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Nginx Stream Server Traffic, "input-plugins", "configuration", "server", "web"]
 introduced: "v1.15.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nginx_sts/README.md, Nginx Stream Server Traffic Plugin Source
 ---
 
 # Nginx Stream Server Traffic Input Plugin

--- a/content/telegraf/v1/input-plugins/nginx_upstream_check/_index.md
+++ b/content/telegraf/v1/input-plugins/nginx_upstream_check/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Nginx Upstream Check, "input-plugins", "configuration", "server", "web"]
 introduced: "v1.10.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nginx_upstream_check/README.md, Nginx Upstream Check Plugin Source
 ---
 
 # Nginx Upstream Check Input Plugin

--- a/content/telegraf/v1/input-plugins/nginx_vts/_index.md
+++ b/content/telegraf/v1/input-plugins/nginx_vts/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Nginx Virtual Host Traffic, "input-plugins", "configuration", "server", "web"]
 introduced: "v1.9.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nginx_vts/README.md, Nginx Virtual Host Traffic Plugin Source
 ---
 
 # Nginx Virtual Host Traffic Input Plugin

--- a/content/telegraf/v1/input-plugins/nomad/_index.md
+++ b/content/telegraf/v1/input-plugins/nomad/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Hashicorp Nomad, "input-plugins", "configuration", "server"]
 introduced: "v1.22.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nomad/README.md, Hashicorp Nomad Plugin Source
 ---
 
 # Hashicorp Nomad Input Plugin

--- a/content/telegraf/v1/input-plugins/nsd/_index.md
+++ b/content/telegraf/v1/input-plugins/nsd/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [NLnet Labs Name Server Daemon, "input-plugins", "configuration", "server"]
 introduced: "v1.0.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nsd/README.md, NLnet Labs Name Server Daemon Plugin Source
 ---
 
 # NLnet Labs Name Server Daemon Input Plugin

--- a/content/telegraf/v1/input-plugins/nsdp/_index.md
+++ b/content/telegraf/v1/input-plugins/nsdp/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Netgear Switch Discovery Protocol, "input-plugins", "configuration", "network"]
 introduced: "v1.34.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nsdp/README.md, Netgear Switch Discovery Protocol Plugin Source
 ---
 
 # Netgear Switch Discovery Protocol Input Plugin

--- a/content/telegraf/v1/input-plugins/nsq/_index.md
+++ b/content/telegraf/v1/input-plugins/nsq/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [NSQ, "input-plugins", "configuration", "server"]
 introduced: "v1.16.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nsq/README.md, NSQ Plugin Source
 ---
 
 # NSQ Input Plugin

--- a/content/telegraf/v1/input-plugins/nsq_consumer/_index.md
+++ b/content/telegraf/v1/input-plugins/nsq_consumer/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [NSQ Consumer, "input-plugins", "configuration", "messaging"]
 introduced: "v0.10.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nsq_consumer/README.md, NSQ Consumer Plugin Source
 ---
 
 # NSQ Consumer Input Plugin

--- a/content/telegraf/v1/input-plugins/nstat/_index.md
+++ b/content/telegraf/v1/input-plugins/nstat/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Kernel Network Statistics, "input-plugins", "configuration", "network", "system"]
 introduced: "v0.13.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nstat/README.md, Kernel Network Statistics Plugin Source
 ---
 
 # Kernel Network Statistics Input Plugin

--- a/content/telegraf/v1/input-plugins/ntpq/_index.md
+++ b/content/telegraf/v1/input-plugins/ntpq/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Network Time Protocol Query, "input-plugins", "configuration", "network"]
 introduced: "v0.11.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/ntpq/README.md, Network Time Protocol Query Plugin Source
 ---
 
 # Network Time Protocol Query Input Plugin

--- a/content/telegraf/v1/input-plugins/nvidia_smi/_index.md
+++ b/content/telegraf/v1/input-plugins/nvidia_smi/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Nvidia System Management Interface (SMI), "input-plugins", "configuration", "hardware", "system"]
 introduced: "v1.7.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/nvidia_smi/README.md, Nvidia System Management Interface (SMI) Plugin Source
 ---
 
 # Nvidia System Management Interface (SMI) Input Plugin

--- a/content/telegraf/v1/input-plugins/opcua/_index.md
+++ b/content/telegraf/v1/input-plugins/opcua/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [OPC UA Client Reader, "input-plugins", "configuration", "iot"]
 introduced: "v1.16.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/opcua/README.md, OPC UA Client Reader Plugin Source
 ---
 
 # OPC UA Client Reader Input Plugin

--- a/content/telegraf/v1/input-plugins/opcua_listener/_index.md
+++ b/content/telegraf/v1/input-plugins/opcua_listener/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [OPC UA Client Listener, "input-plugins", "configuration", "iot"]
 introduced: "v1.25.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/opcua_listener/README.md, OPC UA Client Listener Plugin Source
 ---
 
 # OPC UA Client Listener Input Plugin

--- a/content/telegraf/v1/input-plugins/openldap/_index.md
+++ b/content/telegraf/v1/input-plugins/openldap/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [OpenLDAP, "input-plugins", "configuration", "network", "server"]
 introduced: "v1.4.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/openldap/README.md, OpenLDAP Plugin Source
 ---
 
 # OpenLDAP Input Plugin

--- a/content/telegraf/v1/input-plugins/openntpd/_index.md
+++ b/content/telegraf/v1/input-plugins/openntpd/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [OpenNTPD, "input-plugins", "configuration", "network", "server"]
 introduced: "v1.12.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/openntpd/README.md, OpenNTPD Plugin Source
 ---
 
 # OpenNTPD Input Plugin

--- a/content/telegraf/v1/input-plugins/opensearch_query/_index.md
+++ b/content/telegraf/v1/input-plugins/opensearch_query/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [OpenSearch Query, "input-plugins", "configuration", "datastore"]
 introduced: "v1.26.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/opensearch_query/README.md, OpenSearch Query Plugin Source
 ---
 
 # OpenSearch Query Input Plugin

--- a/content/telegraf/v1/input-plugins/opensmtpd/_index.md
+++ b/content/telegraf/v1/input-plugins/opensmtpd/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [OpenSMTPD, "input-plugins", "configuration", "network", "server"]
 introduced: "v1.5.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/opensmtpd/README.md, OpenSMTPD Plugin Source
 ---
 
 # OpenSMTPD Input Plugin

--- a/content/telegraf/v1/input-plugins/openstack/_index.md
+++ b/content/telegraf/v1/input-plugins/openstack/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [OpenStack, "input-plugins", "configuration", "cloud", "server"]
 introduced: "v1.21.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/openstack/README.md, OpenStack Plugin Source
 ---
 
 # OpenStack Input Plugin

--- a/content/telegraf/v1/input-plugins/opentelemetry/_index.md
+++ b/content/telegraf/v1/input-plugins/opentelemetry/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [OpenTelemetry, "input-plugins", "configuration", "logging", "messaging"]
 introduced: "v1.19.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/opentelemetry/README.md, OpenTelemetry Plugin Source
 ---
 
 # OpenTelemetry Input Plugin

--- a/content/telegraf/v1/input-plugins/openweathermap/_index.md
+++ b/content/telegraf/v1/input-plugins/openweathermap/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [OpenWeatherMap, "input-plugins", "configuration", "applications", "web"]
 introduced: "v1.11.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/openweathermap/README.md, OpenWeatherMap Plugin Source
 ---
 
 # OpenWeatherMap Input Plugin

--- a/content/telegraf/v1/input-plugins/p4runtime/_index.md
+++ b/content/telegraf/v1/input-plugins/p4runtime/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [P4 Runtime, "input-plugins", "configuration", "applications", "network"]
 introduced: "v1.26.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/p4runtime/README.md, P4 Runtime Plugin Source
 ---
 
 # P4 Runtime Input Plugin

--- a/content/telegraf/v1/input-plugins/passenger/_index.md
+++ b/content/telegraf/v1/input-plugins/passenger/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Passenger, "input-plugins", "configuration", "web"]
 introduced: "v0.10.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/passenger/README.md, Passenger Plugin Source
 ---
 
 # Passenger Input Plugin

--- a/content/telegraf/v1/input-plugins/pf/_index.md
+++ b/content/telegraf/v1/input-plugins/pf/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [PF, "input-plugins", "configuration", "network", "system"]
 introduced: "v1.5.0"
 os_support: "freebsd"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/pf/README.md, PF Plugin Source
 ---
 
 # PF Input Plugin

--- a/content/telegraf/v1/input-plugins/pgbouncer/_index.md
+++ b/content/telegraf/v1/input-plugins/pgbouncer/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [PgBouncer, "input-plugins", "configuration", "server", "web"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/pgbouncer/README.md, PgBouncer Plugin Source
 ---
 
 # PgBouncer Input Plugin

--- a/content/telegraf/v1/input-plugins/phpfpm/_index.md
+++ b/content/telegraf/v1/input-plugins/phpfpm/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [PHP-FPM, "input-plugins", "configuration", "server", "web"]
 introduced: "v0.1.10"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/phpfpm/README.md, PHP-FPM Plugin Source
 ---
 
 # PHP-FPM Input Plugin

--- a/content/telegraf/v1/input-plugins/ping/_index.md
+++ b/content/telegraf/v1/input-plugins/ping/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Ping, "input-plugins", "configuration", "network"]
 introduced: "v0.1.8"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/ping/README.md, Ping Plugin Source
 ---
 
 # Ping Input Plugin

--- a/content/telegraf/v1/input-plugins/postfix/_index.md
+++ b/content/telegraf/v1/input-plugins/postfix/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Postfix, "input-plugins", "configuration", "server"]
 introduced: "v1.5.0"
 os_support: "freebsd, linux, macos, solaris"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/postfix/README.md, Postfix Plugin Source
 ---
 
 # Postfix Input Plugin

--- a/content/telegraf/v1/input-plugins/postgresql/_index.md
+++ b/content/telegraf/v1/input-plugins/postgresql/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [PostgreSQL, "input-plugins", "configuration", "datastore"]
 introduced: "v0.10.3"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/postgresql/README.md, PostgreSQL Plugin Source
 ---
 
 # PostgreSQL Input Plugin

--- a/content/telegraf/v1/input-plugins/postgresql_extensible/_index.md
+++ b/content/telegraf/v1/input-plugins/postgresql_extensible/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [PostgreSQL Extensible, "input-plugins", "configuration", "datastore"]
 introduced: "v0.12.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/postgresql_extensible/README.md, PostgreSQL Extensible Plugin Source
 ---
 
 # PostgreSQL Extensible Input Plugin

--- a/content/telegraf/v1/input-plugins/powerdns/_index.md
+++ b/content/telegraf/v1/input-plugins/powerdns/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [PowerDNS, "input-plugins", "configuration", "server"]
 introduced: "v0.10.2"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/powerdns/README.md, PowerDNS Plugin Source
 ---
 
 # PowerDNS Input Plugin

--- a/content/telegraf/v1/input-plugins/powerdns_recursor/_index.md
+++ b/content/telegraf/v1/input-plugins/powerdns_recursor/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [PowerDNS Recursor, "input-plugins", "configuration", "server"]
 introduced: "v1.11.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/powerdns_recursor/README.md, PowerDNS Recursor Plugin Source
 ---
 
 # PowerDNS Recursor Input Plugin

--- a/content/telegraf/v1/input-plugins/processes/_index.md
+++ b/content/telegraf/v1/input-plugins/processes/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Processes, "input-plugins", "configuration", "system"]
 introduced: "v0.11.0"
 os_support: "freebsd, linux, macos"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/processes/README.md, Processes Plugin Source
 ---
 
 # Processes Input Plugin

--- a/content/telegraf/v1/input-plugins/procstat/_index.md
+++ b/content/telegraf/v1/input-plugins/procstat/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Procstat, "input-plugins", "configuration", "system"]
 introduced: "v0.2.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/procstat/README.md, Procstat Plugin Source
 ---
 
 # Procstat Input Plugin

--- a/content/telegraf/v1/input-plugins/prometheus/_index.md
+++ b/content/telegraf/v1/input-plugins/prometheus/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Prometheus, "input-plugins", "configuration", "applications", "server"]
 introduced: "v0.1.5"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/prometheus/README.md, Prometheus Plugin Source
 ---
 
 # Prometheus Input Plugin

--- a/content/telegraf/v1/input-plugins/promql/_index.md
+++ b/content/telegraf/v1/input-plugins/promql/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [PromQL, "input-plugins", "configuration", "datastore"]
 introduced: "v1.37.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/promql/README.md, PromQL Plugin Source
 ---
 
 # PromQL Input Plugin

--- a/content/telegraf/v1/input-plugins/proxmox/_index.md
+++ b/content/telegraf/v1/input-plugins/proxmox/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Proxmox, "input-plugins", "configuration", "server"]
 introduced: "v1.16.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/proxmox/README.md, Proxmox Plugin Source
 ---
 
 # Proxmox Input Plugin

--- a/content/telegraf/v1/input-plugins/puppetagent/_index.md
+++ b/content/telegraf/v1/input-plugins/puppetagent/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Puppet Agent, "input-plugins", "configuration", "system"]
 introduced: "v0.2.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/puppetagent/README.md, Puppet Agent Plugin Source
 ---
 
 # Puppet Agent Input Plugin

--- a/content/telegraf/v1/input-plugins/rabbitmq/_index.md
+++ b/content/telegraf/v1/input-plugins/rabbitmq/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [RabbitMQ, "input-plugins", "configuration", "server"]
 introduced: "v0.1.5"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/rabbitmq/README.md, RabbitMQ Plugin Source
 ---
 
 # RabbitMQ Input Plugin

--- a/content/telegraf/v1/input-plugins/radius/_index.md
+++ b/content/telegraf/v1/input-plugins/radius/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Radius, "input-plugins", "configuration", "server"]
 introduced: "v1.26.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/radius/README.md, Radius Plugin Source
 ---
 
 # Radius Input Plugin

--- a/content/telegraf/v1/input-plugins/raindrops/_index.md
+++ b/content/telegraf/v1/input-plugins/raindrops/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Raindrops Middleware, "input-plugins", "configuration", "server"]
 introduced: "v0.10.3"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/raindrops/README.md, Raindrops Middleware Plugin Source
 ---
 
 # Raindrops Middleware Input Plugin

--- a/content/telegraf/v1/input-plugins/ras/_index.md
+++ b/content/telegraf/v1/input-plugins/ras/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [RAS Daemon, "input-plugins", "configuration", "server"]
 introduced: "v1.16.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/ras/README.md, RAS Daemon Plugin Source
 ---
 
 # RAS Daemon Input Plugin

--- a/content/telegraf/v1/input-plugins/ravendb/_index.md
+++ b/content/telegraf/v1/input-plugins/ravendb/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [RavenDB, "input-plugins", "configuration", "server"]
 introduced: "v1.18.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/ravendb/README.md, RavenDB Plugin Source
 ---
 
 # RavenDB Input Plugin

--- a/content/telegraf/v1/input-plugins/redfish/_index.md
+++ b/content/telegraf/v1/input-plugins/redfish/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Redfish, "input-plugins", "configuration", "server"]
 introduced: "v1.15.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/redfish/README.md, Redfish Plugin Source
 ---
 
 # Redfish Input Plugin

--- a/content/telegraf/v1/input-plugins/redis/_index.md
+++ b/content/telegraf/v1/input-plugins/redis/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Redis, "input-plugins", "configuration", "server"]
 introduced: "v0.1.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/redis/README.md, Redis Plugin Source
 ---
 
 # Redis Input Plugin

--- a/content/telegraf/v1/input-plugins/redis_sentinel/_index.md
+++ b/content/telegraf/v1/input-plugins/redis_sentinel/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Redis Sentinel, "input-plugins", "configuration", "server"]
 introduced: "v1.22.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/redis_sentinel/README.md, Redis Sentinel Plugin Source
 ---
 
 # Redis Sentinel Input Plugin

--- a/content/telegraf/v1/input-plugins/rethinkdb/_index.md
+++ b/content/telegraf/v1/input-plugins/rethinkdb/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [RethinkDB, "input-plugins", "configuration", "server"]
 introduced: "v0.1.3"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/rethinkdb/README.md, RethinkDB Plugin Source
 ---
 
 # RethinkDB Input Plugin

--- a/content/telegraf/v1/input-plugins/riak/_index.md
+++ b/content/telegraf/v1/input-plugins/riak/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Riak, "input-plugins", "configuration", "server"]
 introduced: "v0.10.4"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/riak/README.md, Riak Plugin Source
 ---
 
 # Riak Input Plugin

--- a/content/telegraf/v1/input-plugins/riemann_listener/_index.md
+++ b/content/telegraf/v1/input-plugins/riemann_listener/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Riemann Listener, "input-plugins", "configuration", "datastore"]
 introduced: "v1.17.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/riemann_listener/README.md, Riemann Listener Plugin Source
 ---
 
 # Riemann Listener Input Plugin

--- a/content/telegraf/v1/input-plugins/s7comm/_index.md
+++ b/content/telegraf/v1/input-plugins/s7comm/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Siemens S7, "input-plugins", "configuration", "hardware"]
 introduced: "v1.28.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/s7comm/README.md, Siemens S7 Plugin Source
 ---
 
 # Siemens S7 Input Plugin

--- a/content/telegraf/v1/input-plugins/salesforce/_index.md
+++ b/content/telegraf/v1/input-plugins/salesforce/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Salesforce, "input-plugins", "configuration", "cloud", "server"]
 introduced: "v1.4.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/salesforce/README.md, Salesforce Plugin Source
 ---
 
 # Salesforce Input Plugin

--- a/content/telegraf/v1/input-plugins/sensors/_index.md
+++ b/content/telegraf/v1/input-plugins/sensors/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [LM Sensors, "input-plugins", "configuration", "hardware", "system"]
 introduced: "v0.10.1"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/sensors/README.md, LM Sensors Plugin Source
 ---
 
 # LM Sensors Input Plugin

--- a/content/telegraf/v1/input-plugins/sflow/_index.md
+++ b/content/telegraf/v1/input-plugins/sflow/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [SFlow, "input-plugins", "configuration", "network"]
 introduced: "v1.14.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/sflow/README.md, SFlow Plugin Source
 ---
 
 # SFlow Input Plugin

--- a/content/telegraf/v1/input-plugins/sip/_index.md
+++ b/content/telegraf/v1/input-plugins/sip/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [SIP, "input-plugins", "configuration", "network"]
 introduced: "v1.38.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/sip/README.md, SIP Plugin Source
 ---
 
 # SIP Input Plugin

--- a/content/telegraf/v1/input-plugins/slab/_index.md
+++ b/content/telegraf/v1/input-plugins/slab/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Slab, "input-plugins", "configuration", "system"]
 introduced: "v1.23.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/slab/README.md, Slab Plugin Source
 ---
 
 # Slab Input Plugin

--- a/content/telegraf/v1/input-plugins/slurm/_index.md
+++ b/content/telegraf/v1/input-plugins/slurm/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [SLURM, "input-plugins", "configuration", "server"]
 introduced: "v1.32.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/slurm/README.md, SLURM Plugin Source
 ---
 
 # SLURM Input Plugin

--- a/content/telegraf/v1/input-plugins/smart/_index.md
+++ b/content/telegraf/v1/input-plugins/smart/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [S.M.A.R.T., "input-plugins", "configuration", "hardware", "system"]
 introduced: "v1.5.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/smart/README.md, S.M.A.R.T. Plugin Source
 ---
 
 # S.M.A.R.T. Input Plugin

--- a/content/telegraf/v1/input-plugins/smartctl/_index.md
+++ b/content/telegraf/v1/input-plugins/smartctl/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [smartctl JSON, "input-plugins", "configuration", "hardware", "system"]
 introduced: "v1.31.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/smartctl/README.md, smartctl JSON Plugin Source
 ---
 
 # smartctl JSON Input Plugin

--- a/content/telegraf/v1/input-plugins/snmp/_index.md
+++ b/content/telegraf/v1/input-plugins/snmp/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [SNMP, "input-plugins", "configuration", "hardware", "network"]
 introduced: "v0.10.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/snmp/README.md, SNMP Plugin Source
 ---
 
 # SNMP Input Plugin

--- a/content/telegraf/v1/input-plugins/snmp_trap/_index.md
+++ b/content/telegraf/v1/input-plugins/snmp_trap/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [SNMP Trap, "input-plugins", "configuration", "hardware", "network"]
 introduced: "v1.13.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/snmp_trap/README.md, SNMP Trap Plugin Source
 ---
 
 # SNMP Trap Input Plugin

--- a/content/telegraf/v1/input-plugins/socket_listener/_index.md
+++ b/content/telegraf/v1/input-plugins/socket_listener/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Socket Listener, "input-plugins", "configuration", "network"]
 introduced: "v1.3.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/socket_listener/README.md, Socket Listener Plugin Source
 ---
 
 # Socket Listener Input Plugin

--- a/content/telegraf/v1/input-plugins/socketstat/_index.md
+++ b/content/telegraf/v1/input-plugins/socketstat/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Socket Statistics, "input-plugins", "configuration", "network"]
 introduced: "v1.22.0"
 os_support: "freebsd, linux, macos"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/socketstat/README.md, Socket Statistics Plugin Source
 ---
 
 # Socket Statistics Input Plugin

--- a/content/telegraf/v1/input-plugins/solr/_index.md
+++ b/content/telegraf/v1/input-plugins/solr/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Apache Solr, "input-plugins", "configuration", "server"]
 introduced: "v1.5.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/solr/README.md, Apache Solr Plugin Source
 ---
 
 # Apache Solr Input Plugin

--- a/content/telegraf/v1/input-plugins/sql/_index.md
+++ b/content/telegraf/v1/input-plugins/sql/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [SQL, "input-plugins", "configuration", "datastore"]
 introduced: "v1.19.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/sql/README.md, SQL Plugin Source
 ---
 
 # SQL Input Plugin

--- a/content/telegraf/v1/input-plugins/sqlserver/_index.md
+++ b/content/telegraf/v1/input-plugins/sqlserver/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Microsoft SQL Server, "input-plugins", "configuration", "datastore"]
 introduced: "v0.10.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/sqlserver/README.md, Microsoft SQL Server Plugin Source
 ---
 
 # Microsoft SQL Server Input Plugin

--- a/content/telegraf/v1/input-plugins/stackdriver/_index.md
+++ b/content/telegraf/v1/input-plugins/stackdriver/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Stackdriver Google Cloud Monitoring, "input-plugins", "configuration", "cloud"]
 introduced: "v1.10.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/stackdriver/README.md, Stackdriver Google Cloud Monitoring Plugin Source
 ---
 
 # Stackdriver Google Cloud Monitoring Input Plugin

--- a/content/telegraf/v1/input-plugins/statsd/_index.md
+++ b/content/telegraf/v1/input-plugins/statsd/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [StatsD, "input-plugins", "configuration", "applications"]
 introduced: "v0.2.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/statsd/README.md, StatsD Plugin Source
 ---
 
 # StatsD Input Plugin

--- a/content/telegraf/v1/input-plugins/supervisor/_index.md
+++ b/content/telegraf/v1/input-plugins/supervisor/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Supervisor, "input-plugins", "configuration", "applications"]
 introduced: "v1.24.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/supervisor/README.md, Supervisor Plugin Source
 ---
 
 # Supervisor Input Plugin

--- a/content/telegraf/v1/input-plugins/suricata/_index.md
+++ b/content/telegraf/v1/input-plugins/suricata/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Suricata, "input-plugins", "configuration", "applications", "network"]
 introduced: "v1.13.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/suricata/README.md, Suricata Plugin Source
 ---
 
 # Suricata Input Plugin

--- a/content/telegraf/v1/input-plugins/swap/_index.md
+++ b/content/telegraf/v1/input-plugins/swap/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Swap, "input-plugins", "configuration", "system"]
 introduced: "v1.7.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/swap/README.md, Swap Plugin Source
 ---
 
 # Swap Input Plugin

--- a/content/telegraf/v1/input-plugins/synproxy/_index.md
+++ b/content/telegraf/v1/input-plugins/synproxy/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Synproxy, "input-plugins", "configuration", "network"]
 introduced: "v1.13.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/synproxy/README.md, Synproxy Plugin Source
 ---
 
 # Synproxy Input Plugin

--- a/content/telegraf/v1/input-plugins/syslog/_index.md
+++ b/content/telegraf/v1/input-plugins/syslog/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Syslog, "input-plugins", "configuration", "logging"]
 introduced: "v1.7.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/syslog/README.md, Syslog Plugin Source
 ---
 
 # Syslog Input Plugin

--- a/content/telegraf/v1/input-plugins/sysstat/_index.md
+++ b/content/telegraf/v1/input-plugins/sysstat/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [System Performance Statistics, "input-plugins", "configuration", "system"]
 introduced: "v0.12.1"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/sysstat/README.md, System Performance Statistics Plugin Source
 ---
 
 # System Performance Statistics Input Plugin

--- a/content/telegraf/v1/input-plugins/system/_index.md
+++ b/content/telegraf/v1/input-plugins/system/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [System, "input-plugins", "configuration", "system"]
 introduced: "v0.1.6"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/system/README.md, System Plugin Source
 ---
 
 # System Input Plugin

--- a/content/telegraf/v1/input-plugins/systemd_units/_index.md
+++ b/content/telegraf/v1/input-plugins/systemd_units/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Systemd-Units, "input-plugins", "configuration", "system"]
 introduced: "v1.13.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/systemd_units/README.md, Systemd-Units Plugin Source
 ---
 
 # Systemd-Units Input Plugin

--- a/content/telegraf/v1/input-plugins/tacacs/_index.md
+++ b/content/telegraf/v1/input-plugins/tacacs/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Tacacs, "input-plugins", "configuration", "network"]
 introduced: "v1.28.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/tacacs/README.md, Tacacs Plugin Source
 ---
 
 # Tacacs Input Plugin

--- a/content/telegraf/v1/input-plugins/tail/_index.md
+++ b/content/telegraf/v1/input-plugins/tail/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Tail, "input-plugins", "configuration", "logging"]
 introduced: "v1.1.2"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/tail/README.md, Tail Plugin Source
 ---
 
 # Tail Input Plugin

--- a/content/telegraf/v1/input-plugins/teamspeak/_index.md
+++ b/content/telegraf/v1/input-plugins/teamspeak/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Teamspeak, "input-plugins", "configuration", "server"]
 introduced: "v1.5.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/teamspeak/README.md, Teamspeak Plugin Source
 ---
 
 # Teamspeak Input Plugin

--- a/content/telegraf/v1/input-plugins/temp/_index.md
+++ b/content/telegraf/v1/input-plugins/temp/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Temperature, "input-plugins", "configuration", "hardware", "system"]
 introduced: "v1.8.0"
 os_support: "linux, macos, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/temp/README.md, Temperature Plugin Source
 ---
 
 # Temperature Input Plugin

--- a/content/telegraf/v1/input-plugins/tengine/_index.md
+++ b/content/telegraf/v1/input-plugins/tengine/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Tengine Web Server, "input-plugins", "configuration", "server", "web"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/tengine/README.md, Tengine Web Server Plugin Source
 ---
 
 # Tengine Web Server Input Plugin

--- a/content/telegraf/v1/input-plugins/timex/_index.md
+++ b/content/telegraf/v1/input-plugins/timex/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Timex, "input-plugins", "configuration", "hardware", "system"]
 introduced: "v1.37.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/timex/README.md, Timex Plugin Source
 ---
 
 # Timex Input Plugin

--- a/content/telegraf/v1/input-plugins/tomcat/_index.md
+++ b/content/telegraf/v1/input-plugins/tomcat/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Apache Tomcat, "input-plugins", "configuration", "server", "web"]
 introduced: "v1.4.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/tomcat/README.md, Apache Tomcat Plugin Source
 ---
 
 # Apache Tomcat Input Plugin

--- a/content/telegraf/v1/input-plugins/trig/_index.md
+++ b/content/telegraf/v1/input-plugins/trig/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Trig, "input-plugins", "configuration", "testing"]
 introduced: "v0.3.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/trig/README.md, Trig Plugin Source
 ---
 
 # Trig Input Plugin

--- a/content/telegraf/v1/input-plugins/turbostat/_index.md
+++ b/content/telegraf/v1/input-plugins/turbostat/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Turbostat, "input-plugins", "configuration", "hardware", "system"]
 introduced: "v1.36.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/turbostat/README.md, Turbostat Plugin Source
 ---
 
 # Turbostat Input Plugin

--- a/content/telegraf/v1/input-plugins/twemproxy/_index.md
+++ b/content/telegraf/v1/input-plugins/twemproxy/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Twemproxy, "input-plugins", "configuration", "server"]
 introduced: "v0.3.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/twemproxy/README.md, Twemproxy Plugin Source
 ---
 
 # Twemproxy Input Plugin

--- a/content/telegraf/v1/input-plugins/unbound/_index.md
+++ b/content/telegraf/v1/input-plugins/unbound/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Unbound, "input-plugins", "configuration", "network", "server"]
 introduced: "v1.5.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/unbound/README.md, Unbound Plugin Source
 ---
 
 # Unbound Input Plugin

--- a/content/telegraf/v1/input-plugins/upsd/_index.md
+++ b/content/telegraf/v1/input-plugins/upsd/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [UPSD, "input-plugins", "configuration", "hardware", "server"]
 introduced: "v1.24.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/upsd/README.md, UPSD Plugin Source
 ---
 
 # UPSD Input Plugin

--- a/content/telegraf/v1/input-plugins/uwsgi/_index.md
+++ b/content/telegraf/v1/input-plugins/uwsgi/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [uWSGI, "input-plugins", "configuration", "cloud"]
 introduced: "v1.12.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/uwsgi/README.md, uWSGI Plugin Source
 ---
 
 # uWSGI Input Plugin

--- a/content/telegraf/v1/input-plugins/varnish/_index.md
+++ b/content/telegraf/v1/input-plugins/varnish/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Varnish, "input-plugins", "configuration", "server", "web"]
 introduced: "v0.13.1"
 os_support: "freebsd, linux, macos"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/varnish/README.md, Varnish Plugin Source
 ---
 
 # Varnish Input Plugin

--- a/content/telegraf/v1/input-plugins/vault/_index.md
+++ b/content/telegraf/v1/input-plugins/vault/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Hashicorp Vault, "input-plugins", "configuration", "server"]
 introduced: "v1.22.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/vault/README.md, Hashicorp Vault Plugin Source
 ---
 
 # Hashicorp Vault Input Plugin

--- a/content/telegraf/v1/input-plugins/vsphere/_index.md
+++ b/content/telegraf/v1/input-plugins/vsphere/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [VMware vSphere, "input-plugins", "configuration", "containers"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/vsphere/README.md, VMware vSphere Plugin Source
 ---
 
 # VMware vSphere Input Plugin

--- a/content/telegraf/v1/input-plugins/webhooks/_index.md
+++ b/content/telegraf/v1/input-plugins/webhooks/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Webhooks, "input-plugins", "configuration", "applications", "web"]
 introduced: "v1.0.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/webhooks/README.md, Webhooks Plugin Source
 ---
 
 # Webhooks Input Plugin

--- a/content/telegraf/v1/input-plugins/whois/_index.md
+++ b/content/telegraf/v1/input-plugins/whois/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [WHOIS, "input-plugins", "configuration", "network", "web"]
 introduced: "v1.35.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/whois/README.md, WHOIS Plugin Source
 ---
 
 # WHOIS Input Plugin

--- a/content/telegraf/v1/input-plugins/win_eventlog/_index.md
+++ b/content/telegraf/v1/input-plugins/win_eventlog/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Windows Eventlog, "input-plugins", "configuration", "logging"]
 introduced: "v1.16.0"
 os_support: "windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/win_eventlog/README.md, Windows Eventlog Plugin Source
 ---
 
 # Windows Eventlog Input Plugin

--- a/content/telegraf/v1/input-plugins/win_perf_counters/_index.md
+++ b/content/telegraf/v1/input-plugins/win_perf_counters/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Windows Performance Counters, "input-plugins", "configuration", "system"]
 introduced: "v0.10.2"
 os_support: "windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/win_perf_counters/README.md, Windows Performance Counters Plugin Source
 ---
 
 # Windows Performance Counters Input Plugin

--- a/content/telegraf/v1/input-plugins/win_services/_index.md
+++ b/content/telegraf/v1/input-plugins/win_services/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Windows Services, "input-plugins", "configuration", "system"]
 introduced: "v1.4.0"
 os_support: "windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/win_services/README.md, Windows Services Plugin Source
 ---
 
 # Windows Services Input Plugin

--- a/content/telegraf/v1/input-plugins/win_wmi/_index.md
+++ b/content/telegraf/v1/input-plugins/win_wmi/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Windows Management Instrumentation, "input-plugins", "configuration", "system"]
 introduced: "v1.26.0"
 os_support: "windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/win_wmi/README.md, Windows Management Instrumentation Plugin Source
 ---
 
 # Windows Management Instrumentation Input Plugin

--- a/content/telegraf/v1/input-plugins/wireguard/_index.md
+++ b/content/telegraf/v1/input-plugins/wireguard/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Wireguard, "input-plugins", "configuration", "network"]
 introduced: "v1.14.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/wireguard/README.md, Wireguard Plugin Source
 ---
 
 # Wireguard Input Plugin

--- a/content/telegraf/v1/input-plugins/wireless/_index.md
+++ b/content/telegraf/v1/input-plugins/wireless/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Wireless, "input-plugins", "configuration", "network"]
 introduced: "v1.9.0"
 os_support: "linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/wireless/README.md, Wireless Plugin Source
 ---
 
 # Wireless Input Plugin

--- a/content/telegraf/v1/input-plugins/x509_cert/_index.md
+++ b/content/telegraf/v1/input-plugins/x509_cert/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [x509 Certificate, "input-plugins", "configuration", "network"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/x509_cert/README.md, x509 Certificate Plugin Source
 ---
 
 # x509 Certificate Input Plugin

--- a/content/telegraf/v1/input-plugins/xtremio/_index.md
+++ b/content/telegraf/v1/input-plugins/xtremio/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Dell EMC XtremIO, "input-plugins", "configuration", "network"]
 introduced: "v1.22.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/xtremio/README.md, Dell EMC XtremIO Plugin Source
 ---
 
 # Dell EMC XtremIO Input Plugin

--- a/content/telegraf/v1/input-plugins/zfs/_index.md
+++ b/content/telegraf/v1/input-plugins/zfs/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [ZFS, "input-plugins", "configuration", "system"]
 introduced: "v0.2.1"
 os_support: "freebsd, linux"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/zfs/README.md, ZFS Plugin Source
 ---
 
 # ZFS Input Plugin

--- a/content/telegraf/v1/input-plugins/zipkin/_index.md
+++ b/content/telegraf/v1/input-plugins/zipkin/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Zipkin, "input-plugins", "configuration", "cloud"]
 introduced: "v1.4.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/zipkin/README.md, Zipkin Plugin Source
 ---
 
 # Zipkin Input Plugin

--- a/content/telegraf/v1/input-plugins/zookeeper/_index.md
+++ b/content/telegraf/v1/input-plugins/zookeeper/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Apache Zookeeper, "input-plugins", "configuration", "applications"]
 introduced: "v0.2.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/inputs/zookeeper/README.md, Apache Zookeeper Plugin Source
 ---
 
 # Apache Zookeeper Input Plugin

--- a/content/telegraf/v1/output-plugins/amon/_index.md
+++ b/content/telegraf/v1/output-plugins/amon/_index.md
@@ -10,9 +10,6 @@ introduced: "v0.2.1"
 deprecated: v1.37.0
 removal: v1.40.0
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/amon/README.md, Amon Plugin Source
 ---
 
 # Amon Output Plugin

--- a/content/telegraf/v1/output-plugins/amqp/_index.md
+++ b/content/telegraf/v1/output-plugins/amqp/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [AMQP, "output-plugins", "configuration", "messaging"]
 introduced: "v0.1.9"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/amqp/README.md, AMQP Plugin Source
 ---
 
 # AMQP Output Plugin

--- a/content/telegraf/v1/output-plugins/application_insights/_index.md
+++ b/content/telegraf/v1/output-plugins/application_insights/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Azure Application Insights, "output-plugins", "configuration", "applications", "cloud"]
 introduced: "v1.7.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/application_insights/README.md, Azure Application Insights Plugin Source
 ---
 
 # Azure Application Insights Output Plugin

--- a/content/telegraf/v1/output-plugins/arc/_index.md
+++ b/content/telegraf/v1/output-plugins/arc/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Arc, "output-plugins", "configuration", "datastore"]
 introduced: "v1.37.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/arc/README.md, Arc Plugin Source
 ---
 
 # Arc Output Plugin

--- a/content/telegraf/v1/output-plugins/azure_data_explorer/_index.md
+++ b/content/telegraf/v1/output-plugins/azure_data_explorer/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Azure Data Explorer, "output-plugins", "configuration", "cloud", "datastore"]
 introduced: "v1.20.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/azure_data_explorer/README.md, Azure Data Explorer Plugin Source
 ---
 
 # Azure Data Explorer Output Plugin

--- a/content/telegraf/v1/output-plugins/azure_monitor/_index.md
+++ b/content/telegraf/v1/output-plugins/azure_monitor/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Azure Monitor, "output-plugins", "configuration", "cloud", "datastore"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/azure_monitor/README.md, Azure Monitor Plugin Source
 ---
 
 # Azure Monitor Output Plugin

--- a/content/telegraf/v1/output-plugins/bigquery/_index.md
+++ b/content/telegraf/v1/output-plugins/bigquery/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Google BigQuery, "output-plugins", "configuration", "cloud", "datastore"]
 introduced: "v1.18.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/bigquery/README.md, Google BigQuery Plugin Source
 ---
 
 # Google BigQuery Output Plugin

--- a/content/telegraf/v1/output-plugins/clarify/_index.md
+++ b/content/telegraf/v1/output-plugins/clarify/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Clarify, "output-plugins", "configuration", "cloud", "datastore"]
 introduced: "v1.27.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/clarify/README.md, Clarify Plugin Source
 ---
 
 # Clarify Output Plugin

--- a/content/telegraf/v1/output-plugins/cloud_pubsub/_index.md
+++ b/content/telegraf/v1/output-plugins/cloud_pubsub/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Google Cloud PubSub, "output-plugins", "configuration", "cloud", "messaging"]
 introduced: "v1.10.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/cloud_pubsub/README.md, Google Cloud PubSub Plugin Source
 ---
 
 # Google Cloud PubSub Output Plugin

--- a/content/telegraf/v1/output-plugins/cloudwatch/_index.md
+++ b/content/telegraf/v1/output-plugins/cloudwatch/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Amazon CloudWatch, "output-plugins", "configuration", "cloud"]
 introduced: "v0.10.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/cloudwatch/README.md, Amazon CloudWatch Plugin Source
 ---
 
 # Amazon CloudWatch Output Plugin

--- a/content/telegraf/v1/output-plugins/cloudwatch_logs/_index.md
+++ b/content/telegraf/v1/output-plugins/cloudwatch_logs/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Amazon CloudWatch Logs, "output-plugins", "configuration", "cloud", "logging"]
 introduced: "v1.19.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/cloudwatch_logs/README.md, Amazon CloudWatch Logs Plugin Source
 ---
 
 # Amazon CloudWatch Logs Output Plugin

--- a/content/telegraf/v1/output-plugins/cratedb/_index.md
+++ b/content/telegraf/v1/output-plugins/cratedb/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [CrateDB, "output-plugins", "configuration", "cloud", "datastore"]
 introduced: "v1.5.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/cratedb/README.md, CrateDB Plugin Source
 ---
 
 # CrateDB Output Plugin

--- a/content/telegraf/v1/output-plugins/datadog/_index.md
+++ b/content/telegraf/v1/output-plugins/datadog/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Datadog, "output-plugins", "configuration", "applications", "cloud", "datastore"]
 introduced: "v0.1.6"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/datadog/README.md, Datadog Plugin Source
 ---
 
 # Datadog Output Plugin

--- a/content/telegraf/v1/output-plugins/discard/_index.md
+++ b/content/telegraf/v1/output-plugins/discard/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Discard, "output-plugins", "configuration", "testing"]
 introduced: "v1.2.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/discard/README.md, Discard Plugin Source
 ---
 
 # Discard Output Plugin

--- a/content/telegraf/v1/output-plugins/dynatrace/_index.md
+++ b/content/telegraf/v1/output-plugins/dynatrace/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Dynatrace, "output-plugins", "configuration", "cloud", "datastore"]
 introduced: "v1.16.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/dynatrace/README.md, Dynatrace Plugin Source
 ---
 
 # Dynatrace Output Plugin

--- a/content/telegraf/v1/output-plugins/elasticsearch/_index.md
+++ b/content/telegraf/v1/output-plugins/elasticsearch/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Elasticsearch, "output-plugins", "configuration", "datastore", "logging"]
 introduced: "v0.1.5"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/elasticsearch/README.md, Elasticsearch Plugin Source
 ---
 
 # Elasticsearch Output Plugin

--- a/content/telegraf/v1/output-plugins/event_hubs/_index.md
+++ b/content/telegraf/v1/output-plugins/event_hubs/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Azure Event Hubs, "output-plugins", "configuration", "cloud", "datastore"]
 introduced: "v1.21.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/event_hubs/README.md, Azure Event Hubs Plugin Source
 ---
 
 # Azure Event Hubs Output Plugin

--- a/content/telegraf/v1/output-plugins/exec/_index.md
+++ b/content/telegraf/v1/output-plugins/exec/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Executable, "output-plugins", "configuration", "system"]
 introduced: "v1.12.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/exec/README.md, Executable Plugin Source
 ---
 
 # Executable Output Plugin

--- a/content/telegraf/v1/output-plugins/execd/_index.md
+++ b/content/telegraf/v1/output-plugins/execd/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Executable Daemon, "output-plugins", "configuration", "system"]
 introduced: "v1.15.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/execd/README.md, Executable Daemon Plugin Source
 ---
 
 # Executable Daemon Output Plugin

--- a/content/telegraf/v1/output-plugins/file/_index.md
+++ b/content/telegraf/v1/output-plugins/file/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [File, "output-plugins", "configuration", "system"]
 introduced: "v0.10.3"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/file/README.md, File Plugin Source
 ---
 
 # File Output Plugin

--- a/content/telegraf/v1/output-plugins/graphite/_index.md
+++ b/content/telegraf/v1/output-plugins/graphite/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Graphite, "output-plugins", "configuration", "datastore"]
 introduced: "v0.10.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/graphite/README.md, Graphite Plugin Source
 ---
 
 # Graphite Output Plugin

--- a/content/telegraf/v1/output-plugins/graylog/_index.md
+++ b/content/telegraf/v1/output-plugins/graylog/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Graylog, "output-plugins", "configuration", "datastore", "logging"]
 introduced: "v1.0.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/graylog/README.md, Graylog Plugin Source
 ---
 
 # Graylog Output Plugin

--- a/content/telegraf/v1/output-plugins/groundwork/_index.md
+++ b/content/telegraf/v1/output-plugins/groundwork/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [GroundWork, "output-plugins", "configuration", "applications", "messaging"]
 introduced: "v1.21.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/groundwork/README.md, GroundWork Plugin Source
 ---
 
 # GroundWork Output Plugin

--- a/content/telegraf/v1/output-plugins/health/_index.md
+++ b/content/telegraf/v1/output-plugins/health/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Health, "output-plugins", "configuration", "applications"]
 introduced: "v1.11.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/health/README.md, Health Plugin Source
 ---
 
 # Health Output Plugin

--- a/content/telegraf/v1/output-plugins/heartbeat/_index.md
+++ b/content/telegraf/v1/output-plugins/heartbeat/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Heartbeat, "output-plugins", "configuration", "applications"]
 introduced: "v1.37.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/heartbeat/README.md, Heartbeat Plugin Source
 ---
 
 # Heartbeat Output Plugin

--- a/content/telegraf/v1/output-plugins/http/_index.md
+++ b/content/telegraf/v1/output-plugins/http/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [HTTP, "output-plugins", "configuration", "applications"]
 introduced: "v1.7.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/http/README.md, HTTP Plugin Source
 ---
 
 # HTTP Output Plugin

--- a/content/telegraf/v1/output-plugins/influxdb/_index.md
+++ b/content/telegraf/v1/output-plugins/influxdb/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [InfluxDB v1.x, "output-plugins", "configuration", "datastore"]
 introduced: "v0.1.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/influxdb/README.md, InfluxDB v1.x Plugin Source
 ---
 
 # InfluxDB v1.x Output Plugin

--- a/content/telegraf/v1/output-plugins/influxdb_v2/_index.md
+++ b/content/telegraf/v1/output-plugins/influxdb_v2/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [InfluxDB v2.x, "output-plugins", "configuration", "datastore"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/influxdb_v2/README.md, InfluxDB v2.x Plugin Source
 ---
 
 # InfluxDB v2.x Output Plugin

--- a/content/telegraf/v1/output-plugins/influxdb_v3/_index.md
+++ b/content/telegraf/v1/output-plugins/influxdb_v3/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [InfluxDB v3.x, "output-plugins", "configuration", "datastore"]
 introduced: "v1.38.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/influxdb_v3/README.md, InfluxDB v3.x Plugin Source
 ---
 
 # InfluxDB v3.x Output Plugin

--- a/content/telegraf/v1/output-plugins/inlong/_index.md
+++ b/content/telegraf/v1/output-plugins/inlong/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Inlong, "output-plugins", "configuration", "messaging"]
 introduced: "v1.35.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/inlong/README.md, Inlong Plugin Source
 ---
 
 # Inlong Output Plugin

--- a/content/telegraf/v1/output-plugins/instrumental/_index.md
+++ b/content/telegraf/v1/output-plugins/instrumental/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Instrumental, "output-plugins", "configuration", "applications"]
 introduced: "v0.13.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/instrumental/README.md, Instrumental Plugin Source
 ---
 
 # Instrumental Output Plugin

--- a/content/telegraf/v1/output-plugins/iotdb/_index.md
+++ b/content/telegraf/v1/output-plugins/iotdb/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Apache IoTDB, "output-plugins", "configuration", "datastore"]
 introduced: "v1.24.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/iotdb/README.md, Apache IoTDB Plugin Source
 ---
 
 # Apache IoTDB Output Plugin

--- a/content/telegraf/v1/output-plugins/kafka/_index.md
+++ b/content/telegraf/v1/output-plugins/kafka/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Kafka, "output-plugins", "configuration", "messaging"]
 introduced: "v0.1.7"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/kafka/README.md, Kafka Plugin Source
 ---
 
 # Kafka Output Plugin

--- a/content/telegraf/v1/output-plugins/kinesis/_index.md
+++ b/content/telegraf/v1/output-plugins/kinesis/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Amazon Kinesis, "output-plugins", "configuration", "cloud", "messaging"]
 introduced: "v0.2.5"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/kinesis/README.md, Amazon Kinesis Plugin Source
 ---
 
 # Amazon Kinesis Output Plugin

--- a/content/telegraf/v1/output-plugins/librato/_index.md
+++ b/content/telegraf/v1/output-plugins/librato/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Librato, "output-plugins", "configuration", "cloud", "datastore"]
 introduced: "v0.2.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/librato/README.md, Librato Plugin Source
 ---
 
 # Librato Output Plugin

--- a/content/telegraf/v1/output-plugins/logzio/_index.md
+++ b/content/telegraf/v1/output-plugins/logzio/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Logz.io, "output-plugins", "configuration", "cloud", "datastore"]
 introduced: "v1.17.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/logzio/README.md, Logz.io Plugin Source
 ---
 
 # Logz.io Output Plugin

--- a/content/telegraf/v1/output-plugins/loki/_index.md
+++ b/content/telegraf/v1/output-plugins/loki/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Grafana Loki, "output-plugins", "configuration", "logging"]
 introduced: "v1.18.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/loki/README.md, Grafana Loki Plugin Source
 ---
 
 # Grafana Loki Output Plugin

--- a/content/telegraf/v1/output-plugins/microsoft_fabric/_index.md
+++ b/content/telegraf/v1/output-plugins/microsoft_fabric/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Microsoft Fabric, "output-plugins", "configuration", "datastore"]
 introduced: "v1.35.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/microsoft_fabric/README.md, Microsoft Fabric Plugin Source
 ---
 
 # Microsoft Fabric Output Plugin

--- a/content/telegraf/v1/output-plugins/mongodb/_index.md
+++ b/content/telegraf/v1/output-plugins/mongodb/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [MongoDB, "output-plugins", "configuration", "datastore"]
 introduced: "v1.21.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/mongodb/README.md, MongoDB Plugin Source
 ---
 
 # MongoDB Output Plugin

--- a/content/telegraf/v1/output-plugins/mqtt/_index.md
+++ b/content/telegraf/v1/output-plugins/mqtt/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [MQTT Producer, "output-plugins", "configuration", "messaging"]
 introduced: "v0.2.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/mqtt/README.md, MQTT Producer Plugin Source
 ---
 
 # MQTT Producer Output Plugin

--- a/content/telegraf/v1/output-plugins/nats/_index.md
+++ b/content/telegraf/v1/output-plugins/nats/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [NATS, "output-plugins", "configuration", "messaging"]
 introduced: "v1.1.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/nats/README.md, NATS Plugin Source
 ---
 
 # NATS Output Plugin

--- a/content/telegraf/v1/output-plugins/nebius_cloud_monitoring/_index.md
+++ b/content/telegraf/v1/output-plugins/nebius_cloud_monitoring/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Nebius Cloud Monitoring, "output-plugins", "configuration", "cloud", "datastore"]
 introduced: "v1.27.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/nebius_cloud_monitoring/README.md, Nebius Cloud Monitoring Plugin Source
 ---
 
 # Nebius Cloud Monitoring Output Plugin

--- a/content/telegraf/v1/output-plugins/newrelic/_index.md
+++ b/content/telegraf/v1/output-plugins/newrelic/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [New Relic, "output-plugins", "configuration", "applications"]
 introduced: "v1.15.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/newrelic/README.md, New Relic Plugin Source
 ---
 
 # New Relic Output Plugin

--- a/content/telegraf/v1/output-plugins/nsq/_index.md
+++ b/content/telegraf/v1/output-plugins/nsq/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [NSQ, "output-plugins", "configuration", "messaging"]
 introduced: "v0.2.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/nsq/README.md, NSQ Plugin Source
 ---
 
 # NSQ Output Plugin

--- a/content/telegraf/v1/output-plugins/opensearch/_index.md
+++ b/content/telegraf/v1/output-plugins/opensearch/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [OpenSearch, "output-plugins", "configuration", "datastore", "logging"]
 introduced: "v1.29.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/opensearch/README.md, OpenSearch Plugin Source
 ---
 
 # OpenSearch Output Plugin

--- a/content/telegraf/v1/output-plugins/opentelemetry/_index.md
+++ b/content/telegraf/v1/output-plugins/opentelemetry/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [OpenTelemetry, "output-plugins", "configuration", "logging", "messaging"]
 introduced: "v1.20.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/opentelemetry/README.md, OpenTelemetry Plugin Source
 ---
 
 # OpenTelemetry Output Plugin

--- a/content/telegraf/v1/output-plugins/opentsdb/_index.md
+++ b/content/telegraf/v1/output-plugins/opentsdb/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [OpenTSDB, "output-plugins", "configuration", "datastore"]
 introduced: "v0.1.9"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/opentsdb/README.md, OpenTSDB Plugin Source
 ---
 
 # OpenTSDB Output Plugin

--- a/content/telegraf/v1/output-plugins/parquet/_index.md
+++ b/content/telegraf/v1/output-plugins/parquet/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Parquet, "output-plugins", "configuration", "datastore"]
 introduced: "v1.32.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/parquet/README.md, Parquet Plugin Source
 ---
 
 # Parquet Output Plugin

--- a/content/telegraf/v1/output-plugins/postgresql/_index.md
+++ b/content/telegraf/v1/output-plugins/postgresql/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [PostgreSQL, "output-plugins", "configuration", "datastore"]
 introduced: "v1.24.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/postgresql/README.md, PostgreSQL Plugin Source
 ---
 
 # PostgreSQL Output Plugin

--- a/content/telegraf/v1/output-plugins/prometheus_client/_index.md
+++ b/content/telegraf/v1/output-plugins/prometheus_client/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Prometheus, "output-plugins", "configuration", "applications"]
 introduced: "v0.2.1"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/prometheus_client/README.md, Prometheus Plugin Source
 ---
 
 # Prometheus Output Plugin

--- a/content/telegraf/v1/output-plugins/quix/_index.md
+++ b/content/telegraf/v1/output-plugins/quix/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Quix, "output-plugins", "configuration", "cloud", "messaging"]
 introduced: "v1.33.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/quix/README.md, Quix Plugin Source
 ---
 
 # Quix Output Plugin

--- a/content/telegraf/v1/output-plugins/redistimeseries/_index.md
+++ b/content/telegraf/v1/output-plugins/redistimeseries/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Redis Time Series, "output-plugins", "configuration", "datastore"]
 introduced: "v1.0.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/redistimeseries/README.md, Redis Time Series Plugin Source
 ---
 
 # Redis Time Series Output Plugin

--- a/content/telegraf/v1/output-plugins/remotefile/_index.md
+++ b/content/telegraf/v1/output-plugins/remotefile/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Remote File, "output-plugins", "configuration", "datastore"]
 introduced: "v1.32.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/remotefile/README.md, Remote File Plugin Source
 ---
 
 # Remote File Output Plugin

--- a/content/telegraf/v1/output-plugins/riemann/_index.md
+++ b/content/telegraf/v1/output-plugins/riemann/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Riemann, "output-plugins", "configuration", "datastore"]
 introduced: "v1.3.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/riemann/README.md, Riemann Plugin Source
 ---
 
 # Riemann Output Plugin

--- a/content/telegraf/v1/output-plugins/sensu/_index.md
+++ b/content/telegraf/v1/output-plugins/sensu/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Sensu Go, "output-plugins", "configuration", "applications"]
 introduced: "v1.18.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/sensu/README.md, Sensu Go Plugin Source
 ---
 
 # Sensu Go Output Plugin

--- a/content/telegraf/v1/output-plugins/signalfx/_index.md
+++ b/content/telegraf/v1/output-plugins/signalfx/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [SignalFx, "output-plugins", "configuration", "applications"]
 introduced: "v1.18.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/signalfx/README.md, SignalFx Plugin Source
 ---
 
 # SignalFx Output Plugin

--- a/content/telegraf/v1/output-plugins/socket_writer/_index.md
+++ b/content/telegraf/v1/output-plugins/socket_writer/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Socket Writer, "output-plugins", "configuration", "applications", "network"]
 introduced: "v1.3.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/socket_writer/README.md, Socket Writer Plugin Source
 ---
 
 # Socket Writer Output Plugin

--- a/content/telegraf/v1/output-plugins/sql/_index.md
+++ b/content/telegraf/v1/output-plugins/sql/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [SQL, "output-plugins", "configuration", "datastore"]
 introduced: "v1.19.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/sql/README.md, SQL Plugin Source
 ---
 
 # SQL Output Plugin

--- a/content/telegraf/v1/output-plugins/stackdriver/_index.md
+++ b/content/telegraf/v1/output-plugins/stackdriver/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Google Cloud Monitoring, "output-plugins", "configuration", "cloud", "datastore"]
 introduced: "v1.9.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/stackdriver/README.md, Google Cloud Monitoring Plugin Source
 ---
 
 # Google Cloud Monitoring Output Plugin

--- a/content/telegraf/v1/output-plugins/stomp/_index.md
+++ b/content/telegraf/v1/output-plugins/stomp/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [ActiveMQ STOMP, "output-plugins", "configuration", "messaging"]
 introduced: "v1.24.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/stomp/README.md, ActiveMQ STOMP Plugin Source
 ---
 
 # ActiveMQ STOMP Output Plugin

--- a/content/telegraf/v1/output-plugins/sumologic/_index.md
+++ b/content/telegraf/v1/output-plugins/sumologic/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Sumo Logic, "output-plugins", "configuration", "logging"]
 introduced: "v1.16.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/sumologic/README.md, Sumo Logic Plugin Source
 ---
 
 # Sumo Logic Output Plugin

--- a/content/telegraf/v1/output-plugins/syslog/_index.md
+++ b/content/telegraf/v1/output-plugins/syslog/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Syslog, "output-plugins", "configuration", "logging"]
 introduced: "v1.11.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/syslog/README.md, Syslog Plugin Source
 ---
 
 # Syslog Output Plugin

--- a/content/telegraf/v1/output-plugins/timestream/_index.md
+++ b/content/telegraf/v1/output-plugins/timestream/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Amazon Timestream, "output-plugins", "configuration", "cloud", "datastore"]
 introduced: "v1.16.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/timestream/README.md, Amazon Timestream Plugin Source
 ---
 
 # Amazon Timestream Output Plugin

--- a/content/telegraf/v1/output-plugins/warp10/_index.md
+++ b/content/telegraf/v1/output-plugins/warp10/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Warp10, "output-plugins", "configuration", "cloud", "datastore"]
 introduced: "v1.14.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/warp10/README.md, Warp10 Plugin Source
 ---
 
 # Warp10 Output Plugin

--- a/content/telegraf/v1/output-plugins/wavefront/_index.md
+++ b/content/telegraf/v1/output-plugins/wavefront/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Wavefront, "output-plugins", "configuration", "applications", "cloud"]
 introduced: "v1.5.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/wavefront/README.md, Wavefront Plugin Source
 ---
 
 # Wavefront Output Plugin

--- a/content/telegraf/v1/output-plugins/websocket/_index.md
+++ b/content/telegraf/v1/output-plugins/websocket/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Websocket, "output-plugins", "configuration", "applications", "web"]
 introduced: "v1.19.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/websocket/README.md, Websocket Plugin Source
 ---
 
 # Websocket Output Plugin

--- a/content/telegraf/v1/output-plugins/yandex_cloud_monitoring/_index.md
+++ b/content/telegraf/v1/output-plugins/yandex_cloud_monitoring/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Yandex Cloud Monitoring, "output-plugins", "configuration", "cloud"]
 introduced: "v1.17.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/yandex_cloud_monitoring/README.md, Yandex Cloud Monitoring Plugin Source
 ---
 
 # Yandex Cloud Monitoring Output Plugin

--- a/content/telegraf/v1/output-plugins/zabbix/_index.md
+++ b/content/telegraf/v1/output-plugins/zabbix/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Zabbix, "output-plugins", "configuration", "datastore"]
 introduced: "v1.30.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/outputs/zabbix/README.md, Zabbix Plugin Source
 ---
 
 # Zabbix Output Plugin

--- a/content/telegraf/v1/processor-plugins/aws_ec2/_index.md
+++ b/content/telegraf/v1/processor-plugins/aws_ec2/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [AWS EC2 Metadata, "processor-plugins", "configuration", "annotation", "cloud"]
 introduced: "v1.18.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/aws_ec2/README.md, AWS EC2 Metadata Plugin Source
 ---
 
 # AWS EC2 Metadata Processor Plugin

--- a/content/telegraf/v1/processor-plugins/batch/_index.md
+++ b/content/telegraf/v1/processor-plugins/batch/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Batch, "processor-plugins", "configuration", "grouping"]
 introduced: "v1.33.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/batch/README.md, Batch Plugin Source
 ---
 
 # Batch Processor Plugin

--- a/content/telegraf/v1/processor-plugins/clone/_index.md
+++ b/content/telegraf/v1/processor-plugins/clone/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Clone, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.13.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/clone/README.md, Clone Plugin Source
 ---
 
 # Clone Processor Plugin

--- a/content/telegraf/v1/processor-plugins/converter/_index.md
+++ b/content/telegraf/v1/processor-plugins/converter/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Converter, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.7.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/converter/README.md, Converter Plugin Source
 ---
 
 # Converter Processor Plugin

--- a/content/telegraf/v1/processor-plugins/cumulative_sum/_index.md
+++ b/content/telegraf/v1/processor-plugins/cumulative_sum/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Cumulative Sum, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.35.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/cumulative_sum/README.md, Cumulative Sum Plugin Source
 ---
 
 # Cumulative Sum Processor Plugin

--- a/content/telegraf/v1/processor-plugins/date/_index.md
+++ b/content/telegraf/v1/processor-plugins/date/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Date, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.12.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/date/README.md, Date Plugin Source
 ---
 
 # Date Processor Plugin

--- a/content/telegraf/v1/processor-plugins/dedup/_index.md
+++ b/content/telegraf/v1/processor-plugins/dedup/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Dedup, "processor-plugins", "configuration", "filtering"]
 introduced: "v1.14.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/dedup/README.md, Dedup Plugin Source
 ---
 
 # Dedup Processor Plugin

--- a/content/telegraf/v1/processor-plugins/defaults/_index.md
+++ b/content/telegraf/v1/processor-plugins/defaults/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Defaults, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.15.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/defaults/README.md, Defaults Plugin Source
 ---
 
 # Defaults Processor Plugin

--- a/content/telegraf/v1/processor-plugins/enum/_index.md
+++ b/content/telegraf/v1/processor-plugins/enum/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Enum, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/enum/README.md, Enum Plugin Source
 ---
 
 # Enum Processor Plugin

--- a/content/telegraf/v1/processor-plugins/execd/_index.md
+++ b/content/telegraf/v1/processor-plugins/execd/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Execd, "processor-plugins", "configuration", "general purpose"]
 introduced: "v1.15.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/execd/README.md, Execd Plugin Source
 ---
 
 # Execd Processor Plugin

--- a/content/telegraf/v1/processor-plugins/filepath/_index.md
+++ b/content/telegraf/v1/processor-plugins/filepath/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Filepath, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.15.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/filepath/README.md, Filepath Plugin Source
 ---
 
 # Filepath Processor Plugin

--- a/content/telegraf/v1/processor-plugins/filter/_index.md
+++ b/content/telegraf/v1/processor-plugins/filter/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Filter, "processor-plugins", "configuration", "filtering"]
 introduced: "v1.29.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/filter/README.md, Filter Plugin Source
 ---
 
 # Filter Processor Plugin

--- a/content/telegraf/v1/processor-plugins/ifname/_index.md
+++ b/content/telegraf/v1/processor-plugins/ifname/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Network Interface Name, "processor-plugins", "configuration", "annotation"]
 introduced: "v1.15.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/ifname/README.md, Network Interface Name Plugin Source
 ---
 
 # Network Interface Name Processor Plugin

--- a/content/telegraf/v1/processor-plugins/lookup/_index.md
+++ b/content/telegraf/v1/processor-plugins/lookup/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Lookup, "processor-plugins", "configuration", "annotation"]
 introduced: "v1.15.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/lookup/README.md, Lookup Plugin Source
 ---
 
 # Lookup Processor Plugin

--- a/content/telegraf/v1/processor-plugins/noise/_index.md
+++ b/content/telegraf/v1/processor-plugins/noise/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Noise, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.22.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/noise/README.md, Noise Plugin Source
 ---
 
 # Noise Processor Plugin

--- a/content/telegraf/v1/processor-plugins/override/_index.md
+++ b/content/telegraf/v1/processor-plugins/override/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Override, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.6.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/override/README.md, Override Plugin Source
 ---
 
 # Override Processor Plugin

--- a/content/telegraf/v1/processor-plugins/parser/_index.md
+++ b/content/telegraf/v1/processor-plugins/parser/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Parser, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/parser/README.md, Parser Plugin Source
 ---
 
 # Parser Processor Plugin

--- a/content/telegraf/v1/processor-plugins/pivot/_index.md
+++ b/content/telegraf/v1/processor-plugins/pivot/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Pivot, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.12.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/pivot/README.md, Pivot Plugin Source
 ---
 
 # Pivot Processor Plugin

--- a/content/telegraf/v1/processor-plugins/port_name/_index.md
+++ b/content/telegraf/v1/processor-plugins/port_name/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Port Name Lookup, "processor-plugins", "configuration", "annotation"]
 introduced: "v1.15.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/port_name/README.md, Port Name Lookup Plugin Source
 ---
 
 # Port Name Lookup Processor Plugin

--- a/content/telegraf/v1/processor-plugins/printer/_index.md
+++ b/content/telegraf/v1/processor-plugins/printer/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Printer, "processor-plugins", "configuration", "testing"]
 introduced: "v1.1.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/printer/README.md, Printer Plugin Source
 ---
 
 # Printer Processor Plugin

--- a/content/telegraf/v1/processor-plugins/regex/_index.md
+++ b/content/telegraf/v1/processor-plugins/regex/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Regex, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.7.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/regex/README.md, Regex Plugin Source
 ---
 
 # Regex Processor Plugin

--- a/content/telegraf/v1/processor-plugins/rename/_index.md
+++ b/content/telegraf/v1/processor-plugins/rename/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Rename, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/rename/README.md, Rename Plugin Source
 ---
 
 # Rename Processor Plugin

--- a/content/telegraf/v1/processor-plugins/reverse_dns/_index.md
+++ b/content/telegraf/v1/processor-plugins/reverse_dns/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Reverse DNS, "processor-plugins", "configuration", "annotation"]
 introduced: "v1.15.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/reverse_dns/README.md, Reverse DNS Plugin Source
 ---
 
 # Reverse DNS Processor Plugin

--- a/content/telegraf/v1/processor-plugins/round/_index.md
+++ b/content/telegraf/v1/processor-plugins/round/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Round, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.36.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/round/README.md, Round Plugin Source
 ---
 
 # Round Processor Plugin

--- a/content/telegraf/v1/processor-plugins/s2geo/_index.md
+++ b/content/telegraf/v1/processor-plugins/s2geo/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [S2 Geo, "processor-plugins", "configuration", "annotation"]
 introduced: "v1.14.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/s2geo/README.md, S2 Geo Plugin Source
 ---
 
 # S2 Geo Processor Plugin

--- a/content/telegraf/v1/processor-plugins/scale/_index.md
+++ b/content/telegraf/v1/processor-plugins/scale/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Scale, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.27.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/scale/README.md, Scale Plugin Source
 ---
 
 # Scale Processor Plugin

--- a/content/telegraf/v1/processor-plugins/snmp_lookup/_index.md
+++ b/content/telegraf/v1/processor-plugins/snmp_lookup/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [SNMP Lookup, "processor-plugins", "configuration", "annotation"]
 introduced: "v1.30.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/snmp_lookup/README.md, SNMP Lookup Plugin Source
 ---
 
 # SNMP Lookup Processor Plugin

--- a/content/telegraf/v1/processor-plugins/split/_index.md
+++ b/content/telegraf/v1/processor-plugins/split/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Split, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.28.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/split/README.md, Split Plugin Source
 ---
 
 # Split Processor Plugin

--- a/content/telegraf/v1/processor-plugins/starlark/_index.md
+++ b/content/telegraf/v1/processor-plugins/starlark/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Starlark, "processor-plugins", "configuration", "general purpose"]
 introduced: "v1.15.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/starlark/README.md, Starlark Plugin Source
 ---
 
 # Starlark Processor Plugin

--- a/content/telegraf/v1/processor-plugins/strings/_index.md
+++ b/content/telegraf/v1/processor-plugins/strings/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Strings, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.8.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/strings/README.md, Strings Plugin Source
 ---
 
 # Strings Processor Plugin

--- a/content/telegraf/v1/processor-plugins/tag_limit/_index.md
+++ b/content/telegraf/v1/processor-plugins/tag_limit/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Tag Limit, "processor-plugins", "configuration", "filtering"]
 introduced: "v1.12.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/tag_limit/README.md, Tag Limit Plugin Source
 ---
 
 # Tag Limit Processor Plugin

--- a/content/telegraf/v1/processor-plugins/template/_index.md
+++ b/content/telegraf/v1/processor-plugins/template/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Template, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.14.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/template/README.md, Template Plugin Source
 ---
 
 # Template Processor Plugin

--- a/content/telegraf/v1/processor-plugins/timestamp/_index.md
+++ b/content/telegraf/v1/processor-plugins/timestamp/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Timestamp, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.31.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/timestamp/README.md, Timestamp Plugin Source
 ---
 
 # Timestamp Processor Plugin

--- a/content/telegraf/v1/processor-plugins/topk/_index.md
+++ b/content/telegraf/v1/processor-plugins/topk/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [TopK, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.7.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/topk/README.md, TopK Plugin Source
 ---
 
 # TopK Processor Plugin

--- a/content/telegraf/v1/processor-plugins/unpivot/_index.md
+++ b/content/telegraf/v1/processor-plugins/unpivot/_index.md
@@ -8,9 +8,6 @@ menu:
 tags: [Unpivot, "processor-plugins", "configuration", "transformation"]
 introduced: "v1.12.0"
 os_support: "freebsd, linux, macos, solaris, windows"
-related:
-  - /telegraf/v1/configure_plugins/
-  - https://github.com/influxdata/telegraf/tree/v1.38.4/plugins/processors/unpivot/README.md, Unpivot Plugin Source
 ---
 
 # Unpivot Processor Plugin

--- a/telegraf-build/templates/aggregator_plugin.tmpl
+++ b/telegraf-build/templates/aggregator_plugin.tmpl
@@ -14,9 +14,6 @@ deprecated: {{.}}
 removal: {{.}}
 {{- end}}
 os_support: "{{.OSTags | join ", "}}"
-related:
-  - /telegraf/v1/configure_plugins/
-  - {{.URL}}, {{.Name}} Plugin Source
 ---
 
 {{.Readme}}

--- a/telegraf-build/templates/input_plugin.tmpl
+++ b/telegraf-build/templates/input_plugin.tmpl
@@ -14,9 +14,6 @@ deprecated: {{.}}
 removal: {{.}}
 {{- end}}
 os_support: "{{.OSTags | join ", "}}"
-related:
-  - /telegraf/v1/configure_plugins/
-  - {{.URL}}, {{.Name}} Plugin Source
 ---
 
 {{.Readme}}

--- a/telegraf-build/templates/output_plugin.tmpl
+++ b/telegraf-build/templates/output_plugin.tmpl
@@ -14,9 +14,6 @@ deprecated: {{.}}
 removal: {{.}}
 {{- end}}
 os_support: "{{.OSTags | join ", "}}"
-related:
-  - /telegraf/v1/configure_plugins/
-  - {{.URL}}, {{.Name}} Plugin Source
 ---
 
 {{.Readme}}

--- a/telegraf-build/templates/processor_plugin.tmpl
+++ b/telegraf-build/templates/processor_plugin.tmpl
@@ -14,9 +14,6 @@ deprecated: {{.}}
 removal: {{.}}
 {{- end}}
 os_support: "{{.OSTags | join ", "}}"
-related:
-  - /telegraf/v1/configure_plugins/
-  - {{.URL}}, {{.Name}} Plugin Source
 ---
 
 {{.Readme}}


### PR DESCRIPTION
## Summary

With PR #7216 introducing page buttons to navigate to the github page for plugins we can get rid of direct version references in the plugin pages. This helps to keep the diff for new Telegraf versions as small as possible by not requiring to regenerate _every single plugin page_ due to the version increase.

This PR adapts the plugin templates by removing the `related` section in frontmatter. The PR also regenerates all plugin pages to remove the obsolete references. No other changes are applied.

## Checklist

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
- [ ] Local build passes (`npx hugo --quiet`)
