### PR TITLE
Feat/telegraf enterprise landing

### DIFF
--- a/assets/styles/layouts/_homepage.scss
+++ b/assets/styles/layouts/_homepage.scss
@@ -228,6 +228,44 @@
       background: $article-bg;
     }
 
+    a.alt-color {
+      text-decoration: none;
+      color: $article-link;
+      font-weight: $medium;
+      position: relative;
+
+      &::before {
+        content: "";
+        position: absolute;
+        bottom: -2px;
+        height: 2px;
+        width: 0%;
+        @include gradient($grad-blue-light);
+        transition: width .2s;
+      }
+
+      &::after {
+        content: "\e90a";
+        font-family: 'icomoon-v4';
+        font-weight: bold;
+        font-size: 1.3rem;
+        display: inline-block;
+        position: absolute;
+        @include gradient($grad-blue-light);
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+        right: 0;
+        transform: translateX(.25rem);
+        opacity: 0;
+        transition: transform .2s, opacity .2s;
+      }
+
+      &:hover {
+        &::before {width: 100%;}
+        &::after {transform: translateX(1.5rem); opacity: 1;}
+      }
+    }
+
     .categories {
       display: flex;
       flex-direction: row;

--- a/assets/styles/layouts/article/blocks/_special-state.scss
+++ b/assets/styles/layouts/article/blocks/_special-state.scss
@@ -121,7 +121,7 @@
 
       .telegraf-enterprise-text {
         flex: 2;
-        min-width: 400px;
+        min-width: 360px;
         p { margin-bottom: 0; }
       }
       .telegraf-enterprise-cta {
@@ -135,5 +135,15 @@
         }
       }
     }
+  }
+}
+
+///////////////////////////////// MEDIA QUERIES ////////////////////////////////
+
+@include media(small) {
+  .block.special-state .state-content.telegraf-enterprise {
+    flex-direction: column;
+    align-items: flex-start;
+    .telegraf-enterprise-text { min-width: unset; }
   }
 }

--- a/config/_default/hugo.yml
+++ b/config/_default/hugo.yml
@@ -20,6 +20,43 @@ blackfriday:
   hrefTargetBlank: true
   smartDashes: false
 
+# telegraf_enterprise sidebar: curated cross-section nav for the
+# /telegraf/enterprise/ landing. These entries are explicit URLs (not pages)
+# because the landing routes users into Telegraf, Telegraf Controller, and
+# the license-management operational pages — none of which are descendants
+# of /telegraf/enterprise/.
+menu:
+  telegraf_enterprise:
+    - name: Telegraf
+      url: /telegraf/v1/
+      weight: 10
+    - name: Enterprise support for Telegraf
+      url: /telegraf/v1/enterprise/
+      weight: 11
+      parent: Telegraf
+    - name: Telegraf Controller
+      url: /telegraf/controller/
+      weight: 20
+    - name: Apply a license
+      url: /telegraf/controller/telegraf-enterprise/apply-license/
+      weight: 21
+      parent: Telegraf Controller
+    - name: Manage a license
+      url: /telegraf/controller/telegraf-enterprise/manage-license/
+      weight: 22
+      parent: Telegraf Controller
+    - name: License enforcement
+      url: /telegraf/controller/telegraf-enterprise/license-enforcement/
+      weight: 23
+      parent: Telegraf Controller
+    - name: Troubleshoot licensing
+      url: /telegraf/controller/telegraf-enterprise/troubleshoot/
+      weight: 24
+      parent: Telegraf Controller
+    - name: Contact InfluxData sales
+      url: https://www.influxdata.com/contact-sales/
+      weight: 99
+
 taxonomies:
   influxdb/v2/tag: influxdb/v2/tags
   influxdb/cloud/tag: influxdb/cloud/tags

--- a/content/telegraf/controller/audit-logs/_index.md
+++ b/content/telegraf/controller/audit-logs/_index.md
@@ -13,7 +13,7 @@ cascade:
   related:
     - /telegraf/controller/reference/config-options/
     - /telegraf/controller/reference/authentication-authorization/
-    - /telegraf/controller/telegraf-enterprise/
+    - /telegraf/enterprise/
 ---
 
 {{% product-name %}} records security-relevant events to an append-only,
@@ -72,7 +72,7 @@ Any modification, deletion, or out-of-order insertion breaks the chain.
 
 ## License and permissions
 
-Audit logging is part of [Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/)
+Audit logging is part of [Telegraf Enterprise](/telegraf/enterprise/)
 and is unavailable in the free tier.
 With a valid license:
 

--- a/content/telegraf/controller/audit-logs/enable-configure.md
+++ b/content/telegraf/controller/audit-logs/enable-configure.md
@@ -29,7 +29,7 @@ destinations for long-term storage or SIEM integration.
 
 ## Prerequisites
 
-- A valid [Telegraf Enterprise license](/telegraf/controller/telegraf-enterprise/)
+- A valid [Telegraf Enterprise license](/telegraf/enterprise/)
   applied to your {{% product-name %}} instance.
 - Permission to modify the {{% product-name %}} startup environment (for
   example, the systemd unit file or Docker run command).

--- a/content/telegraf/controller/authentication/_index.md
+++ b/content/telegraf/controller/authentication/_index.md
@@ -21,8 +21,8 @@ individually or together:
 | Provider  | Availability                                                     | How users sign in                                    |
 | :-------- | :--------------------------------------------------------------- | :--------------------------------------------------- |
 | **Local** | Free                                                             | Username and password stored in {{% product-name %}} |
-| **LDAP**  | [Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/) | Bind against an LDAP or Active Directory server      |
-| **OIDC**  | [Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/) | Authorization code + PKCE flow with an OIDC provider |
+| **LDAP**  | [Telegraf Enterprise](/telegraf/enterprise/) | Bind against an LDAP or Active Directory server      |
+| **OIDC**  | [Telegraf Enterprise](/telegraf/enterprise/) | Authorization code + PKCE flow with an OIDC provider |
 
 Each provider is enabled and configured independently. You can run all three
 at once and let users choose at the sign-in screen, or restrict sign-in to a

