### PR TITLE
docs(controller): document audit logging

### DIFF
--- a/DOCS-SHORTCODES.md
+++ b/DOCS-SHORTCODES.md
@@ -1114,6 +1114,31 @@ Use the following shortcode parameters to customize the content of the InfluxDB 
 - **action**: Text of the button
 - **link**: URL the button links to
 
+### Telegraf Enterprise feature callout
+
+Use the `{{< telegraf/enterprise-feature >}}` shortcode on Telegraf Controller pages to display a callout that identifies an Enterprise-only feature and links to the Telegraf Enterprise product page.
+
+```md
+{{< telegraf/enterprise-feature "Audit logging" >}}
+```
+
+Pass a second argument to change the verb form when the feature name is plural or uses a different word form:
+
+```md
+{{< telegraf/enterprise-feature "Audit logs" "are" >}}
+```
+
+#### Arguments
+
+The shortcode accepts two positional arguments:
+
+| Position | Argument   | Default        | Description                                                                             |
+| -------- | ---------- | -------------- | --------------------------------------------------------------------------------------- |
+| 0        | `feature`  | "This feature" | Name of the Enterprise feature. Use the singular or plural form that fits the sentence. |
+| 1        | `wordForm` | "is"           | Verb form that follows the feature name—for example, `is` (singular) or `are` (plural). |
+
+The rendered callout reads: *"{feature} {wordForm} only available with Telegraf Enterprise..."* followed by a link and an **Upgrade to Enterprise** call-to-action button.
+
 ### Reference content
 
 The InfluxDB documentation is "task-based," meaning content primarily focuses on what a user is **doing**, not what they are **using**. However, there is a need to document tools and other things that don't necessarily fit in the task-based style. This is referred to as "reference content."

--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -3,7 +3,8 @@
   "baseUrl": ".",
   "paths": {
    "*": [
-    "*"
+    "*",
+    "../node_modules/*"
    ]
   }
  }

--- a/assets/styles/layouts/article/blocks/_special-state.scss
+++ b/assets/styles/layouts/article/blocks/_special-state.scss
@@ -110,5 +110,30 @@
         }       
       }
     }
+    // Styles specific to the Telegraf Enterprise feature callout
+    &.telegraf-enterprise {
+      display: flex;
+      gap: 2rem;
+      flex-wrap: wrap;
+      justify-content: center;
+      align-items: center;
+      padding-bottom: 1.5rem;
+
+      .telegraf-enterprise-text {
+        flex: 2;
+        min-width: 400px;
+        p { margin-bottom: 0; }
+      }
+      .telegraf-enterprise-cta {
+        flex: 1;
+        margin-top: -.25rem;
+        white-space: nowrap;
+        .cf-icon::before {
+          margin-right: .25rem;
+          font-size: 1.25rem;
+          vertical-align: middle;
+        }
+      }
+    }
   }
 }

