### PR TITLE
feat(tc-builder): mark Telegaf Builder as beta

### DIFF
--- a/DOCS-FRONTMATTER.md
+++ b/DOCS-FRONTMATTER.md
@@ -27,6 +27,8 @@ menu:
   influxdb_2_0:
     name: # Article name that only appears in the left nav
     parent: # Specifies a parent group and nests navigation items
+    params: # Optional Hugo menu parameters
+      state: # Status badge on the nav item ("alpha", "beta", or "new"; case-insensitive)
 weight: # Determines sort order in both the nav tree and in article lists
 draft: # If true, will not render page on build
 product/v2.x/tags: # Tags specific to each version (replace product and .x" with the appropriate product and minor version )
@@ -79,6 +81,35 @@ by the [`{{< children >}}` shortcode](#generate-a-list-of-children-articles).
 The `name` attribute under the `menu` frontmatter determines the text used in each page's link in the site navigation.
 It should be short and assume the context of its parent if it has one.
 
+#### `menu > params > state`
+
+The `state` parameter under `menu > params` adds a status badge next to the nav item in the left sidebar.
+Use this to mark a page (and its sidebar entry) as `alpha`, `beta`, or `new`.
+Values are case-insensitive. `Beta`, `BETA`, and `beta` all render the same badge.
+
+```yaml
+menu:
+  telegraf_controller:
+    name: Telegraf Builder
+    parent: Configuration UI tools
+    params:
+      state: beta
+```
+
+**Supported values and styling:**
+
+| Value   | Badge style                                                  |
+| :------ | :----------------------------------------------------------- |
+| `alpha` | Outlined pill, uppercase, muted text.                        |
+| `beta`  | Outlined pill, uppercase, muted text.                        |
+| `new`   | Filled pill with gradient background, uppercase, white text. |
+
+Any other string also renders as a badge, but with the default unstyled fallback (small italic text in the sidebar's muted color).
+
+> \[!Note]
+> Use `menu > params > state` for status annotations on sidebar entries instead of appending text like `(beta)` to `menu > name`.
+> The `state` parameter is rendered with dedicated sidebar styling that matches the rest of the site.
+
 ### Page Weights
 
 To ensure pages are sorted both by weight and their depth in the directory
@@ -87,7 +118,7 @@ All top level pages are weighted 1-99.
 The next level is 101-199.
 Then 201-299 and so on.
 
-_**Note:** `_index.md` files should be weighted one level up from the other `.md` files in the same directory._
+***Note:** `_index.md` files should be weighted one level up from the other `.md` files in the same directory.*
 
 ### Related Content
 
@@ -118,7 +149,7 @@ documentation using the latest version of the current product and the current pa
 
 Use the `canonical` frontmatter to override the auto-generated canonical URL.
 
-_**Note:** The `canonical` frontmatter supports the [`{{< latest >}}` shortcode](#latest-links)._
+***Note:** The `canonical` frontmatter supports the [`{{< latest >}}` shortcode](#latest-links).*
 
 ```yaml
 canonical: /path/to/canonical/doc/
@@ -142,8 +173,8 @@ shared.
 canonical: self
 ```
 
-_**Note:** The value is case-sensitive. `Self` or `SELF` is interpreted as
-a URL path and produces a broken canonical._
+***Note:** The value is case-sensitive. `Self` or `SELF` is interpreted as
+a URL path and produces a broken canonical.*
 
 ### v2 Equivalent Documentation
 
@@ -154,7 +185,7 @@ add the following frontmatter to the 1.x page:
 v2: /influxdb/v2.0/get-started/
 ```
 
-### Alternative Links (alt_links)
+### Alternative Links (alt\_links)
 
 Use the `alt_links` frontmatter to specify equivalent pages in other InfluxDB products,
 for example, when a page exists at a different path in a different version or if
@@ -171,6 +202,7 @@ alt_links:
 ```
 
 Supported product keys for InfluxDB 3:
+
 - `core`
 - `enterprise`
 - `cloud-serverless`
@@ -236,12 +268,14 @@ For more information, see [show-in](DOCS-SHORTCODES.md#show-in) and [hide-in](DO
 When creating links in shared content files, you can use the `version` keyword, which gets replaced during the build process with the appropriate product version.
 
 **Use this in shared content:**
+
 ```markdown
 [Configuration options](/influxdb3/version/reference/config-options/)
 [CLI serve command](/influxdb3/version/reference/cli/influxdb3/serve/)
 ```
 
 **Not this:**
+
 ```markdown
 [Configuration options](/influxdb3/{{% product-key %}}/reference/config-options/)
 [CLI serve command](/influxdb3/{{% product-key %}}/reference/cli/influxdb3/serve/)

--- a/assets/styles/layouts/_sidebar.scss
+++ b/assets/styles/layouts/_sidebar.scss
@@ -183,6 +183,49 @@
       }
     }
 
+    .nav-category, .nav-item {
+      position: relative;
+
+      &[state] {
+        &::after {
+          content: attr(state);
+          margin-left: .1rem;
+          font-size: .9em;
+          color: rgba($nav-item, .6);
+          font-style: italic;
+        }
+      }
+
+      &[state~='alpha' i], &[state~='beta' i] {
+        &::after {
+          padding: .1em .5em;
+          font-size: .55em;
+          font-weight: 500;
+          text-transform: uppercase;
+          color: rgba($nav-item, .6);
+          border: 1px solid rgba($nav-item, .6);
+          border-radius: 10px;
+          font-style: normal;
+          letter-spacing: .06em;
+          vertical-align: middle;
+        }
+      }
+      &[state~='new' i] {
+        &::after {
+          padding: .1em .5em;
+          font-size: .55em;
+          font-weight: 500;
+          text-transform: uppercase;
+          @include gradient($grad-burningDusk);
+          color: $g20-white;
+          border-radius: 10px;
+          font-style: normal;
+          letter-spacing: .06em;
+          vertical-align: middle;
+        }
+      }
+    }
+
     .children {
       height: 0;
       overflow: hidden;

--- a/content/telegraf/controller/configs/create.md
+++ b/content/telegraf/controller/configs/create.md
@@ -41,10 +41,11 @@ _For detailed information about using the Code Editor, see
 
 {{< img-hd src="/img/telegraf/controller-code-editor.png" alt="Telegraf Controller Code Editor" />}}
 
-### Use the Telegraf Builder
+### Use the Telegraf Builder {note="Beta"}
 
 The **Telegraf Builder** is a visual interface for adding and configuring
-Telegraf plugins in a Telegraf configuration.
+Telegraf plugins in a Telegraf configuration. The Telegraf Builder is
+currently a beta feature.
 
 _For detailed information about using the Telegraf Builder, see
 [Use the Telegraf Builder](/telegraf/controller/configs/ui/telegraf-builder)._

--- a/content/telegraf/controller/configs/ui/_index.md
+++ b/content/telegraf/controller/configs/ui/_index.md
@@ -14,7 +14,10 @@ weight: 103
 
 Use Telegraf configuration user interface tools in Telegraf Controller to
 create, edit, and update Telegraf TOML configuration files.
-Upload or write raw TOML in the **Code Editor** or use
-the **Telegraf Builder** visual interface to manage and configure plugins.
+{{% product-name %}} provides two configuration tools:
+
+- **Code Editor**: Upload or manually write raw Telegraf configuration TOML.
+- **Telegraf Builder**: Use a visual interface to manage and configure
+  Telegraf plugins. _The Telegraf Builder is currently a beta feature._
 
 {{< children hlevel="h2" >}}

--- a/content/telegraf/controller/configs/ui/telegraf-builder.md
+++ b/content/telegraf/controller/configs/ui/telegraf-builder.md
@@ -2,17 +2,28 @@
 title: Use the Telegraf Builder
 description: >
   Use the **Telegraf Builder** visual interface in {{% product-name %}} to
-  manage and configure Telegraf plugins.
+  manage and configure Telegraf plugins. The Telegraf Builder is a beta
+  feature; for a generally available alternative, use the Code Editor.
 menu:
   telegraf_controller:
     name: Telegraf Builder
     parent: Configuration UI tools
+    params:
+      state: beta
 weight: 202
 ---
 
 The **Telegraf Builder** is a visual interface for managing and configuring
 Telegraf plugins in a configuration. The builder is available when creating or
 updating a configuration.
+
+> [!Important]
+> #### The Telegraf Builder is a beta feature
+>
+> The Telegraf Builder is in beta. Some plugins or options may be missing or
+> incomplete. For a generally available alternative, use the
+> [Code Editor](/telegraf/controller/configs/ui/code-editor/) to upload, write,
+> or edit raw Telegraf configuration TOML.
 
 {{< img-hd src="/img/telegraf/controller-telegraf-builder.png" alt="Telegraf Builder in Telegraf Controller" />}}
 

--- a/layouts/partials/sidebar/nested-menu.html
+++ b/layouts/partials/sidebar/nested-menu.html
@@ -13,7 +13,7 @@
     {{/* Check if this is the InfluxDB HTTP API menu item for InfluxDB 3 products */}}
     {{ $isApiParent := and (or (eq .Name "InfluxDB HTTP API") (eq .Name "InfluxDB Management API")) (or (hasPrefix .URL "/influxdb3/") (hasPrefix .URL "/influxdb/") (hasPrefix .URL "/enterprise_influxdb/")) }}
 
-    <li class="nav-{{ $navClass }} {{ if eq $currentPage.RelPermalink .URL }}active{{end}}">
+    <li class="nav-{{ $navClass }} {{ if eq $currentPage.RelPermalink .URL }}active{{end}}" {{ if .Params.state }}state="{{ .Params.state }}"{{ end }}>
       {{ if $isApiParent }}
         {{/* API Reference: render custom API nav children instead of standard menu children */}}
         {{ $hasApiContent := or ($currentPage.IsMenuCurrent .Menu .) ($currentPage.HasMenuCurrent .Menu .) (hasPrefix $currentPage.RelPermalink .URL) }}


### PR DESCRIPTION
## Summary

- Telegraf Controller 1.0 is GA, but the Telegraf Builder tab remains beta. Surface that distinction in the docs everywhere a reader meets the Builder.
- Add a `menu > params > state` reference to `DOCS-FRONTMATTER.md` so future status badges (`alpha`, `beta`, `new`) use the existing sidebar styling instead of inline `(beta)` text in menu names.

## Changes

- `content/telegraf/controller/configs/ui/telegraf-builder.md` — `Important` callout mirroring the in-app tooltip, plus `menu.params.state: beta` for the sidebar badge.
- `content/telegraf/controller/configs/ui/_index.md` — Code Editor (GA) vs Telegraf Builder (beta) distinction at the decision point.
- `content/telegraf/controller/configs/create.md` — `{note="Beta"}` on the *Use the Telegraf Builder* subheading.
- `DOCS-FRONTMATTER.md` — new `menu > params > state` field documentation with supported values, styling table, and a note recommending the param over inline `(beta)` text.

## Pages to preview

| URL | Expected |
| --- | --- |
| /telegraf/controller/configs/ui/telegraf-builder/ | Beta callout above the screenshot; sidebar entry shows styled `beta` badge. |
| /telegraf/controller/configs/ui/ | Code Editor vs Telegraf Builder split, with Builder marked as beta. |
| /telegraf/controller/configs/create/ | *Use the Telegraf Builder* subheading shows the `Beta` annotation. |

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)