### PR TITLE
feat(telegraf): standardize Enterprise contact-sales CTA and menu

### DIFF
--- a/assets/styles/layouts/article/_buttons.scss
+++ b/assets/styles/layouts/article/_buttons.scss
@@ -56,6 +56,18 @@ a.btn {
     margin-right: -.65rem;
   }
 
+  &.magenta {
+    @include gradient($grad-burningDusk, -135deg);
+    &:after {
+      @include gradient($grad-coolDusk);
+    }
+  }
+
+  &.large {
+    padding: 1.25rem 2rem;
+    font-size: 1.15rem;
+  }
+
   &.small {
     padding: .4rem 1rem;
   }

--- a/config/_default/hugo.yml
+++ b/config/_default/hugo.yml
@@ -20,43 +20,6 @@ blackfriday:
   hrefTargetBlank: true
   smartDashes: false
 
-# telegraf_enterprise sidebar: curated cross-section nav for the
-# /telegraf/enterprise/ landing. These entries are explicit URLs (not pages)
-# because the landing routes users into Telegraf, Telegraf Controller, and
-# the license-management operational pages — none of which are descendants
-# of /telegraf/enterprise/.
-menu:
-  telegraf_enterprise:
-    - name: Telegraf
-      url: /telegraf/v1/
-      weight: 10
-    - name: Enterprise support for Telegraf
-      url: /telegraf/v1/enterprise/
-      weight: 11
-      parent: Telegraf
-    - name: Telegraf Controller
-      url: /telegraf/controller/
-      weight: 20
-    - name: Apply a license
-      url: /telegraf/controller/telegraf-enterprise/apply-license/
-      weight: 21
-      parent: Telegraf Controller
-    - name: Manage a license
-      url: /telegraf/controller/telegraf-enterprise/manage-license/
-      weight: 22
-      parent: Telegraf Controller
-    - name: License enforcement
-      url: /telegraf/controller/telegraf-enterprise/license-enforcement/
-      weight: 23
-      parent: Telegraf Controller
-    - name: Troubleshoot licensing
-      url: /telegraf/controller/telegraf-enterprise/troubleshoot/
-      weight: 24
-      parent: Telegraf Controller
-    - name: Contact InfluxData sales
-      url: https://www.influxdata.com/contact-sales/
-      weight: 99
-
 taxonomies:
   influxdb/v2/tag: influxdb/v2/tags
   influxdb/cloud/tag: influxdb/cloud/tags

--- a/content/telegraf/controller/_index.md
+++ b/content/telegraf/controller/_index.md
@@ -7,6 +7,9 @@ description: >
 menu:
   telegraf_controller:
     name: Telegraf Controller
+  telegraf_enterprise:
+    name: Telegraf Controller
+    weight: 20
 weight: 1
 cascade:
   product: telegraf_controller

--- a/content/telegraf/controller/telegraf-enterprise/_index.md
+++ b/content/telegraf/controller/telegraf-enterprise/_index.md
@@ -20,7 +20,8 @@ in {{% product-name %}}. For the Telegraf Enterprise package overview
 
 This section documents how to apply, manage, and troubleshoot Telegraf
 Enterprise licenses *in {{% product-name %}}*. The license file itself, and
