### PR TITLE
docs(influxdb3): add 3.10 release banners; rename catalog v3 to catalog format upgrade

### DIFF
--- a/content/shared/influxdb3-admin/upgrade.md
+++ b/content/shared/influxdb3-admin/upgrade.md
@@ -22,9 +22,10 @@ Before upgrading your {{% product-name %}} cluster, review the [release notes](/
 > [!Warning]
 > #### Upgrading to InfluxDB 3.10 is a one-way migration
 >
-> The first time you start InfluxDB 3.10, it automatically migrates the on-disk
-> catalog to an updated format. After migration, 3.9.x and older binaries are
-> unable to read the new catalog, and fail to start on the same cluster data.
+> The first time you start InfluxDB 3.10, it automatically upgrades the on-disk
+> catalog format from v2 to v3. After migration, 3.9.x and older
+> binaries are unable to read the new catalog, and fail to start on the same
+> cluster data.
 >
 > Before upgrading, back up `{prefix}/catalogs/` and `{prefix}/_catalog_checkpoint`.
 > Restoring these objects is the only way to roll back to 3.9.x.

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -12,7 +12,7 @@
 
 #### Features
 
-- **Catalog v3**: InfluxDB 3.10 automatically migrates the on-disk catalog to v3 format on first startup. The v3 catalog uses a compact binary record format (~5–6x smaller than v2). Migration is automatic, idempotent, and crash-safe. Back up `{prefix}/catalogs/` and `{prefix}/_catalog_checkpoint` before upgrading — the migration is one-way and 3.9.x binaries cannot read a v3 catalog.
+- **Catalog format upgrade (catalog v2 → v3)**: InfluxDB 3.10 automatically migrates the on-disk catalog to v3 format on first startup. The v3 catalog uses a compact binary record format (~5–6x smaller than v2). Migration is automatic, idempotent, and crash-safe. Back up `{prefix}/catalogs/` and `{prefix}/_catalog_checkpoint` before upgrading — the migration is one-way and 3.9.x binaries cannot read a v3 catalog.
 
 - **`influxdb3 debug catalog` command**: Inspect catalog state offline directly from object storage — no running server required. Subcommands: `list`, `snapshot`, `sequence`. Available in both Core and Enterprise.
 
@@ -42,7 +42,7 @@
 
 #### Breaking changes
 
-- **Catalog v3 migration is one-way**: The first startup of InfluxDB 3.10 migrates the catalog to v3. After migration, 3.9.x binaries cannot start against the same object store. Back up `{prefix}/catalogs/` and `{prefix}/_catalog_checkpoint` before upgrading.
+- **Catalog format upgrade (catalog v2 → v3) is one-way**: The first startup of InfluxDB 3.10 migrates the catalog to v3. After migration, 3.9.x binaries cannot start against the same object store. Back up `{prefix}/catalogs/` and `{prefix}/_catalog_checkpoint` before upgrading.
 
 - **`influxdb3 write` output changed**: The write command now prints a throughput report on success instead of printing `success`. Scripts that parse the previous output should use `--quiet` (`-q`) to suppress all output.
 

--- a/data/notifications.yaml
+++ b/data/notifications.yaml
@@ -91,35 +91,63 @@
 
     For more details, see [Explorer 1.8 release notes](/influxdb3/explorer/release-notes/#v180)
 
-- id: influxdb3-9-performance-preview
+- id: influxdb3-10-core-release
   level: note
   scope:
-    - /influxdb3/enterprise/
-  exclude:
-    - /influxdb3/enterprise/performance-preview/
-  title: 'InfluxDB 3.9: Performance upgrade preview'
+    - /influxdb3/core/
+  title: 'InfluxDB 3.10 is now available'
   slug: |
-    InfluxDB 3 Enterprise 3.9 includes a beta of major performance upgrades
-    with faster single-series queries, wide-and-sparse table support, and more.
+    InfluxDB 3 Core 3.10 adds catalog v3 migration, a configurable
+    query-concurrency limit, and processing engine improvements.
 
   message: |
-    InfluxDB 3 Enterprise 3.9 includes a beta of major performance and
-    feature updates.
+    InfluxDB 3 Core 3.10 is now available.
 
-    **Key improvements:**
+    **Key updates:**
 
-    - Faster single-series queries
-    - Consistent resource usage
-    - Wide-and-sparse table support
-    - Automatic distinct value caches for reduced latency with metadata queries
+    - **Catalog v3**: the on-disk catalog migrates automatically on first 3.10 startup. Migration is one-way—back up your catalog before upgrading.
+    - **`--max-concurrent-queries`**: limit concurrent queries (adjustable at runtime).
+    - **`GET /ready` endpoint** for readiness probes.
+    - **Processing engine**: cross-database queries and trigger lockdown flags.
 
-    _Preview features are subject to breaking changes._
+    For more information, see the
+    [InfluxDB 3 Core release notes](/influxdb3/core/release-notes/).
 
-    For more information, see:
+- id: influxdb3-10-enterprise-release
+  level: note
+  scope:
+    - /influxdb3/
+    - /influxdb3/enterprise/
+  exclude:
+    - /influxdb3/core/
+    - /influxdb3/explorer/
+    - /influxdb3/cloud-dedicated/
+    - /influxdb3/cloud-serverless/
+    - /influxdb3/clustered/
+  title: 'InfluxDB 3.10 is now available'
+  slug: |
+    InfluxDB 3 Enterprise 3.10 adds automated backup and restore, row-level
+    deletions, and user management, with catalog v3 migration and performance
+    preview improvements.
 
-    - [Performance upgrade preview](/influxdb3/enterprise/performance-preview/)
-    - [InfluxDB 3 Enterprise release notes](/influxdb3/enterprise/release-notes/)
-    - [InfluxData Blog post](https://www.influxdata.com/blog/influxdb-3-9/)
+  message: |
+    InfluxDB 3 Enterprise 3.10 is now available.
+
+    **Key updates:**
+
+    - **Catalog v3**: the on-disk catalog migrates automatically on first 3.10 startup. Migration is one-way—back up your catalog before upgrading.
+    - **Automated backup and restore** (beta)
+    - **Row-level deletions**
+    - **User management** (authentication and RBAC) — preview
+    - **Performance preview improvements**
+
+    Backup and restore, row-level deletions, and the performance preview require
+    the Enterprise storage engine upgrade, available as an opt-in beta.
+    _Beta and preview features are subject to breaking changes and aren't
+    recommended for production use._
+
+    For more information, see the
+    [InfluxDB 3 Enterprise release notes](/influxdb3/enterprise/release-notes/)
 
 - id: telegraf-enterprise-beta
   level: note

--- a/data/notifications.yaml
+++ b/data/notifications.yaml
@@ -97,15 +97,12 @@
     - /influxdb3/core/
   title: 'InfluxDB 3.10 is now available'
   slug: |
-    InfluxDB 3 Core 3.10 adds catalog v3 migration, a configurable
-    query-concurrency limit, and processing engine improvements.
-
+    InfluxDB 3 Core 3.10 adds an automatic catalog format upgrade, a
+    configurable query-concurrency limit, and processing engine improvements.
   message: |
-    InfluxDB 3 Core 3.10 is now available.
+    **Key updates in InfluxDB 3 Core 3.10:**
 
-    **Key updates:**
-
-    - **Catalog v3**: the on-disk catalog migrates automatically on first 3.10 startup. Migration is one-way—back up your catalog before upgrading.
+    - **Catalog format upgrade**: the on-disk catalog automatically upgrades from format v2 to v3 on first 3.10 startup. Migration is one-way—back up your catalog before upgrading.
     - **`--max-concurrent-queries`**: limit concurrent queries (adjustable at runtime).
     - **`GET /ready` endpoint** for readiness probes.
     - **Processing engine**: cross-database queries and trigger lockdown flags.
@@ -127,24 +124,21 @@
   title: 'InfluxDB 3.10 is now available'
   slug: |
     InfluxDB 3 Enterprise 3.10 adds automated backup and restore, row-level
-    deletions, and user management, with catalog v3 migration and performance
-    preview improvements.
-
+    deletions, and user management, with an automatic catalog format upgrade
+    and performance preview improvements.
   message: |
-    InfluxDB 3 Enterprise 3.10 is now available.
+    **Key updates in InfluxDB 3 Enterprise 3.10:**
 
-    **Key updates:**
-
-    - **Catalog v3**: the on-disk catalog migrates automatically on first 3.10 startup. Migration is one-way—back up your catalog before upgrading.
+    - **Catalog format upgrade**: the on-disk catalog automatically upgrades from format v2 to v3 on first 3.10 startup. Migration is one-way—back up your catalog before upgrading.
     - **Automated backup and restore** (beta)
     - **Row-level deletions**
     - **User management** (authentication and RBAC) — preview
     - **Performance preview improvements**
 
     Backup and restore, row-level deletions, and the performance preview require
-    the Enterprise storage engine upgrade, available as an opt-in beta.
-    _Beta and preview features are subject to breaking changes and aren't
-    recommended for production use._
+    the Enterprise storage engine upgrade (opt-in beta). _Beta and preview
+    features are subject to breaking changes and aren't recommended for
+    production use._
 
     For more information, see the
     [InfluxDB 3 Enterprise release notes](/influxdb3/enterprise/release-notes/)


### PR DESCRIPTION
Adds InfluxDB 3.10 release notification banners (Core + Enterprise), retires the 3.9 `influxdb3-9-performance-preview` banner, and renames "Catalog v3" to **"Catalog format upgrade"** across the 3.10 release surfaces.

## Banners
- **Core banner** (`influxdb3-10-core-release`): `/influxdb3/core/`
- **Enterprise banner** (`influxdb3-10-enterprise-release`): broad `/influxdb3/` scope, excluding `/influxdb3/core/` (its own banner), `/influxdb3/explorer/`, and the distributed products (`cloud-dedicated`, `cloud-serverless`, `clustered`) — they're on separate release cycles.
- Trimmed both banners by removing the redundant message openers (net −6 lines).

### Content
- Core: catalog format upgrade (one-way migration), `--max-concurrent-queries`, `GET /ready`, processing engine improvements.
- Enterprise: catalog format upgrade, **automated backup and restore (beta)**, row-level deletions, **user management (RBAC) — preview**, performance preview improvements; beta/preview caveat noted.

## Catalog naming
Renamed **"Catalog v3" → "Catalog format upgrade"** so it doesn't read as a separate product. Version numbers are bound to the noun (`catalog format v2 → v3`) so they aren't confused with the InfluxDB **v2-to-v3 product migration**. The short label is used on banners; the explicit `catalog v2 → v3` form appears only where precision matters (release notes). Applied in:
- `data/notifications.yaml` (both 3.10 banners)
- `content/shared/v3-core-enterprise-release-notes/_index.md` (Features + one-way migration notes)
- `content/shared/influxdb3-admin/upgrade.md` (one-way migration warning)

The general "catalog version" compatibility content (cross-release rolling upgrades) was deliberately left unchanged — it's a distinct concept from the 3.10 catalog format version.

## Pages to preview

| URL | Expected |
| --- | --- |
| /influxdb3/ | **Enterprise** 3.10 banner (hub root, in scope) |
| /influxdb3/enterprise/ | **Enterprise** 3.10 banner |
| /influxdb3/enterprise/admin/upgrade/ | **Enterprise** 3.10 banner; warning reads "upgrades the on-disk catalog format from v2 to v3" |
| /influxdb3/core/ | **Core** 3.10 banner only (Enterprise banner excluded) |
| /influxdb3/explorer/ | **No** 3.10 Enterprise banner (excluded) |
| /influxdb3/cloud-dedicated/ | **No** 3.10 Enterprise banner (excluded) |
