### PR TITLE
feat(influxdb3): add 3.9.3 release notes

### DIFF
--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -6,6 +6,23 @@
 > All updates to Core are automatically included in Enterprise.
 > The Enterprise sections below only list updates exclusive to Enterprise.
 
+## v3.9.3 {date="2026-05-29"}
+
+### Core
+
+Maintenance release: v3.9.3 Core includes only build and dependency updates—no user-facing changes.
+
+### Enterprise
+
+All Core updates are included in Enterprise.
+Additional Enterprise-specific updates:
+
+#### Bug fixes
+
+- **Query chunk deduplication**: Fixed an issue where the same file could reach the query path from both the compactor and the ingester, causing affected queries to abort.
+- **Large file uploads during compaction**: Index files written during compaction now use adaptive uploads, preventing errors when writing large files to object storage.
+- Other bug fixes and performance improvements
+
 ## v3.9.2 {date="2026-04-30"}
 
 ### Core

--- a/data/products.yml
+++ b/data/products.yml
@@ -12,7 +12,7 @@ influxdb3_core:
   versions: [core]
   list_order: 2
   latest: core
-  latest_patch: 3.9.2
+  latest_patch: 3.9.3
   placeholder_host: localhost:8181
   limits:
     database: 5
@@ -56,7 +56,7 @@ influxdb3_enterprise:
   versions: [enterprise]
   list_order: 2
   latest: enterprise
-  latest_patch: 3.9.2
+  latest_patch: 3.9.3
   placeholder_host: localhost:8181
   limits:
     database: 100


### PR DESCRIPTION
## Summary

Documents the InfluxDB 3 Core and Enterprise **v3.9.3** release and bumps `latest_patch` to `3.9.3` for both products.

- **Core** — maintenance release (build/dependency updates only, no user-facing changes), consistent with the 3.9.1/3.9.2 entries.
- **Enterprise** — two bug fixes plus the standard "Other bug fixes and performance improvements" line.

## How the notes were derived

Comparing `v3.9.2..v3.9.3` in `influxdata/influxdb_pro`, the substantive changes were both Enterprise-only (`ent/` paths):

| Commit | Area | Classification |
| --- | --- | --- |
| `cc14b2ab8` query chunk dedup (EAR6833) | `ent/` | Enterprise bug fix |
| `ad79fe68a` `put_adaptive` for compaction index files | `ent/` | Enterprise bug fix |
| `8f72e6a7c` Rust 1.95.0 toolchain + clippy lints | `oss/` + `ent/` | maintenance |
| `1b96fbef9` version bump to 3.9.3 | — | not user-facing |

Nothing user-facing landed in Core (`oss/` saw only clippy-lint tweaks), so Core is documented as a maintenance release. The `date="2026-05-29"` comes from the `v3.9.3` tag.

## Changes

- `content/shared/v3-core-enterprise-release-notes/_index.md` — add v3.9.3 section above v3.9.2.
- `data/products.yml` — bump `latest_patch` 3.9.2 → 3.9.3 for `influxdb3_core` and `influxdb3_enterprise`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)