### PR TITLE
docs(influxdb3): move Wide-tag support to Enterprise in v3.10.0 release notes

### DIFF
--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -28,8 +28,6 @@
 
 - **Observability: per-request query traces**: Query tracing is now opt-in per request rather than enabled for all queries. This reduces trace volume for high-throughput deployments. See the monitoring documentation for how to enable tracing on individual requests.
 
-- **Wide-tag support**: Tag IDs have been widened from u8 to u16. This raises the practical limit to thousands of tables and millions of columns per database.
-
 - **Embedded Python updated to 3.13.14**: The Processing engine's embedded Python is updated to 3.13.14, which includes upstream security fixes.
 
 #### Bug fixes
@@ -63,6 +61,8 @@
 All Core updates are included in Enterprise. The following updates are exclusive to Enterprise.
 
 #### Features
+
+- **Wide-tag support**: Tag IDs have been widened from u8 to u16. This raises the practical limit to thousands of tables and millions of columns per database. Available with the storage engine upgrade (`--use-pacha-tree`).
 
 - **Row-level deletion**: Delete rows by time range and tag predicates using `influxdb3 delete rows` and `influxdb3 cancel row-delete`. Deletion is asynchronous — requests persist to object storage and the compactor applies them when rewriting run sets. Requires `--use-pacha-tree`. Monitor pending deletes with the `system.row_deletes` system table and 9 new `influxdb3_compactor_row_delete_*` metrics.
 


### PR DESCRIPTION
Corrects the v3.10.0 release notes: **Wide-tag support** (u8→u16 tag IDs) was listed under **Core**, but it's part of the **Enterprise performance beta** (storage engine upgrade, `--use-pacha-tree`) — not a standalone Core feature.

- Removes the bullet from the Core Features section.
- Adds it to the Enterprise Features section with the `--use-pacha-tree` requirement note.

Source: confirmed against source PR `influxdb_pro#3324`.