-the purchasing/contract process, are handled by InfluxData —
-[contact sales](https://www.influxdata.com/contact-sales/) to obtain a license.
+the purchasing/contract process, are handled by InfluxData.
+To purchase a Telegraf Enterprise license,
+[contact InfluxData]({{% cta-link %}}).
 
 {{< children >}}

--- a/content/telegraf/controller/telegraf-enterprise/apply-license.md
+++ b/content/telegraf/controller/telegraf-enterprise/apply-license.md
@@ -9,6 +9,10 @@ menu:
   telegraf_controller:
     name: Apply a license
     parent: Telegraf Enterprise licensing
+  telegraf_enterprise:
+    name: Apply a license
+    weight: 21
+    parent: Telegraf Controller
 weight: 101
 related:
   - /telegraf/controller/telegraf-enterprise/manage-license/
@@ -31,7 +35,7 @@ through an environment variable or at runtime through the user interface.
 ## Prerequisites
 
 - A Telegraf Enterprise license file (`.jwt` or `.txt`) issued by InfluxData.
-  If you don't have one, [contact InfluxData sales](https://www.influxdata.com/contact-sales/).
+  If you don't have one, [contact InfluxData sales]({{% cta-link %}}).
 - For the UI method: the **Owner** role on the {{% product-name %}} instance.
 
 ## About the license file

--- a/content/telegraf/controller/telegraf-enterprise/license-enforcement.md
+++ b/content/telegraf/controller/telegraf-enterprise/license-enforcement.md
@@ -9,6 +9,10 @@ menu:
   telegraf_controller:
     name: License enforcement
     parent: Telegraf Enterprise licensing
+  telegraf_enterprise:
+    name: License enforcement
+    weight: 23
+    parent: Telegraf Controller
 weight: 103
 related:
   - /telegraf/controller/telegraf-enterprise/troubleshoot/

--- a/content/telegraf/controller/telegraf-enterprise/manage-license.md
+++ b/content/telegraf/controller/telegraf-enterprise/manage-license.md
@@ -9,6 +9,10 @@ menu:
   telegraf_controller:
     name: View and update a license
     parent: Telegraf Enterprise licensing
+  telegraf_enterprise:
+    name: Manage a license
+    weight: 22
+    parent: Telegraf Controller
 weight: 102
 related:
   - /telegraf/controller/telegraf-enterprise/apply-license/

--- a/content/telegraf/controller/telegraf-enterprise/troubleshoot.md
+++ b/content/telegraf/controller/telegraf-enterprise/troubleshoot.md
@@ -9,6 +9,10 @@ menu:
   telegraf_controller:
     name: Troubleshoot licensing
     parent: Telegraf Enterprise licensing
+  telegraf_enterprise:
+    name: Troubleshoot licensing
+    weight: 24
+    parent: Telegraf Controller
 weight: 104
 related:
   - /telegraf/controller/telegraf-enterprise/apply-license/

--- a/content/telegraf/enterprise/_index.md
+++ b/content/telegraf/enterprise/_index.md
@@ -9,6 +9,8 @@ menu:
   telegraf_enterprise:
     name: Telegraf Enterprise
 weight: 1
+cascade:
+  product: telegraf_enterprise
 ---
 
 **Telegraf Enterprise** is the commercial package for organizations running
@@ -16,6 +18,8 @@ weight: 1
 scale. It combines higher Telegraf Controller limits, enterprise authentication
 and audit logging, and an enterprise support contract from InfluxData covering
 both the Telegraf agent and Telegraf Controller.
+
+<a href="{{% cta-link %}}" class="btn magenta large">Purchase Telegraf Enterprise</a>
 
 - [What's included](#whats-included)
 - [Free tier and Enterprise comparison](#free-tier-and-enterprise-comparison)
@@ -31,7 +35,7 @@ both the Telegraf agent and Telegraf Controller.
 Telegraf Enterprise includes an enterprise support contract from InfluxData
 covering both the open source Telegraf agent and Telegraf Controller. For
 details on support coverage and SLAs,
-[contact InfluxData](https://www.influxdata.com/contact-sales/).
+[contact InfluxData]({{% cta-link %}}).
 
 ### Higher scale limits in Telegraf Controller
 
@@ -107,7 +111,7 @@ names for each state (such as `expired_grace`), see
 ## How to obtain Telegraf Enterprise
 
 To purchase Telegraf Enterprise or request an evaluation license,
-[contact InfluxData sales](https://www.influxdata.com/contact-sales/).
+[contact InfluxData sales]({{% cta-link %}}).
 InfluxData issues a license file that you apply to your Telegraf Controller
 instance.
 
@@ -124,4 +128,4 @@ If you're evaluating:
 
 - [Telegraf documentation](/telegraf/v1/)
 - [Telegraf Controller documentation](/telegraf/controller/)
-- [Contact InfluxData sales](https://www.influxdata.com/contact-sales/)
+- [Contact InfluxData sales]({{% cta-link %}})

--- a/content/telegraf/enterprise/contact-sales.md
+++ b/content/telegraf/enterprise/contact-sales.md
@@ -1,0 +1,19 @@
+---
+title: Purchase Telegraf Enterprise
+description: Contact InfluxData sales to purchase Telegraf Enterprise.
+menu:
+  telegraf_enterprise:
+    name: Contact InfluxData sales
+    url: https://influxdata.com/contact-sales-telegraf-enterprise/?utm_source=website&utm_medium=direct&utm_campaign=Telegraf-Enterprise
+    weight: 99
+---
+
+To purchase {{% product-name %}}, [contact InfluxData sales]({{% cta-link %}}).
+
+<a href="{{% cta-link %}}" class="btn magenta large">Purchase Telegraf Enterprise</a>
+
+#### More information
+
+- [Telegraf Enterprise overview](/telegraf/enterprise/)
+- [Telegraf Enterprise with Telegraf OSS](/telegraf/v1/enterprise/)
+- [Telegraf Enterprise with Telegraf Controller](/telegraf/controller/telegraf-enterprise/)

--- a/content/telegraf/v1/_index.md
+++ b/content/telegraf/v1/_index.md
@@ -6,6 +6,9 @@ description: >
 menu:
   telegraf_v1:
     name: Telegraf
+  telegraf_enterprise:
+    name: Telegraf
+    weight: 10
 weight: 1
 related:
   - /resources/videos/intro-to-telegraf/

--- a/content/telegraf/v1/enterprise.md
+++ b/content/telegraf/v1/enterprise.md
@@ -8,6 +8,14 @@ menu:
   telegraf_v1:
     name: Telegraf Enterprise
     weight: 90
+    params:
+      state: new
+  telegraf_enterprise:
+    name: Enterprise support for Telegraf
+    weight: 11
+    parent: Telegraf
+    params:
+      state: new
 weight: 90
 ---
 
@@ -16,9 +24,11 @@ Telegraf in production. It provides an enterprise support contract from
 InfluxData covering Telegraf, plus higher limits and enterprise security
 features in [Telegraf Controller](/telegraf/controller/).
 
-For the full Telegraf Enterprise overview — what's included, the free-tier
-comparison, and how licensing works — see
+For the full Telegraf Enterprise overview--what's included, the free-tier
+comparison, and how licensing works--see
 [Telegraf Enterprise](/telegraf/enterprise/).
+
+{{% telegraf/enterprise-upgrade %}}
 
 ## Enterprise support for Telegraf
 
@@ -31,7 +41,7 @@ A Telegraf Enterprise contract gives your organization:
   deployments.
 
 For coverage and SLA details,
-[contact InfluxData](https://www.influxdata.com/contact-sales/).
+[contact InfluxData]({{% cta-link %}}).
 
 ## What else is in the package
 
@@ -52,4 +62,4 @@ For details on these features, see
 ## How to obtain Telegraf Enterprise
 
 To purchase Telegraf Enterprise or request an evaluation license,
-[contact InfluxData sales](https://www.influxdata.com/contact-sales/).
+[contact InfluxData sales]({{% cta-link %}}).

--- a/data/products.yml
+++ b/data/products.yml
@@ -334,6 +334,7 @@ telegraf:
   label_group: telegraf
   menu_category: other
   list_order: 6
+  link: 'https://influxdata.com/contact-sales-telegraf-enterprise/?utm_source=website&utm_medium=direct&utm_campaign=Telegraf-Enterprise'
   versions: [v1]
   latest: v1.38
   latest_patches:
@@ -355,6 +356,7 @@ telegraf_controller:
   altname: Controller
   namespace: telegraf
   menu_category: other
+  link: 'https://influxdata.com/contact-sales-telegraf-enterprise/?utm_source=website&utm_medium=direct&utm_campaign=Telegraf-Enterprise'
   versions: [v1]
   latest: 1.0
   latest_patch: 1.0.0
@@ -367,6 +369,7 @@ telegraf_enterprise:
   altname: Telegraf Enterprise
   namespace: telegraf
   menu_category: other
+  link: 'https://influxdata.com/contact-sales-telegraf-enterprise/?utm_source=website&utm_medium=direct&utm_campaign=Telegraf-Enterprise'
   versions: [v1]
   latest: 1.0
   latest_patch: 1.0.0


### PR DESCRIPTION
## Summary

- Centralize the Telegraf Enterprise "contact sales" CTA on a campaign URL via the `cta-link` shortcode and product `link` config.
- Add magenta/large button styles and a purchase landing page
- Drive the `telegraf_enterprise` section nav from page frontmatter instead of hardcoded config menu entries.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
