### PR TITLE
Update InfluxDB Docker latest tag date to September 2026

### DIFF
--- a/data/notifications.yaml
+++ b/data/notifications.yaml
@@ -189,7 +189,7 @@
 #     - [InfluxDB 3 Core release notes](/influxdb3/core/release-notes/)
 #     - [InfluxDB 3 Enterprise release notes](/influxdb3/enterprise/release-notes/)
 
-- id: influxdb-docker-latest-tag-apr
+- id: influxdb-docker-latest-tag-sept
   level: warn
   scope:
     - /
@@ -204,7 +204,7 @@
     - /influxdb/cloud
   title: InfluxDB Docker latest tag changing to InfluxDB 3 Core
   slug: |
-    On **May 27, 2026**, the `latest` tag for InfluxDB Docker images will
+    On **September 15, 2026**, the `latest` tag for InfluxDB Docker images will
     point to InfluxDB 3 Core. To avoid unexpected upgrades, use specific version
     tags in your Docker deployments.
   message: |


### PR DESCRIPTION
## Summary

Update the Docker latest tag transition date to September 15, 2026.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)