### PR TITLE
fix(vale): disable write-good.E-Prime, re-enable write-good.Cliches

### DIFF
--- a/.vale-instructions.ini
+++ b/.vale-instructions.ini
@@ -11,3 +11,13 @@ BasedOnStyles = Vale, write-good
 
 # Disable style rules that are too opinionated for instruction files
 Vale.Spelling = NO
+
+# Mirror the content-config disables. Keep write-good.Cliches and
+# write-good.Illusions (clichés + repeated words — high signal); silence
+# the rest (too noisy in technical writing and instruction files).
+write-good.Passive = NO
+write-good.So = NO
+write-good.ThereIs = NO
+write-good.TooWordy = NO
+write-good.Weasel = NO
+write-good.E-Prime = NO

--- a/.vale.ini
+++ b/.vale.ini
@@ -37,10 +37,14 @@ Google.FirstPerson = NO
 Google.Passive = NO
 Google.We = NO
 Google.Will = NO
-write-good.Cliches = NO
 write-good.Passive = NO
 write-good.So = NO
 write-good.ThereIs = NO
 # Flags legitimate technical terms like "aggregate", "expiration", "multiple".
 write-good.TooWordy = NO
 write-good.Weasel = NO
+# Suggestion-level; fires on every "is/are/was/were" and shows as ::notice::
+# in PR Files Changed. Useful for batch prose cleanup, too noisy for daily PRs.
+write-good.E-Prime = NO
+# Keep enabled: write-good.Cliches (clichéd phrases),
+# write-good.Illusions (repeated words like "the the").

--- a/content/influxdb/v2/.vale.ini
+++ b/content/influxdb/v2/.vale.ini
@@ -30,13 +30,17 @@ Google.FirstPerson = NO
 Google.Passive = NO
 Google.We = NO
 Google.Will = NO
-write-good.Cliches = NO
 write-good.Passive = NO
 write-good.So = NO
 write-good.ThereIs = NO
 # Flags legitimate technical terms like "aggregate", "expiration", "multiple".
 write-good.TooWordy = NO
 write-good.Weasel = NO
+# Suggestion-level; fires on every "is/are/was/were" and shows as ::notice::
+# in PR Files Changed. Useful for batch prose cleanup, too noisy for daily PRs.
+write-good.E-Prime = NO
+# Keep enabled: write-good.Cliches (clichéd phrases),
+# write-good.Illusions (repeated words like "the the").
 
 # Ignore URL paths like /api/v3/..., /cli/..., /influxdb3/...
 # Ignore full URLs like https://example.com/...

--- a/content/influxdb3/cloud-dedicated/.vale.ini
+++ b/content/influxdb3/cloud-dedicated/.vale.ini
@@ -30,13 +30,17 @@ Google.FirstPerson = NO
 Google.Passive = NO
 Google.We = NO
 Google.Will = NO
-write-good.Cliches = NO
 write-good.Passive = NO
 write-good.So = NO
 write-good.ThereIs = NO
 # Flags legitimate technical terms like "aggregate", "expiration", "multiple".
 write-good.TooWordy = NO
 write-good.Weasel = NO
+# Suggestion-level; fires on every "is/are/was/were" and shows as ::notice::
+# in PR Files Changed. Useful for batch prose cleanup, too noisy for daily PRs.
+write-good.E-Prime = NO
+# Keep enabled: write-good.Cliches (clichéd phrases),
+# write-good.Illusions (repeated words like "the the").
 
 # Ignore URL paths like /api/v3/..., /cli/..., /influxdb3/...
 # Ignore full URLs like https://example.com/...

--- a/content/influxdb3/cloud-serverless/.vale.ini
+++ b/content/influxdb3/cloud-serverless/.vale.ini
@@ -30,13 +30,17 @@ Google.FirstPerson = NO
 Google.Passive = NO
 Google.We = NO
 Google.Will = NO
-write-good.Cliches = NO
 write-good.Passive = NO
 write-good.So = NO
 write-good.ThereIs = NO
 # Flags legitimate technical terms like "aggregate", "expiration", "multiple".
 write-good.TooWordy = NO
 write-good.Weasel = NO
+# Suggestion-level; fires on every "is/are/was/were" and shows as ::notice::
+# in PR Files Changed. Useful for batch prose cleanup, too noisy for daily PRs.
+write-good.E-Prime = NO
+# Keep enabled: write-good.Cliches (clichéd phrases),
+# write-good.Illusions (repeated words like "the the").
 
 # Ignore URL paths like /api/v3/..., /cli/..., /influxdb3/...
 # Ignore full URLs like https://example.com/...

--- a/content/influxdb3/clustered/.vale.ini
+++ b/content/influxdb3/clustered/.vale.ini
@@ -30,13 +30,17 @@ Google.FirstPerson = NO
 Google.Passive = NO
 Google.We = NO
 Google.Will = NO
