### PR TITLE
docs(controller): document TELEGRAF_CONTROLLER_TOKEN env var

### DIFF
--- a/content/telegraf/controller/agents/create.md
+++ b/content/telegraf/controller/agents/create.md
@@ -65,7 +65,7 @@ to specify the `instance_id`.
 [[outputs.heartbeat]]
   url = "http://telegraf_controller.example.com/agents/heartbeat"
   instance_id = "&{agent_id}"
-  token = "${INFLUX_TOKEN}"
+  token = "${TELEGRAF_CONTROLLER_TOKEN}"
   interval = "1m"
   include = ["hostname", "statistics", "configs"]
 
@@ -81,8 +81,10 @@ to specify the `instance_id`.
 > Provide a {{% product-name %}} token with **write** permissions on the
 > **Heartbeat** API.
 >
-> We recommend defining the `INFLUX_TOKEN` environment variable when starting
-> Telegraf and using that to define the token in your heartbeat plugin.
+> We recommend defining the `TELEGRAF_CONTROLLER_TOKEN` environment variable
+> when starting Telegraf and using it to define the token in your heartbeat
+> plugin. On **Telegraf 1.38.x or earlier**, use `INFLUX_TOKEN` instead. For
+> details, see [Use API tokens](/telegraf/controller/tokens/use/#for-heartbeat-requests).
 
 ## Verify a new agent
 

--- a/content/telegraf/controller/agents/status.md
+++ b/content/telegraf/controller/agents/status.md
@@ -64,7 +64,7 @@ If no metrics arrive, fall back to the `fail` status.
 [[outputs.heartbeat]]
   url = "http://telegraf_controller.example.com/agents/heartbeat"
   instance_id = "&{agent_id}"
-  token = "${INFLUX_TOKEN}"
+  token = "${TELEGRAF_CONTROLLER_TOKEN}"
   interval = "1m"
   include = ["hostname", "statistics", "configs", "logs", "status"]
 
@@ -81,7 +81,7 @@ Warn when errors are logged, fail when the error count is high.
 [[outputs.heartbeat]]
   url = "http://telegraf_controller.example.com/agents/heartbeat"
   instance_id = "&{agent_id}"
-  token = "${INFLUX_TOKEN}"
+  token = "${TELEGRAF_CONTROLLER_TOKEN}"
   interval = "1m"
   include = ["hostname", "statistics", "configs", "logs", "status"]
 
@@ -101,7 +101,7 @@ Combine error count and buffer pressure signals.
 [[outputs.heartbeat]]
   url = "http://telegraf_controller.example.com/agents/heartbeat"
   instance_id = "&{agent_id}"
-  token = "${INFLUX_TOKEN}"
+  token = "${TELEGRAF_CONTROLLER_TOKEN}"
   interval = "1m"
   include = ["hostname", "statistics", "configs", "logs", "status"]
 

--- a/content/telegraf/controller/configs/create.md
+++ b/content/telegraf/controller/configs/create.md
@@ -71,7 +71,7 @@ url = "http://localhost:8000/agents/heartbeat"
 instance_id = "&{agent_id}"
 interval = "1m"
 include = ["hostname", "statistics", "configs"]
-token = "${INFLUX_TOKEN}"
+token = "${TELEGRAF_CONTROLLER_TOKEN}"
 ```
 
 To monitor agents with {{% product-name %}}, include a heartbeat plugin in
@@ -85,8 +85,10 @@ your Telegraf configurations.
 > Provide a {{% product-name %}} token with **write** permissions on the
 > **Heartbeat** API.
 >
-> We recommend defining the `INFLUX_TOKEN` environment variable when starting
-> Telegraf and using that to define the token in your heartbeat plugin.
+> We recommend defining the `TELEGRAF_CONTROLLER_TOKEN` environment variable
+> when starting Telegraf and using it to define the token in your heartbeat
+> plugin. On **Telegraf 1.38.x or earlier**, use `INFLUX_TOKEN` instead. For
+> details, see [Use API tokens](/telegraf/controller/tokens/use/#for-heartbeat-requests).
 
 ## Next steps
 

--- a/content/telegraf/controller/configs/use.md
+++ b/content/telegraf/controller/configs/use.md
@@ -43,20 +43,25 @@ and then starts the `telegraf` process using the loaded configuration.
 ### Retrieve a configuration with authorization enabled
 
 If {{% product-name %}} is configured to require authentication on the **Configs**
-API, define the `INFLUX_TOKEN` environment variable to authorize Telegraf
-to retrieve a configuration:
+API, define the `TELEGRAF_CONTROLLER_TOKEN` environment variable to authorize
+Telegraf to retrieve a configuration:
 
 <!--pytest.mark.skip-->
 ```bash { placeholders="YOUR_TC_API_TOKEN" }
-export INFLUX_TOKEN=YOUR_TC_API_TOKEN
+export TELEGRAF_CONTROLLER_TOKEN=YOUR_TC_API_TOKEN
 
 telegraf \
-  --config "http://telegraf_controller.example.com/api/configs/xxxxxx/toml
+  --config "http://telegraf_controller.example.com/api/configs/xxxxxx/toml"
 ```
 
 Replace {{% code-placeholder-key %}}`YOUR_TC_API_TOKEN`{{% /code-placeholder-key %}}
 with your {{% product-name %}} API token. This token must have **read**
 permissions on the **Configs** API.
+
+> [!Important]
+> `TELEGRAF_CONTROLLER_TOKEN` requires **Telegraf 1.39+**. On earlier versions,
+> use `INFLUX_TOKEN` instead. For details, see
+> [Use API tokens with Telegraf agents](/telegraf/controller/tokens/use/#with-telegraf-agents).
 
 ## Set dynamic values
 

--- a/content/telegraf/controller/tokens/use.md
+++ b/content/telegraf/controller/tokens/use.md
@@ -24,30 +24,48 @@ Telegraf agents require API tokens with the following permissions:
 - **Configs**: Read
 - **Heartbeat**: Write
 
-### Use the INFLUX_TOKEN environment variable
+### Use the TELEGRAF_CONTROLLER_TOKEN environment variable {note="Telegraf 1.39+"}
 
-When retrieving a configuration from a URL, Telegraf only sends an `Authorization`
-when it detects the `INFLUX_TOKEN` environment variable. To authorize Telegraf
-to retrieve a configuration from {{% product-name %}}, define the `INFLUX_TOKEN`
-environment variable:
+When retrieving a configuration from a URL, Telegraf only sends an
+`Authorization` header when it detects an authentication environment variable.
+To authorize Telegraf to retrieve a configuration from {{% product-name %}},
+define the `TELEGRAF_CONTROLLER_TOKEN` environment variable before starting
+Telegraf:
 
 <!--pytest.mark.skip-->
 ```bash { placeholders="YOUR_TC_API_TOKEN" }
-export INFLUX_TOKEN=YOUR_TC_API_TOKEN
+export TELEGRAF_CONTROLLER_TOKEN=YOUR_TC_API_TOKEN
 
 telegraf \
-  --config "http://telegraf_controller.example.com/api/configs/xxxxxx/toml
+  --config "http://telegraf_controller.example.com/api/configs/xxxxxx/toml"
 ```
 
 Replace {{% code-placeholder-key %}}`YOUR_TC_API_TOKEN`{{% /code-placeholder-key %}}
 with your {{% product-name %}} API token.
 
+When `TELEGRAF_CONTROLLER_TOKEN` is set, Telegraf sends the token in the
+`Authorization` header using the `Bearer` scheme. The Telegraf config watcher
+(enabled with `--config-url-watch-interval`) uses the same environment variable
+to authorize its periodic update checks.
+
+> [!Note]
+> #### Using Telegraf 1.38.x or earlier?
+>
+> Telegraf 1.39+ is required to read `TELEGRAF_CONTROLLER_TOKEN`. On earlier
+> versions, use the `INFLUX_TOKEN` environment variable instead. Telegraf sends
+> `INFLUX_TOKEN` in the `Authorization` header using the `Token` scheme.
+> {{% product-name %}} accepts tokens sent with either scheme, so you can
+> upgrade Telegraf at your own pace.
+>
+> If both environment variables are set on Telegraf 1.39+,
+> `TELEGRAF_CONTROLLER_TOKEN` takes precedence.
+
 ### For heartbeat requests
 
 Telegraf uses the [Heartbeat output plugin](/telegraf/v1/output-plugins/heartbeat/)
 to send heartbeats to {{% product-name %}}.
-Use the `INFLUX_TOKEN` environment variable to define the `token` option in your
-heartbeat plugin configuration.
+Use the `TELEGRAF_CONTROLLER_TOKEN` environment variable to define the `token`
+option in your heartbeat plugin configuration.
 Telegraf uses the environment variable value defined when starting Telegraf.
 
 ```toml { .tc-dynamic-values }
@@ -56,7 +74,7 @@ Telegraf uses the environment variable value defined when starting Telegraf.
   instance_id = "&{agent_id}"
   interval = "1m"
   include = ["hostname", "statistics", "configs"]
-  token = "${INFLUX_TOKEN}"
+  token = "${TELEGRAF_CONTROLLER_TOKEN}"
 ```
 
 When authentication is required for the heartbeat endpoint, agents must include

--- a/content/telegraf/controller/tokens/use.md
+++ b/content/telegraf/controller/tokens/use.md
@@ -95,5 +95,6 @@ The token's permissions determine which API endpoints and operations are accessi
 Requests made with a token that lacks the required permissions are rejected with an authorization error.
 
 > [!Note]
-> If authentication is disabled for an endpoint group in **Settings**, requests to those endpoints do not require a token.
-> See [Settings](/telegraf/controller/settings/#require-authentication-per-endpoint) for details on configuring authentication requirements per endpoint.
+> If authentication is disabled for an endpoint, requests to those endpoints do not require a token.
+> See [Endpoint authentication](/telegraf/controller/reference/authentication-authorization/#endpoint-authentication)
+> for details on configuring authentication requirements per endpoint.


### PR DESCRIPTION
## Summary

Telegraf 1.39 adds `TELEGRAF_CONTROLLER_TOKEN` for authenticating remote-configuration requests to Telegraf Controller, sent in the `Authorization` header using the `Bearer` scheme.

- Update the Telegraf Controller docs to recommend the new env var, note the Telegraf 1.39+ version requirement, and document `INFLUX_TOKEN` as the backward-compatible fallback (sent with the Token scheme; both schemes accepted by Controller).
- Updates the canonical tokens/use page, the configs/use config-fetch example, and all heartbeat TOML examples and recommendation callouts across configs/create, agents/create, and agents/status.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