--- a/content/telegraf/controller/audit-logs/_index.md
+++ b/content/telegraf/controller/audit-logs/_index.md
@@ -1,0 +1,84 @@
+---
+title: Audit logs
+description: >
+  Telegraf Controller records security-relevant events to a tamper-evident,
+  append-only audit log. Use audit logs to investigate access, detect
+  unauthorized changes, and demonstrate compliance.
+menu:
+  telegraf_controller:
+    name: Audit logs
+weight: 11
+cascade:
+  metadata: [Telegraf Enterprise]
+  related:
+    - /telegraf/controller/reference/config-options/
+    - /telegraf/controller/reference/authorization/
+    - /telegraf/controller/telegraf-enterprise/
+---
+
+{{% product-name %}} records security-relevant events to an append-only,
+tamper-evident audit log.
+Use audit logs to investigate access patterns, detect unauthorized changes,
+and demonstrate compliance with internal or external policies.
+
+- [What gets audited](#what-gets-audited)
+- [Where audit logs are stored](#where-audit-logs-are-stored)
+- [Tamper detection](#tamper-detection)
+- [License and permissions](#license-and-permissions)
+
+## What gets audited
+
+{{% product-name %}} captures the following categories of events:
+
+- **Authentication** --- user sign-in (local, LDAP, or OIDC) and sign-out.
+- **Agent lifecycle** --- agent registration, status transitions (such as
+  moving in and out of the **not reporting** state), and agent deletion
+  (manual deletions and removals driven by reporting-rule retention).
+
+Each entry records:
+
+- **Action** --- the specific event identifier.
+- **Actor** --- the user, API token, or system component that triggered
+  the event.
+- **Source** --- IP address and user-agent of the request, where applicable.
+- **Outcome** --- `Success`, `Failure`, or `Denied`.
+- **Timestamp** --- when the event occurred, in UTC.
+- **Sequence number, hash, and previous hash** --- used to detect tampering.
+
+## Where audit logs are stored
+
+{{% product-name %}} writes audit entries to per-month SQLite files in a
+platform-specific data directory:
+
+| Platform | Default location                                                                         |
+| :------- | :--------------------------------------------------------------------------------------- |
+| Linux    | `$XDG_STATE_HOME/telegraf-controller/` (typically `~/.local/state/telegraf-controller/`) |
+| macOS    | `~/Library/Logs/telegraf-controller/`                                                    |
+| Windows  | `%LOCALAPPDATA%\telegraf-controller\Log`                                                 |
+
+Files are named `audit-YYYY-MM.log` --- one per calendar month.
+Each file is a SQLite database that enforces immutability through a database
+trigger: attempts to delete rows are rolled back.
+{{% product-name %}} keeps up to 48 months of audit files available for query.
+
+## Tamper detection
+
+Each entry includes a SHA-256 hash that incorporates the entry's contents
+and the hash of the previous entry, forming a chain.
+Sequence numbers are contiguous within and across monthly files.
+Any modification, deletion, or out-of-order insertion breaks the chain.
+
+## License and permissions
+
+Audit logging is part of [Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/)
+and is unavailable in the free tier.
+With a valid license:
+
+- Audit logging is **enabled at startup only** by setting `AUDIT_ENABLED`.
+  See [Enable and configure audit logging](/telegraf/controller/audit-logs/enable-configure/).
+- Only the retention period is modifiable at runtime, from the **Settings**
+  page.
+- Only the **Owner** and **Administrator** roles can read audit log entries.
+  See [View audit logs](/telegraf/controller/audit-logs/view/).
+
+{{< children hlevel="h2" >}}

--- a/content/telegraf/controller/audit-logs/_index.md
+++ b/content/telegraf/controller/audit-logs/_index.md
@@ -58,7 +58,7 @@ platform-specific data directory:
 | macOS    | `~/Library/Logs/telegraf-controller/`                                                    |
 | Windows  | `%LOCALAPPDATA%\telegraf-controller\Log`                                                 |
 
-Files are named `audit-YYYY-MM.log`, one per calendar month.
+Files are named `audit-YYYY-MM.log`--one per calendar month.
 Each file is a SQLite database that enforces immutability through a database
 trigger: attempts to delete rows are rolled back.
 {{% product-name %}} keeps up to 48 months of audit files available for query.

--- a/content/telegraf/controller/audit-logs/_index.md
+++ b/content/telegraf/controller/audit-logs/_index.md
@@ -21,6 +21,8 @@ tamper-evident audit log.
 Use audit logs to investigate access patterns, detect unauthorized changes,
 and demonstrate compliance with internal or external policies.
 
+{{< telegraf/enterprise-feature "Audit logging" >}}
+
 - [What gets audited](#what-gets-audited)
 - [Where audit logs are stored](#where-audit-logs-are-stored)
 - [Tamper detection](#tamper-detection)
@@ -30,20 +32,20 @@ and demonstrate compliance with internal or external policies.
 
 {{% product-name %}} captures the following categories of events:
 
-- **Authentication** --- user sign-in (local, LDAP, or OIDC) and sign-out.
-- **Agent lifecycle** --- agent registration, status transitions (such as
+- **Authentication**: user sign-in (local, LDAP, or OIDC) and sign-out.
+- **Agent lifecycle**: agent registration, status transitions (such as
   moving in and out of the **not reporting** state), and agent deletion
   (manual deletions and removals driven by reporting-rule retention).
 
 Each entry records:
 
-- **Action** --- the specific event identifier.
-- **Actor** --- the user, API token, or system component that triggered
+- **Action**: the specific event identifier.
+- **Actor**: the user, API token, or system component that triggered
   the event.
-- **Source** --- IP address and user-agent of the request, where applicable.
-- **Outcome** --- `Success`, `Failure`, or `Denied`.
-- **Timestamp** --- when the event occurred, in UTC.
-- **Sequence number, hash, and previous hash** --- used to detect tampering.
+- **Source**: IP address and user-agent of the request, where applicable.
+- **Outcome**: `Success`, `Failure`, or `Denied`.
+- **Timestamp**: when the event occurred, in UTC.
+- **Sequence number, hash, and previous hash**: used to detect tampering.
 
 ## Where audit logs are stored
 
@@ -56,7 +58,7 @@ platform-specific data directory:
 | macOS    | `~/Library/Logs/telegraf-controller/`                                                    |
 | Windows  | `%LOCALAPPDATA%\telegraf-controller\Log`                                                 |
 
-Files are named `audit-YYYY-MM.log` --- one per calendar month.
+Files are named `audit-YYYY-MM.log`, one per calendar month.
 Each file is a SQLite database that enforces immutability through a database
 trigger: attempts to delete rows are rolled back.
 {{% product-name %}} keeps up to 48 months of audit files available for query.

--- a/content/telegraf/controller/audit-logs/enable-configure.md
+++ b/content/telegraf/controller/audit-logs/enable-configure.md
@@ -148,14 +148,14 @@ export AUDIT_LOG_RETENTION=8760
 > [!Note]
 > `AUDIT_LOG_RETENTION` only sets the initial value.
 > After first startup, the database is authoritative.
-> Update retention from the **Settings** page.
+> To update audit log retention, use the **Settings** page.
 
 ## Forward audit events
 
 {{% product-name %}} can forward each audit event to one or more external
 destinations in addition to writing it to local storage.
-Forwarders are configured **at startup only** and run independently.
-You can enable any combination of syslog, webhook, and file forwarders.
+Forwarders are configured **at startup only** and run independently, which lets
+you enable any combination of syslog, webhook, and file forwarders.
 
 ### Forward to syslog
 

--- a/content/telegraf/controller/audit-logs/enable-configure.md
+++ b/content/telegraf/controller/audit-logs/enable-configure.md
@@ -1,0 +1,216 @@
+---
+title: Enable and configure audit logging
+list_title: Enable and configure audit logging
+description: >
+  Enable audit logging in Telegraf Controller at startup, configure the
+  retention period, and optionally forward audit events to syslog, a
+  webhook, or a file.
+menu:
+  telegraf_controller:
+    name: Enable and configure
+    parent: Audit logs
+weight: 101
+related:
+  - /telegraf/controller/reference/config-options/
+  - /telegraf/controller/telegraf-enterprise/apply-license/
+---
+
+Enable audit logging in {{% product-name %}} at startup, change the
+retention period as needed, and optionally forward events to external
+destinations for long-term storage or SIEM integration.
+
+- [Prerequisites](#prerequisites)
+- [Enable audit logging](#enable-audit-logging)
+- [Configure retention](#configure-retention)
+- [Forward audit events](#forward-audit-events)
+- [Disable audit logging](#disable-audit-logging)
+
+## Prerequisites
+
+- A valid [Telegraf Enterprise license](/telegraf/controller/telegraf-enterprise/)
+  applied to your {{% product-name %}} instance.
+- Permission to modify the {{% product-name %}} startup environment (for
+  example, the systemd unit file or Docker run command).
+- The **Owner** or **Administrator** role to change the retention period
+  from the UI.
+
+> [!Important]
+> #### Audit-logging state changes only at startup
+>
+> Per {{% product-name %}}'s security policy, settings that change the
+> application's security boundary, including whether audit logging is
+> enabled and where audit events are forwarded, can only be changed at startup.
+> Retention is the only audit setting that can be modified at runtime.
+
+## Enable audit logging
+
+Set `AUDIT_ENABLED` to `true` before starting {{% product-name %}}.
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[systemd](#)
+[Docker](#)
+[Shell](#)
+{{% /tabs %}}
+{{% tab-content %}}
+
+Add `AUDIT_ENABLED=true` to your systemd unit file (typically
+`/etc/systemd/system/telegraf-controller.service`):
+
+```ini
+[Service]
+Environment=AUDIT_ENABLED=true
+```
+
+Reload systemd and restart the service:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart telegraf-controller
+```
+
+{{% /tab-content %}}
+{{% tab-content %}}
+
+Pass `AUDIT_ENABLED=true` when starting the container:
+
+```bash
+docker run \
+  -e AUDIT_ENABLED=true \
+  influxdata/telegraf-controller
+```
+
+{{% /tab-content %}}
+{{% tab-content %}}
+
+Set the variable, or pass `--audit-enabled` on the command line:
+
+```bash
+export AUDIT_ENABLED=true
+telegraf_controller --no-interactive
+```
+
+```bash
+telegraf_controller --audit-enabled --no-interactive
+```
+
+{{% /tab-content %}}
+{{< /tabs-wrapper >}}
+
+After {{% product-name %}} starts:
+
+- The **Settings > Audit Logging** section displays as enabled.
+- Audit entries begin appearing in the platform data directory described in
+  [Where audit logs are stored](/telegraf/controller/audit-logs/#where-audit-logs-are-stored).
+
+<!-- TODO: screenshot of the Settings > Audit Logging section rendering as enabled (header, status indicator, and retention dropdown visible). Save to /static/img/telegraf/controller-settings-audit-enabled.png and replace this comment with: {{< img-hd src="/img/telegraf/controller-settings-audit-enabled.png" alt="Telegraf Controller Settings page showing Audit Logging enabled" />}} -->
+
+## Configure retention
+
+{{% product-name %}} keeps audit entries for 90 days (2160 hours) by default
+and runs a cleanup job every 12 hours that removes entries older than the
+retention threshold.
+
+Available retention values:
+
+| Value      | Hours   |
+| :--------- | :------ |
+| 30 days    | `720`   |
+| 3 months   | `2160`  |
+| 6 months   | `4320`  |
+| 1 year     | `8760`  |
+| 2 years    | `17520` |
+| Infinite   | `0`     |
+
+### Change audit log retention from the Settings page
+
+1. Sign in as an **Owner** or **Administrator**.
+2. Navigate to the **Settings** page from the left navigation menu.
+3. In the **Audit Logging** section, select a value from **Audit log retention**.
+4. Click **Save**.
+
+<!-- TODO: screenshot of the Settings > Audit Logging section with the Audit log retention dropdown expanded, showing the 30 days / 3 months / 6 months / 1 year / 2 years / Infinite options. Save to /static/img/telegraf/controller-settings-audit-retention.png and replace this comment with: {{< img-hd src="/img/telegraf/controller-settings-audit-retention.png" alt="Telegraf Controller audit log retention dropdown" />}} -->
+
+The new retention value takes effect immediately.
+The next cleanup run removes any entries that fall outside the new window.
+
+### Set the initial retention at startup
+
+Use the `AUDIT_LOG_RETENTION` environment variable to seed the retention
+period when {{% product-name %}} initializes its settings on first startup.
+
+```bash
+export AUDIT_LOG_RETENTION=8760
+```
+
+> [!Note]
+> `AUDIT_LOG_RETENTION` only sets the initial value.
+> After first startup, the database is authoritative --- update retention
+> from the **Settings** page.
+
+## Forward audit events
+
+{{% product-name %}} can forward each audit event to one or more external
+destinations in addition to writing it to local storage.
+Forwarders are configured **at startup only** and run independently --- you
+can enable any combination of syslog, webhook, and file forwarders.
+
+### Forward to syslog
+
+Forward audit events to a syslog server over TCP or UDP.
+
+```bash
+export AUDIT_SYSLOG_HOST=syslog.example.com
+export AUDIT_SYSLOG_PORT=514
+export AUDIT_SYSLOG_PROTOCOL=tcp
+```
+
+| Variable                | Description                              | Required |
+| :---------------------- | :--------------------------------------- | :------- |
+| `AUDIT_SYSLOG_HOST`     | Syslog server hostname or IP             | Yes      |
+| `AUDIT_SYSLOG_PORT`     | Syslog server port                       | Yes      |
+| `AUDIT_SYSLOG_PROTOCOL` | Transport protocol: `tcp` or `udp`       | Yes      |
+
+### Forward to a webhook
+
+Forward audit events as JSON `POST` requests to an HTTP webhook.
+
+```bash
+export AUDIT_WEBHOOK_URL=https://siem.example.com/ingest
+export AUDIT_WEBHOOK_AUTH_HEADER="Bearer xxxxxxxxxxxx"
+```
+
+| Variable                    | Description                                            | Required |
+| :-------------------------- | :----------------------------------------------------- | :------- |
+| `AUDIT_WEBHOOK_URL`         | Full URL the webhook receives `POST` requests at       | Yes      |
+| `AUDIT_WEBHOOK_AUTH_HEADER` | Optional value sent in the `Authorization` HTTP header | No       |
+
+The webhook forwarder retries each event up to three times with backoff and a
+10-second request timeout.
+Events that return `408`, `429`, or `5xx` responses are retried; events that
+return other `4xx` responses are dropped.
+{{% product-name %}} honors a `Retry-After` response header when present.
+
+### Append to a file
+
+Append each event to a file as a single JSON object per line (`.jsonl`).
+
+```bash
+export AUDIT_FILE_PATH=/var/log/telegraf-controller/audit.jsonl
+```
+
+The path must be writable by the {{% product-name %}} process.
+{{% product-name %}} does not rotate or trim this file --- pair it with a
+system log rotator (such as `logrotate`) if you keep the forwarder on long
+term.
+
+## Disable audit logging
+
+To turn audit logging off, remove `AUDIT_ENABLED` (or set it to a value
+other than `true`) and restart {{% product-name %}}.
+The startup-only policy applies in both directions: audit logging cannot be
+disabled from the UI.
+
+Existing audit files remain on disk and continue to be readable through
+[`GET /api/audit-logger`](/telegraf/controller/audit-logs/view/) until they
+age out of retention.

--- a/content/telegraf/controller/audit-logs/enable-configure.md
+++ b/content/telegraf/controller/audit-logs/enable-configure.md
@@ -19,6 +19,8 @@ Enable audit logging in {{% product-name %}} at startup, change the
 retention period as needed, and optionally forward events to external
 destinations for long-term storage or SIEM integration.
 
+{{< telegraf/enterprise-feature "Audit logging" >}}
+
 - [Prerequisites](#prerequisites)
 - [Enable audit logging](#enable-audit-logging)
 - [Configure retention](#configure-retention)
@@ -145,15 +147,15 @@ export AUDIT_LOG_RETENTION=8760
 
 > [!Note]
 > `AUDIT_LOG_RETENTION` only sets the initial value.
-> After first startup, the database is authoritative --- update retention
-> from the **Settings** page.
+> After first startup, the database is authoritative.
+> Update retention from the **Settings** page.
 
 ## Forward audit events
 
 {{% product-name %}} can forward each audit event to one or more external
 destinations in addition to writing it to local storage.
-Forwarders are configured **at startup only** and run independently --- you
-can enable any combination of syslog, webhook, and file forwarders.
+Forwarders are configured **at startup only** and run independently.
+You can enable any combination of syslog, webhook, and file forwarders.
 
 ### Forward to syslog
 
@@ -200,7 +202,7 @@ export AUDIT_FILE_PATH=/var/log/telegraf-controller/audit.jsonl
 ```
 
 The path must be writable by the {{% product-name %}} process.
-{{% product-name %}} does not rotate or trim this file --- pair it with a
+{{% product-name %}} does not rotate or trim this file. Pair it with a
 system log rotator (such as `logrotate`) if you keep the forwarder on long
 term.
 

--- a/content/telegraf/controller/audit-logs/view.md
+++ b/content/telegraf/controller/audit-logs/view.md
@@ -1,0 +1,90 @@
+---
+title: View audit logs
+list_title: View audit logs
+description: >
+  Query Telegraf Controller audit logs through the audit log API. Read
+  access is restricted to Owners and Administrators.
+menu:
+  telegraf_controller:
+    name: View audit logs
+    parent: Audit logs
+weight: 102
+related:
+  - /telegraf/controller/audit-logs/enable-configure/
+  - /telegraf/controller/reference/authorization/
+  - /telegraf/controller/tokens/create/
+---
+
+Use the {{% product-name %}} API to query and read audit entries.
+
+- [Prerequisites](#prerequisites)
+- [Query the audit log API](#query-the-audit-log-api)
+- [Response shape](#response-shape)
+- [Verify integrity](#verify-integrity)
+
+## Prerequisites
+
+- Audit logging must be [enabled](/telegraf/controller/audit-logs/enable-configure/).
+- The **Owner** or **Administrator** role assigned to your account.
+- An API token issued to a user with one of those roles.
+  See [Create an API token](/telegraf/controller/tokens/create/).
+
+## Query the audit log API
+
+Send `GET` requests to `/api/audit-logger`.
+The endpoint accepts the following query parameters:
+
+| Parameter | Description                                       | Default   |
+| :-------- | :------------------------------------------------ | :-------- |
+| `from`    | Earliest event timestamp to return, as ISO 8601   | Unbounded |
+| `to`      | Latest event timestamp to return, as ISO 8601     | Unbounded |
+| `page`    | Page number for paginated results                 | `1`       |
+| `limit`   | Maximum number of entries returned per page       | `9999`    |
+
+```bash { placeholders="YOUR_TC_API_TOKEN" }
+curl -H "Authorization: Bearer YOUR_TC_API_TOKEN" \
+  "https://telegraf_controller.example.com/api/audit-logger?from=2026-05-01T00:00:00Z&to=2026-05-31T23:59:59Z&page=1&limit=500"
+```
+
+Replace {{% code-placeholder-key %}}`YOUR_TC_API_TOKEN`{{% /code-placeholder-key %}}
+with a {{% product-name %}} API token issued to an Owner or Administrator.
+
+## Response shape
+
+The response is a JSON array.
+Each entry includes the event, the actor, the outcome, and the
+tamper-detection hash chain fields.
+
+```json
+[
+  {
+    "seq": 4827,
+    "timestamp": "2026-05-27T18:42:11.512Z",
+    "action": "user.login",
+    "actorId": "01HZ8R5T4VX9YQK0M2N3P4Q5R6",
+    "actorType": "User",
+    "ipAddress": "10.0.4.17",
+    "userAgent": "Mozilla/5.0 ...",
+    "outcome": "Success",
+    "hash": "f7c1...",
+    "prevHash": "a309..."
+  }
+]
+```
+
+`actorType` is one of `User`, `Token`, or `System`.
+For the categories of events captured, see
+[What gets audited](/telegraf/controller/audit-logs/#what-gets-audited).
+
+## Verify integrity
+
+The `hash` and `prevHash` fields form a SHA-256 chain across all entries.
+To detect tampering, walk the result set in `seq` order and check that:
+
+1. Each entry's `prevHash` equals the previous entry's `hash`.
+2. `seq` numbers are contiguous within and across monthly files.
+
+If either check fails, an entry has been altered, removed, or inserted out
+of order.
+For background on how the chain is constructed, see
+[Tamper detection](/telegraf/controller/audit-logs/#tamper-detection).

--- a/content/telegraf/controller/reference/authorization.md
+++ b/content/telegraf/controller/reference/authorization.md
@@ -65,11 +65,11 @@ By default, {{% product-name %}} requires authentication for API endpoints.
 Operators can selectively disable authentication for individual endpoint groups
 at startup:
 
-- **Agents** --- agent management endpoints
-- **Configs** --- configuration management endpoints
-- **Labels** --- label management endpoints
-- **Reporting rules** --- reporting rule management endpoints
-- **Heartbeat** --- agent heartbeat endpoints
+- **Agents**: agent management endpoints
+- **Configs**: configuration management endpoints
+- **Labels**: label management endpoints
+- **Reporting rules**: reporting rule management endpoints
+- **Heartbeat**: agent heartbeat endpoints
 
 When authentication is enabled for an endpoint group, every request to that
 group must include a valid API token or an active session.

--- a/content/telegraf/controller/reference/config-options.md
+++ b/content/telegraf/controller/reference/config-options.md
@@ -93,6 +93,15 @@ telegraf_controller --no-interactive
 - [Logging](#logging)
   - [rust-log](#rust-log)
   - [logs-dir](#logs-dir)
+- [Audit logging](#audit-logging)
+  - [audit-enabled](#audit-enabled)
+  - [audit-log-retention](#audit-log-retention)
+  - [audit-syslog-host](#audit-syslog-host)
+  - [audit-syslog-port](#audit-syslog-port)
+  - [audit-syslog-protocol](#audit-syslog-protocol)
+  - [audit-webhook-url](#audit-webhook-url)
+  - [audit-webhook-auth-header](#audit-webhook-auth-header)
+  - [audit-file-path](#audit-file-path)
 - [EULA and setup](#eula-and-setup)
   - [eula-accept](#eula-accept)
   - [no-interactive](#no-interactive)
@@ -381,6 +390,130 @@ Absolute path for heartbeat agent logs.
 | Command flag | Environment variable |
 | :----------- | :------------------- |
 | `--logs-dir` | `LOGS_DIR`           |
+
+---
+
+### Audit logging
+
+Audit logging is a [Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/)
+feature. All of the following options are read at startup only; changes
+after startup require a restart. For a task-based walkthrough, see
+[Enable and configure audit logging](/telegraf/controller/audit-logs/enable-configure/).
+
+- [audit-enabled](#audit-enabled)
+- [audit-log-retention](#audit-log-retention)
+- [audit-syslog-host](#audit-syslog-host)
+- [audit-syslog-port](#audit-syslog-port)
+- [audit-syslog-protocol](#audit-syslog-protocol)
+- [audit-webhook-url](#audit-webhook-url)
+- [audit-webhook-auth-header](#audit-webhook-auth-header)
+- [audit-file-path](#audit-file-path)
+
+#### audit-enabled
+
+Enable audit logging on startup. Audit logging requires a Telegraf
+Enterprise license to take effect.
+
+**Default:** `false`
+
+| Command flag      | Environment variable |
+| :---------------- | :------------------- |
+| `--audit-enabled` | `AUDIT_ENABLED`      |
+
+---
+
+#### audit-log-retention
+
+Sets the initial audit log retention period, in hours.
+{{% product-name %}} persists this value to the database on first startup;
+later changes to the environment variable have no effect.
+Update retention after first startup from the **Settings** page.
+
+Supported values: `720` (30 days), `2160` (90 days), `4320` (180 days),
+`8760` (1 year), `17520` (2 years), or `0` (infinite).
+
+**Default:** `2160`
+
+| Command flag | Environment variable  |
+| :----------- | :-------------------- |
+| _(none)_     | `AUDIT_LOG_RETENTION` |
+
+---
+
+#### audit-syslog-host
+
+Hostname or IP address of a syslog server.
+When set together with [`audit-syslog-port`](#audit-syslog-port) and
+[`audit-syslog-protocol`](#audit-syslog-protocol),
+{{% product-name %}} forwards each audit event to the configured syslog
+destination.
+
+| Command flag          | Environment variable |
+| :-------------------- | :------------------- |
+| `--audit-syslog-host` | `AUDIT_SYSLOG_HOST`  |
+
+---
+
+#### audit-syslog-port
+
+Port number of the syslog server. Required to enable syslog forwarding.
+
+| Command flag          | Environment variable |
+| :-------------------- | :------------------- |
+| `--audit-syslog-port` | `AUDIT_SYSLOG_PORT`  |
+
+---
+
+#### audit-syslog-protocol
+
+Transport protocol used to deliver audit events to the syslog server.
+Required to enable syslog forwarding.
+
+Supported values: `tcp`, `udp`
+
+| Command flag              | Environment variable    |
+| :------------------------ | :---------------------- |
+| `--audit-syslog-protocol` | `AUDIT_SYSLOG_PROTOCOL` |
+
+---
+
+#### audit-webhook-url
+
+URL that receives each audit event as a JSON-encoded HTTP `POST` request.
+{{% product-name %}} retries each delivery up to three times with backoff
+and honors `Retry-After` response headers.
+
+| Command flag          | Environment variable |
+| :-------------------- | :------------------- |
+| `--audit-webhook-url` | `AUDIT_WEBHOOK_URL`  |
+
+---
+
+#### audit-webhook-auth-header
+
+Optional value sent as the `Authorization` HTTP header on webhook requests.
+Use it to pass a bearer token, basic-auth credential, or other shared
+secret your webhook endpoint requires.
+
+| Command flag                  | Environment variable        |
+| :---------------------------- | :-------------------------- |
+| `--audit-webhook-auth-header` | `AUDIT_WEBHOOK_AUTH_HEADER` |
+
+---
+
+#### audit-file-path
+
+Absolute path to a local file.
+When set, {{% product-name %}} appends each audit event as a single JSON
+object on its own line (`.jsonl` format).
+The path must be writable by the {{% product-name %}} process.
+
+{{% product-name %}} does not rotate or trim this file.
+Pair it with a system log rotator if you keep the forwarder on long term.
+
+| Command flag        | Environment variable |
+| :------------------ | :------------------- |
+| `--audit-file-path` | `AUDIT_FILE_PATH`    |
 
 ---
 

--- a/content/telegraf/controller/settings.md
+++ b/content/telegraf/controller/settings.md
@@ -1,7 +1,8 @@
 ---
 title: Manage settings
 description: >
-  Configure login security and password policies in Telegraf Controller.
+  Configure login security, password policies, and audit log retention in
+  Telegraf Controller.
 menu:
   telegraf_controller:
     name: Manage settings
@@ -9,6 +10,7 @@ weight: 9
 related:
   - /telegraf/controller/reference/config-options/
   - /telegraf/controller/reference/authorization/
+  - /telegraf/controller/audit-logs/
 ---
 
 Owners and administrators can configure login security and password requirements
@@ -84,6 +86,28 @@ Changes made on the **Settings** page override initialized settings.
 
 _For detailed descriptions and bootstrap behavior, see the
 [Authentication and security section in the configuration options reference](/telegraf/controller/reference/config-options/#authentication-and-security)._
+
+## Audit logging
+
+When audit logging is enabled, the **Settings** page lets you change the
+retention period for audit entries.
+The default retention is 90 days (2160 hours), and available values range
+from 30 days to 2 years or infinite.
+
+> [!Note]
+> Audit logging itself is enabled at startup only and requires a
+> [Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/) license.
+> For details, see
+> [Enable and configure audit logging](/telegraf/controller/audit-logs/enable-configure/).
+
+To change the audit log retention period:
+
+1. Navigate to the **Settings** page.
+2. In the **Audit Logging** section, select a value from
+   **Audit log retention**.
+3. Click **Save**.
+
+<!-- TODO: screenshot of the Settings > Audit Logging section showing the Audit log retention dropdown. Save to /static/img/telegraf/controller-settings-audit-retention.png and replace this comment with: {{< img-hd src="/img/telegraf/controller-settings-audit-retention.png" alt="Telegraf Controller audit log retention dropdown" />}} -->
 
 ## Enterprise licensing
 

--- a/content/telegraf/controller/telegraf-enterprise/_index.md
+++ b/content/telegraf/controller/telegraf-enterprise/_index.md
@@ -39,11 +39,11 @@ for the free-tier defaults.
 A Telegraf Enterprise license unlocks the following features in
 {{% product-name %}}:
 
-- **Audit logging** --- Tamper-evident log of administrative actions
+- **Audit logging**: Tamper-evident log of administrative actions
   performed in {{% product-name %}}.
-- **LDAP authentication** --- Authenticate {{% product-name %}} users
+- **LDAP authentication**: Authenticate {{% product-name %}} users
   against an LDAP directory.
-- **OIDC authentication** --- Single sign-on through OpenID Connect
+- **OIDC authentication**: Single sign-on through OpenID Connect
   providers such as Okta, Auth0, and Microsoft Entra ID.
 
 ### Enterprise support contract

--- a/content/telegraf/controller/telegraf-enterprise/manage-license.md
+++ b/content/telegraf/controller/telegraf-enterprise/manage-license.md
@@ -29,14 +29,14 @@ free tier.
 
 **In the UI**, navigate to **Settings > Enterprise** to view:
 
-- **License ID** --- the unique identifier for your license. Include this
+- **License ID**: the unique identifier for your license. Include this
   value when contacting InfluxData support.
-- **Loaded** --- the date and time the license was applied to this
+- **Loaded**: the date and time the license was applied to this
   {{% product-name %}} instance.
-- **Expires** --- the contractual expiration date, with a status chip
+- **Expires**: the contractual expiration date, with a status chip
   indicating current state (valid, expiring, or expired).
-- **Max configurations** --- the configurations entitlement from the license.
-- **Max reporting agents** --- the reporting agents entitlement from the
+- **Max configurations**: the configurations entitlement from the license.
+- **Max reporting agents**: the reporting agents entitlement from the
   license.
 
 <!-- TODO: screenshot of the license details card on Settings > Enterprise, save to /static/img/telegraf/controller-licensing-details-card.png and replace with img-hd shortcode -->

--- a/content/telegraf/controller/telegraf-enterprise/troubleshoot.md
+++ b/content/telegraf/controller/telegraf-enterprise/troubleshoot.md
@@ -139,13 +139,13 @@ logs (stdout and stderr by default).
 
 Look for log lines containing:
 
-- `license` --- license bootstrap, validation, and replacement events.
-- `License bootstrap` --- the message emitted when `LICENSE_FILE_PATH` is
+- `license`: license bootstrap, validation, and replacement events.
+- `License bootstrap`: the message emitted when `LICENSE_FILE_PATH` is
   processed at startup. A successful load includes the license ID; a failure
   includes the validation error.
-- `License upload` --- the message emitted when a license is uploaded
+- `License upload`: the message emitted when a license is uploaded
   through the UI.
-- `License expiration` --- messages emitted by the hourly expiration check
+- `License expiration`: messages emitted by the hourly expiration check
   when a license transitions between lifecycle states.
 
 ## Get help

--- a/content/telegraf/controller/users/_index.md
+++ b/content/telegraf/controller/users/_index.md
@@ -21,11 +21,11 @@ your {{% product-name %}} instance.
 
 Each user account is in one of the following states:
 
-- **Active** --- The user can log in and perform actions based on their assigned
+- **Active**: The user can log in and perform actions based on their assigned
   role.
-- **Disabled** --- The user cannot log in. Existing API tokens remain associated
+- **Disabled**: The user cannot log in. Existing API tokens remain associated
   with the account but are unusable while the user is disabled.
-- **Locked** --- A temporary state triggered by too many failed login attempts.
+- **Locked**: A temporary state triggered by too many failed login attempts.
   The lock clears automatically after the configured lockout period. See the
   [Settings](/telegraf/controller/settings/) page for configuration options.
 

--- a/layouts/shortcodes/telegraf/enterprise-feature.html
+++ b/layouts/shortcodes/telegraf/enterprise-feature.html
@@ -1,0 +1,16 @@
+{{ $feature := .Get 0 | default "This feature" }}
+{{ $wordForm := .Get 1 | default "is" }}
+<div class="block special-state">
+  <div class="state-content telegraf-enterprise">
+    <div class="telegraf-enterprise-text">
+      <h4 id="telegraf-enterprise-feature">Available with Telegraf Enterprise</h4>
+      <p>
+        {{ $feature }} {{ $wordForm }} only available with Telegraf Enterprise. If you are interested in learning more about Telegraf Enterprise, 
+        <a href="https://www.influxdata.com/products/telegraf-enterprise/">contact us</a>.
+      </p>
+    </div>
+    <div class="telegraf-enterprise-cta">
+      <a href="https://www.influxdata.com/products/telegraf-enterprise/" class="btn"><span class="cf-icon Shield"></span> Upgrade to Enterprise</a>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

- Add a new audit-logs section with an overview (what gets audited, storage, integrity, license/permissions), a task-based enable-and-configure page covering retention and event forwarders, and a view-via-API page.
- Add an Audit logging section to the configuration options reference (eight `AUDIT_*` env vars and flags) and to the in-app Settings page (retention dropdown).

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
