### PR TITLE
docs(controller): cross-link user sign-in and API token sections

### DIFF
--- a/content/telegraf/controller/authentication/_index.md
+++ b/content/telegraf/controller/authentication/_index.md
@@ -15,6 +15,10 @@ cascade:
     - /telegraf/controller/settings/
 ---
 
+This section describes how users sign in to {{% product-name %}}.
+To authenticate API requests and Telegraf agent connections, see
+[Manage API tokens](/telegraf/controller/tokens/).
+
 {{% product-name %}} supports three authentication providers that you can run
 individually or together:
 

--- a/content/telegraf/controller/tokens/_index.md
+++ b/content/telegraf/controller/tokens/_index.md
@@ -15,6 +15,10 @@ cascade:
 API tokens authenticate requests to the {{% product-name %}} API and Telegraf agent connections.
 Use tokens to authorize Telegraf agents, heartbeat requests, and external API clients.
 
+API tokens are separate from user sign-in.
+To configure how users sign in to {{% product-name %}}, see
+[Authentication](/telegraf/controller/authentication/).
+
 ## Token format
 
 All API tokens use the `tc-apiv1_` prefix, making them easy to identify in


### PR DESCRIPTION
## Summary

- Adds a scope note to `/telegraf/controller/authentication/` stating that the section covers user sign-in, with a link to [Manage API tokens](/telegraf/controller/tokens/) for API and agent authentication.
- Adds the corresponding note to `/telegraf/controller/tokens/` linking to [Authentication](/telegraf/controller/authentication/) for user sign-in.
- Normalizes two stray CRLF line endings in `authentication/_index.md` to LF.

The `authentication/` section documents user sign-in providers only; API authentication is documented under `tokens/` and the API reference (#7314). These notes route readers between the two at the top of each section landing page.

`authentication/_index.md` and `tokens/_index.md` both set `weight: 8`. This PR leaves the weights unchanged: 9–11 are assigned to settings, licensing, and audit logs, so distinct values require renumbering those pages. The current tie resolves alphabetically (Authentication before Manage API tokens).

## Pages to preview

| URL | Expected |
| --- | --- |
| /telegraf/controller/authentication/ | First paragraph states the section covers user sign-in and links to Manage API tokens |
| /telegraf/controller/tokens/ | Second paragraph links to Authentication for user sign-in |

## Checklist

- [x] Vale: 0 errors on both files