--- a/content/telegraf/controller/authentication/ldap.md
+++ b/content/telegraf/controller/authentication/ldap.md
@@ -12,7 +12,7 @@ menu:
 weight: 102
 related:
   - /telegraf/controller/authentication/
-  - /telegraf/controller/telegraf-enterprise/
+  - /telegraf/enterprise/
   - /telegraf/controller/reference/config-options/#authentication-and-security
   - /telegraf/controller/settings/
 ---
@@ -35,7 +35,7 @@ roles and provision accounts.
 
 ## Prerequisites
 
-- A valid [Telegraf Enterprise license](/telegraf/controller/telegraf-enterprise/)
+- A valid [Telegraf Enterprise license](/telegraf/enterprise/)
   applied to your {{% product-name %}} instance.
 - A reachable LDAP server (`ldap://` or `ldaps://`) and a service-account
   bind DN that can search the user subtree.

--- a/content/telegraf/controller/authentication/oidc.md
+++ b/content/telegraf/controller/authentication/oidc.md
@@ -12,7 +12,7 @@ menu:
 weight: 103
 related:
   - /telegraf/controller/authentication/
-  - /telegraf/controller/telegraf-enterprise/
+  - /telegraf/enterprise/
   - /telegraf/controller/reference/config-options/#authentication-and-security
   - /telegraf/controller/settings/
 ---
@@ -36,7 +36,7 @@ provision accounts.
 
 ## Prerequisites
 
-- A valid [Telegraf Enterprise license](/telegraf/controller/telegraf-enterprise/)
+- A valid [Telegraf Enterprise license](/telegraf/enterprise/)
   applied to your {{% product-name %}} instance.
 - An OIDC-compliant identity provider that supports authorization code flow
   with PKCE (S256).

--- a/content/telegraf/controller/install/_index.md
+++ b/content/telegraf/controller/install/_index.md
@@ -595,7 +595,7 @@ For more information about user roles and permissions, see
 
 ## Apply a Telegraf Enterprise license (optional)
 
-If you have a [Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/)
+If you have a [Telegraf Enterprise](/telegraf/enterprise/)
 license, you can apply it at startup by setting the `LICENSE_FILE_PATH`
 environment variable to the path of your license file.
 
@@ -610,7 +610,7 @@ and Docker examples, see
 
 Without a license, {{% product-name %}} runs in a free tier with reduced
 scale limits and enterprise features disabled. See
-[Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/) for a
+[Telegraf Enterprise](/telegraf/enterprise/) for a
 comparison.
 
 ## Access {{% product-name %}}

--- a/content/telegraf/controller/reference/authentication-authorization.md
+++ b/content/telegraf/controller/reference/authentication-authorization.md
@@ -44,8 +44,8 @@ individually or together:
 | Provider  | Availability                                                     | How users sign in                                    |
 | :-------- | :--------------------------------------------------------------- | :--------------------------------------------------- |
 | **Local** | Free tier                                                        | Username and password stored in {{% product-name %}} |
-| **LDAP**  | [Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/) | Bind against an LDAP or Active Directory server      |
-| **OIDC**  | [Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/) | Authorization code + PKCE flow with an OIDC provider |
+| **LDAP**  | [Telegraf Enterprise](/telegraf/enterprise/) | Bind against an LDAP or Active Directory server      |
+| **OIDC**  | [Telegraf Enterprise](/telegraf/enterprise/) | Authorization code + PKCE flow with an OIDC provider |
 
 Each provider is enabled at startup with a dedicated environment variable
 (`AUTH_LOCAL_ENABLED`, `AUTH_LDAP_ENABLED`, `AUTH_OIDC_ENABLED`). Provider
@@ -181,7 +181,7 @@ groups skip authentication, update the value and restart
 ## License management
 
 {{% product-name %}} exposes two permission resources for the
-[Telegraf Enterprise license](/telegraf/controller/telegraf-enterprise/):
+[Telegraf Enterprise license](/telegraf/enterprise/):
 
 | Resource | Actions | Required role | Description |
 | :------- | :------ | :------------ | :---------- |

--- a/content/telegraf/controller/reference/config-options.md
+++ b/content/telegraf/controller/reference/config-options.md
@@ -414,7 +414,7 @@ telegraf_controller --disable-auth-endpoints="*"
 
 Local authentication is enabled by default and is the only authentication
 provider available without a
