### PR TITLE
feat(platform): expand FAQ with category-level Q&As and FAQPage JSON-LD

### DIFF
--- a/content/platform/faq.md
+++ b/content/platform/faq.md
@@ -1,33 +1,14 @@
 ---
 title: Frequently asked questions
-description: Frequently asked questions about time series data and the InfluxData platform.
+description: >
+  Frequently asked questions about time series data, what InfluxDB is used for,
+  which industries use it, and which version of InfluxDB to choose.
 menu:
   platform:
     name: Frequently asked questions
     weight: 70
+faq_data: platform
+faq_canonical: true
 ---
 
-[What is time series data?](#what-is-time-series-data)  
-[Why shouldn't I just use a relational database?](#why-shouldnt-i-just-use-a-relational-database)  
-[Which version of InfluxDB should I use?](#which-version-of-influxdb-should-i-use)  
-
-## What is time series data?
-Time series data is a series of data points each associated with a specific time.
-Examples include:
-
-- Server performance metrics
-- Financial averages over time
-- Sensor data, such as temperature, barometric pressure, wind speeds, etc.
-
-## Why shouldn't I just use a relational database?
-Relational databases can be used to store and analyze time series data, but depending
-on the precision of your data, a query can involve potentially millions of rows.
-InfluxDB is purpose-built to store and query data by time, providing out-of-the-box
-functionality that optionally downsamples data after a specific age and a query
-engine optimized for time-based data.
-
-## Which version of InfluxDB should I use?
-For new projects, use InfluxDB 3.
-See [Which InfluxDB 3 should I use?](/influxdb3/which-influxdb-3/)
-for a decision guide across InfluxDB 3 products and migration
-from InfluxDB 1 or InfluxDB 2.
+{{< faq >}}

--- a/cypress/e2e/content/platform-faq.cy.js
+++ b/cypress/e2e/content/platform-faq.cy.js
@@ -1,0 +1,84 @@
+/// <reference types="cypress" />
+
+// Issue #7202: expand /platform/faq/ with category-level Q&As and emit
+// FAQPage JSON-LD. The page is data-driven (data/faqs/platform.yml) via the
+// `faq` shortcode and the header/faq-jsonld.html partial (faq_data: platform,
+// faq_canonical: true).
+
+describe('Platform FAQ page', function () {
+  const url = '/platform/faq/';
+
+  // Question text + anchorized id. Anchors are stable URLs that LLMs and
+  // search engines deep-link to, so changing them is a breaking change.
+  const questions = [
+    { text: 'What is time series data?', anchor: 'what-is-time-series-data' },
+    {
+      text: 'What is InfluxDB used for?',
+      anchor: 'what-is-influxdb-used-for',
+    },
+    {
+      text: 'What industries use InfluxDB?',
+      anchor: 'what-industries-use-influxdb',
+    },
+    {
+      text: 'When should I use a time series database?',
+      anchor: 'when-should-i-use-a-time-series-database',
+    },
+    {
+      text: "What's the difference between a time series database and a relational database?",
+      anchor:
+        'whats-the-difference-between-a-time-series-database-and-a-relational-database',
+    },
+    { text: 'Is InfluxDB open source?', anchor: 'is-influxdb-open-source' },
+    {
+      text: 'Which version of InfluxDB should I use?',
+      anchor: 'which-version-of-influxdb-should-i-use',
+    },
+  ];
+
+  beforeEach(() => cy.visit(url));
+
+  it('renders each FAQ question as an H2 with a stable anchor', function () {
+    questions.forEach(({ text, anchor }) => {
+      cy.get(`h2#${anchor}`).should('contain.text', text);
+    });
+  });
+
+  it('wraps each FAQ answer in <div class="faq-answer"><p>...</p></div>', function () {
+    cy.get('div.faq-answer').should('have.length', questions.length);
+    cy.get('div.faq-answer').each(($div) => {
+      cy.wrap($div).find('p').should('have.length.gte', 1);
+    });
+  });
+
+  it('cross-links to the decision page from the version Q&A', function () {
+    cy.get('a[href="/influxdb3/which-influxdb-3/"]').should('exist');
+  });
+
+  it('does NOT leak raw markdown headings or list markers into the HTML', function () {
+    cy.get('article.article--content').then(($article) => {
+      const html = $article[0].innerHTML;
+      expect(html).not.to.match(/(^|\n)## /);
+      expect(html).not.to.match(/(^|\n)- \[/);
+    });
+  });
+
+  it('emits FAQPage JSON-LD with one Question entity per visible Q&A', function () {
+    cy.get('script[type="application/ld+json"]').then(($scripts) => {
+      const faq = [...$scripts]
+        .map((s) => JSON.parse(s.textContent))
+        .find((j) => j['@type'] === 'FAQPage');
+      expect(faq, 'FAQPage JSON-LD present').to.exist;
+      expect(faq['@context']).to.equal('https://schema.org');
+      expect(faq.mainEntity).to.have.length(questions.length);
+      faq.mainEntity.forEach((q) => {
+        expect(q['@type']).to.equal('Question');
+        expect(q.name).to.be.a('string').and.not.empty;
+        expect(q.acceptedAnswer['@type']).to.equal('Answer');
+        expect(q.acceptedAnswer.text).to.be.a('string').and.not.empty;
+        // Plain text only — no leftover HTML tags from markdownify | plainify.
+        expect(q.acceptedAnswer.text).to.not.match(/<[a-z][^>]*>/i);
+      });
+    });
+  });
+});

--- a/data/faqs/platform.yml
+++ b/data/faqs/platform.yml
@@ -1,0 +1,71 @@
+# FAQ data for /platform/faq/. Rendered as visible Q&As by the `faq`
+# shortcode and emitted as schema.org FAQPage JSON-LD by
+# layouts/partials/header/faq-jsonld.html (page sets faq_data: platform and
+# faq_canonical: true). Answers are front-loaded: lead with the direct answer,
+# then add detail.
+
+- question: "What is time series data?"
+  answer: |
+    Time series data is a sequence of data points, each associated with a
+    timestamp, that measure how something changes over time. Common examples
+    include server and application metrics, network telemetry, financial
+    prices, and sensor readings such as temperature, pressure, and voltage.
+    Time series workloads are write-heavy, append-mostly, and queried by time
+    range.
+
+- question: "What is InfluxDB used for?"
+  answer: |
+    InfluxDB is a purpose-built time series database for storing and querying
+    large volumes of timestamped data in real time. Common use cases include
+    infrastructure and application monitoring, network monitoring, IoT and
+    industrial sensor data, energy and battery (BESS) systems, and financial
+    market analytics. It is optimized for high-ingest workloads and fast
+    queries that power dashboards, alerting, and automation.
+
+- question: "What industries use InfluxDB?"
+  answer: |
+    InfluxDB is used across industrial IoT (IIoT) and manufacturing, energy
+    and battery energy storage systems (BESS), software observability and
+    DevOps monitoring, telecommunications and network operations, financial
+    services, and aerospace. These domains share a common need: ingest
+    high-frequency measurements from many sources and query them by time for
+    monitoring, analytics, and control.
+
+- question: "When should I use a time series database?"
+  answer: |
+    Use a time series database when your primary access pattern is "what
+    happened over this time range" and you ingest a continuous stream of
+    timestamped measurements. It is the right choice for metrics, events,
+    sensor data, and telemetry, where write throughput is high and queries
+    aggregate or downsample data by time. A general-purpose relational
+    database is a better fit for transactional, relationship-heavy data that
+    isn't primarily organized by time.
+
+- question: "What's the difference between a time series database and a relational database?"
+  answer: |
+    A time series database is optimized for timestamped data: it ingests
+    millions of points per second, indexes by time, and runs time-windowed
+    aggregations efficiently. A relational database is optimized for
+    transactional integrity and relationships across normalized tables. You
+    can store time series in a relational database, but a single time-range
+    query can scan millions of rows. InfluxDB stores and queries data by time
+    out of the box, optionally downsamples data after a set age, and uses a
+    query engine tuned for time-based access.
+
+- question: "Is InfluxDB open source?"
+  answer: |
+    Yes. InfluxDB 3 Core is open source under the permissive MIT or Apache 2.0
+    license and is free to download and run with no license key. InfluxDB 3
+    Enterprise is a commercial product built on the same engine; it offers a
+    30-day free trial and a free at-home license for non-commercial use.
+    The earlier InfluxDB 1 and InfluxDB 2 open source releases remain
+    available under open source licenses. For new projects, use InfluxDB 3.
+
+- question: "Which version of InfluxDB should I use?"
+  answer: |
+    For new projects, use InfluxDB 3. For new production workloads, use
+    InfluxDB 3 Enterprise; use InfluxDB 3 Core for free, open source,
+    single-node deployments. See
+    [Which InfluxDB 3 should I use?](/influxdb3/which-influxdb-3/) for a full
+    decision guide across InfluxDB 3 products and for migrating from
+    InfluxDB 1 or InfluxDB 2.


### PR DESCRIPTION
## Summary

Moves `/platform/faq/` to the data-driven FAQ pattern and adds a schema.org `FAQPage` JSON-LD node, completing the AI-visibility goal of #7202.

- Questions now live in `data/faqs/platform.yml`, rendered as visible Q&As by the `faq` shortcode and emitted as `FAQPage` JSON-LD by `layouts/partials/header/faq-jsonld.html` (gated on `faq_data` + `faq_canonical` frontmatter).
- Adds category-level Q&As: what time series data is, what InfluxDB is used for, which industries use it, when to use a time series database, time series vs. relational databases, and whether InfluxDB is open source.
- The "Which version should I use?" answer links to the `/influxdb3/which-influxdb-3/` decision guide rather than duplicating it.
- Adds a Cypress spec asserting the visible Q&As, stable heading anchors, and the `FAQPage` JSON-LD shape.

## Design note

`data/faqs/platform.yml` is intentionally separate from `data/faqs/which-influxdb-3.yml`. The two files share no Q&As — platform is conceptual/category-level, which-influxdb-3 is product-decision-specific. Per-page data files keep a 1:1 mapping between the file, the rendered page, and the page-scoped `FAQPage` node, so the visible content and the structured data can't drift. This matches the pattern shipped in #7220.

## Pages to preview

| URL | Expected |
| --- | --- |
| /platform/faq/ | Seven visible Q&As with stable `id` anchors; one `FAQPage` JSON-LD `<script>` in `<head>` whose `mainEntity` matches the visible questions |

## Validation

- `FAQPage` JSON-LD validated against `validator.schema.org` (0 errors) — not the Rich Results Test.
- Cypress: `cypress/e2e/content/platform-faq.cy.js`

Closes #7202

<img width="2533" height="1398" alt="Screenshot 2026-06-03 at 4 50 00 PM" src="https://github.com/user-attachments/assets/3744d307-3a65-46c2-8c04-cd0ab23f198d" />