-write-good.Cliches = NO
 write-good.Passive = NO
 write-good.So = NO
 write-good.ThereIs = NO
 # Flags legitimate technical terms like "aggregate", "expiration", "multiple".
 write-good.TooWordy = NO
 write-good.Weasel = NO
+# Suggestion-level; fires on every "is/are/was/were" and shows as ::notice::
+# in PR Files Changed. Useful for batch prose cleanup, too noisy for daily PRs.
+write-good.E-Prime = NO
+# Keep enabled: write-good.Cliches (clichéd phrases),
+# write-good.Illusions (repeated words like "the the").
 
 # Ignore URL paths like /api/v3/..., /cli/..., /influxdb3/...
 # Ignore full URLs like https://example.com/...

--- a/content/influxdb3/core/.vale.ini
+++ b/content/influxdb3/core/.vale.ini
@@ -35,13 +35,17 @@ Google.FirstPerson = NO
 Google.Passive = NO
 Google.We = NO
 Google.Will = NO
-write-good.Cliches = NO
 write-good.Passive = NO
 write-good.So = NO
 write-good.ThereIs = NO
 # Flags legitimate technical terms like "aggregate", "expiration", "multiple".
 write-good.TooWordy = NO
 write-good.Weasel = NO
+# Suggestion-level; fires on every "is/are/was/were" and shows as ::notice::
+# in PR Files Changed. Useful for batch prose cleanup, too noisy for daily PRs.
+write-good.E-Prime = NO
+# Keep enabled: write-good.Cliches (clichéd phrases),
+# write-good.Illusions (repeated words like "the the").
 
 # Ignore URL paths like /api/v3/..., /cli/..., /influxdb3/...
 # Ignore full URLs like https://example.com/...


### PR DESCRIPTION
## Summary

Reduces Vale noise in PR Files Changed annotations by disabling the suggestion-level `write-good.E-Prime` rule across all 7 Vale configs. Re-enables `write-good.Cliches` (was off everywhere; it's high-signal and low-false-positive).

### Why

`write-good.E-Prime` fires at `suggestion` level on every form of "to be" (`is`, `are`, `was`, `were`, `been`). The CI annotations job (`.github/workflows/pr-vale-check.yml:118-141`) emits `::notice::` annotations for every suggestion, so on a typical docs PR these notices drown out genuine warnings and errors. "Try to avoid using 'is'" on every paragraph isn't actionable feedback for engineers and support staff writing daily docs — it's useful for a one-off prose cleanup pass, not for PR review.

`write-good.Cliches` was disabled across all configs but has a finite, well-targeted token list ("back to the drawing board", "in a nutshell", etc.) that rarely false-positives on technical writing.

### Configs touched

| Config | Used for |
| --- | --- |
| `.vale.ini` | `content/**` catch-all |
| `.vale-instructions.ini` | READMEs, AGENTS.md, CLAUDE.md, `.github/**`, `.claude/**`, `docs/**` |
| `content/influxdb/v2/.vale.ini` | `content/influxdb/v2/**` |
| `content/influxdb3/core/.vale.ini` | `content/influxdb3/core/**` |
| `content/influxdb3/clustered/.vale.ini` | `content/influxdb3/clustered/**` |
| `content/influxdb3/cloud-serverless/.vale.ini` | `content/influxdb3/cloud-serverless/**` |
| `content/influxdb3/cloud-dedicated/.vale.ini` | `content/influxdb3/cloud-dedicated/**` |

### Final write-good state across all configs

| Rule | State | Why |
| --- | --- | --- |
| `Cliches` | **enabled** (warning) | Finite token list, high signal |
| `Illusions` | **enabled** (warning) | Repeated-word detector ("the the") |
| `E-Prime` | disabled | Fires on every "is/are/was/were" — too noisy |
| `Passive` | disabled | Passive is fine in tech reference docs |
| `So`, `ThereIs` | disabled | High false-positive in reference writing |
| `TooWordy` | disabled | Flags legitimate technical terms |
| `Weasel` | disabled | Catches valid hedge words |

## Test plan

- [x] Local repro before: `.ci/vale/vale.sh --config=.vale.ini content/telegraf/v1/release-notes.md` emitted `write-good.E-Prime` suggestion
- [x] Local repro after: same command silent on write-good
- [x] Confirmed `write-good.Cliches` still trips on test input ("back to the drawing board")
- [x] Confirmed `Vale.Repetition` (built-in) still trips on test input ("the the")

## Follow-up

Older docs likely accumulated content that the now-disabled rules would have flagged (especially `TooWordy` and `Passive`). When prose cleanup capacity opens, run the dictionary rules in one-shot mode with `--minAlertLevel=suggestion` and triage by file.