-[Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/) license.
+[Telegraf Enterprise](/telegraf/enterprise/) license.
 The variables in this group apply only when
 [`auth-local-enabled`](#auth-local-enabled) is `true`. LDAP and OIDC
 providers enforce their own credential and lockout policies.
@@ -503,7 +503,7 @@ initial setup, password changes, password resets, and invite completion.
 #### LDAP authentication
 
 LDAP authentication is a
-[Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/) feature.
+[Telegraf Enterprise](/telegraf/enterprise/) feature.
 If `AUTH_LDAP_*` variables are set on an unlicensed instance,
 {{% product-name %}} starts normally, logs a warning, and leaves LDAP
 inactive until a license is applied and the application is restarted.
@@ -681,7 +681,7 @@ group-to-role mappings configured on the **Settings** page.
 #### OIDC authentication
 
 OIDC authentication is a
-[Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/) feature.
+[Telegraf Enterprise](/telegraf/enterprise/) feature.
 If `AUTH_OIDC_*` variables are set on an unlicensed instance,
 {{% product-name %}} starts normally, logs a warning, and leaves OIDC
 inactive until a license is applied and the application is restarted.
@@ -866,7 +866,7 @@ Absolute path for heartbeat agent logs.
 
 ### Audit logging
 
-Audit logging is a [Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/)
+Audit logging is a [Telegraf Enterprise](/telegraf/enterprise/)
 feature. All of the following options are read at startup only; changes
 after startup require a restart. For a task-based walkthrough, see
 [Enable and configure audit logging](/telegraf/controller/audit-logs/enable-configure/).

--- a/content/telegraf/controller/settings.md
+++ b/content/telegraf/controller/settings.md
@@ -97,7 +97,7 @@ accounts.
 
 > [!Note]
 > LDAP authentication requires a
-> [Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/) license.
+> [Telegraf Enterprise](/telegraf/enterprise/) license.
 > For setup instructions, see
 > [Configure LDAP authentication](/telegraf/controller/authentication/ldap/).
 
@@ -135,7 +135,7 @@ accounts.
 
 > [!Note]
 > OIDC authentication requires a
-> [Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/) license.
+> [Telegraf Enterprise](/telegraf/enterprise/) license.
 > For setup instructions, see
 > [Configure OIDC authentication](/telegraf/controller/authentication/oidc/).
 
@@ -176,7 +176,7 @@ from 30 days to 2 years or infinite.
 
 > [!Note]
 > Audit logging itself is enabled at startup only and requires a
-> [Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/) license.
+> [Telegraf Enterprise](/telegraf/enterprise/) license.
 > For details, see
 > [Enable and configure audit logging](/telegraf/controller/audit-logs/enable-configure/).
 
@@ -196,4 +196,4 @@ Owners can view the current Telegraf Enterprise license, upload a new
 license, and remove a license. All users see current entitlements and usage.
 
 For details on applying, replacing, and removing a license, see
-[Manage your license](/telegraf/controller/telegraf-enterprise/).
+[Manage your license](/telegraf/controller/telegraf-enterprise/manage-license/).

--- a/content/telegraf/controller/telegraf-enterprise/_index.md
+++ b/content/telegraf/controller/telegraf-enterprise/_index.md
@@ -1,123 +1,24 @@
 ---
-title: Telegraf Enterprise
+title: Telegraf Enterprise licensing
 description: >
-  Telegraf Enterprise combines Telegraf Controller with higher scale limits,
-  enterprise authentication and audit logging, and enterprise support from
-  InfluxData for organizations running Telegraf at scale.
+  Apply and manage Telegraf Enterprise licenses in Telegraf Controller to
+  unlock higher limits, audit logging, and enterprise authentication.
 menu:
   telegraf_controller:
-    name: Telegraf Enterprise
+    name: Telegraf Enterprise licensing
 weight: 10
 cascade:
   metadata: [Telegraf Enterprise]
 ---
 
-Telegraf Enterprise is the premium offering for organizations running
-Telegraf at scale. It combines {{% product-name %}} with higher scale limits,
-enterprise authentication and audit logging, and enterprise support from
-InfluxData.
+A **Telegraf Enterprise** license unlocks higher limits and enterprise features
+in {{% product-name %}}. For the Telegraf Enterprise package overview
+(what's included, comparison with the free tier, how to obtain a license), see
+[Telegraf Enterprise](/telegraf/enterprise/).
 
-{{< telegraf/enterprise-upgrade >}}
+This section documents how to apply, manage, and troubleshoot Telegraf
+Enterprise licenses *in {{% product-name %}}*. The license file itself, and
+the purchasing/contract process, are handled by InfluxData —
+[contact sales](https://www.influxdata.com/contact-sales/) to obtain a license.
 
-- [What's included](#whats-included)
-- [Free tier and Enterprise comparison](#free-tier-and-enterprise-comparison)
-- [How licensing works](#how-licensing-works)
-- [License lifecycle](#license-lifecycle)
-- [How to obtain Telegraf Enterprise](#how-to-obtain-telegraf-enterprise)
-- [Next steps](#next-steps)
-
-## What's included
-
-### Higher scale limits
-
-Telegraf Enterprise raises the per-instance limits on configurations and
-reporting agents that {{% product-name %}} can manage. The exact limits are
-defined in your license and are part of your contract. See
-[Free tier and Enterprise comparison](#free-tier-and-enterprise-comparison)
-for the free-tier defaults.
-
-### Enterprise features
-
-A Telegraf Enterprise license unlocks the following features in
-{{% product-name %}}:
-
-- **Audit logging**: Tamper-evident log of administrative actions
-  performed in {{% product-name %}}.
-- **LDAP authentication**: Authenticate {{% product-name %}} users
-  against an LDAP directory.
-- **OIDC authentication**: Single sign-on through OpenID Connect
-  providers such as Okta, Auth0, and Microsoft Entra ID.
-
-### Enterprise support contract
-
-Telegraf Enterprise includes a support contract from InfluxData covering
-both {{% product-name %}} and Telegraf itself. For details on support
-coverage and SLAs, [contact InfluxData](https://www.influxdata.com/contact-sales/).
-
-## Free tier and Enterprise comparison
-
-{{% product-name %}} runs in a free tier suitable for evaluation and small
-deployments when no license is applied.
-
-| | Free tier | Telegraf Enterprise |
-| :--- | :--- | :--- |
-| Configurations | 20 | Defined per contract |
-| Reporting agents | 100 | Defined per contract |
-| Audit logging | --- | Included |
-| LDAP authentication | --- | Included |
-| OIDC authentication | --- | Included |
-| Local authentication and API tokens | Included | Included |
-| User management (RBAC) | Included | Included |
-| Support | Community | Enterprise support contract |
-
-## How licensing works
-
-Licenses are signed [JSON Web Tokens (JWTs)](https://jwt.io/) issued by
-InfluxData. {{% product-name %}} validates licenses in both connected and
-air-gapped environments.
-
-A {{% product-name %}} instance has one active license at a time.
-Replacing a license takes effect immediately, with no restart required.
-
-{{% product-name %}} accepts a license two ways:
-
-- **At startup** using the `LICENSE_FILE_PATH` environment variable.
-  Preferred for automated and infrastructure-as-code deployments.
-- **At runtime** by uploading the license through the {{% product-name %}}
-  user interface. Preferred for interactive setup.
-
-The **Owner** role is required to apply, replace, or remove a license. Any
-authenticated user can view the current entitlements and usage.
-
-## License lifecycle
-
-A license moves through the following states as its expiration date approaches:
-
-| State | When | Behavior |
-| :---- | :--- | :------- |
-| **Unlicensed** | No license applied | Free-tier limits apply; enterprise features are disabled. |
-| **Valid** | License is active and more than 30 days from expiration | Licensed entitlements apply; enterprise features are enabled. |
-| **Expiring** | License expires within 30 days | Licensed entitlements still apply; an informational banner appears in the UI. |
-| **Grace Period** | License has expired but less than 15 days have elapsed | Licensed entitlements still apply; an error banner appears in the UI. |
-| **Expired** | License expired 15 or more days ago | Limits revert to the free tier; enterprise features are disabled. |
-
-For full details on what changes at each stage, including the API status
-names for each state (such as `expired_grace`), see
-[License enforcement](/telegraf/controller/telegraf-enterprise/license-enforcement/).
-
-## How to obtain Telegraf Enterprise
-
-To purchase Telegraf Enterprise or request an evaluation license,
-[contact InfluxData sales](https://www.influxdata.com/contact-sales/).
-InfluxData issues a license file that you apply to your {{% product-name %}}
-instance.
-
-## Next steps
-
-If you already have a license file:
-
-- [Apply a license to Telegraf Controller](/telegraf/controller/telegraf-enterprise/apply-license/)
-- [View and update a license](/telegraf/controller/telegraf-enterprise/manage-license/)
-- [Understand license enforcement](/telegraf/controller/telegraf-enterprise/license-enforcement/)
-
-{{< children hlevel="h2" >}}
+{{< children >}}

--- a/content/telegraf/controller/telegraf-enterprise/_index.md
+++ b/content/telegraf/controller/telegraf-enterprise/_index.md
@@ -16,6 +16,8 @@ in {{% product-name %}}. For the Telegraf Enterprise package overview
 (what's included, comparison with the free tier, how to obtain a license), see
 [Telegraf Enterprise](/telegraf/enterprise/).
 
+{{< telegraf/enterprise-upgrade >}}
+
 This section documents how to apply, manage, and troubleshoot Telegraf
 Enterprise licenses *in {{% product-name %}}*. The license file itself, and
 the purchasing/contract process, are handled by InfluxData —

--- a/content/telegraf/controller/telegraf-enterprise/apply-license.md
+++ b/content/telegraf/controller/telegraf-enterprise/apply-license.md
@@ -8,7 +8,7 @@ description: >
 menu:
   telegraf_controller:
     name: Apply a license
-    parent: Telegraf Enterprise
+    parent: Telegraf Enterprise licensing
 weight: 101
 related:
   - /telegraf/controller/telegraf-enterprise/manage-license/

--- a/content/telegraf/controller/telegraf-enterprise/license-enforcement.md
+++ b/content/telegraf/controller/telegraf-enterprise/license-enforcement.md
@@ -8,7 +8,7 @@ description: >
 menu:
   telegraf_controller:
     name: License enforcement
-    parent: Telegraf Enterprise
+    parent: Telegraf Enterprise licensing
 weight: 103
 related:
   - /telegraf/controller/telegraf-enterprise/troubleshoot/

--- a/content/telegraf/controller/telegraf-enterprise/manage-license.md
+++ b/content/telegraf/controller/telegraf-enterprise/manage-license.md
@@ -8,7 +8,7 @@ description: >
 menu:
   telegraf_controller:
     name: View and update a license
-    parent: Telegraf Enterprise
+    parent: Telegraf Enterprise licensing
 weight: 102
 related:
   - /telegraf/controller/telegraf-enterprise/apply-license/

--- a/content/telegraf/controller/telegraf-enterprise/troubleshoot.md
+++ b/content/telegraf/controller/telegraf-enterprise/troubleshoot.md
@@ -8,7 +8,7 @@ description: >
 menu:
   telegraf_controller:
     name: Troubleshoot licensing
-    parent: Telegraf Enterprise
+    parent: Telegraf Enterprise licensing
 weight: 104
 related:
   - /telegraf/controller/telegraf-enterprise/apply-license/

--- a/content/telegraf/controller/users/_index.md
+++ b/content/telegraf/controller/users/_index.md
@@ -38,7 +38,7 @@ Every user account is tied to one authentication provider:
   and [group-to-role mappings](/telegraf/controller/authentication/#group-to-role-mapping).
 
 LDAP and OIDC require a
-[Telegraf Enterprise](/telegraf/controller/telegraf-enterprise/) license.
+[Telegraf Enterprise](/telegraf/enterprise/) license.
 For setup instructions, see
 [Authentication](/telegraf/controller/authentication/).
 

--- a/content/telegraf/enterprise/_index.md
+++ b/content/telegraf/enterprise/_index.md
@@ -6,10 +6,9 @@ description: >
   enterprise support contract from InfluxData for organizations running
   Telegraf at scale.
 menu:
-  telegraf:
+  telegraf_enterprise:
     name: Telegraf Enterprise
-    weight: 3
-weight: 3
+weight: 1
 ---
 
 **Telegraf Enterprise** is the commercial package for organizations running

--- a/content/telegraf/enterprise/_index.md
+++ b/content/telegraf/enterprise/_index.md
@@ -1,0 +1,128 @@
+---
+title: Telegraf Enterprise
+description: >
+  Telegraf Enterprise combines Telegraf and Telegraf Controller with higher
+  scale limits, enterprise authentication and audit logging, and an
+  enterprise support contract from InfluxData for organizations running
+  Telegraf at scale.
+menu:
+  telegraf:
+    name: Telegraf Enterprise
+    weight: 3
+weight: 3
+---
+
+**Telegraf Enterprise** is the commercial package for organizations running
+[Telegraf](/telegraf/v1/) and [Telegraf Controller](/telegraf/controller/) at
+scale. It combines higher Telegraf Controller limits, enterprise authentication
+and audit logging, and an enterprise support contract from InfluxData covering
+both the Telegraf agent and Telegraf Controller.
+
+- [What's included](#whats-included)
+- [Free tier and Enterprise comparison](#free-tier-and-enterprise-comparison)
+- [How licensing works](#how-licensing-works)
+- [License lifecycle](#license-lifecycle)
+- [How to obtain Telegraf Enterprise](#how-to-obtain-telegraf-enterprise)
+- [Next steps](#next-steps)
+
+## What's included
+
+### Enterprise support for Telegraf and Telegraf Controller
+
+Telegraf Enterprise includes an enterprise support contract from InfluxData
+covering both the open source Telegraf agent and Telegraf Controller. For
+details on support coverage and SLAs,
+[contact InfluxData](https://www.influxdata.com/contact-sales/).
+
+### Higher scale limits in Telegraf Controller
+
+Telegraf Enterprise raises the per-instance limits on configurations and
+reporting agents that Telegraf Controller can manage. The exact limits are
+defined in your license and are part of your contract. See
+[Free tier and Enterprise comparison](#free-tier-and-enterprise-comparison)
+for the free-tier defaults.
+
+### Enterprise features in Telegraf Controller
+
+A Telegraf Enterprise license unlocks the following features in
+Telegraf Controller:
+
+- **Audit logging**: Tamper-evident log of administrative actions
+  performed in Telegraf Controller.
+- **LDAP authentication**: Authenticate Telegraf Controller users
+  against an LDAP directory.
+- **OIDC authentication**: Single sign-on through OpenID Connect
+  providers such as Okta, Auth0, and Microsoft Entra ID.
+
+## Free tier and Enterprise comparison
+
+Telegraf Controller runs in a free tier suitable for evaluation and small
+deployments when no license is applied.
+
+| | Free tier | Telegraf Enterprise |
+| :--- | :--- | :--- |
+| Configurations | 20 | Defined per contract |
+| Reporting agents | 100 | Defined per contract |
+| Audit logging | --- | Included |
+| LDAP authentication | --- | Included |
+| OIDC authentication | --- | Included |
+| Local authentication and API tokens | Included | Included |
+| User management (RBAC) | Included | Included |
+| Support | Community | Enterprise support contract |
+
+## How licensing works
+
+Licenses are signed [JSON Web Tokens (JWTs)](https://jwt.io/) issued by
+InfluxData. Telegraf Controller validates licenses in both connected and
+air-gapped environments.
+
+A Telegraf Controller instance has one active license at a time. Replacing a
+license takes effect immediately, with no restart required.
+
+Telegraf Controller accepts a license two ways:
+
+- **At startup** using the `LICENSE_FILE_PATH` environment variable.
+  Preferred for automated and infrastructure-as-code deployments.
+- **At runtime** by uploading the license through the Telegraf Controller
+  user interface. Preferred for interactive setup.
+
+The **Owner** role is required to apply, replace, or remove a license. Any
+authenticated user can view the current entitlements and usage.
+
+## License lifecycle
+
+A license moves through the following states as its expiration date approaches:
+
+| State | When | Behavior |
+| :---- | :--- | :------- |
+| **Unlicensed** | No license applied | Free-tier limits apply; enterprise features are disabled. |
+| **Valid** | License is active and more than 30 days from expiration | Licensed entitlements apply; enterprise features are enabled. |
+| **Expiring** | License expires within 30 days | Licensed entitlements still apply; an informational banner appears in the UI. |
+| **Grace Period** | License has expired but less than 15 days have elapsed | Licensed entitlements still apply; an error banner appears in the UI. |
+| **Expired** | License expired 15 or more days ago | Limits revert to the free tier; enterprise features are disabled. |
+
+For full details on what changes at each stage, including the API status
+names for each state (such as `expired_grace`), see
+[License enforcement](/telegraf/controller/telegraf-enterprise/license-enforcement/).
+
+## How to obtain Telegraf Enterprise
+
+To purchase Telegraf Enterprise or request an evaluation license,
+[contact InfluxData sales](https://www.influxdata.com/contact-sales/).
+InfluxData issues a license file that you apply to your Telegraf Controller
+instance.
+
+## Next steps
+
+If you already have a license file:
+
+- [Apply a license to Telegraf Controller](/telegraf/controller/telegraf-enterprise/apply-license/)
+- [View and update a license](/telegraf/controller/telegraf-enterprise/manage-license/)
+- [Understand license enforcement](/telegraf/controller/telegraf-enterprise/license-enforcement/)
+- [Troubleshoot licensing](/telegraf/controller/telegraf-enterprise/troubleshoot/)
+
+If you're evaluating:
+
+- [Telegraf documentation](/telegraf/v1/)
+- [Telegraf Controller documentation](/telegraf/controller/)
+- [Contact InfluxData sales](https://www.influxdata.com/contact-sales/)

--- a/content/telegraf/v1/enterprise.md
+++ b/content/telegraf/v1/enterprise.md
@@ -1,0 +1,55 @@
+---
+title: Telegraf Enterprise
+description: >
+  Telegraf Enterprise provides an enterprise support contract for Telegraf
+  from InfluxData, plus higher limits and enterprise security features
+  through Telegraf Controller.
+menu:
+  telegraf_v1:
+    name: Telegraf Enterprise
+    weight: 90
+weight: 90
+---
+
+**Telegraf Enterprise** is the commercial package for organizations running
+Telegraf in production. It provides an enterprise support contract from
+InfluxData covering Telegraf, plus higher limits and enterprise security
+features in [Telegraf Controller](/telegraf/controller/).
+
+For the full Telegraf Enterprise overview — what's included, the free-tier
+comparison, and how licensing works — see
+[Telegraf Enterprise](/telegraf/enterprise/).
+
+## Enterprise support for Telegraf
+
+A Telegraf Enterprise contract gives your organization:
+
+- Direct support from InfluxData for the Telegraf agent, including the
+  open source plugins shipped in Telegraf releases.
+- SLA-backed response times for production issues.
+- Guidance on plugin selection, configuration, and scaling Telegraf
+  deployments.
+
+For coverage and SLA details,
+[contact InfluxData](https://www.influxdata.com/contact-sales/).
+
+## What else is in the package
+
+Telegraf Enterprise also includes Telegraf Controller — the centralized
+application for managing Telegraf deployments at scale — with these
+license-gated enhancements:
+
+- **Higher configuration and agent limits** (defined per contract)
+- **Audit logging** of administrative actions
+- **LDAP authentication** against your directory
+- **OIDC authentication** for SSO through Okta, Auth0, Microsoft Entra ID,
+  and other providers
+
+For details on these features, see
+[Telegraf Controller documentation](/telegraf/controller/) and the
+[Telegraf Enterprise overview](/telegraf/enterprise/).
+
+## How to obtain Telegraf Enterprise
+
+To purchase Telegraf Enterprise or request an evaluation license,
+[contact InfluxData sales](https://www.influxdata.com/contact-sales/).

--- a/data/products.yml
+++ b/data/products.yml
@@ -356,11 +356,23 @@ telegraf_controller:
   namespace: telegraf
   menu_category: other
   versions: [v1]
-  latest: 0.0
-  latest_patch: 0.0.5-beta
+  latest: 1.0
+  latest_patch: 1.0.0
   schema:
     operating_system: "Docker"
     application_category: "DeveloperApplication"
+
+telegraf_enterprise:
+  name: Telegraf Enterprise
+  altname: Telegraf Enterprise
+  namespace: telegraf
+  menu_category: other
+  versions: [v1]
+  latest: 1.0
+  latest_patch: 1.0.0
+  schema:
+    operating_system: "Linux, macOS, Windows, Docker"
+    application_category: "BusinessApplication"
 
 chronograf:
   name: Chronograf

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,11 @@
+{{ $influxdb3CoreVersion := replaceRE `\.[0-9]+$` "" .Site.Data.products.influxdb3_core.latest_patch }}
+{{ $influxdb3EnterpriseVersion := replaceRE `\.[0-9]+$` "" .Site.Data.products.influxdb3_enterprise.latest_patch }}
+{{ $influxdb3ExplorerVersion := replaceRE `\.[0-9]+$` "" .Site.Data.products.influxdb3_explorer.latest_patch }}
 {{ $influxdbVersionV2 := replaceRE `\.[0-9]+$` "" .Site.Data.products.influxdb.latest_patches.v2 }}
 {{ $influxdbVersionV1 := replaceRE `\.[0-9]+$` "" .Site.Data.products.influxdb.latest_patches.v1 }}
 {{ $enterpriseVersion := replaceRE "v" "" .Site.Data.products.enterprise_influxdb.latest }}
 {{ $telegrafVersion := replaceRE "v" "" .Site.Data.products.telegraf.latest }}
+{{ $telegrafControllerVersion := replaceRE `\.[0-9]+$` ""  .Site.Data.products.telegraf_controller.latest_patch }}
 {{ $chronografVersion := replaceRE "v" "" .Site.Data.products.chronograf.latest }}
 {{ $kapacitorVersion := replaceRE "v" "" .Site.Data.products.kapacitor.latest }}
 {{ $fluxVersion := cond (isset .Site.Data.products.flux "version_label") .Site.Data.products.flux.version_label (replaceRE "v" "" .Site.Data.products.flux.latest) }}
@@ -39,7 +43,7 @@
     <div id="influxdb3" class="product-group">      
       <h2>InfluxDB 3</h2>
       <p>InfluxDB 3 is the current generation of InfluxDB and the recommended platform for new time series workloads—built for high-speed, high-cardinality data from the edge to the cloud.</p>
-      <p class="decision-cta">Not sure which product fits your use case? See <a href="/influxdb3/which-influxdb-3/">Which InfluxDB 3 should I use?</a></p>
+      <p class="decision-cta">Not sure which product fits your use case? See <a class="alt-color" href="/influxdb3/which-influxdb-3/">Which InfluxDB 3 should I use?</a></p>
       <div class="categories">
         <div class="category full">
           <div class="category-head">
@@ -48,7 +52,7 @@
           <div class="products">
             <div class="product">
               <div class="product-info">
-                <h3 state="New"><a href="/influxdb3/core/">InfluxDB 3 Core</a></h3>
+                <h3><a href="/influxdb3/core/">InfluxDB 3 Core <span class="version">{{ $influxdb3CoreVersion }}</span></a></h3>
                 <p>The open source recent data engine optimized for time series and event data.</p>
               </div>
               <ul class="product-links">
@@ -58,7 +62,7 @@
             </div>
             <div class="product" >
               <div class="product-info">
-                <h3 state="New"><a href="/influxdb3/enterprise/">InfluxDB 3 Enterprise</a></h3>
+                <h3><a href="/influxdb3/enterprise/">InfluxDB 3 Enterprise <span class="version">{{ $influxdb3EnterpriseVersion }}</span></a></h3>
                 <p>The scalable data engine built for recent and historical time series and event data.</p>
               </div>
               <ul class="product-links">
@@ -112,7 +116,7 @@
           <div class="products">
             <div class="product">
               <div class="product-info">
-                <h3 state="New"><a href="/influxdb3/explorer/">InfluxDB 3 Explorer</a></h3>
+                <h3><a href="/influxdb3/explorer/">InfluxDB 3 Explorer <span class="version">{{ $influxdb3ExplorerVersion }}</span></a></h3>
                 <p>A standalone UI designed for visualizing, querying, and managing data in InfluxDB 3 Core and Enterprise.</p>
               </div>
               <ul class="product-links">
@@ -143,7 +147,7 @@
         </div>
         <div class="product">
           <div class="product-info">
-            <h3 state="beta"><a href="/telegraf/controller/">Telegraf Controller</a></h3>
+            <h3 state="New"><a href="/telegraf/controller/">Telegraf Controller</a></h3>
             <p>Centralized Telegraf configuration management and agent observability with an intuitive UI.</p>
           </div>
           <ul class="product-links">
@@ -153,12 +157,12 @@
         </div>
         <div class="product">
           <div class="product-info">
-            <h3><a href="/telegraf/enterprise/">Telegraf Enterprise</a></h3>
+            <h3 state="New"><a href="/telegraf/enterprise/">Telegraf Enterprise</a></h3>
             <p>Enterprise support for Telegraf and Telegraf Controller, plus higher limits and enterprise security features in Telegraf Controller.</p>
           </div>
           <ul class="product-links">
-            <li><a href="/telegraf/enterprise/">View Telegraf Enterprise overview</a></li>
-            <li><a href="https://www.influxdata.com/contact-sales/">Contact InfluxData sales</a></li>
+            <li><a href="/telegraf/enterprise/">Telegraf Enterprise overview</a></li>
+            <li><a href="https://www.influxdata.com/contact-sales/">Upgrade to Telegraf Enterprise</a></li>
           </ul>
         </div>
       </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -151,9 +151,19 @@
             <li><a href="/telegraf/controller/">View documentation</a></li>
           </ul>
         </div>
+        <div class="product">
+          <div class="product-info">
+            <h3><a href="/telegraf/enterprise/">Telegraf Enterprise</a></h3>
+            <p>Enterprise support for Telegraf and Telegraf Controller, plus higher limits and enterprise security features in Telegraf Controller.</p>
+          </div>
+          <ul class="product-links">
+            <li><a href="/telegraf/enterprise/">View Telegraf Enterprise overview</a></li>
+            <li><a href="https://www.influxdata.com/contact-sales/">Contact InfluxData sales</a></li>
+          </ul>
+        </div>
       </div>
     </div>
-  
+
     <div id="influxdbv2" class="product-group">
       <h2>InfluxDB 2</h2>
       <div class="products">

--- a/layouts/partials/article/feedback.html
+++ b/layouts/partials/article/feedback.html
@@ -79,9 +79,11 @@
       {{ if and (eq $product "influxdb3") (or (eq $version "core") (eq $version "enterprise") (eq $version "explorer")) }}
         <li><a class="discord" href="https://discord.gg/9zaNCW2PRT" target="_blank"><strong>InfluxDB Discord Server</strong> <em style="opacity:.5">(Preferred)</em></a></li>
         <li><a class="slack" href="https://influxdata.com/slack" target="_blank">InfluxDB Community Slack</a></li>
-      {{ else }}
+      {{ else if or (eq $product "influxdb3") (and (eq $product "influxdb")) }}
         <li><a class="slack" href="https://influxdata.com/slack" target="_blank"><strong>InfluxDB Community Slack</strong>  <em style="opacity:.5">(Preferred)</em></a></li>
         <li><a class="discord" href="https://discord.gg/9zaNCW2PRT" target="_blank">InfluxDB Discord Server</a></li>
+      {{ else }}
+        <li><a class="slack" href="https://influxdata.com/slack" target="_blank"><strong>InfluxDB Community Slack</strong>  <em style="opacity:.5">(Preferred)</em></a></li>
       {{ end }}
       <li><a class="community" href="https://community.influxdata.com/" target="_blank">InfluxData Community</a></li>
       <li><a class="reddit" href="https://reddit.com/r/influxdb" target="_blank">InfluxDB Subreddit</a></li>

--- a/layouts/partials/article/special-state.html
+++ b/layouts/partials/article/special-state.html
@@ -13,7 +13,7 @@
 {{ $productKey := .Store.Get "productKey" }}
 {{ $productData := index $.Site.Data.products $productKey }}
 {{ $displayName := $productData.name }}
-{{ $productPathWhitelist := slice "telegraf/controller" }}
+{{ $productPathWhitelist := slice "" }}
 
 {{ if in $productPathWhitelist (print $product "/" $version )}}
 <div class="block special-state">

--- a/layouts/partials/header/title.html
+++ b/layouts/partials/header/title.html
@@ -20,6 +20,8 @@
   {{ $scratch.Set "siteTitle" "InfluxDB Cloud (TSM) Documentation" }}
 {{ else if eq $currentVersion "core"}}
   {{ $scratch.Set "siteTitle" "InfluxDB 3 Core Documentation" }}
+{{ else if and (eq $product "telegraf") (eq $currentVersion "enterprise")}}
+  {{ $scratch.Set "siteTitle" "Telegraf Enterprise Documentation" }}
 {{ else if eq $currentVersion "enterprise"}}
   {{ $scratch.Set "siteTitle" "InfluxDB 3 Enterprise Documentation" }}
 {{ else if eq $currentVersion "explorer"}}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -36,7 +36,13 @@
 {{ else if (eq $currentVersion nil) }}
   {{ .Scratch.Set "searchPlaceholder"  (print "Search " (index .Site.Data.products $product).name) }}
 {{ else if (eq $product "telegraf") }}
-  {{ .Scratch.Set "searchPlaceholder"  (print "Search " (cond (eq $currentVersion "v1") "Telegraf" "Telegraf Controller")) }}
+  {{ if eq $currentVersion "v1" }}
+    {{ .Scratch.Set "searchPlaceholder" "Search Telegraf" }}
+  {{ else if eq $currentVersion "enterprise" }}
+    {{ .Scratch.Set "searchPlaceholder" "Search Telegraf Enterprise" }}
+  {{ else }}
+    {{ .Scratch.Set "searchPlaceholder" "Search Telegraf Controller" }}
+  {{ end }}
 {{ else if eq $product "influxdb" }}
   {{ if eq $currentVersion "v3" }}
     {{ .Scratch.Set "searchPlaceholder"  "Search InfluxDB OSS v3" }}

--- a/layouts/partials/topnav/product-selector.html
+++ b/layouts/partials/topnav/product-selector.html
@@ -28,13 +28,14 @@ Identify products by their product path. Dictionary schema:
 {{ $influxdb3Clustered := dict "influxdb3/clustered" (slice $.Site.Data.products.influxdb3_clustered.name "clustered") }}
 {{ $telegraf := dict "telegraf/v1" (slice "Telegraf" "telegraf") }}
 {{ $telegrafController := dict "telegraf/controller" (slice "Telegraf Controller" "telegraf_controller") }}
+{{ $telegrafEnterprise := dict "telegraf/enterprise" (slice "Telegraf Enterprise" "telegraf_enterprise") }}
 {{ $chronograf := dict "chronograf/v1" (slice "Chronograf" "chronograf") }}
 {{ $kapacitor := dict "kapacitor/v1" (slice "Kapacitor" "kapacitor") }}
 {{ $flux := dict "flux/v0" (slice "Flux" "flux") }}
 {{ $enterpriseInfluxdb := dict "enterprise_influxdb/v1" (slice "InfluxDB Enterprise" "enterprise_v1") }}
 {{ $influxdbCloud1 := dict "influxcloud/v1" (slice $.Site.Data.products.influxdb_cloud1.name "v1") }}
 
-{{ $productInfo := merge $influxdbOSSv1 $influxdbOSSv2 $influxdbCloud $influxdb3Core $influxdb3Enterprise $influxdb3CloudServerless $influxdb3CloudDedicated $influxdb3Clustered $telegraf $telegrafController $chronograf $kapacitor $influxdb3Explorer $flux $enterpriseInfluxdb $influxdbCloud1 }}
+{{ $productInfo := merge $influxdbOSSv1 $influxdbOSSv2 $influxdbCloud $influxdb3Core $influxdb3Enterprise $influxdb3CloudServerless $influxdb3CloudDedicated $influxdb3Clustered $telegraf $telegrafController $telegrafEnterprise $chronograf $kapacitor $influxdb3Explorer $flux $enterpriseInfluxdb $influxdbCloud1 }}
 
 {{ define "productLink" }}
   {{ $specialLink := "" }}
@@ -94,7 +95,8 @@ Identify products by their product path. Dictionary schema:
       <div class="group-title"><p>Telegraf</p></div>
       <ul class="item-list products">
         <li>{{ template "productLink" (merge (dict "productPath" "telegraf/v1") $templateDefaults) }}</li>
-        <li>{{ template "productLink" (merge (dict "productPath" "telegraf/controller" "state" "beta") $templateDefaults) }}</li>
+        <li>{{ template "productLink" (merge (dict "productPath" "telegraf/controller" "state" "New") $templateDefaults) }}</li>
+        <li>{{ template "productLink" (merge (dict "productPath" "telegraf/enterprise" "state" "New") $templateDefaults) }}</li>
       </ul>
     </div>
     <div class="product-group">

--- a/layouts/shortcodes/telegraf/enterprise-upgrade.html
+++ b/layouts/shortcodes/telegraf/enterprise-upgrade.html
@@ -7,7 +7,7 @@
       </p>
     </div>
     <div class="telegraf-enterprise-cta">
-      <a href="/telegraf/enterprise/" class="btn"><span class="cf-icon Shield"></span> Learn about Telegraf Enterprise</a>
+      <a href="/telegraf/enterprise/" class="btn"><span class="cf-icon Shield"></span> Upgrade to Enterprise</a>
     </div>
   </div>
 </div>

--- a/layouts/shortcodes/telegraf/enterprise-upgrade.html
+++ b/layouts/shortcodes/telegraf/enterprise-upgrade.html
@@ -1,13 +1,13 @@
 <div class="block special-state">
   <div class="state-content telegraf-enterprise">
     <div class="telegraf-enterprise-text">
-      <h4 id="telegraf-enterprise-feature">Upgrade to Telegraf Enterprise</h4>
+      <h4 id="telegraf-enterprise-feature">Telegraf Enterprise</h4>
       <p>
         Unlock higher configuration and agent limits, enhanced security features, and official support for Telegraf and Telegraf Controller.
       </p>
     </div>
     <div class="telegraf-enterprise-cta">
-      <a href="https://www.influxdata.com/products/telegraf-enterprise/" class="btn"><span class="cf-icon Shield"></span> Upgrade to Enterprise</a>
+      <a href="/telegraf/enterprise/" class="btn"><span class="cf-icon Shield"></span> Learn about Telegraf Enterprise</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

Establishes `/telegraf/enterprise/` as the canonical SEO landing for the Telegraf Enterprise package, with a curated cross-section sidebar routing into Telegraf, Telegraf Controller, and license-management pages.

## Changes

### Content
- **New:** `/telegraf/enterprise/` canonical landing — what's included, free-vs-Enterprise comparison, licensing model, how to obtain.
- **New:** `/telegraf/v1/enterprise/` Telegraf-OSS-flavored page so Telegraf users discover Enterprise without leaving Telegraf docs.
- **Slimmed:** `/telegraf/controller/telegraf-enterprise/` becomes a Controller-scoped "Telegraf Enterprise licensing" wrapper pointing at the canonical landing. Operational children (apply/manage/enforcement/troubleshoot) keep their URLs.
- **Link audit:** 10 Controller files retargeted — offering-context `[Telegraf Enterprise]` links now point at `/telegraf/enterprise/`.

### Layouts
- Homepage gets a Telegraf Enterprise card (third in the Telegraf row); Controller and Enterprise marked "New"; InfluxDB 3 "New" badges replaced with version chips.
- New `telegraf_enterprise` menu in `hugo.yml` powers the curated cross-section sidebar.
- Topnav product selector adds Telegraf Enterprise.
- `enterprise-upgrade` shortcode CTA repointed from marketing to `/telegraf/enterprise/`.
- Bug fixes: title partial was labeling `/telegraf/enterprise/` as "InfluxDB 3 Enterprise"; sidebar search placeholder was labeling it as "Search Telegraf Controller".
- `special-state.html` drops `telegraf/controller` from whitelist (Controller is GA).

### Data
- `data/products.yml`: bumps `telegraf_controller` to `1.0.0` GA; adds `telegraf_enterprise` entry for topnav/layout consumers.

## Pages to preview

| URL | Expected |
| --- | --- |
| `/telegraf/enterprise/` | Canonical landing with curated cross-section sidebar |
| `/telegraf/v1/enterprise/` | Telegraf-agent-flavored Enterprise page |
| `/telegraf/controller/telegraf-enterprise/` | Slim Controller licensing wrapper with operational children |
| `/` | Homepage Telegraf row shows Telegraf → Controller (New) → Enterprise (New) |

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
