### PR TITLE
chore(telegraf): Replace sample.conf by 'configuration'

### DIFF
--- a/layouts/partials/article/telegraf-plugin-links.html
+++ b/layouts/partials/article/telegraf-plugin-links.html
@@ -1,5 +1,5 @@
 {{ if (eq .Params.product "telegraf") }}
-  {{ $telegraf_latest := .Site.Data.products.telegraf.latest_patches.v1 }} 
+  {{ $telegraf_latest := .Site.Data.products.telegraf.latest_patches.v1 }}
   {{ if .Parent.HasShortcode "telegraf/plugins" }}
     {{ $plugin_data := split .Params.menu.telegraf_v1_ref.identifier "-" }}
     {{ $plugin_category := print (index $plugin_data 0) "s" }}
@@ -8,6 +8,6 @@
     <a class="btn download"
        data-component="download-external"
        data-filename="telegraf-{{ index $plugin_data 0 }}-{{ $plugin_id }}.sample.conf"
-       href="https://raw.githubusercontent.com/influxdata/telegraf/refs/tags/v{{$telegraf_latest}}/plugins/{{ $plugin_category }}/{{ $plugin_id }}/sample.conf">Download sample.conf</a>
+       href="https://raw.githubusercontent.com/influxdata/telegraf/refs/tags/v{{$telegraf_latest}}/plugins/{{ $plugin_category }}/{{ $plugin_id }}/sample.conf">Download configuration</a>
   {{ end }}
 {{ end }}


### PR DESCRIPTION
## Summary

This PR removes the technically sounding `sample.conf` wording in the download button and replaces it with the word `configuration`.

## Checklist

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
- [ ] Local build passes (`npx hugo --quiet`)
