### PR TITLE
chore(agent): centralize instructions and skills with generated harness adapters

### DIFF
--- a/.agents/instructions/api-docs.md
+++ b/.agents/instructions/api-docs.md
@@ -1,10 +1,11 @@
 ---
-applyTo: "api-docs/**/*.md, api-docs/**/*.yml, api-docs/**/*.yaml"
+name: api-docs
+description: Instructions for editing InfluxDB API documentation files and OpenAPI specs.
+paths:
+  - "api-docs/**/*.md"
+  - "api-docs/**/*.yml"
+  - "api-docs/**/*.yaml"
 ---
-
-<!-- This file is auto-generated from .agents/instructions. Do not edit directly. -->
-
-<!-- Run 'yarn build:agent:instructions' to regenerate it. -->
 
 # InfluxDB API Documentation
 

--- a/.agents/instructions/assets.md
+++ b/.agents/instructions/assets.md
@@ -1,15 +1,15 @@
 ---
-applyTo: "assets/js/**/*.js, assets/js/**/*.ts"
+name: assets
+description: Instructions for JavaScript and TypeScript assets in the Hugo documentation UI.
+paths:
+  - "assets/js/**/*.js"
+  - "assets/js/**/*.ts"
 ---
-
-<!-- This file is auto-generated from .agents/instructions. Do not edit directly. -->
-
-<!-- Run 'yarn build:agent:instructions' to regenerate it. -->
 
 # JavaScript and TypeScript Guidelines
 
 **For detailed TypeScript and Hugo asset pipeline guidance**, see
-[.github/agents/typescript-hugo-agent.md](../agents/typescript-hugo-agent.md)
+[.github/agents/typescript-hugo-agent.md](../../.github/agents/typescript-hugo-agent.md)
 which covers:
 
 - TypeScript migration strategies
@@ -85,6 +85,6 @@ For complete JavaScript documentation, see
 ## Related Resources
 
 - **TypeScript & Hugo development**:
-  [.github/agents/typescript-hugo-agent.md](../agents/typescript-hugo-agent.md)
+  [.github/agents/typescript-hugo-agent.md](../../.github/agents/typescript-hugo-agent.md)
 - **Contributing guidelines**:
   [DOCS-CONTRIBUTING.md](../../DOCS-CONTRIBUTING.md#javascript-in-the-documentation-ui)

--- a/.agents/instructions/content-review.md
+++ b/.agents/instructions/content-review.md
@@ -1,10 +1,9 @@
 ---
-applyTo: "content/**/*.md"
+name: content-review
+description: Review criteria for documentation content changes in content/**/*.md.
+paths:
+  - "content/**/*.md"
 ---
-
-<!-- This file is auto-generated from .agents/instructions. Do not edit directly. -->
-
-<!-- Run 'yarn build:agent:instructions' to regenerate it. -->
 
 # Content Review Criteria
 

--- a/.agents/instructions/content.md
+++ b/.agents/instructions/content.md
@@ -110,10 +110,10 @@ weight:      # Sort order (1-99, 101-199, 201-299...)
 
 ```bash
 # 1. Verify Hugo build
-hugo --quiet
+npx hugo --quiet
 
-# 2. Validate links
-yarn test:links
+# 2. Validate links (build first; see DOCS-TESTING.md)
+link-checker map content/path/*.md | xargs link-checker check
 
 # 3. Test code blocks (if applicable)
 yarn test:codeblocks:all

--- a/.agents/instructions/content.md
+++ b/.agents/instructions/content.md
@@ -1,10 +1,9 @@
 ---
-applyTo: "content/**/*.md"
+name: content
+description: Instructions for creating, editing, and testing documentation content files.
+paths:
+  - "content/**/*.md"
 ---
-
-<!-- This file is auto-generated from .agents/instructions. Do not edit directly. -->
-
-<!-- Run 'yarn build:agent:instructions' to regenerate it. -->
 
 # Content File Guidelines
 
@@ -13,7 +12,7 @@ applyTo: "content/**/*.md"
 **Working examples**: [content/example.md](../../content/example.md)
 
 **For complete content editing workflow**, see
-[content-editing skill](../../.agents/skills/content-editing/SKILL.md) which covers:
+[content-editing skill](../skills/content-editing/SKILL.md) which covers:
 
 - Creating and editing content with CLI tools
 - Shared content management and testing
@@ -24,7 +23,7 @@ applyTo: "content/**/*.md"
 
 The unified `docs` CLI provides tools for content creation and editing.
 For decision guidance on when to use CLI vs direct editing, see
-[docs-cli-workflow skill](../../.agents/skills/docs-cli-workflow/SKILL.md).
+[docs-cli-workflow skill](../skills/docs-cli-workflow/SKILL.md).
 
 ### Creating New Content
 
@@ -91,7 +90,7 @@ When editing files with `source:` frontmatter (shared content):
   Hugo rebuild
 
 For complete shared content workflow, see
-[content-editing skill](../../.agents/skills/content-editing/SKILL.md).
+[content-editing skill](../skills/content-editing/SKILL.md).
 
 ## Required for All Content Files
 
@@ -121,7 +120,7 @@ yarn test:codeblocks:all
 ```
 
 For comprehensive testing workflows, see
-[content-editing skill](../../.agents/skills/content-editing/SKILL.md).
+[content-editing skill](../skills/content-editing/SKILL.md).
 
 ## Style Guidelines
 
@@ -190,9 +189,9 @@ For complete shortcodes reference, see
 
 ## Related Resources
 
-- **Complete workflow**: [content-editing skill](../../.agents/skills/content-editing/SKILL.md)
+- **Complete workflow**: [content-editing skill](../skills/content-editing/SKILL.md)
 - **CLI decision guidance**:
-  [docs-cli-workflow skill](../../.agents/skills/docs-cli-workflow/SKILL.md)
+  [docs-cli-workflow skill](../skills/docs-cli-workflow/SKILL.md)
 - **Frontmatter**: [DOCS-FRONTMATTER.md](../../DOCS-FRONTMATTER.md)
 - **Shortcodes**: [DOCS-SHORTCODES.md](../../DOCS-SHORTCODES.md)
 - **Contributing**: [DOCS-CONTRIBUTING.md](../../DOCS-CONTRIBUTING.md)

--- a/.agents/instructions/layouts.md
+++ b/.agents/instructions/layouts.md
@@ -1,10 +1,9 @@
 ---
-applyTo: "layouts/**/*.html"
+name: layouts
+description: Instructions for Hugo layout, partial, and shortcode implementation.
+paths:
+  - "layouts/**/*.html"
 ---
-
-<!-- This file is auto-generated from .agents/instructions. Do not edit directly. -->
-
-<!-- Run 'yarn build:agent:instructions' to regenerate it. -->
 
 # Layout and Shortcode Implementation Guidelines
 
@@ -12,7 +11,7 @@ applyTo: "layouts/**/*.html"
 **Test examples**: [content/example.md](../../content/example.md)
 
 **For detailed Hugo template development workflow**, see
-[hugo-template-dev skill](../../.agents/skills/hugo-template-dev/SKILL.md) which covers:
+[hugo-template-dev skill](../skills/hugo-template-dev/SKILL.md) which covers:
 
 - Hugo template syntax and data access patterns
 - Build-time vs runtime testing strategies
@@ -77,7 +76,7 @@ documentation.
 ## Related Resources
 
 - **Complete Hugo template workflow**:
-  [hugo-template-dev skill](../../.agents/skills/hugo-template-dev/SKILL.md)
+  [hugo-template-dev skill](../skills/hugo-template-dev/SKILL.md)
 - **Shortcodes reference**: [DOCS-SHORTCODES.md](../../DOCS-SHORTCODES.md)
 - **Test examples**: [content/example.md](../../content/example.md)
 - **Article-level page actions** (buttons/links next to the page title — when

--- a/.agents/skills/content-editing/SKILL.md
+++ b/.agents/skills/content-editing/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: content-editing
 description: "Create, edit, and validate InfluxData documentation. Manages Hugo shared content across InfluxDB products, runs Vale style linting and Hugo builds, validates frontmatter and code blocks, and fact-checks via the documentation MCP server. Use when creating new doc pages, editing markdown .md files, managing shared content, running Vale or Hugo builds, or testing InfluxDB, Telegraf, or Flux documentation."
-author: InfluxData
-version: "1.0"
 ---
 
 # Content Editing Workflow

--- a/.agents/skills/content-editing/SKILL.md
+++ b/.agents/skills/content-editing/SKILL.md
@@ -12,7 +12,7 @@ CLI vs direct editing? → See docs-cli-workflow skill
 Shared content changes? → Touch sourcing files (Part 1)
 Run tests? → Hugo build, Vale, code-block lint, E2E (Part 2)
 Verify technical accuracy? → MCP server (Part 4)
-Write/debug Vale rules? → See vale-linting and vale-rule-config skills
+Run/fix Vale? → vale-linting skill. Author Vale rules/regex? → vale-rule-config skill
 ```
 
 ## Using `docs create` and `docs edit`
@@ -169,9 +169,19 @@ yarn hugo --quiet
 
 ### 2. Link Validation (Recommended)
 
+Link validation uses the `link-checker` binary (see
+[DOCS-TESTING.md § "Link Validation with Link-Checker"](../../../DOCS-TESTING.md#link-validation-with-link-checker)
+for installation). It validates the rendered HTML, so build the site first.
+
 ```bash
-# Test all links in the documentation
-yarn test:links
+# Build the site (link-checker reads public/ HTML)
+yarn hugo --quiet
+
+# Map changed Markdown to public HTML, then check the links
+link-checker map content/influxdb3/core/path/*.md | xargs link-checker check
+
+# Or check a built HTML subtree directly
+link-checker check public/influxdb3/core/get-started/
 
 # This checks:
 # - Internal links (relative paths)
@@ -283,9 +293,9 @@ Vale checks documentation for style guide violations, spelling errors, and brand
 
 # With specific config and alert level
 .ci/vale/vale.sh \
-  --config=content/influxdb/cloud-dedicated/.vale.ini \
+  --config=content/influxdb3/cloud-dedicated/.vale.ini \
   --minAlertLevel=error \
-  content/influxdb/cloud-dedicated/write-data/**/*.md
+  content/influxdb3/cloud-dedicated/write-data/**/*.md
 ```
 
 ### Understanding Vale Alerts
@@ -322,9 +332,9 @@ If Vale incorrectly flags something:
 3. Add inline comments to disable specific rules if necessary:
 
 ```markdown
-<!-- vale InfluxDataDocs.TechnicalTerms = NO -->
+<!-- vale InfluxDataDocs.Spelling = NO -->
 This paragraph contains technical terms that Vale might flag.
-<!-- vale InfluxDataDocs.TechnicalTerms = YES -->
+<!-- vale InfluxDataDocs.Spelling = YES -->
 ```
 
 ### When to Run Vale
@@ -354,7 +364,7 @@ Use the Documentation MCP Server when the information here is inconclusive, when
 **Don't use for:**
 
 - Basic style/grammar checks (use Vale)
-- Link validation (use `yarn test:links`)
+- Link validation (use `link-checker`)
 - Testing code examples (use `yarn test:codeblocks`)
 
 ### Setup
@@ -425,7 +435,7 @@ search_influxdb_knowledge_sources
 
 ```bash
 # Step 1: Create content from draft
-docs create database-tutorial.md --products influxdb3-core,influxdb3-enterprise
+docs create database-tutorial.md --products influxdb3_core,influxdb3_enterprise
 
 # CLI scaffolds files:
 # - content/shared/influxdb3/guides/database-tutorial.md
@@ -443,8 +453,10 @@ yarn hugo --quiet
 node cypress/support/run-e2e-specs.js \
   content/influxdb3/core/guides/database-tutorial.md
 
-# Step 5: Validate links
-yarn test:links
+# Step 5: Validate links (build first, then map + check)
+yarn hugo --quiet
+link-checker map content/influxdb3/core/guides/database-tutorial.md | \
+  xargs link-checker check
 
 # Step 6: Test code examples (if tutorial has code blocks)
 yarn test:codeblocks:all
@@ -477,8 +489,10 @@ node cypress/support/run-e2e-specs.js \
   content/influxdb3/core/reference/sql/_index.md \
   content/influxdb3/enterprise/reference/sql/_index.md
 
-# Step 6: Validate links in SQL reference
-yarn test:links
+# Step 6: Validate links in SQL reference (build first, then map + check)
+yarn hugo --quiet
+link-checker map content/influxdb3/core/reference/sql/_index.md | \
+  xargs link-checker check
 ```
 
 ### Example 3: Quick Fix Without CLI
@@ -518,7 +532,7 @@ yarn hugo server
 | Generate release notes     | `docs release-notes v3.1.0 v3.2.0 --products influxdb3_core`                      |
 | Build Hugo site            | `yarn hugo --quiet`                                                               |
 | Run Vale linting           | `.ci/vale/vale.sh --config=.vale.ini content/path/`                               |
-| Test links                 | `yarn test:links`                                                                 |
+| Test links                 | `link-checker map content/path/*.md \| xargs link-checker check` (build first)    |
 | Lint code block syntax     | `yarn lint-codeblocks content/path/*.md`                                          |
 | Test code blocks           | `yarn test:codeblocks:all`                                                        |
 | Test specific page         | `yarn test:e2e content/path/file.md`                                              |
@@ -568,10 +582,10 @@ credential.
 ## Related Skills
 
 - **docs-cli-workflow** - When to use CLI vs direct editing (decision guidance)
-- **vale-rule-config** - Writing Vale rules and understanding regex patterns (for CI/Quality Engineers)
+- **vale-linting** - Running Vale, fixing flagged content, vocabulary, and product config (operator workflow)
+- **vale-rule-config** - Authoring and testing custom Vale rules and regex (rule-author workflow)
 - **cypress-e2e-testing** - Detailed Cypress test execution and debugging
 - **hugo-template-dev** - Hugo template syntax and development
-- **vale-linting** - Vale style linting configuration and debugging
 
 ## Checklist: Before Claiming Content is Complete
 
@@ -581,7 +595,7 @@ credential.
 - [ ] Technical accuracy verified (MCP fact-check if needed)
 - [ ] Hugo builds without errors (`yarn hugo --quiet`)
 - [ ] Vale style linting passes (`.ci/vale/vale.sh --config=.vale.ini content/path/`)
-- [ ] Links validated (`yarn test:links`)
+- [ ] Links validated (`link-checker` — see DOCS-TESTING.md)
 - [ ] Code examples tested (if applicable)
 - [ ] E2E tests pass for affected pages
 - [ ] Visual preview confirms changes look correct

--- a/.agents/skills/content-editing/SKILL.md
+++ b/.agents/skills/content-editing/SKILL.md
@@ -115,7 +115,7 @@ import matter from 'gray-matter';
 function isSharedContent(filePath) {
   const content = readFileSync(filePath, 'utf8');
   const { data, content: body } = matter(content);
-  
+
   // If has source: frontmatter and minimal/no body content
   return data.source && body.trim().length < 50;
 }

--- a/.agents/skills/cypress-e2e-testing/SKILL.md
+++ b/.agents/skills/cypress-e2e-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cypress-e2e-testing
-description: Run, validate, and analyze Cypress E2E tests for the InfluxData documentation site. Covers Hugo server management, test execution modes, and failure analysis.
+description: "Run, validate, and analyze Cypress E2E tests for the InfluxData documentation site. Covers Hugo server management, test execution modes, and failure analysis. Use when writing or running Cypress tests, verifying rendered pages, checking JSON-LD/structured data, or debugging E2E failures after template, layout, or content changes."
 ---
 
 # Cypress E2E Testing Skill

--- a/.agents/skills/cypress-e2e-testing/SKILL.md
+++ b/.agents/skills/cypress-e2e-testing/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: cypress-e2e-testing
 description: Run, validate, and analyze Cypress E2E tests for the InfluxData documentation site. Covers Hugo server management, test execution modes, and failure analysis.
-author: InfluxData
-version: "1.0"
 ---
 
 # Cypress E2E Testing Skill
@@ -140,12 +138,12 @@ node cypress/support/run-e2e-specs.js \
 
 ## Available Test Specs
 
-| Spec File                                               | Purpose                                       |
-| ------------------------------------------------------- | --------------------------------------------- |
+| Spec File                                               | Purpose                                                     |
+| ------------------------------------------------------- | ----------------------------------------------------------- |
 | `cypress/e2e/content/api-reference.cy.js`               | API reference pages (Hugo-native templates, layouts, links) |
-| `cypress/e2e/content/index.cy.js`                       | General content validation                    |
-| `cypress/e2e/content/markdown-content-validation.cy.js` | LLM markdown generation                       |
-| `cypress/e2e/page-context.cy.js`                        | Page context and navigation                   |
+| `cypress/e2e/content/index.cy.js`                       | General content validation                                  |
+| `cypress/e2e/content/markdown-content-validation.cy.js` | LLM markdown generation                                     |
+| `cypress/e2e/page-context.cy.js`                        | Page context and navigation                                 |
 
 ## Understanding Test Output
 

--- a/.agents/skills/docs-cli-workflow/SKILL.md
+++ b/.agents/skills/docs-cli-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-cli-workflow
-description: Guides when to use docs create/edit CLI tools versus direct file editing for InfluxData documentation.
+description: "Guides when to use the docs create/edit CLI tools versus direct file editing for InfluxData documentation. Use when deciding whether to scaffold new pages with docs create, open existing pages with docs edit, or edit Markdown files directly."
 ---
 
 # docs CLI Workflow Guidance
@@ -102,12 +102,12 @@ Which do you prefer?
 
 ## Edge Cases
 
-| Situation                           | Behavior                                                 |
-| ----------------------------------- | -------------------------------------------------------- |
-| Already in a `docs create` workflow | Don't re-suggest                                         |
-| URL points to non-existent page     | Suggest `docs create --url <url>` instead of `docs edit` |
-| User provides both URL and draft    | Suggest `docs create --url <url> --from-draft <draft>`   |
-| User declines CLI twice in session  | Stop suggesting, respect preference                      |
+| Situation                           | Behavior                                                                                                 |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Already in a `docs create` workflow | Don't re-suggest                                                                                         |
+| URL points to non-existent page     | Suggest creating a draft, then run `docs create --url <url> --from-draft <draft>` instead of `docs edit` |
+| User provides both URL and draft    | Suggest `docs create --url <url> --from-draft <draft>`                                                   |
+| User declines CLI twice in session  | Stop suggesting, respect preference                                                                      |
 
 ## After User Confirms
 

--- a/.agents/skills/docs-cli-workflow/SKILL.md
+++ b/.agents/skills/docs-cli-workflow/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: docs-cli-workflow
 description: Guides when to use docs create/edit CLI tools versus direct file editing for InfluxData documentation.
-author: InfluxData
-version: "1.0"
 ---
 
 # docs CLI Workflow Guidance

--- a/.agents/skills/exec-plan-writing/SKILL.md
+++ b/.agents/skills/exec-plan-writing/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: exec-plan-writing
-description: "Capture durable goal, intent, and decisions for a unit of work as an execution plan under docs/exec-plans/. Use when finishing a non-trivial change that needs a decision record, when a PR closes one or more issues and the rationale would otherwise live only in commit messages or PR descriptions, or when the user asks to write an exec-plan, decision doc, or to document the why behind a change. Distinct from PLAN.md (ephemeral, tracked on feature branches, and blocked from the default branch) and design-docs (architectural)."
-author: InfluxData
-version: "0.1"
+description: "Capture durable goal, intent, and decisions for a unit of work as an execution plan under docs/exec-plans/. Use when finishing a non-trivial change that needs a decision record, when a PR closes one or more issues and the rationale would otherwise live only in commit messages or PR descriptions, or when the user asks to write an exec-plan, decision doc, or to document the why behind a change. Distinct from PLAN.md (ephemeral, scrubbed by CI on merge) and design-docs (architectural)."
 ---
 
 # Writing Execution Plans

--- a/.agents/skills/hugo-template-dev/SKILL.md
+++ b/.agents/skills/hugo-template-dev/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: hugo-template-dev
 description: Hugo template development skill for InfluxData docs-v2. Enforces proper build and runtime testing to catch template errors that build-only validation misses.
-author: InfluxData
-version: "1.2"
 ---
 
 # Hugo Template Development Skill
@@ -133,12 +131,12 @@ enhancement. Most JSON-LD this repo emits is **not** eligible, so the Rich
 Results Test reports "no items detected" even for valid markup — a false
 negative that looks like failure:
 
-| Emitted type          | Rich Results Test | Why |
-| --------------------- | ----------------- | --- |
-| `Organization`        | Not reported      | Feeds the knowledge graph / entity resolution, never a rich result |
+| Emitted type          | Rich Results Test | Why                                                                               |
+| --------------------- | ----------------- | --------------------------------------------------------------------------------- |
+| `Organization`        | Not reported      | Feeds the knowledge graph / entity resolution, never a rich result                |
 | `TechArticle`         | Not reported      | Google's Article rich result fires only for `Article`/`NewsArticle`/`BlogPosting` |
-| `SoftwareApplication` | Not reported      | Google retired the general software-app rich result |
-| `FAQPage`             | Reported          | One of the few eligible types here |
+| `SoftwareApplication` | Not reported      | Google retired the general software-app rich result                               |
+| `FAQPage`             | Reported          | One of the few eligible types here                                                |
 
 `validator.schema.org` validates every schema.org type regardless of
 rich-result eligibility — that's what confirms the node is well-formed.

--- a/.agents/skills/hugo-template-dev/SKILL.md
+++ b/.agents/skills/hugo-template-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hugo-template-dev
-description: Hugo template development skill for InfluxData docs-v2. Enforces proper build and runtime testing to catch template errors that build-only validation misses.
+description: "Hugo template development for InfluxData docs-v2, enforcing build and runtime testing to catch template errors that build-only validation misses. Use when creating or editing Hugo layouts, partials, or shortcodes, debugging template errors, or accessing site data in templates."
 ---
 
 # Hugo Template Development Skill
@@ -21,11 +21,17 @@ Template errors like accessing undefined fields, nil values, or incorrect type a
 
 After modifying files in `layouts/`, `layouts/partials/`, or `layouts/shortcodes/`:
 
-**Step 1: Start Hugo server and capture output**
+**Step 1: Start Hugo server in the background and capture output**
 
 ```bash
-npx hugo server --port 1315 2>&1 | head -50
+rm -f /tmp/hugo-1315.log
+npx hugo server --port 1315 >/tmp/hugo-1315.log 2>&1 &
+sleep 5
+head -50 /tmp/hugo-1315.log
 ```
+
+This keeps the server running for the next steps while still showing startup
+output.
 
 **Success criteria:**
 
@@ -70,7 +76,11 @@ pkill -f "hugo server --port 1315"
 Use this one-liner to test and get immediate feedback:
 
 ```bash
-timeout 15 npx hugo server --port 1315 2>&1 | grep -E "(error|Error|ERROR|fail|FAIL)" | head -20; pkill -f "hugo server --port 1315" 2>/dev/null
+rm -f /tmp/hugo-1315.log
+npx hugo server --port 1315 >/tmp/hugo-1315.log 2>&1 &
+sleep 5
+grep -E "(error|Error|ERROR|fail|FAIL)" /tmp/hugo-1315.log | head -20
+pkill -f "hugo server --port 1315" 2>/dev/null
 ```
 
 If output is empty, no errors were detected.
@@ -170,18 +180,25 @@ rich-result eligibility — that's what confirms the node is well-formed.
 
 ## Common Hugo Template Errors
 
-### 1. Accessing Hyphenated Keys
+### 1. Accessing Keys with Hyphens or Dynamic Names
 
-**Wrong:**
+Hugo's dot notation only works for keys that are valid Go identifiers
+(letters, digits, underscores). This repo's data dir is `article_data`
+(underscore), so `.Site.Data.article_data` works. But a hyphenated key — or a
+key held in a variable — must use `index`:
+
+**Wrong (hyphen breaks dot notation; `dataKey` is a variable):**
 
 ```go
-{{ .Site.Data.article-data.influxdb }}
+{{ .Site.Data.my-data.influxdb }}
+{{ .Site.Data.article_data.dataKey }}
 ```
 
 **Correct:**
 
 ```go
-{{ index .Site.Data "article-data" "influxdb" }}
+{{ index .Site.Data "my-data" "influxdb" }}
+{{ index .Site.Data "article_data" $dataKey }}
 ```
 
 ### 2. Nil Field Access
@@ -254,7 +271,7 @@ rich-result eligibility — that's what confirms the node is well-formed.
 
 ```go
 {{/* Build up access with nil checks at each level */}}
-{{ $articleDataRoot := index .Site.Data "article-data" }}
+{{ $articleDataRoot := index .Site.Data "article_data" }}
 {{ if $articleDataRoot }}
   {{ $influxdbData := index $articleDataRoot "influxdb" }}
   {{ if $influxdbData }}
@@ -491,7 +508,7 @@ npx hugo server --port 1315 --verbose 2>&1 | head -100
 
 ```bash
 # Verify data files exist and are valid YAML
-cat data/article-data/influxdb/influxdb3-core/articles.yml | head -20
+cat data/article_data/influxdb3/core/api/articles.yml | head -20
 ```
 
 ## Integration with CI/CD

--- a/.agents/skills/influxdb3-test-setup/SKILL.md
+++ b/.agents/skills/influxdb3-test-setup/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: influxdb3-test-setup
 description: Set up InfluxDB 3 Core and Enterprise instances for running documentation code block tests. Handles service initialization, worktree-specific databases, and test environment configuration.
-author: InfluxData
-version: "1.0"
 ---
 
 # InfluxDB 3 Test Setup Skill

--- a/.agents/skills/influxdb3-test-setup/SKILL.md
+++ b/.agents/skills/influxdb3-test-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: influxdb3-test-setup
-description: Set up InfluxDB 3 Core and Enterprise instances for running documentation code block tests. Handles service initialization, worktree-specific databases, and test environment configuration.
+description: "Set up InfluxDB 3 Core and Enterprise instances for running documentation code block tests. Handles service initialization, worktree-specific databases, and test environment configuration. Use when preparing to run InfluxDB 3 code block tests, starting Core or Enterprise instances, or configuring .env.test and worktree-specific test databases."
 ---
 
 # InfluxDB 3 Test Setup Skill

--- a/.agents/skills/vale-linting/SKILL.md
+++ b/.agents/skills/vale-linting/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: vale-linting
 description: Vale style linting workflow for InfluxData documentation. Covers running Vale, understanding rules, adding vocabulary, and creating custom rules.
-author: InfluxData
-version: "1.0"
 ---
 
 # Vale Style Linting Workflow
@@ -86,32 +84,32 @@ Rules are disabled in two categories across `.vale.ini` and all product configs:
 
 **Mechanical rules disabled** (replaced by custom equivalents or incompatible with InfluxDB syntax):
 
-| Rule | Reason |
-|------|--------|
-| `Google.Acronyms` | Custom `InfluxDataDocs.Acronyms` handles this |
-| `Google.DateFormat` | Custom `InfluxDataDocs.DateFormat` handles this |
-| `Google.Ellipses` | Custom `InfluxDataDocs.Ellipses` handles this |
-| `Google.Headings` | Too strict for technical doc headings |
-| `Google.WordList` | Custom `InfluxDataDocs.WordList` handles this |
-| `Google.Units` | Flags InfluxDB duration literals (30d, 24h); custom `InfluxDataDocs.Units` checks byte units only |
-| `Vale.Spelling` | Custom `InfluxDataDocs.Spelling` handles this |
-| `Vale.Terms` | False positives from URLs, file paths, and code |
+| Rule                | Reason                                                                                            |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| `Google.Acronyms`   | Custom `InfluxDataDocs.Acronyms` handles this                                                     |
+| `Google.DateFormat` | Custom `InfluxDataDocs.DateFormat` handles this                                                   |
+| `Google.Ellipses`   | Custom `InfluxDataDocs.Ellipses` handles this                                                     |
+| `Google.Headings`   | Too strict for technical doc headings                                                             |
+| `Google.WordList`   | Custom `InfluxDataDocs.WordList` handles this                                                     |
+| `Google.Units`      | Flags InfluxDB duration literals (30d, 24h); custom `InfluxDataDocs.Units` checks byte units only |
+| `Vale.Spelling`     | Custom `InfluxDataDocs.Spelling` handles this                                                     |
+| `Vale.Terms`        | False positives from URLs, file paths, and code                                                   |
 
 **Style rules disabled** (high false-positive rate in technical docs):
 
-| Rule | Reason |
-|------|--------|
-| `Google.Contractions` | Not relevant to InfluxData style |
-| `Google.FirstPerson` | Tutorials use "I" intentionally |
-| `Google.Passive` | Technical docs use passive voice legitimately |
-| `Google.We` | "We recommend" is standard in docs |
-| `Google.Will` | Future tense is standard in docs |
-| `write-good.Cliches` | High false positive rate |
-| `write-good.Passive` | Duplicate of Google.Passive concern |
-| `write-good.So` | Starting with "So" is fine |
-| `write-good.ThereIs` | Often the clearest phrasing |
+| Rule                  | Reason                                                  |
+| --------------------- | ------------------------------------------------------- |
+| `Google.Contractions` | Not relevant to InfluxData style                        |
+| `Google.FirstPerson`  | Tutorials use "I" intentionally                         |
+| `Google.Passive`      | Technical docs use passive voice legitimately           |
+| `Google.We`           | "We recommend" is standard in docs                      |
+| `Google.Will`         | Future tense is standard in docs                        |
+| `write-good.Cliches`  | High false positive rate                                |
+| `write-good.Passive`  | Duplicate of Google.Passive concern                     |
+| `write-good.So`       | Starting with "So" is fine                              |
+| `write-good.ThereIs`  | Often the clearest phrasing                             |
 | `write-good.TooWordy` | Flags legitimate terms: aggregate, expiration, multiple |
-| `write-good.Weasel` | Context-dependent, better handled during content review |
+| `write-good.Weasel`   | Context-dependent, better handled during content review |
 
 ### Active Custom Rules
 
@@ -329,7 +327,7 @@ echo "systemd" >> .ci/vale/styles/config/vocabularies/InfluxDataDocs/accept.txt
 
 ### Creating a Product-Specific Override
 
-> [!Important]
+> \[!Important]
 > Product-specific `.vale.ini` files must include the same disabled rules as the
 > root `.vale.ini`. Rules disabled in the root config are **not** inherited by
 > product-specific configs. Omitting them re-enables the rules for those products.
@@ -410,15 +408,15 @@ grep TokenIgnores .vale.ini
 
 ## Related Files
 
-| File | Purpose |
-|------|---------|
-| `.vale.ini` | Main configuration |
-| `.vale-instructions.ini` | Config for non-content files (READMEs, AGENTS.md, etc.) |
-| `.ci/vale/vale.sh` | Vale wrapper (local binary or Docker fallback) |
-| `.ci/vale/styles/` | All Vale style rules |
-| `.ci/scripts/check-support-links.sh` | Support URL validation (can't use Vale — see Part 6) |
-| `.github/scripts/vale-check.sh` | CI script: groups files by product config, runs Vale |
+| File                                        | Purpose                                                 |
+| ------------------------------------------- | ------------------------------------------------------- |
+| `.vale.ini`                                 | Main configuration                                      |
+| `.vale-instructions.ini`                    | Config for non-content files (READMEs, AGENTS.md, etc.) |
+| `.ci/vale/vale.sh`                          | Vale wrapper (local binary or Docker fallback)          |
+| `.ci/vale/styles/`                          | All Vale style rules                                    |
+| `.ci/scripts/check-support-links.sh`        | Support URL validation (can't use Vale — see Part 6)    |
+| `.github/scripts/vale-check.sh`             | CI script: groups files by product config, runs Vale    |
 | `.github/scripts/resolve-shared-content.sh` | CI script: resolves `content/shared/*` to product pages |
-| `.github/workflows/pr-vale-check.yml` | CI workflow: runs Vale on PR changes |
-| `lefthook.yml` | Pre-commit hooks that run Vale |
-| `DOCS-TESTING.md` | Testing documentation (includes Vale CI section) |
+| `.github/workflows/pr-vale-check.yml`       | CI workflow: runs Vale on PR changes                    |
+| `lefthook.yml`                              | Pre-commit hooks that run Vale                          |
+| `DOCS-TESTING.md`                           | Testing documentation (includes Vale CI section)        |

--- a/.agents/skills/vale-linting/SKILL.md
+++ b/.agents/skills/vale-linting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vale-linting
-description: Vale style linting workflow for InfluxData documentation. Covers running Vale, understanding rules, adding vocabulary, and creating custom rules.
+description: "Run, debug, and maintain Vale style linting for InfluxData documentation: run Vale, interpret alerts, manage vocabulary, configure product-specific .vale.ini files, and understand which rules are enabled and why. Use when running Vale, investigating or fixing Vale warnings, adding accept/ignore vocabulary terms, or setting up a product config. To author custom rule patterns and regex, see vale-rule-config."
 ---
 
 # Vale Style Linting Workflow
@@ -169,6 +169,11 @@ deadman
 | Variable name appearing in prose        | `ignore.txt` |
 
 ## Part 4: Creating Custom Rules
+
+> This section covers where rules live in this repo and shows two real
+> examples. For the rule-authoring deep dive — rule types, the regexp2 engine,
+> PCRE lookarounds, and testing patterns in isolation — use the
+> **vale-rule-config** skill.
 
 ### Rule File Location
 

--- a/.agents/skills/vale-rule-config/SKILL.md
+++ b/.agents/skills/vale-rule-config/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: vale-rule-config
 description: Configure Vale style linting rules, write custom patterns, and manage CI/quality checks for InfluxData documentation
-author: InfluxData
-version: "1.0"
 ---
 
 # Vale Rule Configuration

--- a/.agents/skills/vale-rule-config/SKILL.md
+++ b/.agents/skills/vale-rule-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vale-rule-config
-description: Configure Vale style linting rules, write custom patterns, and manage CI/quality checks for InfluxData documentation
+description: "Author and test custom Vale rules for InfluxData documentation: rule types (existence, substitution, conditional), the regexp2 engine and PCRE lookarounds, and testing rule patterns in isolation. Use when writing a new Vale rule, debugging why a rule pattern does not match, or working with Vale regex. To run Vale, manage vocabulary, or fix flagged content, see vale-linting."
 ---
 
 # Vale Rule Configuration
@@ -74,14 +74,18 @@ tokens:
 
 Suggests replacements for problematic patterns.
 
+Substitution rules in this repo expand abbreviations rather than introduce
+them (the real terminology rule lives in
+`.ci/vale/styles/InfluxDataDocs/WordList.yml`):
+
 ```yaml
-# .ci/vale/styles/InfluxDataDocs/Terms.yml
+# Illustrative — mirrors the style of InfluxDataDocs/WordList.yml
 extends: substitution
 message: "Use '%s' instead of '%s'"
 level: warning
 swap:
-  database: DB
-  endpoint: API
+  admin: administrator
+  repo: repository
 ```
 
 ### Conditional Rules
@@ -185,12 +189,13 @@ Vocabulary files manage accepted and rejected terms across the documentation.
 
 ```
 .ci/vale/styles/config/vocabularies/
-├── InfluxDataDocs/
-│   ├── accept.txt       # Accepted terms (won't be flagged)
-│   └── reject.txt       # Rejected terms (will be flagged)
-└── Cloud-Dedicated/
-    ├── accept.txt
-    └── reject.txt
+└── InfluxDataDocs/
+    ├── accept.txt       # Accepted terms (won't be flagged)
+    └── reject.txt       # Rejected terms (will be flagged)
+
+# Only InfluxDataDocs exists today. To add a product-specific vocabulary,
+# create a sibling directory (for example, Cloud-Dedicated/) with its own
+# accept.txt/reject.txt and reference it via Vocab in the product .vale.ini.
 ```
 
 ### accept.txt Format
@@ -232,19 +237,20 @@ obviously
 
 Create product-specific vocabularies by:
 
-1. Creating a new style directory in `.ci/vale/styles/`
-2. Adding vocabulary files
+1. Creating a new vocabulary directory in
+   `.ci/vale/styles/config/vocabularies/`
+2. Adding `accept.txt` and `reject.txt`
 3. Configuring in product's `.vale.ini`
 
 **Example:**
 
 ```yaml
-# content/influxdb/cloud-dedicated/.vale.ini
-StylesPath = .ci/vale/styles
+# content/influxdb3/cloud-dedicated/.vale.ini
+StylesPath = ../../../.ci/vale/styles
 Vocab = Cloud-Dedicated
 
 [*.md]
-BasedOnStyles = Google, InfluxDataDocs, Cloud-Dedicated
+BasedOnStyles = Vale, InfluxDataDocs, Cloud-Dedicated, Google, write-good
 ```
 
 ## Part 4: Vale Configuration Files
@@ -259,7 +265,7 @@ MinAlertLevel = suggestion
 Vocab = InfluxDataDocs
 
 [*.md]
-BasedOnStyles = Google, InfluxDataDocs
+BasedOnStyles = Vale, InfluxDataDocs, Google, write-good
 ```
 
 ### Product-Specific Config
@@ -278,7 +284,7 @@ Individual rules are YAML files in style directories:
 │   └── ...
 ├── InfluxDataDocs/
 │   ├── Branding.yml
-│   ├── TechnicalTerms.yml
+│   ├── WordList.yml
 │   └── ...
 └── config/
     └── vocabularies/
@@ -297,9 +303,9 @@ Individual rules are YAML files in style directories:
 
 # Test only error-level issues
 .ci/vale/vale.sh \
-  --config=content/influxdb/cloud-dedicated/.vale.ini \
+  --config=content/influxdb3/cloud-dedicated/.vale.ini \
   --minAlertLevel=error \
-  content/influxdb/cloud-dedicated/**/*.md
+  content/influxdb3/cloud-dedicated/**/*.md
 ```
 
 ### Test Rule Pattern Before Adding to Vale

--- a/.claude/rules/api-docs.md
+++ b/.claude/rules/api-docs.md
@@ -1,5 +1,8 @@
 ---
-applyTo: "api-docs/**/*.md, api-docs/**/*.yml, api-docs/**/*.yaml"
+paths:
+  - "api-docs/**/*.md"
+  - "api-docs/**/*.yml"
+  - "api-docs/**/*.yaml"
 ---
 
 <!-- This file is auto-generated from .agents/instructions. Do not edit directly. -->

--- a/.claude/rules/assets.md
+++ b/.claude/rules/assets.md
@@ -1,5 +1,7 @@
 ---
-applyTo: "assets/js/**/*.js, assets/js/**/*.ts"
+paths:
+  - "assets/js/**/*.js"
+  - "assets/js/**/*.ts"
 ---
 
 <!-- This file is auto-generated from .agents/instructions. Do not edit directly. -->
@@ -9,7 +11,7 @@ applyTo: "assets/js/**/*.js, assets/js/**/*.ts"
 # JavaScript and TypeScript Guidelines
 
 **For detailed TypeScript and Hugo asset pipeline guidance**, see
-[.github/agents/typescript-hugo-agent.md](../agents/typescript-hugo-agent.md)
+[.github/agents/typescript-hugo-agent.md](../../.github/agents/typescript-hugo-agent.md)
 which covers:
 
 - TypeScript migration strategies
@@ -85,6 +87,6 @@ For complete JavaScript documentation, see
 ## Related Resources
 
 - **TypeScript & Hugo development**:
-  [.github/agents/typescript-hugo-agent.md](../agents/typescript-hugo-agent.md)
+  [.github/agents/typescript-hugo-agent.md](../../.github/agents/typescript-hugo-agent.md)
 - **Contributing guidelines**:
   [DOCS-CONTRIBUTING.md](../../DOCS-CONTRIBUTING.md#javascript-in-the-documentation-ui)

--- a/.claude/rules/content-review.md
+++ b/.claude/rules/content-review.md
@@ -1,5 +1,6 @@
 ---
-applyTo: "content/**/*.md"
+paths:
+  - "content/**/*.md"
 ---
 
 <!-- This file is auto-generated from .agents/instructions. Do not edit directly. -->

--- a/.claude/rules/content.md
+++ b/.claude/rules/content.md
@@ -112,10 +112,10 @@ weight:      # Sort order (1-99, 101-199, 201-299...)
 
 ```bash
 # 1. Verify Hugo build
-hugo --quiet
+npx hugo --quiet
 
-# 2. Validate links
-yarn test:links
+# 2. Validate links (build first; see DOCS-TESTING.md)
+link-checker map content/path/*.md | xargs link-checker check
 
 # 3. Test code blocks (if applicable)
 yarn test:codeblocks:all

--- a/.claude/rules/content.md
+++ b/.claude/rules/content.md
@@ -1,5 +1,6 @@
 ---
-applyTo: "content/**/*.md"
+paths:
+  - "content/**/*.md"
 ---
 
 <!-- This file is auto-generated from .agents/instructions. Do not edit directly. -->

--- a/.claude/rules/layouts.md
+++ b/.claude/rules/layouts.md
@@ -1,5 +1,6 @@
 ---
-applyTo: "layouts/**/*.html"
+paths:
+  - "layouts/**/*.html"
 ---
 
 <!-- This file is auto-generated from .agents/instructions. Do not edit directly. -->

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,4 +38,5 @@ CLAUDE.md                              @influxdata/docs-team
 /.github/copilot-instructions.md       @influxdata/docs-team
 /.github/agents/                       @influxdata/docs-team
 /.github/instructions/                 @influxdata/docs-team
+/.agents/                              @influxdata/docs-team
 /.claude/                              @influxdata/docs-team

--- a/.github/INSTRUCTIONS.md
+++ b/.github/INSTRUCTIONS.md
@@ -20,14 +20,18 @@ docs-v2/
 │   ├── agents/
 │   │   └── typescript-hugo-agent.md   # Custom specialist for TypeScript/Hugo work
 │   └── instructions/
-│       ├── content.instructions.md    # Auto-loaded for content files
-│       ├── layouts.instructions.md    # Auto-loaded for layout files
-│       ├── api-docs.instructions.md   # Auto-loaded for API doc files
-│       └── assets.instructions.md     # Auto-loaded for JS/TS files
+│       ├── content.instructions.md    # Generated from .agents/instructions
+│       ├── layouts.instructions.md    # Generated from .agents/instructions
+│       ├── api-docs.instructions.md   # Generated from .agents/instructions
+│       └── assets.instructions.md     # Generated from .agents/instructions
+├── .agents/
+│   ├── instructions/                  # Canonical path-specific instructions
+│   └── skills/                        # Canonical Agent Skills
 ├── .claude/                           # Claude MCP configuration
 │   ├── agents/                        # Specialized agents for Claude
 │   ├── commands/                      # Custom commands for Claude
-│   ├── skills/                        # Claude skills
+│   ├── rules/                         # Generated from .agents/instructions
+│   ├── skills -> ../.agents/skills    # Claude skills adapter
 │   └── settings.json                  # Claude settings
 ├── AGENTS.md                          # Comprehensive guide for general AI assistants
 └── CLAUDE.md                          # Pointer for Claude with MCP
@@ -54,9 +58,15 @@ docs-v2/
 
 **[../CLAUDE.md](../CLAUDE.md)** - Lightweight pointer to other instruction resources
 
-**[instructions/](instructions/)** - Auto-loaded pattern-specific instructions:
+**[../.agents/](../.agents/)** - Canonical agent assets:
 
-- `content.instructions.md` - For Markdown content files (references Claude skills)
+- `instructions/` - Path-specific instruction sources for all harnesses
+- `skills/` - Agent Skills shared by Codex, Claude Code, GitHub Copilot, and
+  compatible harnesses
+
+**[instructions/](instructions/)** - Generated Copilot pattern-specific instructions:
+
+- `content.instructions.md` - For Markdown content files (references canonical skills)
 - `layouts.instructions.md` - For Hugo template files
 - `api-docs.instructions.md` - For OpenAPI spec files
 - `assets.instructions.md` - For JavaScript/TypeScript files
@@ -68,13 +78,14 @@ docs-v2/
 
 **[../.claude/](../.claude/)** - Claude MCP configuration with specialized agents, commands, and skills:
 
-- `skills/` - Detailed workflow guidance (referenced by Copilot instructions)
+- `skills/` - Symlink to canonical skills in `.agents/skills`
+- `rules/` - Generated path-specific Claude rules from `.agents/instructions`
 - `commands/` - Custom Claude commands
 - `agents/` - Claude-specific agents
 
 ## Choosing the Right Instructions
 
-- **GitHub Copilot?** → [copilot-instructions.md](copilot-instructions.md) (now references Claude skills)
+- **GitHub Copilot?** → [copilot-instructions.md](copilot-instructions.md) and generated [instructions/](instructions/)
 - **General AI assistants?** → [../AGENTS.md](../AGENTS.md)
 - **Claude with MCP?** → [../CLAUDE.md](../CLAUDE.md) and [../.claude/](../.claude/)
 - **Creating/improving Copilot instructions?** → [agents/copilot-instructions-agent.md](agents/copilot-instructions-agent.md)
@@ -83,7 +94,7 @@ docs-v2/
 
 1. **New to the repository?** Start with [../README.md](../README.md)
 2. **Using GitHub Copilot?** Read [copilot-instructions.md](copilot-instructions.md)
-   - For detailed workflows, refer to [../.claude/skills/](../.claude/skills/)
+   - For detailed workflows, refer to [../.agents/skills/](../.agents/skills/)
 3. **Using other AI assistants?** Read [../AGENTS.md](../AGENTS.md)
 4. **Using Claude with MCP?** Check [../CLAUDE.md](../CLAUDE.md) and [../.claude/](../.claude/)
 5. **Managing Copilot instructions?** Use [agents/copilot-instructions-agent.md](agents/copilot-instructions-agent.md)

--- a/.github/agents/copilot-instructions-agent.md
+++ b/.github/agents/copilot-instructions-agent.md
@@ -9,13 +9,13 @@ version: "1.0"
 
 ## Purpose
 
-This agent specializes in creating, improving, and managing GitHub Copilot instructions, custom instructions, and agent configurations. It helps maintain consistency between Claude and Copilot instruction files while adapting content appropriately for each platform.
+This agent specializes in creating, improving, and managing GitHub Copilot instructions, custom instructions, and agent configurations. It helps maintain consistency between canonical `.agents` sources and generated Copilot instruction files while adapting content appropriately for Copilot.
 
 **Use this agent when:**
 
 - Creating new Copilot instruction files
 - Improving existing Copilot instructions
-- Porting Claude skills/commands to Copilot format
+- Porting canonical `.agents` skills and instructions to Copilot format
 - Ensuring consistency across AI assistant configurations
 - Optimizing instructions for GitHub Copilot's capabilities
 
@@ -34,6 +34,7 @@ GitHub Copilot supports several types of customization:
    - Auto-loaded based on file patterns
    - Uses frontmatter `applyTo` field to specify glob patterns
    - More targeted than repository-wide instructions
+   - Generated from `.agents/instructions/*.md`; don't edit directly in this repo
 
 3. **Custom Agents** (`.github/agents/*.md`)
    - Specialized agents for specific tasks
@@ -266,23 +267,23 @@ When editing files with `source:` frontmatter:
 - Use `docs edit <url>` to automatically open all related files
 - Or manually touch sourcing files after editing source
 
-For complete workflow, see [.claude/skills/content-editing/](../../.claude/skills/content-editing/SKILL.md).
+For complete workflow, see [.agents/skills/content-editing/](../../.agents/skills/content-editing/SKILL.md).
 
 ````
 
-## Reference to Claude Resources
+## Reference to Canonical Agent Resources
 
-Copilot instructions should reference Claude resources for detailed workflows:
+Copilot instructions should reference canonical `.agents` resources for detailed workflows:
 
 ```markdown
 ## Detailed Workflows
 
 For comprehensive guidance:
 
-- **Content editing**: [.claude/skills/content-editing/](../.claude/skills/content-editing/SKILL.md)
-- **Testing**: [.claude/skills/cypress-e2e-testing/](../.claude/skills/cypress-e2e-testing/SKILL.md)
-- **InfluxDB setup**: [.claude/skills/influxdb3-test-setup/](../.claude/skills/influxdb3-test-setup/SKILL.md)
-- **Template dev**: [.claude/skills/hugo-template-dev/](../.claude/skills/hugo-template-dev/SKILL.md)
+- **Content editing**: [.agents/skills/content-editing/](../.agents/skills/content-editing/SKILL.md)
+- **Testing**: [.agents/skills/cypress-e2e-testing/](../.agents/skills/cypress-e2e-testing/SKILL.md)
+- **InfluxDB setup**: [.agents/skills/influxdb3-test-setup/](../.agents/skills/influxdb3-test-setup/SKILL.md)
+- **Template dev**: [.agents/skills/hugo-template-dev/](../.agents/skills/hugo-template-dev/SKILL.md)
 
 These resources provide detailed step-by-step guidance for complex workflows.
 ````
@@ -427,7 +428,7 @@ Before finalizing Copilot instructions:
 - [ ] **Consistent**: Matches other instruction formats
 - [ ] **Complete**: All necessary context provided
 - [ ] **CLI-aware**: Uses `docs` CLI where appropriate
-- [ ] **Cross-referenced**: Points to Claude skills when helpful
+- [ ] **Cross-referenced**: Points to canonical Agent Skills when helpful
 
 ## Maintenance Guidelines
 
@@ -503,7 +504,7 @@ From `.github/copilot-instructions.md`:
 
 | Skill | File | Description |
 |-------|------|-------------|
-| **content-editing** | [.claude/skills/content-editing/](../.claude/skills/content-editing/SKILL.md) | Complete content workflow |
+| **content-editing** | [.agents/skills/content-editing/](../.agents/skills/content-editing/SKILL.md) | Complete content workflow |
 ````
 
 ## Quick Checklist: Improving Existing Instructions
@@ -522,11 +523,12 @@ From `.github/copilot-instructions.md`:
 ## Resources
 
 - **GitHub Copilot Docs**: <https://docs.github.com/en/copilot>
-- **Claude skills directory**: `../.claude/skills/`
+- **Canonical skills directory**: `../.agents/skills/`
+- **Canonical path instructions**: `../.agents/instructions/`
 - **Existing Copilot instructions**: `.github/copilot-instructions.md`
 - **Pattern instructions**: `.github/instructions/`
 - **Main documentation**: `../AGENTS.md`, `../CLAUDE.md`
 
 ***
 
-Remember: Copilot instructions should be concise, actionable, and complementary to Claude's detailed skills. When in doubt, reference the detailed resource rather than duplicating it.
+Remember: Copilot instructions should be concise, actionable, and complementary to canonical Agent Skills. When in doubt, reference the detailed resource rather than duplicating it.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,60 +1,24 @@
 # InfluxData Documentation Repository (docs-v2)
 
 > **For GitHub Copilot and other AI coding agents**
->
-> **Instruction resources**:
->
-> - [.github/instructions/](instructions/) - **Pattern-specific** (auto-loaded by file type)
-> - [AGENTS.md](../AGENTS.md) - Shared project guidelines (style, constraints, content structure)
-> - [.agents/](../.agents/) - Canonical agent skills and path-specific instruction sources
-> - [.github/LABEL\_GUIDE.md](LABEL_GUIDE.md) - Label taxonomy and review pipeline
 
-## Quick Reference
+This is Copilot's pointer file. Shared, harness-neutral instructions —
+commands, style, constraints, content structure, and where detailed guidance
+lives — come from [AGENTS.md](../AGENTS.md). Only Copilot-specific
+configuration belongs here.
 
-| Task             | Command                                 | Time    |
-| ---------------- | --------------------------------------- | ------- |
-| Install          | `CYPRESS_INSTALL_BINARY=0 yarn install` | \~4s    |
-| Build            | `npx hugo --quiet`                      | \~75s   |
-| Dev Server       | `npx hugo server`                       | \~92s   |
-| Create Docs      | `docs create <draft> --products <keys>` | varies  |
-| Edit Docs        | `docs edit <url>`                       | instant |
-| Add Placeholders | `docs placeholders <file>`              | instant |
-| Audit Docs       | `docs audit --products <keys>`          | varies  |
-| Test All         | `yarn test:codeblocks:all`              | 15-45m  |
-| Lint             | `yarn lint`                             | \~1m    |
+## Instruction resources
 
-**NEVER CANCEL** Hugo builds (\~75s) or test runs (15-45m).
+- [AGENTS.md](../AGENTS.md) — shared project guidelines (start here)
+- [.agents/](../.agents/) — canonical agent skills and path-specific instruction sources
+- [.github/instructions/](instructions/) — pattern-specific instructions, auto-loaded by file type (see table below)
+- [.github/LABEL\_GUIDE.md](LABEL_GUIDE.md) — label taxonomy and review pipeline
 
-## CLI Tools
+## File pattern-specific instructions
 
-```bash
-docs --help                                     # Full reference
-```
-
-Non-blocking by default. Use `--wait` for interactive editing.
-
-## Workflows
-
-- **Content editing**: See [content-editing skill](../.agents/skills/content-editing/SKILL.md)
-- **Testing**: See [DOCS-TESTING.md](../DOCS-TESTING.md)
-- **Hugo templates**: See [hugo-template-dev skill](../.agents/skills/hugo-template-dev/SKILL.md)
-
-## Product and Content Paths
-
-Defined in [data/products.yml](../data/products.yml).
-
-## Content Guidelines
-
-- [DOCS-CONTRIBUTING.md](../DOCS-CONTRIBUTING.md) - Style, workflow, commit format
-- [DOCS-SHORTCODES.md](../DOCS-SHORTCODES.md) - Shortcode reference
-- [DOCS-FRONTMATTER.md](../DOCS-FRONTMATTER.md) - Frontmatter reference
-- [content/example.md](../content/example.md) - Working shortcode examples
-
-## File Pattern-Specific Instructions
-
-Auto-loaded by GitHub Copilot based on changed files.
-These files are generated from `.agents/instructions/`; edit the canonical
-source and run `yarn build:agent:instructions`.
+GitHub Copilot auto-loads these based on the files you change. They are
+generated from `.agents/instructions/`; edit the canonical source and run
+`yarn build:agent:instructions` to regenerate them.
 
 | Pattern                  | File                                                                          | Description                                      |
 | ------------------------ | ----------------------------------------------------------------------------- | ------------------------------------------------ |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,21 +6,22 @@
 >
 > - [.github/instructions/](instructions/) - **Pattern-specific** (auto-loaded by file type)
 > - [AGENTS.md](../AGENTS.md) - Shared project guidelines (style, constraints, content structure)
-> - [.github/LABEL_GUIDE.md](LABEL_GUIDE.md) - Label taxonomy and review pipeline
+> - [.agents/](../.agents/) - Canonical agent skills and path-specific instruction sources
+> - [.github/LABEL\_GUIDE.md](LABEL_GUIDE.md) - Label taxonomy and review pipeline
 
 ## Quick Reference
 
-| Task             | Command                                               | Time    |
-| ---------------- | ----------------------------------------------------- | ------- |
-| Install          | `CYPRESS_INSTALL_BINARY=0 yarn install`               | \~4s    |
-| Build            | `npx hugo --quiet`                                    | \~75s   |
-| Dev Server       | `npx hugo server`                                     | \~92s   |
-| Create Docs      | `docs create <draft> --products <keys>`               | varies  |
-| Edit Docs        | `docs edit <url>`                                     | instant |
-| Add Placeholders | `docs placeholders <file>`                            | instant |
-| Audit Docs       | `docs audit --products <keys>`                        | varies  |
-| Test All         | `yarn test:codeblocks:all`                            | 15-45m  |
-| Lint             | `yarn lint`                                           | \~1m    |
+| Task             | Command                                 | Time    |
+| ---------------- | --------------------------------------- | ------- |
+| Install          | `CYPRESS_INSTALL_BINARY=0 yarn install` | \~4s    |
+| Build            | `npx hugo --quiet`                      | \~75s   |
+| Dev Server       | `npx hugo server`                       | \~92s   |
+| Create Docs      | `docs create <draft> --products <keys>` | varies  |
+| Edit Docs        | `docs edit <url>`                       | instant |
+| Add Placeholders | `docs placeholders <file>`              | instant |
+| Audit Docs       | `docs audit --products <keys>`          | varies  |
+| Test All         | `yarn test:codeblocks:all`              | 15-45m  |
+| Lint             | `yarn lint`                             | \~1m    |
 
 **NEVER CANCEL** Hugo builds (\~75s) or test runs (15-45m).
 
@@ -34,9 +35,9 @@ Non-blocking by default. Use `--wait` for interactive editing.
 
 ## Workflows
 
-- **Content editing**: See [content-editing skill](../.claude/skills/content-editing/SKILL.md)
+- **Content editing**: See [content-editing skill](../.agents/skills/content-editing/SKILL.md)
 - **Testing**: See [DOCS-TESTING.md](../DOCS-TESTING.md)
-- **Hugo templates**: See [hugo-template-dev skill](../.claude/skills/hugo-template-dev/SKILL.md)
+- **Hugo templates**: See [hugo-template-dev skill](../.agents/skills/hugo-template-dev/SKILL.md)
 
 ## Product and Content Paths
 
@@ -51,12 +52,14 @@ Defined in [data/products.yml](../data/products.yml).
 
 ## File Pattern-Specific Instructions
 
-Auto-loaded by GitHub Copilot based on changed files:
+Auto-loaded by GitHub Copilot based on changed files.
+These files are generated from `.agents/instructions/`; edit the canonical
+source and run `yarn build:agent:instructions`.
 
-| Pattern                  | File                                                              | Description                                      |
-| ------------------------ | ----------------------------------------------------------------- | ------------------------------------------------ |
-| `content/**/*.md`        | [content.instructions.md](instructions/content.instructions.md)   | Content file guidelines, frontmatter, shortcodes |
-| `content/**/*.md`        | [content-review.instructions.md](instructions/content-review.instructions.md) | Review criteria for content changes |
-| `layouts/**/*.html`      | [layouts.instructions.md](instructions/layouts.instructions.md)   | Shortcode implementation patterns and testing    |
-| `api-docs/**/*.yml`      | [api-docs.instructions.md](instructions/api-docs.instructions.md) | OpenAPI spec workflow                            |
-| `assets/js/**/*.{js,ts}` | [assets.instructions.md](instructions/assets.instructions.md)     | TypeScript/JavaScript and CSS development        |
+| Pattern                  | File                                                                          | Description                                      |
+| ------------------------ | ----------------------------------------------------------------------------- | ------------------------------------------------ |
+| `content/**/*.md`        | [content.instructions.md](instructions/content.instructions.md)               | Content file guidelines, frontmatter, shortcodes |
+| `content/**/*.md`        | [content-review.instructions.md](instructions/content-review.instructions.md) | Review criteria for content changes              |
+| `layouts/**/*.html`      | [layouts.instructions.md](instructions/layouts.instructions.md)               | Shortcode implementation patterns and testing    |
+| `api-docs/**/*.yml`      | [api-docs.instructions.md](instructions/api-docs.instructions.md)             | OpenAPI spec workflow                            |
+| `assets/js/**/*.{js,ts}` | [assets.instructions.md](instructions/assets.instructions.md)                 | TypeScript/JavaScript and CSS development        |

--- a/.github/instructions/content.instructions.md
+++ b/.github/instructions/content.instructions.md
@@ -111,10 +111,10 @@ weight:      # Sort order (1-99, 101-199, 201-299...)
 
 ```bash
 # 1. Verify Hugo build
-hugo --quiet
+npx hugo --quiet
 
-# 2. Validate links
-yarn test:links
+# 2. Validate links (build first; see DOCS-TESTING.md)
+link-checker map content/path/*.md | xargs link-checker check
 
 # 3. Test code blocks (if applicable)
 yarn test:codeblocks:all

--- a/.github/scripts/link-extractor.cjs
+++ b/.github/scripts/link-extractor.cjs
@@ -8,8 +8,21 @@
 const fs = require('fs');
 const crypto = require('crypto');
 const matter = require('gray-matter');
+const yaml = require('js-yaml');
 const path = require('path');
 const process = require('process');
+
+// gray-matter 4.0.3 binds its default YAML engine to the removed
+// js-yaml 3 safeLoad/safeDump APIs. js-yaml 4 is safe by default, so point
+// the engine at load/dump to stay compatible with the pinned js-yaml version.
+const MATTER_OPTIONS = {
+  engines: {
+    yaml: {
+      parse: (input) => yaml.load(input),
+      stringify: (input) => yaml.dump(input),
+    },
+  },
+};
 
 /**
  * Extract links from markdown content
@@ -276,7 +289,7 @@ function extractLinksFromFile(filePath) {
     // Parse frontmatter for .md files
     if (extension === '.md') {
       try {
-        const parsed = matter(content);
+        const parsed = matter(content, MATTER_OPTIONS);
         frontmatter = parsed.data || {};
         bodyContent = parsed.content;
       } catch (err) {

--- a/.github/scripts/link-extractor.js
+++ b/.github/scripts/link-extractor.js
@@ -11,6 +11,7 @@ import matter from 'gray-matter';
 import path from 'path';
 import process from 'process';
 import { fileURLToPath } from 'url';
+import { MATTER_OPTIONS } from '../../scripts/lib/file-operations.js';
 
 /**
  * Extract links from markdown content
@@ -277,7 +278,7 @@ function extractLinksFromFile(filePath) {
     // Parse frontmatter for .md files
     if (extension === '.md') {
       try {
-        const parsed = matter(content);
+        const parsed = matter(content, MATTER_OPTIONS);
         frontmatter = parsed.data || {};
         bodyContent = parsed.content;
       } catch (err) {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,20 +3,22 @@
 > **Shared project guidelines for all AI assistants**
 >
 > **Other instruction resources**:
+>
 > - [.github/copilot-instructions.md](.github/copilot-instructions.md) - GitHub Copilot (CLI tools, workflows, repo structure)
 > - [CLAUDE.md](CLAUDE.md) - Claude with MCP (pointer file)
-> - [.claude/](.claude/) - Claude MCP configuration (commands, agents, skills)
-> - [.github/instructions/](.github/instructions/) - File pattern-specific instructions
+> - [.agents/](.agents/) - Canonical agent skills and path-specific instructions
+> - [.claude/](.claude/) - Claude MCP configuration (commands, agents, rules, skills adapter)
+> - [.github/instructions/](.github/instructions/) - Generated Copilot path-specific instructions
 
 ## Commands
 
-| Task | Command | Notes |
-|------|---------|-------|
-| Install | `CYPRESS_INSTALL_BINARY=0 yarn install` | ~4s |
-| Build | `npx hugo --quiet` | ~75s — **NEVER CANCEL** |
-| Dev server | `npx hugo server` | ~92s, port 1313 |
-| Test code blocks | `yarn test:codeblocks:all` | 15-45m — **NEVER CANCEL** |
-| Lint | `yarn lint` | ~1m |
+| Task             | Command                                 | Notes                     |
+| ---------------- | --------------------------------------- | ------------------------- |
+| Install          | `CYPRESS_INSTALL_BINARY=0 yarn install` | \~4s                      |
+| Build            | `npx hugo --quiet`                      | \~75s — **NEVER CANCEL**  |
+| Dev server       | `npx hugo server`                       | \~92s, port 1313          |
+| Test code blocks | `yarn test:codeblocks:all`              | 15-45m — **NEVER CANCEL** |
+| Lint             | `yarn lint`                             | \~1m                      |
 
 ## Repository Structure
 
@@ -33,6 +35,7 @@ docs-v2/
 ├── assets/                 # JS, CSS, TypeScript
 ├── api-docs/              # InfluxDB OpenAPI specifications, API reference documentation generation scripts
 ├── data/                  # YAML/JSON data files
+├── .agents/               # Canonical agent skills and path-specific instructions
 ├── public/                # Build output (gitignored, ~529MB)
 └── .github/
     └── copilot-instructions.md  # Primary AI instructions
@@ -52,6 +55,7 @@ See the [InfluxDB documentation MCP server guide](https://docs.influxdata.com/in
 ### Creating/Editing Content
 
 **Frontmatter** (page metadata):
+
 ```yaml
 title: Page Title          # Required - becomes h1
 description: Brief desc    # Required - for SEO
@@ -63,15 +67,18 @@ weight: 1                  # Required - sort order
 ```
 
 **Shared Content** (avoid duplication):
+
 ```yaml
 source: /shared/path/to/content.md
 ```
 
 Shared content files (`/shared/path/to/content.md`):
+
 - Don't store frontmatter
 - Can use `{{% show-in %}}`, `{{% hide-in %}}`, and the `version` keyword (`/influxdb3/version/content.md`)
 
 **Common Shortcodes**:
+
 - Callouts: `> [!Note]`, `> [!Warning]`, `> [!Important]`, `> [!Tip]`
 - Tabs: `{{< tabs-wrapper >}}` + `{{% tabs %}}` + `{{% tab-content %}}`
 - Required: `{{< req >}}` or `{{< req type="key" >}}`
@@ -82,6 +89,7 @@ Shared content files (`/shared/path/to/content.md`):
 ### Testing Changes
 
 **Always test before committing**:
+
 ```bash
 # Verify server renders (check 200 status)
 curl -s -o /dev/null -w "%{http_code}" http://localhost:1313/influxdb3/core/
@@ -94,7 +102,6 @@ yarn test:links content/influxdb3/core/**/*.md
 ```
 
 **📖 Complete Reference**: [DOCS-TESTING.md](DOCS-TESTING.md)
-
 
 ## Worktree Awareness
 
@@ -110,6 +117,7 @@ directory, not the main clone path.
 
 When searching for InfluxDB 3 content, search these paths in parallel (not
 sequentially):
+
 - `content/shared/influxdb3-*/` — actual content (most content lives here)
 - `content/influxdb3/core/` — Core frontmatter stubs with `source:` references
 - `content/influxdb3/enterprise/` — Enterprise frontmatter stubs
@@ -119,7 +127,7 @@ parallel — one call per directory — rather than one at a time.
 
 ## Constraints
 
-- **NEVER cancel** Hugo builds (~75s) or test runs (15-45m) — the site has 5,359+ pages
+- **NEVER cancel** Hugo builds (\~75s) or test runs (15-45m) — the site has 5,359+ pages
 - Set timeouts: Hugo 180s+, tests 30m+
 - Use `python` not `py` for code block language identifiers (pytest won't collect `py` blocks)
 - Shared content files (`content/shared/`) have no frontmatter — the consuming page provides it via `source:` reference. For InfluxDB 3, the shared directories (`content/shared/influxdb3-*/`) contain the actual prose; product directories contain thin stubs
@@ -148,51 +156,69 @@ Follows [Google Developer Documentation Style Guide](https://developers.google.c
 **Shortcodes**: Callouts use `> [!Note]` / `> [!Warning]` syntax
 — see [DOCS-SHORTCODES.md](DOCS-SHORTCODES.md) and [content/example.md](content/example.md)
 
+## Agent Instructions and Skills
+
+Use `.agents/` as the canonical source for reusable agent guidance:
+
+- `.agents/skills/` contains Agent Skills shared by Codex, Claude Code, GitHub
+  Copilot, and other compatible harnesses.
+- `.agents/instructions/` contains canonical path-specific instruction sources.
+- `.github/instructions/*.instructions.md`, `.claude/rules/*.md`, and scoped
+  `AGENTS.md` files under major directories are generated adapters.
+- `.claude/skills` is a symlink to `.agents/skills`.
+
+After editing `.agents/**` or `AGENTS.md`, run:
+
+```bash
+yarn build:agent:instructions
+yarn validate:agent-instructions
+```
+
 ## Product Content Paths
 
 Canonical paths from `data/products.yml`:
 
-| Product | Content Path |
-|---------|-------------|
-| InfluxDB 3 Core | `content/influxdb3/core/` |
-| InfluxDB 3 Enterprise | `content/influxdb3/enterprise/` |
-| InfluxDB 3 Explorer | `content/influxdb3/explorer/` |
+| Product                   | Content Path                          |
+| ------------------------- | ------------------------------------- |
+| InfluxDB 3 Core           | `content/influxdb3/core/`             |
+| InfluxDB 3 Enterprise     | `content/influxdb3/enterprise/`       |
+| InfluxDB 3 Explorer       | `content/influxdb3/explorer/`         |
 | InfluxDB Cloud Serverless | `content/influxdb3/cloud-serverless/` |
-| InfluxDB Cloud Dedicated | `content/influxdb3/cloud-dedicated/` |
-| InfluxDB Clustered | `content/influxdb3/clustered/` |
-| InfluxDB OSS v2 | `content/influxdb/v2/` |
-| InfluxDB OSS v1 | `content/influxdb/v1/` |
-| InfluxDB Cloud (TSM) | `content/influxdb/cloud/` |
-| InfluxDB Enterprise v1 | `content/enterprise_influxdb/` |
-| Telegraf | `content/telegraf/` |
-| Chronograf | `content/chronograf/` |
-| Kapacitor | `content/kapacitor/` |
-| Flux | `content/flux/` |
-| Shared content | `content/shared/` |
+| InfluxDB Cloud Dedicated  | `content/influxdb3/cloud-dedicated/`  |
+| InfluxDB Clustered        | `content/influxdb3/clustered/`        |
+| InfluxDB OSS v2           | `content/influxdb/v2/`                |
+| InfluxDB OSS v1           | `content/influxdb/v1/`                |
+| InfluxDB Cloud (TSM)      | `content/influxdb/cloud/`             |
+| InfluxDB Enterprise v1    | `content/enterprise_influxdb/`        |
+| Telegraf                  | `content/telegraf/`                   |
+| Chronograf                | `content/chronograf/`                 |
+| Kapacitor                 | `content/kapacitor/`                  |
+| Flux                      | `content/flux/`                       |
+| Shared content            | `content/shared/`                     |
 
 ## Doc Review Pipeline
 
 Automated PR review for documentation changes.
-See [.github/LABEL_GUIDE.md](.github/LABEL_GUIDE.md) for the label taxonomy.
+See [.github/LABEL\_GUIDE.md](.github/LABEL_GUIDE.md) for the label taxonomy.
 
-| Resource | Path |
-|----------|------|
-| Label guide | [.github/LABEL_GUIDE.md](.github/LABEL_GUIDE.md) |
-| Triage agent | [.claude/agents/doc-triage-agent.md](.claude/agents/doc-triage-agent.md) |
+| Resource                    | Path                                                                                                       |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Label guide                 | [.github/LABEL\_GUIDE.md](.github/LABEL_GUIDE.md)                                                          |
+| Triage agent                | [.claude/agents/doc-triage-agent.md](.claude/agents/doc-triage-agent.md)                                   |
 | Content review instructions | [.github/instructions/content-review.instructions.md](.github/instructions/content-review.instructions.md) |
-| Review agent (local) | [.claude/agents/doc-review-agent.md](.claude/agents/doc-review-agent.md) |
-| Auto-label workflow | [.github/workflows/auto-label.yml](.github/workflows/auto-label.yml) |
-| Doc review workflow | [.github/workflows/doc-review.yml](.github/workflows/doc-review.yml) |
+| Review agent (local)        | [.claude/agents/doc-review-agent.md](.claude/agents/doc-review-agent.md)                                   |
+| Auto-label workflow         | [.github/workflows/auto-label.yml](.github/workflows/auto-label.yml)                                       |
+| Doc review workflow         | [.github/workflows/doc-review.yml](.github/workflows/doc-review.yml)                                       |
 
 ## Reference
 
-| Document | Purpose |
-|----------|---------|
-| [DOCS-CONTRIBUTING.md](DOCS-CONTRIBUTING.md) | Style guidelines, commit format, contribution workflow |
-| [DOCS-TESTING.md](DOCS-TESTING.md) | Code block testing, link validation, Vale linting |
-| [DOCS-SHORTCODES.md](DOCS-SHORTCODES.md) | Complete shortcode reference |
-| [DOCS-FRONTMATTER.md](DOCS-FRONTMATTER.md) | Complete frontmatter field reference |
-| [api-docs/README.md](api-docs/README.md) | API documentation workflow |
-| [content/example.md](content/example.md) | Live shortcode examples |
-| [.github/copilot-instructions.md](.github/copilot-instructions.md) | CLI tools, repo structure, workflows |
-| [.github/LABEL_GUIDE.md](.github/LABEL_GUIDE.md) | Label taxonomy and review pipeline |
+| Document                                                           | Purpose                                                |
+| ------------------------------------------------------------------ | ------------------------------------------------------ |
+| [DOCS-CONTRIBUTING.md](DOCS-CONTRIBUTING.md)                       | Style guidelines, commit format, contribution workflow |
+| [DOCS-TESTING.md](DOCS-TESTING.md)                                 | Code block testing, link validation, Vale linting      |
+| [DOCS-SHORTCODES.md](DOCS-SHORTCODES.md)                           | Complete shortcode reference                           |
+| [DOCS-FRONTMATTER.md](DOCS-FRONTMATTER.md)                         | Complete frontmatter field reference                   |
+| [api-docs/README.md](api-docs/README.md)                           | API documentation workflow                             |
+| [content/example.md](content/example.md)                           | Live shortcode examples                                |
+| [.github/copilot-instructions.md](.github/copilot-instructions.md) | CLI tools, repo structure, workflows                   |
+| [.github/LABEL\_GUIDE.md](.github/LABEL_GUIDE.md)                  | Label taxonomy and review pipeline                     |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,224 +1,81 @@
 # InfluxData Documentation (docs-v2)
 
-> **Shared project guidelines for all AI assistants**
->
-> **Other instruction resources**:
->
-> - [.github/copilot-instructions.md](.github/copilot-instructions.md) - GitHub Copilot (CLI tools, workflows, repo structure)
-> - [CLAUDE.md](CLAUDE.md) - Claude with MCP (pointer file)
-> - [.agents/](.agents/) - Canonical agent skills and path-specific instructions
-> - [.claude/](.claude/) - Claude MCP configuration (commands, agents, rules, skills adapter)
-> - [.github/instructions/](.github/instructions/) - Generated Copilot path-specific instructions
+Shared startup guidance for all AI assistants working in this repository.
 
-## Commands
+## Canonical agent resources
 
-| Task             | Command                                 | Notes                     |
-| ---------------- | --------------------------------------- | ------------------------- |
-| Install          | `CYPRESS_INSTALL_BINARY=0 yarn install` | \~4s                      |
-| Build            | `npx hugo --quiet`                      | \~75s — **NEVER CANCEL**  |
-| Dev server       | `npx hugo server`                       | \~92s, port 1313          |
-| Test code blocks | `yarn test:codeblocks:all`              | 15-45m — **NEVER CANCEL** |
-| Lint             | `yarn lint`                             | \~1m                      |
-
-## Repository Structure
-
-```
-docs-v2/
-├── content/                 # Documentation content
-│   ├── influxdb3/          # InfluxDB 3 (core, enterprise, cloud-*)
-│   ├── influxdb/           # InfluxDB v2 and v1
-│   ├── enterprise_influxdb/ # InfluxDB Enterprise v1
-│   ├── telegraf/           # Telegraf docs
-│   ├── shared/             # Shared content across products
-│   └── example.md          # Shortcode testing playground
-├── layouts/                # Hugo templates and shortcodes
-├── assets/                 # JS, CSS, TypeScript
-├── api-docs/              # InfluxDB OpenAPI specifications, API reference documentation generation scripts
-├── data/                  # YAML/JSON data files
-├── .agents/               # Canonical agent skills and path-specific instructions
-├── public/                # Build output (gitignored, ~529MB)
-└── .github/
-    └── copilot-instructions.md  # Primary AI instructions
-```
-
-**Content Paths**: See [copilot-instructions.md](.github/copilot-instructions.md#content-organization)
-
-## Documentation MCP Server
-
-A hosted MCP server provides semantic search over all InfluxDB documentation.
-Use it to verify technical accuracy, check API syntax, and find related docs.
-
-See the [InfluxDB documentation MCP server guide](https://docs.influxdata.com/influxdb3/core/admin/mcp-server/) for setup instructions.
-
-## Common Workflows
-
-### Creating/Editing Content
-
-**Frontmatter** (page metadata):
-
-```yaml
-title: Page Title          # Required - becomes h1
-description: Brief desc    # Required - for SEO
-menu:
-  influxdb_2_0:
-    name: Nav Label       # Optional - nav display name
-    parent: Parent Node   # Optional - for nesting
-weight: 1                  # Required - sort order
-```
-
-**Shared Content** (avoid duplication):
-
-```yaml
-source: /shared/path/to/content.md
-```
-
-Shared content files (`/shared/path/to/content.md`):
-
-- Don't store frontmatter
-- Can use `{{% show-in %}}`, `{{% hide-in %}}`, and the `version` keyword (`/influxdb3/version/content.md`)
-
-**Common Shortcodes**:
-
-- Callouts: `> [!Note]`, `> [!Warning]`, `> [!Important]`, `> [!Tip]`
-- Tabs: `{{< tabs-wrapper >}}` + `{{% tabs %}}` + `{{% tab-content %}}`
-- Required: `{{< req >}}` or `{{< req type="key" >}}`
-- Code placeholders: `{ placeholders="<PLACEHOLDER>" }`
-
-**📖 Complete Reference**: [DOCS-SHORTCODES.md](DOCS-SHORTCODES.md) | [DOCS-FRONTMATTER.md](DOCS-FRONTMATTER.md)
-
-### Testing Changes
-
-**Always test before committing**:
-
-```bash
-# Verify server renders (check 200 status)
-curl -s -o /dev/null -w "%{http_code}" http://localhost:1313/influxdb3/core/
-
-# Test specific content
-yarn test:links content/influxdb3/core/**/*.md
-
-# Run style linting
-.ci/vale/vale.sh content/**/*.md
-```
-
-**📖 Complete Reference**: [DOCS-TESTING.md](DOCS-TESTING.md)
-
-## Worktree Awareness
-
-This repository uses git worktrees. When running in a worktree, the working
-directory IS the repo root — use it for all file paths. Never hardcode or resolve
-paths to the main clone (`/Users/*/docs-v2/` without `.claude/worktrees/`).
-
-Scripts that need `PROJECT_ROOT` derive it from `SCRIPT_DIR` (see
-`test/scripts/init-influxdb3.sh`). Agents should use their current working
-directory, not the main clone path.
-
-## Search Patterns
-
-When searching for InfluxDB 3 content, search these paths in parallel (not
-sequentially):
-
-- `content/shared/influxdb3-*/` — actual content (most content lives here)
-- `content/influxdb3/core/` — Core frontmatter stubs with `source:` references
-- `content/influxdb3/enterprise/` — Enterprise frontmatter stubs
-
-Use Grep and Glob for all local content searches. Run independent searches in
-parallel — one call per directory — rather than one at a time.
-
-## Constraints
-
-- **NEVER cancel** Hugo builds (\~75s) or test runs (15-45m) — the site has 5,359+ pages
-- Set timeouts: Hugo 180s+, tests 30m+
-- Use `python` not `py` for code block language identifiers (pytest won't collect `py` blocks)
-- Shared content files (`content/shared/`) have no frontmatter — the consuming page provides it via `source:` reference. For InfluxDB 3, the shared directories (`content/shared/influxdb3-*/`) contain the actual prose; product directories contain thin stubs
-- Product names and versions come from `data/products.yml` (single source of truth)
-- Commit format: `type(scope): description` — see [DOCS-CONTRIBUTING.md](DOCS-CONTRIBUTING.md#commit-guidelines)
-- Network-restricted environments: Cypress (`CYPRESS_INSTALL_BINARY=0`), Docker builds, and Alpine packages may fail
-
-## Style Rules
-
-Follows [Google Developer Documentation Style Guide](https://developers.google.com/style) with these project-specific additions:
-
-- **Semantic line feeds** — one sentence per line (better diffs)
-- **No h1 in content** — `title` frontmatter auto-generates h1
-- Active voice, present tense, second person
-- Long options in CLI examples (`--output` not `-o`)
-- Code blocks within 80 characters
-
-## Content Structure
-
-**Required frontmatter**: `title`, `description`, `menu`, `weight`
-— see [DOCS-FRONTMATTER.md](DOCS-FRONTMATTER.md)
-
-**Shared content**: `source: /shared/path/to/content.md`
-— shared files use `{{% show-in %}}` / `{{% hide-in %}}` for product-specific content
-
-**Shortcodes**: Callouts use `> [!Note]` / `> [!Warning]` syntax
-— see [DOCS-SHORTCODES.md](DOCS-SHORTCODES.md) and [content/example.md](content/example.md)
-
-## Agent Instructions and Skills
-
-Use `.agents/` as the canonical source for reusable agent guidance:
-
-- `.agents/skills/` contains Agent Skills shared by Codex, Claude Code, GitHub
-  Copilot, and other compatible harnesses.
+- `AGENTS.md` is the shared repo-wide instruction file.
+- `.agents/skills/` contains reusable Agent Skills shared by Codex, Claude
+  Code, GitHub Copilot, and other compatible harnesses.
 - `.agents/instructions/` contains canonical path-specific instruction sources.
 - `.github/instructions/*.instructions.md`, `.claude/rules/*.md`, and scoped
   `AGENTS.md` files under major directories are generated adapters.
 - `.claude/skills` is a symlink to `.agents/skills`.
 
-After editing `.agents/**` or `AGENTS.md`, run:
+After editing `AGENTS.md` or `.agents/**`, run:
 
 ```bash
 yarn build:agent:instructions
 yarn validate:agent-instructions
 ```
 
-## Product Content Paths
+## Core commands
 
-Canonical paths from `data/products.yml`:
+| Task             | Command                                 | Notes                                         |
+| ---------------- | --------------------------------------- | --------------------------------------------- |
+| Install          | `CYPRESS_INSTALL_BINARY=0 yarn install` | Use in network-restricted environments        |
+| Build            | `npx hugo --quiet`                      | \~75s; never cancel                           |
+| Dev server       | `npx hugo server`                       | \~92s; serves on port 1313                    |
+| Test code blocks | `yarn test:codeblocks:all`              | 15-45m; never cancel                          |
+| Lint             | `yarn lint`                             | Runs pre-commit and pre-push hook validations |
 
-| Product                   | Content Path                          |
-| ------------------------- | ------------------------------------- |
-| InfluxDB 3 Core           | `content/influxdb3/core/`             |
-| InfluxDB 3 Enterprise     | `content/influxdb3/enterprise/`       |
-| InfluxDB 3 Explorer       | `content/influxdb3/explorer/`         |
-| InfluxDB Cloud Serverless | `content/influxdb3/cloud-serverless/` |
-| InfluxDB Cloud Dedicated  | `content/influxdb3/cloud-dedicated/`  |
-| InfluxDB Clustered        | `content/influxdb3/clustered/`        |
-| InfluxDB OSS v2           | `content/influxdb/v2/`                |
-| InfluxDB OSS v1           | `content/influxdb/v1/`                |
-| InfluxDB Cloud (TSM)      | `content/influxdb/cloud/`             |
-| InfluxDB Enterprise v1    | `content/enterprise_influxdb/`        |
-| Telegraf                  | `content/telegraf/`                   |
-| Chronograf                | `content/chronograf/`                 |
-| Kapacitor                 | `content/kapacitor/`                  |
-| Flux                      | `content/flux/`                       |
-| Shared content            | `content/shared/`                     |
+## Worktree and path rules
 
-## Doc Review Pipeline
+- This repo uses git worktrees. The current working directory is the repo root.
+- Never hardcode paths back to the main clone under `/Users/*/docs-v2/`.
+- Scripts that need `PROJECT_ROOT` derive it from `SCRIPT_DIR`; agents should
+  use the current working directory, not the main clone path.
 
-Automated PR review for documentation changes.
-See [.github/LABEL\_GUIDE.md](.github/LABEL_GUIDE.md) for the label taxonomy.
+## Search rules
 
-| Resource                    | Path                                                                                                       |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| Label guide                 | [.github/LABEL\_GUIDE.md](.github/LABEL_GUIDE.md)                                                          |
-| Triage agent                | [.claude/agents/doc-triage-agent.md](.claude/agents/doc-triage-agent.md)                                   |
-| Content review instructions | [.github/instructions/content-review.instructions.md](.github/instructions/content-review.instructions.md) |
-| Review agent (local)        | [.claude/agents/doc-review-agent.md](.claude/agents/doc-review-agent.md)                                   |
-| Auto-label workflow         | [.github/workflows/auto-label.yml](.github/workflows/auto-label.yml)                                       |
-| Doc review workflow         | [.github/workflows/doc-review.yml](.github/workflows/doc-review.yml)                                       |
+- For InfluxDB 3 content, search these paths in parallel:
+  - `content/shared/influxdb3-*/`
+  - `content/influxdb3/core/`
+  - `content/influxdb3/enterprise/`
+- Use Grep and Glob for local content searches.
+- Run independent searches in parallel rather than one broad sequential search.
 
-## Reference
+## Constraints
 
-| Document                                                           | Purpose                                                |
-| ------------------------------------------------------------------ | ------------------------------------------------------ |
-| [DOCS-CONTRIBUTING.md](DOCS-CONTRIBUTING.md)                       | Style guidelines, commit format, contribution workflow |
-| [DOCS-TESTING.md](DOCS-TESTING.md)                                 | Code block testing, link validation, Vale linting      |
-| [DOCS-SHORTCODES.md](DOCS-SHORTCODES.md)                           | Complete shortcode reference                           |
-| [DOCS-FRONTMATTER.md](DOCS-FRONTMATTER.md)                         | Complete frontmatter field reference                   |
-| [api-docs/README.md](api-docs/README.md)                           | API documentation workflow                             |
-| [content/example.md](content/example.md)                           | Live shortcode examples                                |
-| [.github/copilot-instructions.md](.github/copilot-instructions.md) | CLI tools, repo structure, workflows                   |
-| [.github/LABEL\_GUIDE.md](.github/LABEL_GUIDE.md)                  | Label taxonomy and review pipeline                     |
+- Never cancel Hugo builds or code block test runs.
+- Use timeouts of at least 180s for Hugo and 30m for long tests.
+- Use `python`, not `py`, for code block language identifiers.
+- Shared content files under `content/shared/` have no frontmatter; consuming
+  pages provide metadata through `source:`.
+- For InfluxDB 3, shared directories contain the prose; product directories are
+  usually thin stubs with `source:` references.
+- Product names and versions come from `data/products.yml`.
+- Commit format is `type(scope): description`.
+- Network-restricted environments may fail on Cypress downloads, Docker builds,
+  or Alpine package installs.
+
+## Documentation style
+
+- Follow the Google Developer Documentation Style Guide.
+- Use semantic line feeds: one sentence per line.
+- Do not add `#` h1 headings in content; `title` frontmatter generates the h1.
+- Prefer active voice, present tense, and second person.
+- Use long options in CLI examples.
+- Keep code blocks within 80 characters where practical.
+
+## Where detailed guidance lives
+
+- `content/AGENTS.md`: frontmatter, shortcodes, shared content, and doc editing
+  workflow.
+- `layouts/AGENTS.md`: Hugo template and shortcode guidance.
+- `assets/AGENTS.md`: JS, CSS, and TypeScript guidance.
+- `api-docs/AGENTS.md`: API reference generation workflow.
+- `DOCS-TESTING.md`: content validation workflow.
+- `DOCS-SHORTCODES.md`: shortcode reference.
+- `DOCS-FRONTMATTER.md`: frontmatter reference.
+- `DOCS-CONTRIBUTING.md`: contribution and commit conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,19 @@ yarn validate:agent-instructions
 | Test code blocks | `yarn test:codeblocks:all`              | 15-45m; never cancel                          |
 | Lint             | `yarn lint`                             | Runs pre-commit and pre-push hook validations |
 
+## docs CLI
+
+Scaffold and manage documentation with the `docs` CLI (`docs --help` for full
+reference). Non-blocking by default; use `--wait` for interactive editing.
+
+- `docs create <draft> --products <keys>` — scaffold new pages
+- `docs edit <url|path>` — open existing pages
+- `docs placeholders <file>` — add placeholder syntax to code blocks
+- `docs audit --products <keys>` — audit coverage
+
+See [README.md](README.md) and the
+[docs-cli-workflow skill](.agents/skills/docs-cli-workflow/SKILL.md) for details.
+
 ## Worktree and path rules
 
 - This repo uses git worktrees. The current working directory is the repo root.
@@ -67,6 +80,22 @@ yarn validate:agent-instructions
 - Prefer active voice, present tense, and second person.
 - Use long options in CLI examples.
 - Keep code blocks within 80 characters where practical.
+
+## Documentation search (MCP)
+
+A hosted InfluxDB documentation search server is configured for this repo.
+Use it to verify technical accuracy, check API syntax, and find related docs.
+Harness-specific setup (Claude Code: `.mcp.json`) lives in each harness's own
+instruction file.
+
+## Plans and design docs
+
+- Implementation plans → `PLAN.md` at the repo root. Tracked on feature
+  branches; a required PR check blocks `PLAN.md` and `HANDOVER.md` from merging
+  to the default branch — remove or promote them before merge.
+- Design specs → an existing docs location (`DOCS-*.md` or product `content/`
+  frontmatter) only if useful post-merge; otherwise keep them in the session or
+  alongside `PLAN.md` and remove before merge.
 
 ## Where detailed guidance lives
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,83 +2,23 @@
 
 @AGENTS.md
 
-> **For Claude with MCP**
->
-> This is a lightweight pointer file for Claude.
-> Shared project instructions are imported from `AGENTS.md` above.
-> **Full instruction resources**:
->
-> - [.github/copilot-instructions.md](.github/copilot-instructions.md) - For GitHub Copilot (technical setup, automation)
-> - [AGENTS.md](AGENTS.md) - Shared project guidelines (style, constraints, content structure)
-> - [.agents/](.agents/) - Canonical agent skills and path-specific instructions
-> - [.github/LABEL\_GUIDE.md](.github/LABEL_GUIDE.md) - Label taxonomy and pipeline usage
-> - [.claude/](.claude/) - Claude MCP configuration directory with:
->   - Custom commands in `.claude/commands/`
->   - Specialized agents in `.claude/agents/`
->   - Path rules in `.claude/rules/`
->   - Skills adapter at `.claude/skills` (symlink to `.agents/skills`)
+This is Claude's pointer file. Shared, harness-neutral instructions come from
+`AGENTS.md` above. Only Claude-specific setup belongs here.
 
-## Documentation MCP server
+## Documentation MCP server (Claude Code setup)
 
-This repo includes [`.mcp.json`](.mcp.json) with a hosted InfluxDB documentation search server.
-Use it to verify technical accuracy, check API syntax, and find related docs.
+This repo's [`.mcp.json`](.mcp.json) defines the InfluxDB docs search server.
+See "Documentation search (MCP)" in `AGENTS.md` for when to use it.
 
-- **`influxdb-docs`** — API key auth. Set `INFLUXDATA_DOCS_KAPA_API_KEY` env var before launching Claude Code.
+- **`influxdb-docs`** — API key auth. Set `INFLUXDATA_DOCS_KAPA_API_KEY` before
+  launching Claude Code.
 - **`influxdb-docs-oauth`** — OAuth fallback. No setup needed.
 
-See [content-editing skill](.agents/skills/content-editing/SKILL.md#part-4-fact-checking-with-the-documentation-mcp-server) for usage details.
+See the [content-editing skill](.agents/skills/content-editing/SKILL.md#part-4-fact-checking-with-the-documentation-mcp-server)
+for usage details.
 
-## Purpose and scope
+## Plan paths (superpowers override)
 
-Claude should help document InfluxData products by creating clear, accurate technical content with proper code examples, frontmatter, and formatting.
-
-## Project overview
-
-See @README.md
-
-## Available NPM commands
-
-@package.json
-
-## Instructions for contributing
-
-See @.github/copilot-instructions.md for style guidelines and
-product-specific documentation paths and URLs managed in this project.
-
-See @DOCS-CONTRIBUTING.md for essential InfluxData
-documentation contributing guidelines, such as style and
-formatting, and commonly used shortcodes.
-
-See @DOCS-TESTING.md for comprehensive testing information, including code block
-testing, link validation, style linting, and advanced testing procedures.
-
-See @api-docs/README.md for information about the API reference documentation, how to
-generate it, and how to contribute to it.
-
-## Agent instructions and skills
-
-Edit canonical skills in `.agents/skills/`.
-Claude discovers them through the `.claude/skills` symlink.
-
-Edit canonical path-specific guidance in `.agents/instructions/`.
-Run `yarn build:agent:instructions` to regenerate `.claude/rules/` and other
-agent harness adapters.
-
-## Design docs and implementation plans (superpowers skills)
-
-The `superpowers:brainstorming` and `superpowers:writing-plans` skills default to
-writing output under `docs/superpowers/specs/` and `docs/superpowers/plans/`.
-Do **not** use those paths in this repo. Instead:
-
-- **Implementation plan** → `PLAN.md` at the repo root. This file is tracked on
-  feature branches so the plan travels with the worktree and remains visible in
-  GitHub review. A required PR check blocks `PLAN.md` and `HANDOVER.md` from
-  merging to the default branch; remove or promote them before merge.
-- **Design spec** → if a design doc is genuinely useful post-merge, put it in
-  an existing docs location (for example, `DOCS-*.md` or product-specific
-  `content/` frontmatter). Otherwise skip committing it; keep the spec in the
-  session only, or save it alongside `PLAN.md` on the branch and remove it
-  before merge.
-
-When a superpowers skill asks where to save a plan or spec, use `PLAN.md` (or
-ask the user) — never write to `docs/superpowers/`.
+The `superpowers:brainstorming` and `superpowers:writing-plans` skills default
+to `docs/superpowers/`. Do **not** use that path here — follow "Plans and
+design docs" in `AGENTS.md` (`PLAN.md` at the repo root).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,22 @@
 # Instructions for InfluxData Documentation
 
+@AGENTS.md
+
 > **For Claude with MCP**
 >
-> This is a lightweight pointer file for Claude. For comprehensive instructions, see the files referenced below.
->
+> This is a lightweight pointer file for Claude.
+> Shared project instructions are imported from `AGENTS.md` above.
 > **Full instruction resources**:
 >
 > - [.github/copilot-instructions.md](.github/copilot-instructions.md) - For GitHub Copilot (technical setup, automation)
 > - [AGENTS.md](AGENTS.md) - Shared project guidelines (style, constraints, content structure)
+> - [.agents/](.agents/) - Canonical agent skills and path-specific instructions
 > - [.github/LABEL\_GUIDE.md](.github/LABEL_GUIDE.md) - Label taxonomy and pipeline usage
 > - [.claude/](.claude/) - Claude MCP configuration directory with:
 >   - Custom commands in `.claude/commands/`
 >   - Specialized agents in `.claude/agents/`
->   - Custom skills in `.claude/skills/`
+>   - Path rules in `.claude/rules/`
+>   - Skills adapter at `.claude/skills` (symlink to `.agents/skills`)
 
 ## Documentation MCP server
 
@@ -22,7 +26,7 @@ Use it to verify technical accuracy, check API syntax, and find related docs.
 - **`influxdb-docs`** — API key auth. Set `INFLUXDATA_DOCS_KAPA_API_KEY` env var before launching Claude Code.
 - **`influxdb-docs-oauth`** — OAuth fallback. No setup needed.
 
-See [content-editing skill](.claude/skills/content-editing/SKILL.md#part-4-fact-checking-with-the-documentation-mcp-server) for usage details.
+See [content-editing skill](.agents/skills/content-editing/SKILL.md#part-4-fact-checking-with-the-documentation-mcp-server) for usage details.
 
 ## Purpose and scope
 
@@ -50,6 +54,15 @@ testing, link validation, style linting, and advanced testing procedures.
 
 See @api-docs/README.md for information about the API reference documentation, how to
 generate it, and how to contribute to it.
+
+## Agent instructions and skills
+
+Edit canonical skills in `.agents/skills/`.
+Claude discovers them through the `.claude/skills` symlink.
+
+Edit canonical path-specific guidance in `.agents/instructions/`.
+Run `yarn build:agent:instructions` to regenerate `.claude/rules/` and other
+agent harness adapters.
 
 ## Design docs and implementation plans (superpowers skills)
 

--- a/DOCS-CONTRIBUTING.md
+++ b/DOCS-CONTRIBUTING.md
@@ -373,8 +373,8 @@ git commit -m "<COMMIT_MESSAGE>" --no-verify
 # Test code blocks
 yarn test:codeblocks:all
 
-# Test links
-yarn test:links content/influxdb3/core/**/*.md
+# Test links (build first; see DOCS-TESTING.md)
+link-checker map content/influxdb3/core/**/*.md | xargs link-checker check
 
 # Run style linting
 .ci/vale/vale.sh content/**/*.md
@@ -432,7 +432,7 @@ For detailed reference documentation, see:
 Run Vale with `.ci/vale/vale.sh`:
 
 1. Lint specific files: `.ci/vale/vale.sh content/influxdb3/core/**/*.md`
-2. Use a product config: `.ci/vale/vale.sh --config=content/influxdb/cloud-dedicated/.vale.ini content/path/`
+2. Use a product config: `.ci/vale/vale.sh --config=content/influxdb3/cloud-dedicated/.vale.ini content/path/`
 3. Set alert level: `.ci/vale/vale.sh --minAlertLevel=error content/path/`
 
 Vale raises the following alert levels:
@@ -450,7 +450,7 @@ Vale raises the following alert levels:
 
 The easiest way to add accepted or rejected spellings is to enter your terms (or regular expression patterns) into the Vocabulary files at `.ci/vale/styles/config/vocabularies`.
 
-To add accepted/rejected terms for specific products, configure a style for the product and include a `Branding.yml` configuration. As an example, see `content/influxdb/cloud-dedicated/.vale.ini` and `.ci/vale/styles/Cloud-Dedicated/Branding.yml`.
+To add accepted/rejected terms for specific products, configure a style for the product and include a `Branding.yml` configuration. As an example, see `content/influxdb3/cloud-dedicated/.vale.ini` and `.ci/vale/styles/Cloud-Dedicated/Branding.yml`.
 
 To learn more about configuration and rules, see [Vale configuration](https://vale.sh/docs/topics/config).
 

--- a/DOCS-TESTING.md
+++ b/DOCS-TESTING.md
@@ -14,7 +14,7 @@ This guide covers all testing procedures for the InfluxData documentation, inclu
 | Test Type               | Purpose                                                              | Command                    |
 | ----------------------- | -------------------------------------------------------------------- | -------------------------- |
 | **Code blocks**         | Validate shell/Python code examples                                  | `yarn test:codeblocks:all` |
-| **Link validation**     | Check internal/external links                                        | `yarn test:links`          |
+| **Link validation**     | Check internal/external links                                        | `link-checker` (see below) |
 | **Style linting**       | Enforce writing standards                                            | `.ci/vale/vale.sh`         |
 | **Markdown generation** | Generate LLM-friendly Markdown                                       | `yarn build:md`            |
 | **E2E tests**           | UI and functionality testing                                         | `yarn test:e2e`            |
@@ -900,7 +900,7 @@ Style linting uses [Vale](https://vale.sh/) to enforce documentation writing sta
 .ci/vale/vale.sh content/influxdb3/core/**/*.md
 
 # With product config and alert level
-.ci/vale/vale.sh --config=content/influxdb/cloud-dedicated/.vale.ini --minAlertLevel=error content/influxdb/cloud-dedicated/write-data/**/*.md
+.ci/vale/vale.sh --config=content/influxdb3/cloud-dedicated/.vale.ini --minAlertLevel=error content/influxdb3/cloud-dedicated/write-data/**/*.md
 ```
 
 ### VS Code IDE Integration
@@ -920,7 +920,7 @@ Vale can raise different alert levels:
 
 - **Styles**: `.ci/vale/styles/` contains configuration for the custom `InfluxDataDocs` style
 - **Vocabulary**: Add accepted/rejected terms to `.ci/vale/styles/config/vocabularies`
-- **Product-specific**: Configure per-product styles like `content/influxdb/cloud-dedicated/.vale.ini`
+- **Product-specific**: Configure per-product styles like `content/influxdb3/cloud-dedicated/.vale.ini`
 
 For more configuration details, see [Vale configuration](https://vale.sh/docs/topics/config).
 

--- a/PLATFORM_REFERENCE.md
+++ b/PLATFORM_REFERENCE.md
@@ -21,7 +21,7 @@ InfluxDB OSS v2:
 - Host hint: `localhost:8086`
 - Characteristics: Free, Self-hosted, InfluxQL/Flux, Token or Username/Password, Buckets
 - URL contains hints: localhost:8086
-- Ping header hints: x-influxdb-build=OSS, x-influxdb-version=^(1|2).
+- Ping header hints: `x-influxdb-build=OSS`, `x-influxdb-version=^(1|2)\.`
 
 InfluxDB OSS v1:
 
@@ -32,7 +32,7 @@ InfluxDB OSS v1:
 - Host hint: `localhost:8086`
 - Characteristics: Free, Self-hosted, InfluxQL/Flux, Token or Username/Password, Buckets
 - URL contains hints: localhost:8086
-- Ping header hints: x-influxdb-build=OSS, x-influxdb-version=^(1|2).
+- Ping header hints: `x-influxdb-build=OSS`, `x-influxdb-version=^(1|2)\.`
 
 InfluxDB Enterprise v1:
 
@@ -40,7 +40,7 @@ InfluxDB Enterprise v1:
 - Production docs URL: <https://docs.influxdata.com/enterprise_influxdb/>
 - Query languages: InfluxQL, Flux
 - Characteristics: Paid, Self-hosted, InfluxQL/Flux, Username/Password, Databases
-- Ping header hints: x-influxdb-build=Enterprise
+- Ping header hints: `x-influxdb-build=Enterprise`
 
 InfluxDB Cloud (TSM):
 
@@ -79,7 +79,7 @@ InfluxDB Clustered:
 - Query languages: SQL, InfluxQL
 - Host hint: `cluster-host.com`
 - Characteristics: Paid, Self-hosted, SQL/InfluxQL, Token, Databases
-- Ping header hints: x-influxdb-version=influxqlbridged-development
+- Ping header hints: `x-influxdb-version=influxqlbridged-development`
 
 InfluxDB 3 Core:
 
@@ -89,7 +89,7 @@ InfluxDB 3 Core:
 - Host hint: `localhost:8181`
 - Characteristics: Free, Self-hosted, SQL/InfluxQL, No auth required, Databases
 - URL contains hints: localhost:8181
-- Ping header hints: x-influxdb-version=^3., x-influxdb-build=Core
+- Ping header hints: `x-influxdb-version=^3\.`, `x-influxdb-build=Core`
 
 InfluxDB 3 Enterprise:
 
@@ -99,7 +99,7 @@ InfluxDB 3 Enterprise:
 - Host hint: `localhost:8181`
 - Characteristics: Paid, Self-hosted, SQL/InfluxQL, Token, Databases
 - URL contains hints: localhost:8181
-- Ping header hints: x-influxdb-version=^3., x-influxdb-build=Enterprise
+- Ping header hints: `x-influxdb-version=^3\.`, `x-influxdb-build=Enterprise`
 
 InfluxDB 3 Explorer:
 

--- a/PLATFORM_REFERENCE.md
+++ b/PLATFORM_REFERENCE.md
@@ -1,80 +1,129 @@
 <!-- This file is auto-generated from data/products.yml. Do not edit directly. -->
 
-<!-- Run 'npm run build:agent:instructions' to regenerate this file. -->
+<!-- Run 'yarn build:agent:instructions' to regenerate this file. -->
 
-Use the following information to help determine which InfluxDB version and
-product the user is asking about:
+Use this compact product disambiguation reference to map user requests to
+canonical product names, content paths, and production documentation URLs.
+
+Production docs URL rule:
+
+- For each entry with a `Content path`, map it to
+  `https://docs.influxdata.com/<content-path>/`.
+- Treat `data/products.yml` as the canonical source of truth when you need
+  details not listed here.
 
 InfluxDB OSS v2:
 
-- Documentation: <https://docs.influxdata.com/influxdb/v2/>
-- Query languages: InfluxQL and Flux
-- Clients: Telegraf, influx CLI, v1/v2 client libraries
+- Aliases: InfluxDB OSS, v2
+- Content path: `influxdb/v2`
+- Production docs URL: <https://docs.influxdata.com/influxdb/v2/>
+- Query languages: InfluxQL, Flux
+- Host hint: `localhost:8086`
+- Characteristics: Free, Self-hosted, InfluxQL/Flux, Token or Username/Password, Buckets
+- URL contains hints: localhost:8086
+- Ping header hints: x-influxdb-build=OSS, x-influxdb-version=^(1|2).
 
 InfluxDB OSS v1:
 
-- Documentation: <https://docs.influxdata.com/influxdb/v1/>
-- Query languages: InfluxQL and Flux
-- Clients: Telegraf, influx CLI, v1/v2 client libraries
+- Aliases: InfluxDB OSS, v1
+- Content path: `influxdb/v1`
+- Production docs URL: <https://docs.influxdata.com/influxdb/v1/>
+- Query languages: InfluxQL, Flux
+- Host hint: `localhost:8086`
+- Characteristics: Free, Self-hosted, InfluxQL/Flux, Token or Username/Password, Buckets
+- URL contains hints: localhost:8086
+- Ping header hints: x-influxdb-build=OSS, x-influxdb-version=^(1|2).
 
 InfluxDB Enterprise v1:
 
-- Documentation: <https://docs.influxdata.com/enterprise_influxdb/v1.12/>
-- Query languages: InfluxQL and Flux
-- Clients: Telegraf, influx CLI, v1/v2 client libraries
+- Content path: `enterprise_influxdb`
+- Production docs URL: <https://docs.influxdata.com/enterprise_influxdb/>
+- Query languages: InfluxQL, Flux
+- Characteristics: Paid, Self-hosted, InfluxQL/Flux, Username/Password, Databases
+- Ping header hints: x-influxdb-build=Enterprise
 
 InfluxDB Cloud (TSM):
 
-- Documentation: <https://docs.influxdata.com/influxdb/cloud/>
-- Query languages: InfluxQL and Flux
-- Clients: Telegraf, influx CLI, v2 client libraries
+- Aliases: InfluxDB Cloud
+- Content path: `influxdb/cloud`
+- Production docs URL: <https://docs.influxdata.com/influxdb/cloud/>
+- Query languages: InfluxQL, Flux
+- Host hint: `cloud2.influxdata.com`
+- Characteristics: Paid/Free, Cloud, InfluxQL/Flux, Token, Databases/Buckets
+- URL contains hints: us-west-2-1.aws.cloud2.influxdata.com, us-west-2-2.aws.cloud2.influxdata.com, us-east-1-1.aws.cloud2.influxdata.com, eu-central-1-1.aws.cloud2.influxdata.com, us-central1-1.gcp.cloud2.influxdata.com, westeurope-1.azure.cloud2.influxdata.com, eastus-1.azure.cloud2.influxdata.com
 
 InfluxDB Cloud Serverless:
 
-- Documentation: <https://docs.influxdata.com/influxdb3/cloud-serverless/>
-- Query languages: SQL and InfluxQL and Flux
-- Clients: Telegraf, influxctl CLI, v3 client libraries
+- Aliases: InfluxDB Cloud
+- Content path: `influxdb3/cloud-serverless`
+- Production docs URL: <https://docs.influxdata.com/influxdb3/cloud-serverless/>
+- Query languages: SQL, InfluxQL, Flux
+- Host hint: `cloud2.influxdata.com`
+- Characteristics: Paid/Free, Cloud, All languages, Token, Buckets
+- URL contains hints: us-east-1-1.aws.cloud2.influxdata.com, eu-central-1-1.aws.cloud2.influxdata.com
 
 InfluxDB Cloud Dedicated:
 
-- Documentation: <https://docs.influxdata.com/influxdb3/cloud-dedicated/>
-- Query languages: SQL and InfluxQL
-- Clients: Telegraf, influxctl CLI, v3 client libraries
+- Aliases: InfluxDB Cloud
+- Content path: `influxdb3/cloud-dedicated`
+- Production docs URL: <https://docs.influxdata.com/influxdb3/cloud-dedicated/>
+- Query languages: SQL, InfluxQL
+- Host hint: `cluster-id.a.influxdb.io`
+- Characteristics: Paid, Cloud, SQL/InfluxQL, Token, Databases
+- URL contains hints: influxdb.io
 
 InfluxDB Clustered:
 
-- Documentation: <https://docs.influxdata.com/influxdb3/clustered/>
-- Query languages: SQL and InfluxQL
-- Clients: Telegraf, influxctl CLI, v3 client libraries
+- Content path: `influxdb3/clustered`
+- Production docs URL: <https://docs.influxdata.com/influxdb3/clustered/>
+- Query languages: SQL, InfluxQL
+- Host hint: `cluster-host.com`
+- Characteristics: Paid, Self-hosted, SQL/InfluxQL, Token, Databases
+- Ping header hints: x-influxdb-version=influxqlbridged-development
 
 InfluxDB 3 Core:
 
-- Documentation: <https://docs.influxdata.com/influxdb3/core/>
-- Query languages: SQL and InfluxQL
-- Clients: Telegraf, influxdb3 CLI, v3 client libraries, InfluxDB 3 Explorer
+- Content path: `influxdb3/core`
+- Production docs URL: <https://docs.influxdata.com/influxdb3/core/>
+- Query languages: SQL, InfluxQL
+- Host hint: `localhost:8181`
+- Characteristics: Free, Self-hosted, SQL/InfluxQL, No auth required, Databases
+- URL contains hints: localhost:8181
+- Ping header hints: x-influxdb-version=^3., x-influxdb-build=Core
 
 InfluxDB 3 Enterprise:
 
-- Documentation: <https://docs.influxdata.com/influxdb3/enterprise/>
-- Query languages: SQL and InfluxQL
-- Clients: Telegraf, influxdb3 CLI, v3 client libraries, InfluxDB 3 Explorer
+- Content path: `influxdb3/enterprise`
+- Production docs URL: <https://docs.influxdata.com/influxdb3/enterprise/>
+- Query languages: SQL, InfluxQL
+- Host hint: `localhost:8181`
+- Characteristics: Paid, Self-hosted, SQL/InfluxQL, Token, Databases
+- URL contains hints: localhost:8181
+- Ping header hints: x-influxdb-version=^3., x-influxdb-build=Enterprise
 
 InfluxDB 3 Explorer:
 
-- Documentation: <https://docs.influxdata.com/influxdb3/explorer/>
+- Aliases: Explorer
+- Content path: `influxdb3/explorer`
+- Production docs URL: <https://docs.influxdata.com/influxdb3/explorer/>
+- Host hint: `localhost:8080`
 
 Telegraf:
 
-- Documentation: <https://docs.influxdata.com/telegraf/v1.39/>
+- Content path: `telegraf`
+- Production docs URL: <https://docs.influxdata.com/telegraf/>
 
 Chronograf:
 
-- Documentation: <https://docs.influxdata.com/chronograf/v1.11/>
+- Content path: `chronograf`
+- Production docs URL: <https://docs.influxdata.com/chronograf/>
 
 Kapacitor:
 
-- Documentation: <https://docs.influxdata.com/kapacitor/v1.8/>
+- Content path: `kapacitor`
+- Production docs URL: <https://docs.influxdata.com/kapacitor/>
 
 Flux:
 
-- Documentation: <https://docs.influxdata.com/flux/v0/>
+- Content path: `flux`
+- Production docs URL: <https://docs.influxdata.com/flux/>

--- a/PLATFORM_REFERENCE.md
+++ b/PLATFORM_REFERENCE.md
@@ -1,65 +1,80 @@
 <!-- This file is auto-generated from data/products.yml. Do not edit directly. -->
+
 <!-- Run 'npm run build:agent:instructions' to regenerate this file. -->
 
-Use the following information to help determine which InfluxDB version and product the user is asking about:
+Use the following information to help determine which InfluxDB version and
+product the user is asking about:
 
 InfluxDB OSS v2:
-  - Documentation: https://docs.influxdata.com/influxdb/v2/
-  - Query languages: InfluxQL and Flux
-  - Clients: Telegraf, influx CLI, v1/v2 client libraries
+
+- Documentation: <https://docs.influxdata.com/influxdb/v2/>
+- Query languages: InfluxQL and Flux
+- Clients: Telegraf, influx CLI, v1/v2 client libraries
 
 InfluxDB OSS v1:
-  - Documentation: https://docs.influxdata.com/influxdb/v1/
-  - Query languages: InfluxQL and Flux
-  - Clients: Telegraf, influx CLI, v1/v2 client libraries
+
+- Documentation: <https://docs.influxdata.com/influxdb/v1/>
+- Query languages: InfluxQL and Flux
+- Clients: Telegraf, influx CLI, v1/v2 client libraries
 
 InfluxDB Enterprise v1:
-  - Documentation: https://docs.influxdata.com/enterprise_influxdb/v1.12/
-  - Query languages: InfluxQL and Flux
-  - Clients: Telegraf, influx CLI, v1/v2 client libraries
+
+- Documentation: <https://docs.influxdata.com/enterprise_influxdb/v1.12/>
+- Query languages: InfluxQL and Flux
+- Clients: Telegraf, influx CLI, v1/v2 client libraries
 
 InfluxDB Cloud (TSM):
-  - Documentation: https://docs.influxdata.com/influxdb/cloud/
-  - Query languages: InfluxQL and Flux
-  - Clients: Telegraf, influx CLI, v2 client libraries
+
+- Documentation: <https://docs.influxdata.com/influxdb/cloud/>
+- Query languages: InfluxQL and Flux
+- Clients: Telegraf, influx CLI, v2 client libraries
 
 InfluxDB Cloud Serverless:
-  - Documentation: https://docs.influxdata.com/influxdb3/cloud-serverless/
-  - Query languages: SQL and InfluxQL and Flux
-  - Clients: Telegraf, influxctl CLI, v3 client libraries
+
+- Documentation: <https://docs.influxdata.com/influxdb3/cloud-serverless/>
+- Query languages: SQL and InfluxQL and Flux
+- Clients: Telegraf, influxctl CLI, v3 client libraries
 
 InfluxDB Cloud Dedicated:
-  - Documentation: https://docs.influxdata.com/influxdb3/cloud-dedicated/
-  - Query languages: SQL and InfluxQL
-  - Clients: Telegraf, influxctl CLI, v3 client libraries
+
+- Documentation: <https://docs.influxdata.com/influxdb3/cloud-dedicated/>
+- Query languages: SQL and InfluxQL
+- Clients: Telegraf, influxctl CLI, v3 client libraries
 
 InfluxDB Clustered:
-  - Documentation: https://docs.influxdata.com/influxdb3/clustered/
-  - Query languages: SQL and InfluxQL
-  - Clients: Telegraf, influxctl CLI, v3 client libraries
+
+- Documentation: <https://docs.influxdata.com/influxdb3/clustered/>
+- Query languages: SQL and InfluxQL
+- Clients: Telegraf, influxctl CLI, v3 client libraries
 
 InfluxDB 3 Core:
-  - Documentation: https://docs.influxdata.com/influxdb3/core/
-  - Query languages: SQL and InfluxQL
-  - Clients: Telegraf, influxdb3 CLI, v3 client libraries, InfluxDB 3 Explorer
+
+- Documentation: <https://docs.influxdata.com/influxdb3/core/>
+- Query languages: SQL and InfluxQL
+- Clients: Telegraf, influxdb3 CLI, v3 client libraries, InfluxDB 3 Explorer
 
 InfluxDB 3 Enterprise:
-  - Documentation: https://docs.influxdata.com/influxdb3/enterprise/
-  - Query languages: SQL and InfluxQL
-  - Clients: Telegraf, influxdb3 CLI, v3 client libraries, InfluxDB 3 Explorer
+
+- Documentation: <https://docs.influxdata.com/influxdb3/enterprise/>
+- Query languages: SQL and InfluxQL
+- Clients: Telegraf, influxdb3 CLI, v3 client libraries, InfluxDB 3 Explorer
 
 InfluxDB 3 Explorer:
-  - Documentation: https://docs.influxdata.com/influxdb3/explorer/
+
+- Documentation: <https://docs.influxdata.com/influxdb3/explorer/>
 
 Telegraf:
-  - Documentation: https://docs.influxdata.com/telegraf/v1.39/
+
+- Documentation: <https://docs.influxdata.com/telegraf/v1.39/>
 
 Chronograf:
-  - Documentation: https://docs.influxdata.com/chronograf/v1.11/
+
+- Documentation: <https://docs.influxdata.com/chronograf/v1.11/>
 
 Kapacitor:
-  - Documentation: https://docs.influxdata.com/kapacitor/v1.8/
+
+- Documentation: <https://docs.influxdata.com/kapacitor/v1.8/>
 
 Flux:
-  - Documentation: https://docs.influxdata.com/flux/v0/
 
+- Documentation: <https://docs.influxdata.com/flux/v0/>

--- a/api-docs/AGENTS.md
+++ b/api-docs/AGENTS.md
@@ -1,19 +1,19 @@
----
-applyTo: "api-docs/**/*.md, api-docs/**/*.yml, api-docs/**/*.yaml"
----
-
 <!-- This file is auto-generated from .agents/instructions. Do not edit directly. -->
 
 <!-- Run 'yarn build:agent:instructions' to regenerate it. -->
 
-# InfluxDB API Documentation
+# API Documentation Agent Instructions
 
-**Complete guide**: [api-docs/README.md](../../api-docs/README.md)
+These instructions apply when working in `api-docs/`.
+
+## InfluxDB API Documentation
+
+**Complete guide**: [api-docs/README.md](./README.md)
 
 API documentation uses OpenAPI specifications processed by a build pipeline, not
 Hugo shortcodes.
 
-## Workflow
+### Workflow
 
 1. Edit YAML files in `/api-docs/`
 2. Generate HTML documentation locally:
@@ -24,7 +24,7 @@ Hugo shortcodes.
 3. Test generated documentation
 4. Commit YAML changes (HTML is gitignored)
 
-## Key files per product
+### Key files per product
 
 | File                          | Purpose                                                  |
 | ----------------------------- | -------------------------------------------------------- |
@@ -34,15 +34,15 @@ Hugo shortcodes.
 | `content/servers.yml`         | Server URL overlay                                       |
 | `.config.yml`                 | Product config (API keys, spec paths, Hugo output dirs)  |
 
-## Writing tag content
+### Writing tag content
 
 Each product has a colocated `tags.yml` that configures tag descriptions and
 related links.
-See [How to add tag content](../../api-docs/README.md#how-to-add-tag-content-or-describe-a-group-of-paths)
+See [How to add tag content](./README.md#how-to-add-tag-content-or-describe-a-group-of-paths)
 in the API docs README for the full format reference, field descriptions, tag
 categories, and cross-product consistency guidelines.
 
-## Build pipeline
+### Build pipeline
 
 ```
 getswagger.sh          → fetch and bundle specs with @redocly/cli
@@ -50,7 +50,7 @@ post-process-specs.ts  → apply info/servers overlays + tag configs
 generate-openapi-articles.ts → generate Hugo pages + copy specs to static/openapi/
 ```
 
-## Tools
+### Tools
 
 - **@redocly/cli**: Lints, bundles, and resolves `$ref`s in multi-file specs
 - **post-process-specs.ts**: Applies content overlays and tag configs
@@ -58,4 +58,4 @@ generate-openapi-articles.ts → generate Hugo pages + copy specs to static/open
   downloads
 
 For complete documentation workflow, see
-[api-docs/README.md](../../api-docs/README.md).
+[api-docs/README.md](./README.md).

--- a/assets/AGENTS.md
+++ b/assets/AGENTS.md
@@ -1,15 +1,15 @@
----
-applyTo: "assets/js/**/*.js, assets/js/**/*.ts"
----
-
 <!-- This file is auto-generated from .agents/instructions. Do not edit directly. -->
 
 <!-- Run 'yarn build:agent:instructions' to regenerate it. -->
 
-# JavaScript and TypeScript Guidelines
+# Asset Development Agent Instructions
+
+These instructions apply when working in `assets/`.
+
+## JavaScript and TypeScript Guidelines
 
 **For detailed TypeScript and Hugo asset pipeline guidance**, see
-[.github/agents/typescript-hugo-agent.md](../agents/typescript-hugo-agent.md)
+[.github/agents/typescript-hugo-agent.md](../.github/agents/typescript-hugo-agent.md)
 which covers:
 
 - TypeScript migration strategies
@@ -17,7 +17,7 @@ which covers:
 - Component architecture patterns
 - Advanced debugging techniques
 
-## TypeScript Configuration
+### TypeScript Configuration
 
 Project uses TypeScript with ES2020 target:
 
@@ -27,7 +27,7 @@ Project uses TypeScript with ES2020 target:
 - Build: `yarn build:ts`
 - Watch: `yarn build:ts:watch`
 
-## Component Pattern
+### Component Pattern
 
 1. Add `data-component` attribute to HTML element:
    ```html
@@ -49,15 +49,15 @@ Project uses TypeScript with ES2020 target:
    registerComponent('my-component', initMyComponent);
    ```
 
-## Debugging
+### Debugging
 
-### Method 1: Chrome DevTools with Source Maps
+#### Method 1: Chrome DevTools with Source Maps
 
 1. VS Code: Run > Start Debugging
 2. Select "Debug Docs (source maps)"
 3. Set breakpoints in `assets/js/ns-hugo-imp:` namespace
 
-### Method 2: Debug Helpers
+#### Method 2: Debug Helpers
 
 ```typescript
 import { debugLog, debugBreak, debugInspect } from './utils/debug-helpers';
@@ -72,7 +72,7 @@ Debug with: VS Code "Debug JS (debug-helpers)" configuration
 
 **Remove debug statements before committing.**
 
-## Type Safety
+### Type Safety
 
 - Use strict TypeScript mode
 - Add type annotations for parameters and returns
@@ -80,11 +80,11 @@ Debug with: VS Code "Debug JS (debug-helpers)" configuration
 - Enable `checkJs: false` for gradual migration
 
 For complete JavaScript documentation, see
-[DOCS-CONTRIBUTING.md](../../DOCS-CONTRIBUTING.md#javascript-in-the-documentation-ui).
+[DOCS-CONTRIBUTING.md](../DOCS-CONTRIBUTING.md#javascript-in-the-documentation-ui).
 
-## Related Resources
+### Related Resources
 
 - **TypeScript & Hugo development**:
-  [.github/agents/typescript-hugo-agent.md](../agents/typescript-hugo-agent.md)
+  [.github/agents/typescript-hugo-agent.md](../.github/agents/typescript-hugo-agent.md)
 - **Contributing guidelines**:
-  [DOCS-CONTRIBUTING.md](../../DOCS-CONTRIBUTING.md#javascript-in-the-documentation-ui)
+  [DOCS-CONTRIBUTING.md](../DOCS-CONTRIBUTING.md#javascript-in-the-documentation-ui)

--- a/config/_default/hugo.yml
+++ b/config/_default/hugo.yml
@@ -120,10 +120,11 @@ server:
 ignoreLogs:
   - warning-goldmark-raw-html
 
-# Generated agent-instruction adapters may live under content/ for tooling,
-# but they are not publishable docs content.
+# Agent and meta files (AGENTS.md, CLAUDE.md, README.md, etc.) may live under
+# content/ for tooling, but they are not publishable docs content. Ignore any
+# file whose basename is all uppercase (the convention for these meta files).
 ignoreFiles:
-  - '(^|/)AGENTS\.md$'
+  - '(^|/)[A-Z0-9][A-Z0-9_-]*\.md$'
 
 # Disable minification for development
 minify:

--- a/content/AGENTS.md
+++ b/content/AGENTS.md
@@ -111,10 +111,10 @@ weight:      # Sort order (1-99, 101-199, 201-299...)
 
 ```bash
 # 1. Verify Hugo build
-hugo --quiet
+npx hugo --quiet
 
-# 2. Validate links
-yarn test:links
+# 2. Validate links (build first; see DOCS-TESTING.md)
+link-checker map content/path/*.md | xargs link-checker check
 
 # 3. Test code blocks (if applicable)
 yarn test:codeblocks:all

--- a/content/AGENTS.md
+++ b/content/AGENTS.md
@@ -1,32 +1,32 @@
----
-applyTo: "content/**/*.md"
----
-
 <!-- This file is auto-generated from .agents/instructions. Do not edit directly. -->
 
 <!-- Run 'yarn build:agent:instructions' to regenerate it. -->
 
-# Content File Guidelines
+# Documentation Content Agent Instructions
 
-**Frontmatter reference**: [DOCS-FRONTMATTER.md](../../DOCS-FRONTMATTER.md)
-**Shortcodes reference**: [DOCS-SHORTCODES.md](../../DOCS-SHORTCODES.md)
-**Working examples**: [content/example.md](../../content/example.md)
+These instructions apply when working in `content/`.
+
+## Content File Guidelines
+
+**Frontmatter reference**: [DOCS-FRONTMATTER.md](../DOCS-FRONTMATTER.md)
+**Shortcodes reference**: [DOCS-SHORTCODES.md](../DOCS-SHORTCODES.md)
+**Working examples**: [content/example.md](./example.md)
 
 **For complete content editing workflow**, see
-[content-editing skill](../../.agents/skills/content-editing/SKILL.md) which covers:
+[content-editing skill](../.agents/skills/content-editing/SKILL.md) which covers:
 
 - Creating and editing content with CLI tools
 - Shared content management and testing
 - Fact-checking with MCP server
 - Complete validation workflows
 
-## CLI Tools for Content Workflow
+### CLI Tools for Content Workflow
 
 The unified `docs` CLI provides tools for content creation and editing.
 For decision guidance on when to use CLI vs direct editing, see
-[docs-cli-workflow skill](../../.agents/skills/docs-cli-workflow/SKILL.md).
+[docs-cli-workflow skill](../.agents/skills/docs-cli-workflow/SKILL.md).
 
-### Creating New Content
+#### Creating New Content
 
 Use `docs create` for AI-assisted scaffolding:
 
@@ -41,7 +41,7 @@ docs create drafts/feature.md --products influxdb3_core --open
 docs create drafts/feature.md --products influxdb3_core --open --wait
 ```
 
-### Editing Existing Content
+#### Editing Existing Content
 
 Use `docs edit` to quickly find and open content files:
 
@@ -66,7 +66,7 @@ docs edit /influxdb3/core/admin/databases/ --editor nano
 - Use `--list` with `docs edit` to see files without opening
 - Accepts both product keys (`influxdb3_core`) and paths (`/influxdb3/core`)
 
-### Other CLI Commands
+#### Other CLI Commands
 
 ```bash
 # Add placeholder syntax to code blocks
@@ -81,7 +81,7 @@ docs release-notes v3.1.0 v3.2.0 --products influxdb3_core
 
 For complete CLI reference, run `docs --help`.
 
-## Shared Content Management
+### Shared Content Management
 
 When editing files with `source:` frontmatter (shared content):
 
@@ -91,9 +91,9 @@ When editing files with `source:` frontmatter (shared content):
   Hugo rebuild
 
 For complete shared content workflow, see
-[content-editing skill](../../.agents/skills/content-editing/SKILL.md).
+[content-editing skill](../.agents/skills/content-editing/SKILL.md).
 
-## Required for All Content Files
+### Required for All Content Files
 
 Every content file needs:
 
@@ -107,7 +107,7 @@ menu:
 weight:      # Sort order (1-99, 101-199, 201-299...)
 ```
 
-## Testing After Content Changes
+### Testing After Content Changes
 
 ```bash
 # 1. Verify Hugo build
@@ -121,9 +121,9 @@ yarn test:codeblocks:all
 ```
 
 For comprehensive testing workflows, see
-[content-editing skill](../../.agents/skills/content-editing/SKILL.md).
+[content-editing skill](../.agents/skills/content-editing/SKILL.md).
 
-## Style Guidelines
+### Style Guidelines
 
 - Use semantic line feeds (one sentence per line)
 - Test all code examples before committing
@@ -136,7 +136,7 @@ For comprehensive testing workflows, see
   data in their own object storage; InfluxDB reads and writes it but doesn't take
   custody of it.
 
-## Most Common Shortcodes
+### Most Common Shortcodes
 
 **Callouts**:
 
@@ -186,13 +186,88 @@ Content for tab 2
 ```
 
 For complete shortcodes reference, see
-[DOCS-SHORTCODES.md](../../DOCS-SHORTCODES.md).
+[DOCS-SHORTCODES.md](../DOCS-SHORTCODES.md).
 
-## Related Resources
+### Related Resources
 
-- **Complete workflow**: [content-editing skill](../../.agents/skills/content-editing/SKILL.md)
+- **Complete workflow**: [content-editing skill](../.agents/skills/content-editing/SKILL.md)
 - **CLI decision guidance**:
-  [docs-cli-workflow skill](../../.agents/skills/docs-cli-workflow/SKILL.md)
-- **Frontmatter**: [DOCS-FRONTMATTER.md](../../DOCS-FRONTMATTER.md)
-- **Shortcodes**: [DOCS-SHORTCODES.md](../../DOCS-SHORTCODES.md)
-- **Contributing**: [DOCS-CONTRIBUTING.md](../../DOCS-CONTRIBUTING.md)
+  [docs-cli-workflow skill](../.agents/skills/docs-cli-workflow/SKILL.md)
+- **Frontmatter**: [DOCS-FRONTMATTER.md](../DOCS-FRONTMATTER.md)
+- **Shortcodes**: [DOCS-SHORTCODES.md](../DOCS-SHORTCODES.md)
+- **Contributing**: [DOCS-CONTRIBUTING.md](../DOCS-CONTRIBUTING.md)
+
+
+## Content Review Criteria
+
+Review documentation changes against these rules.
+Only flag issues you are confident about.
+Reference the linked docs for detailed rules.
+
+### Frontmatter
+
+Rules: [DOCS-FRONTMATTER.md](../DOCS-FRONTMATTER.md)
+
+- `title` and `description` are required on every page
+- `menu` structure matches the product's menu key
+- `weight` is present for pages in navigation
+- `source` paths point to valid `/shared/` paths
+- No duplicate or conflicting frontmatter keys
+
+### Shortcode Syntax
+
+Rules: [DOCS-SHORTCODES.md](../DOCS-SHORTCODES.md)
+
+- `{{< >}}` for HTML output, `{{% %}}` for Markdown-processed content
+- Closing tags match opening tags
+- Required parameters are present
+- Callouts use GitHub-style syntax: `> [!Note]`, `> [!Warning]`, etc.
+
+### Heading Hierarchy
+
+- No h1 headings in content (h1 comes from `title` frontmatter)
+- Headings don't skip levels (h2 -> h4 without h3)
+
+### Semantic Line Feeds
+
+Rules: [DOCS-CONTRIBUTING.md](../DOCS-CONTRIBUTING.md)
+
+- One sentence per line (better diffs)
+- Long sentences on their own line, not concatenated
+
+### Terminology and Product Names
+
+Products defined in [data/products.yml](../data/products.yml):
+
+- Use official names: "InfluxDB 3 Core", "InfluxDB 3 Enterprise",
+  "InfluxDB Cloud Serverless", "InfluxDB Cloud Dedicated"
+- Don't mix v2/v3 terminology (e.g., "bucket" in v3 Core docs)
+- Version references match the content path
+
+### Links
+
+- Internal links use relative paths or Hugo `relref` shortcodes
+- No hardcoded `docs.influxdata.com` links in content files
+- Anchor links match actual heading IDs
+
+### Code Blocks
+
+- Use `python` not `py` for language identifiers (pytest requirement)
+- Long options in CLI examples (`--output` not `-o`)
+- Keep lines within 80 characters
+- Include language identifier on fenced code blocks
+
+### Shared Content
+
+- `source:` frontmatter points to an existing shared file
+- Shared files don't contain frontmatter (only content)
+- Changes to shared content affect multiple products — flag if unintentional
+
+### Severity
+
+- **BLOCKING**: Broken rendering, wrong product names, missing required
+  frontmatter, malformed shortcodes, h1 in content body
+- **WARNING**: Missing semantic line feeds, skipped heading levels, missing
+  `weight`, long CLI options not used
+- **INFO**: Suggestions, code block missing language identifier, opportunities
+  to use shared content

--- a/cypress/support/map-files-to-urls.js
+++ b/cypress/support/map-files-to-urls.js
@@ -8,6 +8,7 @@ import {
   findPagesReferencingSharedContent,
   categorizeContentFiles,
 } from '../../scripts/lib/content-utils.js';
+import { MATTER_OPTIONS } from '../../scripts/lib/file-operations.js';
 
 // Get file paths from command line arguments
 const filePaths = process.argv.slice(2).filter((arg) => !arg.startsWith('--'));
@@ -28,7 +29,7 @@ function extractSourceFromFile(filePath) {
   try {
     if (fs.existsSync(filePath)) {
       const fileContent = fs.readFileSync(filePath, 'utf8');
-      const { data } = matter(fileContent);
+      const { data } = matter(fileContent, MATTER_OPTIONS);
 
       // If source is specified in frontmatter, return it
       if (data.source) {

--- a/docs/exec-plans/agent-harness-instructions-skills.md
+++ b/docs/exec-plans/agent-harness-instructions-skills.md
@@ -1,0 +1,124 @@
+# Agent harness instructions and skills migration
+
+**Status:** Planned — not implemented
+
+## Goal
+
+Create one repo-owned source of truth for agent instructions and skills.
+Use `.agents/` as the canonical location, then generate or link adapter files
+for Codex, Claude Code, GitHub Copilot, and other agent harnesses.
+
+This should reduce instruction drift across `AGENTS.md`, `CLAUDE.md`,
+`.github/instructions/`, and `.claude/skills/` while preserving each harness's
+native discovery behavior.
+
+## Why now
+
+The repo currently maintains overlapping guidance for different agents:
+
+- `AGENTS.md` is the shared broad instruction file.
+- `CLAUDE.md` points Claude to shared docs and `.claude/`.
+- `.github/copilot-instructions.md` provides Copilot-specific repo guidance.
+- `.github/instructions/*.instructions.md` provides Copilot path-specific
+  guidance.
+- `.claude/skills/*/SKILL.md` provides Claude project skills.
+
+Codex, Claude Code, and GitHub Copilot now all support the open Agent Skills
+shape, and Copilot also recognizes `.agents/skills`.
+This makes `.agents/` a reasonable canonical authoring location.
+
+## Decisions
+
+- **Use `.agents/` as canonical.** Store reusable skills in `.agents/skills`
+  and canonical path/topic instruction sources in `.agents/instructions`.
+- **Keep `AGENTS.md` as the canonical repo-wide instruction file.** It is
+  already the shared guide and is natively read by Codex and Copilot agents.
+- **Use generated committed files for GitHub-facing adapters.** Keep
+  `.github/copilot-instructions.md` and `.github/instructions/*.instructions.md`
+  as real committed files, not symlinks, because GitHub-hosted Copilot and code
+  review read files from the base branch.
+- **Use a Claude import for repo-wide instructions.** Update `CLAUDE.md` to
+  import `@AGENTS.md`, then keep only Claude-specific notes below it.
+- **Use a symlink for Claude skills.** Replace `.claude/skills` with a symlink
+  to `../.agents/skills` because Claude and Codex support symlinked skills in
+  local environments.
+- **Generate Claude path rules.** Generate `.claude/rules/*.md` from
+  `.agents/instructions/*.md` using Claude's `paths` frontmatter.
+- **Generate scoped `AGENTS.md` files only for major directories.** Codex has
+  no direct path-glob instruction equivalent, so generate scoped files for
+  high-signal directory roots such as `content/`, `layouts/`, `assets/`, and
+  `api-docs/`.
+- **Validate drift in hooks.** Use hooks to regenerate and validate adapter
+  files, not to treat copied files as independent sources of truth.
+- **Defer plugin extraction.** Prepare the canonical source so reusable skills
+  can later be packaged for `influxdata/docs-tooling`, but do not build the
+  plugin in this pass.
+
+## Implementation plan
+
+1. Move current `.claude/skills/*` directories to `.agents/skills/*`.
+2. Replace `.claude/skills` with a symlink to `../.agents/skills`.
+3. Normalize canonical skill frontmatter to the shared subset:
+   `name` and `description`.
+4. Create `.agents/instructions/*.md` as canonical path instruction sources.
+   Include frontmatter fields:
+   - `name`
+   - `description`
+   - `paths`
+5. Migrate the current `.github/instructions/*.instructions.md` bodies into the
+   canonical `.agents/instructions` files.
+6. Extend `helper-scripts/build-agent-instructions.js` so it:
+   - keeps generating `PLATFORM_REFERENCE.md` from `data/products.yml`;
+   - generates `.github/instructions/{name}.instructions.md` with `applyTo`;
+   - generates `.claude/rules/{name}.md` with `paths`;
+   - generates scoped `AGENTS.md` files for major directory roots;
+   - verifies or repairs the `.claude/skills` symlink.
+7. Add `helper-scripts/validate-agent-instructions.js` to check:
+   - canonical instruction frontmatter and glob shape;
+   - generated adapters are up to date;
+   - skills have unique hyphen-case names and descriptions;
+   - `.claude/skills` is the expected symlink.
+8. Add package scripts:
+   - `build:agent:instructions` remains the generator entrypoint;
+   - `validate:agent-instructions` runs drift and skill validation.
+9. Update `lefthook.yml` so changes to `AGENTS.md`, `.agents/instructions/**`,
+   `.agents/skills/**`, and `data/products.yml` regenerate and stage adapters.
+10. Update navigation docs and instruction references to describe `.agents/` as
+    canonical and `.github/` / `.claude/` as adapters.
+
+## Explicitly out of scope
+
+- Building the `influxdata/docs-tooling` plugin in this change.
+- Migrating `.claude/agents/` or `.claude/commands/`.
+- Changing product documentation content or Hugo runtime behavior.
+- Reworking the repo-wide instruction content beyond references needed for the
+  new canonical layout.
+
+## How to update after migration
+
+- Add or edit reusable workflows in `.agents/skills/<skill-name>/SKILL.md`.
+- Add or edit path-specific guidance in `.agents/instructions/<name>.md`.
+- Run `yarn build:agent:instructions` after changing canonical sources.
+- Run `yarn validate:agent-instructions` before committing.
+- Do not edit generated `.github/instructions/*.instructions.md` or
+  `.claude/rules/*.md` directly.
+
+## Verification
+
+Planned checks for the implementation commit:
+
+```bash
+yarn build:agent:instructions
+yarn build:agent:instructions
+git diff --exit-code
+yarn validate:agent-instructions
+.ci/vale/vale.sh --config=.vale-instructions.ini --minAlertLevel=warning \
+  AGENTS.md CLAUDE.md .agents/**/*.md .github/**/*.md .claude/rules/**/*.md
+.ci/remark/remark.sh \
+  AGENTS.md CLAUDE.md .agents/**/*.md .github/**/*.md .claude/rules/**/*.md \
+  --quiet
+```
+
+Run `yarn lint` before final review if time permits.
+Do not require a Hugo build unless the implementation changes site-rendered
+content.

--- a/docs/exec-plans/agent-harness-instructions-skills.md
+++ b/docs/exec-plans/agent-harness-instructions-skills.md
@@ -1,6 +1,6 @@
 # Agent harness instructions and skills migration
 
-**Status:** Planned — not implemented
+**Status:** Implemented on `chore/agent-instructions-skills-plan`
 
 ## Goal
 
@@ -54,37 +54,34 @@ This makes `.agents/` a reasonable canonical authoring location.
   can later be packaged for `influxdata/docs-tooling`, but do not build the
   plugin in this pass.
 
-## Implementation plan
+## Implementation status
 
-1. Move current `.claude/skills/*` directories to `.agents/skills/*`.
-2. Replace `.claude/skills` with a symlink to `../.agents/skills`.
-3. Normalize canonical skill frontmatter to the shared subset:
-   `name` and `description`.
-4. Create `.agents/instructions/*.md` as canonical path instruction sources.
-   Include frontmatter fields:
-   - `name`
-   - `description`
-   - `paths`
-5. Migrate the current `.github/instructions/*.instructions.md` bodies into the
-   canonical `.agents/instructions` files.
-6. Extend `helper-scripts/build-agent-instructions.js` so it:
+Completed in this branch:
+
+1. Moved project skills from `.claude/skills/*` to `.agents/skills/*`.
+2. Replaced `.claude/skills` with a symlink to `../.agents/skills`.
+3. Created canonical path instruction sources in `.agents/instructions/` with
+   `name`, `description`, and `paths` frontmatter.
+4. Migrated current `.github/instructions/*.instructions.md` content into the
+   canonical `.agents/instructions/*.md` files.
+5. Extended `helper-scripts/build-agent-instructions.js` so it:
    - keeps generating `PLATFORM_REFERENCE.md` from `data/products.yml`;
    - generates `.github/instructions/{name}.instructions.md` with `applyTo`;
-   - generates `.claude/rules/{name}.md` with `paths`;
-   - generates scoped `AGENTS.md` files for major directory roots;
-   - verifies or repairs the `.claude/skills` symlink.
-7. Add `helper-scripts/validate-agent-instructions.js` to check:
-   - canonical instruction frontmatter and glob shape;
-   - generated adapters are up to date;
-   - skills have unique hyphen-case names and descriptions;
-   - `.claude/skills` is the expected symlink.
-8. Add package scripts:
-   - `build:agent:instructions` remains the generator entrypoint;
-   - `validate:agent-instructions` runs drift and skill validation.
-9. Update `lefthook.yml` so changes to `AGENTS.md`, `.agents/instructions/**`,
-   `.agents/skills/**`, and `data/products.yml` regenerate and stage adapters.
-10. Update navigation docs and instruction references to describe `.agents/` as
-    canonical and `.github/` / `.claude/` as adapters.
+   - generates `.claude/rules/{name}.md` with Claude `paths` frontmatter;
+   - generates scoped `AGENTS.md` files for `api-docs/`, `assets/`,
+     `content/`, and `layouts/`;
+   - verifies the `.claude/skills` symlink target;
+   - normalizes generated trailing newlines to prevent validation drift.
+6. Added `helper-scripts/validate-agent-instructions.js` to validate canonical
+   instruction files, skill metadata, generator drift, and the Claude skills
+   symlink.
+7. Added and wired package scripts:
+   - `yarn build:agent:instructions`
+   - `yarn validate:agent-instructions`
+8. Updated `lefthook.yml` so relevant changes regenerate and validate adapter
+   files.
+9. Updated repo guidance and references so `.agents/` is documented as the
+   canonical source and `.github/` / `.claude/` are adapters.
 
 ## Explicitly out of scope
 
@@ -103,9 +100,18 @@ This makes `.agents/` a reasonable canonical authoring location.
 - Do not edit generated `.github/instructions/*.instructions.md` or
   `.claude/rules/*.md` directly.
 
+## Remaining follow-up
+
+- Decide whether to extract a reusable subset of `.agents/skills` into a
+  separate plugin-oriented repository for `influxdata/docs-tooling`, or to keep
+  plugin packaging logic in this repo and publish from canonical sources later.
+- If plugin extraction proceeds, keep `.agents/` as the source of truth and add
+  packaging/export automation rather than introducing another authored skill
+  tree.
+
 ## Verification
 
-Planned checks for the implementation commit:
+Checks used for this migration:
 
 ```bash
 yarn build:agent:instructions
@@ -119,6 +125,6 @@ yarn validate:agent-instructions
   --quiet
 ```
 
-Run `yarn lint` before final review if time permits.
-Do not require a Hugo build unless the implementation changes site-rendered
-content.
+`yarn lint` also ran as a final aggregate hook check.
+No Hugo build is required because this change affects agent metadata and helper
+scripts, not site-rendered content.

--- a/helper-scripts/build-agent-instructions.js
+++ b/helper-scripts/build-agent-instructions.js
@@ -371,6 +371,8 @@ async function buildPlatformReference() {
     }
   }
 
+  content = content.replace(/\n+$/, '\n');
+
   // Write the file
   fs.writeFileSync(referencePath, content);
 

--- a/helper-scripts/build-agent-instructions.js
+++ b/helper-scripts/build-agent-instructions.js
@@ -260,33 +260,14 @@ function ensureClaudeSkillsSymlink() {
 
 /**
  * Build PLATFORM_REFERENCE.md from data/products.yml
- * This generates a reference document for AI agents to understand
- * the different InfluxDB versions and products
+ * This generates a compact product disambiguation reference for AI agents using
+ * canonical product metadata only.
  */
 async function buildPlatformReference() {
   const yaml = await import('js-yaml');
-
-  // Paths
-  const productsPath = path.join(process.cwd(), 'data', 'products.yml');
-  const referencePath = path.join(process.cwd(), 'PLATFORM_REFERENCE.md');
-
-  // Read and parse the products.yml file
-  const productsContent = fs.readFileSync(productsPath, 'utf8');
-  const products = yaml.load(productsContent);
-
-  // Generate markdown content
-  let content = [
-    '<!-- This file is auto-generated from data/products.yml. Do not edit directly. -->',
-    '',
-    "<!-- Run 'npm run build:agent:instructions' to regenerate this file. -->",
-    '',
-    'Use the following information to help determine which InfluxDB version and',
-    'product the user is asking about:',
-    '',
-    '',
-  ].join('\n');
-
-  // Define product order
+  const productsPath = path.join(PROJECT_ROOT, 'data', 'products.yml');
+  const referencePath = path.join(PROJECT_ROOT, 'PLATFORM_REFERENCE.md');
+  const products = yaml.load(fs.readFileSync(productsPath, 'utf8'));
   const productOrder = [
     'influxdb',
     'enterprise_influxdb',
@@ -303,77 +284,39 @@ async function buildPlatformReference() {
     'flux',
   ];
 
-  // Process each product in order
+  const lines = [
+    '<!-- This file is auto-generated from data/products.yml. Do not edit directly. -->',
+    '',
+    "<!-- Run 'yarn build:agent:instructions' to regenerate this file. -->",
+    '',
+    'Use this compact product disambiguation reference to map user requests to',
+    'canonical product names, content paths, and production documentation URLs.',
+    '',
+    'Production docs URL rule:',
+    '- For each entry with a `Content path`, map it to',
+    '  `https://docs.influxdata.com/<content-path>/`.',
+    '- Treat `data/products.yml` as the canonical source of truth when you need',
+    '  details not listed here.',
+    '',
+  ];
+
   for (const productKey of productOrder) {
     const product = products[productKey];
     if (!product) continue;
 
-    // Handle products with multiple versions (like influxdb with v1 and v2)
     if (product.versions && product.versions.length > 1) {
-      // Generate entries for each version
       for (const version of product.versions) {
-        const versionName =
-          version === 'v2'
-            ? `${product.name} OSS ${version}`
-            : version === 'v1'
-              ? `${product.name} OSS ${version}`
-              : `${product.name} ${version}`;
-
-        content += `${versionName}:\n\n`;
-
-        // Documentation URL
-        const docUrl = generateDocUrlForVersion(productKey, product, version);
-        if (docUrl) {
-          content += `- Documentation: <${docUrl}>\n`;
-        }
-
-        // Query languages
-        if (product.detector_config?.query_languages) {
-          const languages = Object.keys(
-            product.detector_config.query_languages
-          ).join(' and ');
-          content += `- Query languages: ${languages}\n`;
-        }
-
-        // Clients/Tools
-        const clients = generateClientsInfo(productKey);
-        if (clients) {
-          content += `- Clients: ${clients}\n`;
-        }
-
-        content += '\n';
+        lines.push(
+          ...renderProductReferenceEntry(productKey, product, version)
+        );
       }
     } else {
-      // Single version products
-      content += `${product.name}:\n\n`;
-
-      // Documentation URL
-      const docUrl = generateDocUrl(productKey, product);
-      if (docUrl) {
-        content += `- Documentation: <${docUrl}>\n`;
-      }
-
-      // Query languages
-      if (product.detector_config?.query_languages) {
-        const languages = Object.keys(
-          product.detector_config.query_languages
-        ).join(' and ');
-        content += `- Query languages: ${languages}\n`;
-      }
-
-      // Clients/Tools
-      const clients = generateClientsInfo(productKey);
-      if (clients) {
-        content += `- Clients: ${clients}\n`;
-      }
-
-      content += '\n';
+      lines.push(...renderProductReferenceEntry(productKey, product));
     }
   }
 
+  let content = `${lines.join('\n')}\n`;
   content = content.replace(/\n+$/, '\n');
-
-  // Write the file
   fs.writeFileSync(referencePath, content);
 
   const fileSize = fs.statSync(referencePath).size;
@@ -383,86 +326,125 @@ async function buildPlatformReference() {
   );
 }
 
-/**
- * Generate documentation URL for a product
- */
-function generateDocUrl(productKey, product) {
-  const baseUrl = 'https://docs.influxdata.com';
+function renderProductReferenceEntry(productKey, product, version = null) {
+  const lines = [];
+  const displayName = getProductDisplayName(product, version);
+  const aliases = getProductAliases(product, version);
+  const contentPath = getContentPath(product, version);
+  const queryLanguages = getQueryLanguages(product);
+  const placeholderHost = product.placeholder_host;
+  const characteristics = getCharacteristics(product);
+  const urlHints = getDetectionUrlHints(product);
+  const pingHeaders = getPingHeaders(product);
 
-  switch (productKey) {
-    case 'influxdb':
-      return `${baseUrl}/influxdb/${product.latest}/`;
-    case 'enterprise_influxdb':
-      return `${baseUrl}/enterprise_influxdb/${product.latest}/`;
-    case 'influxdb_cloud':
-      return `${baseUrl}/influxdb/cloud/`;
-    case 'influxdb3_cloud_serverless':
-      return `${baseUrl}/influxdb3/cloud-serverless/`;
-    case 'influxdb3_cloud_dedicated':
-      return `${baseUrl}/influxdb3/cloud-dedicated/`;
-    case 'influxdb3_clustered':
-      return `${baseUrl}/influxdb3/clustered/`;
-    case 'influxdb3_core':
-      return `${baseUrl}/influxdb3/core/`;
-    case 'influxdb3_enterprise':
-      return `${baseUrl}/influxdb3/enterprise/`;
-    case 'influxdb3_explorer':
-      return `${baseUrl}/influxdb3/explorer/`;
-    case 'telegraf':
-      return `${baseUrl}/telegraf/${product.latest}/`;
-    case 'chronograf':
-      return `${baseUrl}/chronograf/${product.latest}/`;
-    case 'kapacitor':
-      return `${baseUrl}/kapacitor/${product.latest}/`;
-    case 'flux':
-      return `${baseUrl}/flux/${product.latest}/`;
-    default:
-      return null;
+  lines.push(`${displayName}:`, '');
+
+  if (aliases.length > 0) {
+    lines.push(`- Aliases: ${aliases.join(', ')}`);
   }
+
+  if (contentPath) {
+    lines.push(`- Content path: \`${contentPath}\``);
+    lines.push(
+      `- Production docs URL: <${buildDocsUrlFromContentPath(contentPath)}>`
+    );
+  }
+
+  if (queryLanguages.length > 0) {
+    lines.push(`- Query languages: ${queryLanguages.join(', ')}`);
+  }
+
+  if (placeholderHost) {
+    lines.push(`- Host hint: \`${placeholderHost}\``);
+  }
+
+  if (characteristics.length > 0) {
+    lines.push(`- Characteristics: ${characteristics.join(', ')}`);
+  }
+
+  if (urlHints.length > 0) {
+    lines.push(`- URL contains hints: ${urlHints.join(', ')}`);
+  }
+
+  if (pingHeaders.length > 0) {
+    lines.push(`- Ping header hints: ${pingHeaders.join(', ')}`);
+  }
+
+  lines.push('');
+  return lines;
 }
 
-/**
- * Generate documentation URL for a specific version of a product
- */
-function generateDocUrlForVersion(productKey, product, version) {
+function buildDocsUrlFromContentPath(contentPath) {
   const baseUrl = 'https://docs.influxdata.com';
-
-  switch (productKey) {
-    case 'influxdb':
-      return `${baseUrl}/influxdb/${version}/`;
-    case 'enterprise_influxdb':
-      return `${baseUrl}/enterprise_influxdb/${version}/`;
-    default:
-      return generateDocUrl(productKey, product);
-  }
+  return `${baseUrl}/${contentPath.replace(/^\/+|\/+$/g, '')}/`;
 }
 
-/**
- * Generate client/tool information for a product
- */
-function generateClientsInfo(productKey) {
-  const v3Products = [
-    'influxdb3_core',
-    'influxdb3_enterprise',
-    'influxdb3_cloud_dedicated',
-    'influxdb3_cloud_serverless',
-    'influxdb3_clustered',
-  ];
+function getProductDisplayName(product, version) {
+  if (version && product[`name__${version}`]) {
+    return product[`name__${version}`];
+  }
 
-  if (productKey === 'influxdb3_core') {
-    return 'Telegraf, influxdb3 CLI, v3 client libraries, InfluxDB 3 Explorer';
-  } else if (productKey === 'influxdb3_enterprise') {
-    return 'Telegraf, influxdb3 CLI, v3 client libraries, InfluxDB 3 Explorer';
-  } else if (v3Products.includes(productKey)) {
-    return 'Telegraf, influxctl CLI, v3 client libraries';
-  } else if (
-    productKey === 'influxdb' ||
-    productKey === 'enterprise_influxdb'
-  ) {
-    return 'Telegraf, influx CLI, v1/v2 client libraries';
-  } else if (productKey === 'influxdb_cloud') {
-    return 'Telegraf, influx CLI, v2 client libraries';
+  return product.name;
+}
+
+function getProductAliases(product, version) {
+  const aliases = new Set();
+
+  if (product.altname) {
+    aliases.add(product.altname);
+  }
+
+  if (version && product.version_label) {
+    aliases.add(product.version_label);
+  }
+
+  if (version) {
+    aliases.add(version);
+  }
+
+  return [...aliases].filter(
+    (alias) =>
+      alias && alias !== getProductDisplayName(product, version)
+  );
+}
+
+function getContentPath(product, version) {
+  if (!product.content_path) return null;
+
+  if (typeof product.content_path === 'string') {
+    return product.content_path;
+  }
+
+  if (version && product.content_path[version]) {
+    return product.content_path[version];
   }
 
   return null;
+}
+
+function getQueryLanguages(product) {
+  return Object.keys(product.detector_config?.query_languages || {});
+}
+
+function getCharacteristics(product) {
+  const characteristics = product.detector_config?.characteristics;
+  if (!Array.isArray(characteristics)) return [];
+
+  if (characteristics.length === 1 && Array.isArray(characteristics[0])) {
+    return characteristics[0];
+  }
+
+  return characteristics;
+}
+
+function getDetectionUrlHints(product) {
+  const urlHints = product.detector_config?.detection?.url_contains;
+  return Array.isArray(urlHints) ? urlHints : [];
+}
+
+function getPingHeaders(product) {
+  const headers = product.detector_config?.detection?.ping_headers;
+  if (!headers || typeof headers !== 'object') return [];
+
+  return Object.entries(headers).map(([name, value]) => `${name}=${value}`);
 }

--- a/helper-scripts/build-agent-instructions.js
+++ b/helper-scripts/build-agent-instructions.js
@@ -306,6 +306,7 @@ async function buildPlatformReference() {
     'canonical product names, content paths, and production documentation URLs.',
     '',
     'Production docs URL rule:',
+    '',
     '- For each entry with a `Content path`, map it to',
     '  `https://docs.influxdata.com/<content-path>/`.',
     '- Treat `data/products.yml` as the canonical source of truth when you need',
@@ -458,5 +459,9 @@ function getPingHeaders(product) {
   const headers = product.detector_config?.detection?.ping_headers;
   if (!headers || typeof headers !== 'object') return [];
 
-  return Object.entries(headers).map(([name, value]) => `${name}=${value}`);
+  // Wrap each header token in an inline code span. Values are regex
+  // patterns (for example, `^3\.`); the backslash is meaningful regex
+  // syntax, but in prose Markdown the remark formatter strips it as an
+  // unnecessary escape. Inline code preserves the bytes verbatim.
+  return Object.entries(headers).map(([name, value]) => `\`${name}=${value}\``);
 }

--- a/helper-scripts/build-agent-instructions.js
+++ b/helper-scripts/build-agent-instructions.js
@@ -403,8 +403,7 @@ function getProductAliases(product, version) {
   }
 
   return [...aliases].filter(
-    (alias) =>
-      alias && alias !== getProductDisplayName(product, version)
+    (alias) => alias && alias !== getProductDisplayName(product, version)
   );
 }
 

--- a/helper-scripts/build-agent-instructions.js
+++ b/helper-scripts/build-agent-instructions.js
@@ -320,12 +320,10 @@ async function buildPlatformReference() {
 
     if (product.versions && product.versions.length > 1) {
       for (const version of product.versions) {
-        lines.push(
-          ...renderProductReferenceEntry(productKey, product, version)
-        );
+        lines.push(...renderProductReferenceEntry(product, version));
       }
     } else {
-      lines.push(...renderProductReferenceEntry(productKey, product));
+      lines.push(...renderProductReferenceEntry(product));
     }
   }
 
@@ -340,7 +338,7 @@ async function buildPlatformReference() {
   );
 }
 
-function renderProductReferenceEntry(productKey, product, version = null) {
+function renderProductReferenceEntry(product, version = null) {
   const lines = [];
   const displayName = getProductDisplayName(product, version);
   const aliases = getProductAliases(product, version);

--- a/helper-scripts/build-agent-instructions.js
+++ b/helper-scripts/build-agent-instructions.js
@@ -1,24 +1,262 @@
 #!/usr/bin/env node
 
 /**
- * Script to generate GitHub Copilot instructions
- * for InfluxData documentation.
+ * Script to generate agent instruction adapters for InfluxData documentation.
  */
 import fs from 'fs';
 import path from 'path';
 import process from 'process';
-import { execSync } from 'child_process';
+import matter from 'gray-matter';
+import { pathToFileURL } from 'url';
 
-// Get the current file path and directory
-export { buildPlatformReference };
+export {
+  buildAgentInstructionAdapters,
+  buildPlatformReference,
+  ensureClaudeSkillsSymlink,
+};
 
-(async () => {
-  try {
-    await buildPlatformReference();
-  } catch (error) {
-    console.error('Error generating agent instructions:', error);
+const PROJECT_ROOT = process.cwd();
+const CANONICAL_INSTRUCTIONS_DIR = path.join(
+  PROJECT_ROOT,
+  '.agents',
+  'instructions'
+);
+const CANONICAL_SKILLS_DIR = path.join(PROJECT_ROOT, '.agents', 'skills');
+const CLAUDE_SKILLS_PATH = path.join(PROJECT_ROOT, '.claude', 'skills');
+const GENERATED_HEADER =
+  '<!-- This file is auto-generated from .agents/instructions. Do not edit directly. -->\n\n' +
+  "<!-- Run 'yarn build:agent:instructions' to regenerate it. -->\n\n";
+
+const SCOPED_AGENTS = [
+  { dir: 'api-docs', title: 'API Documentation' },
+  { dir: 'assets', title: 'Asset Development' },
+  { dir: 'content', title: 'Documentation Content' },
+  { dir: 'layouts', title: 'Hugo Layouts and Shortcodes' },
+];
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  (async () => {
+    try {
+      await buildPlatformReference();
+      await buildAgentInstructionAdapters();
+      ensureClaudeSkillsSymlink();
+    } catch (error) {
+      console.error('Error generating agent instructions:', error);
+      process.exitCode = 1;
+    }
+  })();
+}
+
+async function buildAgentInstructionAdapters() {
+  const instructions = readCanonicalInstructions();
+
+  fs.mkdirSync(path.join(PROJECT_ROOT, '.github', 'instructions'), {
+    recursive: true,
+  });
+  fs.mkdirSync(path.join(PROJECT_ROOT, '.claude', 'rules'), {
+    recursive: true,
+  });
+
+  for (const instruction of instructions) {
+    writeCopilotInstruction(instruction);
+    writeClaudeRule(instruction);
   }
-})();
+
+  writeScopedAgents(instructions);
+
+  console.log(`✅ Generated ${instructions.length} instruction adapter set(s)`);
+}
+
+function readCanonicalInstructions() {
+  if (!fs.existsSync(CANONICAL_INSTRUCTIONS_DIR)) {
+    return [];
+  }
+
+  const files = fs
+    .readdirSync(CANONICAL_INSTRUCTIONS_DIR)
+    .filter((file) => file.endsWith('.md'))
+    .sort();
+
+  return files.map((file) => {
+    const sourcePath = path.join(CANONICAL_INSTRUCTIONS_DIR, file);
+    const parsed = matter.read(sourcePath);
+    const { name, description, paths } = parsed.data;
+
+    const hasRequiredFields =
+      name && description && Array.isArray(paths) && paths.length > 0;
+
+    if (!hasRequiredFields) {
+      throw new Error(
+        `${path.relative(PROJECT_ROOT, sourcePath)} must define name, ` +
+          'description, and paths[]'
+      );
+    }
+
+    return {
+      body: parsed.content.trimStart(),
+      description,
+      name,
+      paths,
+      sourceDir: path.dirname(sourcePath),
+      sourcePath,
+    };
+  });
+}
+
+function writeCopilotInstruction(instruction) {
+  const outputPath = path.join(
+    PROJECT_ROOT,
+    '.github',
+    'instructions',
+    `${instruction.name}.instructions.md`
+  );
+  const frontmatter = [
+    '---',
+    `applyTo: "${instruction.paths.join(', ')}"`,
+    '---',
+    '',
+  ].join('\n');
+
+  writeGeneratedMarkdown(outputPath, instruction, frontmatter);
+}
+
+function writeClaudeRule(instruction) {
+  const outputPath = path.join(
+    PROJECT_ROOT,
+    '.claude',
+    'rules',
+    `${instruction.name}.md`
+  );
+  const frontmatter = [
+    '---',
+    'paths:',
+    ...instruction.paths.map((glob) => `  - "${glob}"`),
+    '---',
+    '',
+  ].join('\n');
+
+  writeGeneratedMarkdown(outputPath, instruction, frontmatter);
+}
+
+function writeGeneratedMarkdown(outputPath, instruction, frontmatter) {
+  const body = rewriteRelativeLinks(
+    instruction.body,
+    instruction.sourceDir,
+    path.dirname(outputPath)
+  );
+  fs.writeFileSync(outputPath, `${frontmatter}\n${GENERATED_HEADER}${body}`);
+}
+
+function writeScopedAgents(instructions) {
+  for (const scopedAgent of SCOPED_AGENTS) {
+    const matchingInstructions = instructions
+      .filter((instruction) =>
+        instruction.paths.some((glob) => glob.startsWith(`${scopedAgent.dir}/`))
+      )
+      .sort((a, b) => {
+        const aExact = a.name === scopedAgent.dir ? 0 : 1;
+        const bExact = b.name === scopedAgent.dir ? 0 : 1;
+        return aExact - bExact || a.name.localeCompare(b.name);
+      });
+
+    if (matchingInstructions.length === 0) continue;
+
+    const outputPath = path.join(PROJECT_ROOT, scopedAgent.dir, 'AGENTS.md');
+    const parts = [
+      GENERATED_HEADER.trimEnd(),
+      '',
+      `# ${scopedAgent.title} Agent Instructions`,
+      '',
+      `These instructions apply when working in \`${scopedAgent.dir}/\`.`,
+      '',
+    ];
+
+    for (const instruction of matchingInstructions) {
+      parts.push(
+        demoteHeadings(
+          rewriteRelativeLinks(
+            instruction.body,
+            instruction.sourceDir,
+            path.dirname(outputPath)
+          )
+        ),
+        ''
+      );
+    }
+
+    fs.writeFileSync(outputPath, parts.join('\n').trimEnd() + '\n');
+  }
+}
+
+function demoteHeadings(markdown) {
+  let inFence = false;
+
+  return markdown
+    .split('\n')
+    .map((line) => {
+      if (/^```/.test(line) || /^````/.test(line)) {
+        inFence = !inFence;
+        return line;
+      }
+
+      if (inFence) return line;
+      return line.replace(/^(#{1,5}) /, '#$1 ');
+    })
+    .join('\n');
+}
+
+function rewriteRelativeLinks(markdown, sourceDir, targetDir) {
+  return markdown.replace(
+    /\]\((?![a-z][a-z0-9+.-]*:|#|\/)([^)]+)\)/gi,
+    (match, rawTarget) => {
+      const [targetAndMaybeTitle, ...titleParts] = rawTarget.split(/\s+/);
+      const [targetPath, hash = ''] = targetAndMaybeTitle.split('#');
+
+      if (!targetPath || targetPath.startsWith('<')) {
+        return match;
+      }
+
+      const absoluteTarget = path.resolve(sourceDir, targetPath);
+      let relativeTarget = path.relative(targetDir, absoluteTarget);
+
+      if (!relativeTarget.startsWith('.')) {
+        relativeTarget = `./${relativeTarget}`;
+      }
+
+      relativeTarget = relativeTarget.split(path.sep).join('/');
+      const title = titleParts.length > 0 ? ` ${titleParts.join(' ')}` : '';
+      return `](${relativeTarget}${hash ? `#${hash}` : ''}${title})`;
+    }
+  );
+}
+
+function ensureClaudeSkillsSymlink() {
+  const expectedTarget = path.relative(
+    path.dirname(CLAUDE_SKILLS_PATH),
+    CANONICAL_SKILLS_DIR
+  );
+
+  if (!fs.existsSync(CANONICAL_SKILLS_DIR)) {
+    console.warn('⚠️  .agents/skills does not exist; skipping Claude symlink');
+    return;
+  }
+
+  if (fs.existsSync(CLAUDE_SKILLS_PATH)) {
+    const stat = fs.lstatSync(CLAUDE_SKILLS_PATH);
+
+    if (!stat.isSymbolicLink()) {
+      throw new Error('.claude/skills must be a symlink to ../.agents/skills');
+    }
+
+    const actualTarget = fs.readlinkSync(CLAUDE_SKILLS_PATH);
+    if (actualTarget !== expectedTarget) {
+      fs.unlinkSync(CLAUDE_SKILLS_PATH);
+      fs.symlinkSync(expectedTarget, CLAUDE_SKILLS_PATH, 'dir');
+    }
+  } else {
+    fs.symlinkSync(expectedTarget, CLAUDE_SKILLS_PATH, 'dir');
+  }
+}
 
 /**
  * Build PLATFORM_REFERENCE.md from data/products.yml
@@ -37,12 +275,16 @@ async function buildPlatformReference() {
   const products = yaml.load(productsContent);
 
   // Generate markdown content
-  let content = `<!-- This file is auto-generated from data/products.yml. Do not edit directly. -->
-<!-- Run 'npm run build:agent:instructions' to regenerate this file. -->
-
-Use the following information to help determine which InfluxDB version and product the user is asking about:
-
-`;
+  let content = [
+    '<!-- This file is auto-generated from data/products.yml. Do not edit directly. -->',
+    '',
+    "<!-- Run 'npm run build:agent:instructions' to regenerate this file. -->",
+    '',
+    'Use the following information to help determine which InfluxDB version and',
+    'product the user is asking about:',
+    '',
+    '',
+  ].join('\n');
 
   // Define product order
   const productOrder = [
@@ -77,12 +319,12 @@ Use the following information to help determine which InfluxDB version and produ
               ? `${product.name} OSS ${version}`
               : `${product.name} ${version}`;
 
-        content += `${versionName}:\n`;
+        content += `${versionName}:\n\n`;
 
         // Documentation URL
         const docUrl = generateDocUrlForVersion(productKey, product, version);
         if (docUrl) {
-          content += `  - Documentation: ${docUrl}\n`;
+          content += `- Documentation: <${docUrl}>\n`;
         }
 
         // Query languages
@@ -90,25 +332,25 @@ Use the following information to help determine which InfluxDB version and produ
           const languages = Object.keys(
             product.detector_config.query_languages
           ).join(' and ');
-          content += `  - Query languages: ${languages}\n`;
+          content += `- Query languages: ${languages}\n`;
         }
 
         // Clients/Tools
-        const clients = generateClientsInfo(productKey, product);
+        const clients = generateClientsInfo(productKey);
         if (clients) {
-          content += `  - Clients: ${clients}\n`;
+          content += `- Clients: ${clients}\n`;
         }
 
         content += '\n';
       }
     } else {
       // Single version products
-      content += `${product.name}:\n`;
+      content += `${product.name}:\n\n`;
 
       // Documentation URL
       const docUrl = generateDocUrl(productKey, product);
       if (docUrl) {
-        content += `  - Documentation: ${docUrl}\n`;
+        content += `- Documentation: <${docUrl}>\n`;
       }
 
       // Query languages
@@ -116,13 +358,13 @@ Use the following information to help determine which InfluxDB version and produ
         const languages = Object.keys(
           product.detector_config.query_languages
         ).join(' and ');
-        content += `  - Query languages: ${languages}\n`;
+        content += `- Query languages: ${languages}\n`;
       }
 
       // Clients/Tools
-      const clients = generateClientsInfo(productKey, product);
+      const clients = generateClientsInfo(productKey);
       if (clients) {
-        content += `  - Clients: ${clients}\n`;
+        content += `- Clients: ${clients}\n`;
       }
 
       content += '\n';
@@ -137,19 +379,6 @@ Use the following information to help determine which InfluxDB version and produ
   console.log(
     `✅ Generated platform reference at ${referencePath} (${sizeInKB}KB)`
   );
-
-  // Add the file to git if it has changed
-  try {
-    const gitStatus = execSync(
-      `git status --porcelain "${referencePath}"`
-    ).toString();
-    if (gitStatus.trim()) {
-      execSync(`git add "${referencePath}"`);
-      console.log('✅ Added platform reference to git staging');
-    }
-  } catch (error) {
-    console.warn('⚠️  Could not add file to git:', error.message);
-  }
 }
 
 /**
@@ -209,7 +438,7 @@ function generateDocUrlForVersion(productKey, product, version) {
 /**
  * Generate client/tool information for a product
  */
-function generateClientsInfo(productKey, product) {
+function generateClientsInfo(productKey) {
   const v3Products = [
     'influxdb3_core',
     'influxdb3_enterprise',

--- a/helper-scripts/build-agent-instructions.js
+++ b/helper-scripts/build-agent-instructions.js
@@ -7,12 +7,26 @@ import fs from 'fs';
 import path from 'path';
 import process from 'process';
 import matter from 'gray-matter';
+import yaml from 'js-yaml';
 import { pathToFileURL } from 'url';
 
 export {
   buildAgentInstructionAdapters,
   buildPlatformReference,
   ensureClaudeSkillsSymlink,
+  MATTER_OPTIONS,
+};
+
+// gray-matter 4.0.3 binds its default YAML engine to the removed
+// js-yaml 3 safeLoad/safeDump APIs. js-yaml 4 is safe by default, so point
+// the engine at load/dump to stay compatible with the pinned js-yaml version.
+const MATTER_OPTIONS = {
+  engines: {
+    yaml: {
+      parse: (input) => yaml.load(input),
+      stringify: (input) => yaml.dump(input),
+    },
+  },
 };
 
 const PROJECT_ROOT = process.cwd();
@@ -79,7 +93,7 @@ function readCanonicalInstructions() {
 
   return files.map((file) => {
     const sourcePath = path.join(CANONICAL_INSTRUCTIONS_DIR, file);
-    const parsed = matter.read(sourcePath);
+    const parsed = matter.read(sourcePath, MATTER_OPTIONS);
     const { name, description, paths } = parsed.data;
 
     const hasRequiredFields =
@@ -264,7 +278,6 @@ function ensureClaudeSkillsSymlink() {
  * canonical product metadata only.
  */
 async function buildPlatformReference() {
-  const yaml = await import('js-yaml');
   const productsPath = path.join(PROJECT_ROOT, 'data', 'products.yml');
   const referencePath = path.join(PROJECT_ROOT, 'PLATFORM_REFERENCE.md');
   const products = yaml.load(fs.readFileSync(productsPath, 'utf8'));

--- a/helper-scripts/validate-agent-instructions.js
+++ b/helper-scripts/validate-agent-instructions.js
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+/**
+ * Validate canonical agent instructions, skills, and generated adapters.
+ */
+import fs from 'fs';
+import path from 'path';
+import process from 'process';
+import { execSync } from 'child_process';
+import matter from 'gray-matter';
+import {
+  buildAgentInstructionAdapters,
+  buildPlatformReference,
+  ensureClaudeSkillsSymlink,
+} from './build-agent-instructions.js';
+
+const PROJECT_ROOT = process.cwd();
+const INSTRUCTIONS_DIR = path.join(PROJECT_ROOT, '.agents', 'instructions');
+const SKILLS_DIR = path.join(PROJECT_ROOT, '.agents', 'skills');
+const CLAUDE_SKILLS_PATH = path.join(PROJECT_ROOT, '.claude', 'skills');
+const NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const errors = [];
+
+validateInstructions();
+validateSkills();
+validateClaudeSkillsSymlink();
+await validateGeneratedAdapters();
+
+if (errors.length > 0) {
+  console.error('Agent instruction validation failed:');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log('✅ Agent instructions and skills are valid');
+
+function validateInstructions() {
+  if (!fs.existsSync(INSTRUCTIONS_DIR)) {
+    errors.push('.agents/instructions directory is missing');
+    return;
+  }
+
+  for (const file of fs.readdirSync(INSTRUCTIONS_DIR).sort()) {
+    if (!file.endsWith('.md')) continue;
+
+    const filePath = path.join(INSTRUCTIONS_DIR, file);
+    const parsed = matter.read(filePath);
+    const expectedName = path.basename(file, '.md');
+    const { name, description, paths } = parsed.data;
+    const relPath = path.relative(PROJECT_ROOT, filePath);
+
+    if (name !== expectedName) {
+      errors.push(`${relPath} name must match file name (${expectedName})`);
+    }
+
+    if (!NAME_PATTERN.test(name || '')) {
+      errors.push(`${relPath} name must be lower hyphen-case`);
+    }
+
+    if (!description || typeof description !== 'string') {
+      errors.push(`${relPath} must define a description`);
+    }
+
+    if (!Array.isArray(paths) || paths.length === 0) {
+      errors.push(`${relPath} must define one or more paths`);
+    } else {
+      for (const glob of paths) {
+        if (typeof glob !== 'string' || glob.startsWith('/')) {
+          errors.push(`${relPath} has invalid path glob: ${glob}`);
+        }
+      }
+    }
+
+    if (!parsed.content.trim()) {
+      errors.push(`${relPath} must contain instruction body content`);
+    }
+  }
+}
+
+function validateSkills() {
+  if (!fs.existsSync(SKILLS_DIR)) {
+    errors.push('.agents/skills directory is missing');
+    return;
+  }
+
+  const names = new Map();
+  for (const entry of fs.readdirSync(SKILLS_DIR).sort()) {
+    const skillDir = path.join(SKILLS_DIR, entry);
+    if (!fs.statSync(skillDir).isDirectory()) continue;
+
+    const skillPath = path.join(skillDir, 'SKILL.md');
+    const relPath = path.relative(PROJECT_ROOT, skillPath);
+
+    if (!fs.existsSync(skillPath)) {
+      const relSkillDir = path.relative(PROJECT_ROOT, skillDir);
+      errors.push(`${relSkillDir} is missing SKILL.md`);
+      continue;
+    }
+
+    const parsed = matter.read(skillPath);
+    const { name, description } = parsed.data;
+
+    if (name !== entry) {
+      errors.push(`${relPath} name must match directory name (${entry})`);
+    }
+
+    if (!NAME_PATTERN.test(name || '')) {
+      errors.push(`${relPath} name must be lower hyphen-case`);
+    }
+
+    if (!description || typeof description !== 'string') {
+      errors.push(`${relPath} must define a description`);
+    }
+
+    if (names.has(name)) {
+      errors.push(`${relPath} duplicates skill name from ${names.get(name)}`);
+    }
+    names.set(name, relPath);
+  }
+}
+
+function validateClaudeSkillsSymlink() {
+  if (!fs.existsSync(CLAUDE_SKILLS_PATH)) {
+    errors.push('.claude/skills symlink is missing');
+    return;
+  }
+
+  const stat = fs.lstatSync(CLAUDE_SKILLS_PATH);
+  if (!stat.isSymbolicLink()) {
+    errors.push('.claude/skills must be a symlink to ../.agents/skills');
+    return;
+  }
+
+  const target = fs.readlinkSync(CLAUDE_SKILLS_PATH);
+  if (target !== '../.agents/skills') {
+    errors.push(
+      `.claude/skills points to ${target}, expected ../.agents/skills`
+    );
+  }
+}
+
+async function validateGeneratedAdapters() {
+  const before = gitPorcelain();
+
+  try {
+    await buildPlatformReference();
+    await buildAgentInstructionAdapters();
+    ensureClaudeSkillsSymlink();
+  } catch (error) {
+    errors.push(error.message);
+    return;
+  }
+
+  const after = gitPorcelain();
+  if (after !== before) {
+    errors.push(
+      'generated agent instruction adapters are out of date; run yarn build:agent:instructions'
+    );
+  }
+}
+
+function gitPorcelain() {
+  return execSync('git status --porcelain', {
+    cwd: PROJECT_ROOT,
+    encoding: 'utf8',
+  });
+}

--- a/helper-scripts/validate-agent-instructions.js
+++ b/helper-scripts/validate-agent-instructions.js
@@ -12,6 +12,7 @@ import {
   buildAgentInstructionAdapters,
   buildPlatformReference,
   ensureClaudeSkillsSymlink,
+  MATTER_OPTIONS,
 } from './build-agent-instructions.js';
 
 const PROJECT_ROOT = process.cwd();
@@ -47,7 +48,7 @@ function validateInstructions() {
     if (!file.endsWith('.md')) continue;
 
     const filePath = path.join(INSTRUCTIONS_DIR, file);
-    const parsed = matter.read(filePath);
+    const parsed = matter.read(filePath, MATTER_OPTIONS);
     const expectedName = path.basename(file, '.md');
     const { name, description, paths } = parsed.data;
     const relPath = path.relative(PROJECT_ROOT, filePath);
@@ -100,7 +101,7 @@ function validateSkills() {
       continue;
     }
 
-    const parsed = matter.read(skillPath);
+    const parsed = matter.read(skillPath, MATTER_OPTIONS);
     const { name, description } = parsed.data;
 
     if (name !== entry) {

--- a/layouts/AGENTS.md
+++ b/layouts/AGENTS.md
@@ -1,35 +1,35 @@
----
-applyTo: "layouts/**/*.html"
----
-
 <!-- This file is auto-generated from .agents/instructions. Do not edit directly. -->
 
 <!-- Run 'yarn build:agent:instructions' to regenerate it. -->
 
-# Layout and Shortcode Implementation Guidelines
+# Hugo Layouts and Shortcodes Agent Instructions
 
-**Shortcodes reference**: [DOCS-SHORTCODES.md](../../DOCS-SHORTCODES.md)
-**Test examples**: [content/example.md](../../content/example.md)
+These instructions apply when working in `layouts/`.
+
+## Layout and Shortcode Implementation Guidelines
+
+**Shortcodes reference**: [DOCS-SHORTCODES.md](../DOCS-SHORTCODES.md)
+**Test examples**: [content/example.md](../content/example.md)
 
 **For detailed Hugo template development workflow**, see
-[hugo-template-dev skill](../../.agents/skills/hugo-template-dev/SKILL.md) which covers:
+[hugo-template-dev skill](../.agents/skills/hugo-template-dev/SKILL.md) which covers:
 
 - Hugo template syntax and data access patterns
 - Build-time vs runtime testing strategies
 - Shortcode implementation best practices
 - Complete TDD workflow for Hugo templates
 
-## Implementing Shortcodes
+### Implementing Shortcodes
 
 When creating or modifying Hugo layouts and shortcodes:
 
 1. Use test-driven development using `/cypress/`
 2. Use Hugo template syntax and functions
 3. Follow existing patterns in `/layouts/shortcodes/`
-4. Test in [content/example.md](../../content/example.md)
-5. Document new shortcodes in [DOCS-SHORTCODES.md](../../DOCS-SHORTCODES.md)
+4. Test in [content/example.md](../content/example.md)
+5. Document new shortcodes in [DOCS-SHORTCODES.md](../DOCS-SHORTCODES.md)
 
-## Shortcode Pattern
+### Shortcode Pattern
 
 ```html
 <!-- layouts/shortcodes/example.html -->
@@ -41,7 +41,7 @@ When creating or modifying Hugo layouts and shortcodes:
 </div>
 ```
 
-## Testing
+### Testing
 
 **IMPORTANT:** Use test-driven development with Cypress.
 
@@ -53,7 +53,7 @@ Add shortcode usage examples to `content/example.md` to verify:
 - JavaScript functionality works as expected (check browser console for errors)
 - Interactive elements behave correctly (click links, buttons, etc.)
 
-### TDD Workflow
+#### TDD Workflow
 
 1. Add Cypress tests (high-level to start).
 2. Run tests and make sure they fail.
@@ -62,7 +62,7 @@ Add shortcode usage examples to `content/example.md` to verify:
 5. Add and refine tests.
 6. Repeat.
 
-### Manual Testing Workflow
+#### Manual Testing Workflow
 
 1. Make changes to shortcode/layout files
 2. Wait for Hugo to rebuild (check terminal output)
@@ -71,15 +71,15 @@ Add shortcode usage examples to `content/example.md` to verify:
 5. Test the functionality and check for JavaScript errors
 6. Verify the feature works as intended before marking complete
 
-See [DOCS-SHORTCODES.md](../../DOCS-SHORTCODES.md) for complete shortcode
+See [DOCS-SHORTCODES.md](../DOCS-SHORTCODES.md) for complete shortcode
 documentation.
 
-## Related Resources
+### Related Resources
 
 - **Complete Hugo template workflow**:
-  [hugo-template-dev skill](../../.agents/skills/hugo-template-dev/SKILL.md)
-- **Shortcodes reference**: [DOCS-SHORTCODES.md](../../DOCS-SHORTCODES.md)
-- **Test examples**: [content/example.md](../../content/example.md)
+  [hugo-template-dev skill](../.agents/skills/hugo-template-dev/SKILL.md)
+- **Shortcodes reference**: [DOCS-SHORTCODES.md](../DOCS-SHORTCODES.md)
+- **Test examples**: [content/example.md](../content/example.md)
 - **Article-level page actions** (buttons/links next to the page title — when
   to use, how to add a new one):
-  [DOCS-PAGE-ACTIONS.md](../../DOCS-PAGE-ACTIONS.md)
+  [DOCS-PAGE-ACTIONS.md](../DOCS-PAGE-ACTIONS.md)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -50,8 +50,13 @@ pre-commit:
       run: yarn eslint {staged_files}
       fail_text: "Debug helpers found! Remove debug imports and calls before committing."
     build-agent-instructions:
-      glob: "data/products.yml"
+      glob:
+        - "AGENTS.md"
+        - ".agents/instructions/**/*.md"
+        - ".agents/skills/**/SKILL.md"
+        - "data/products.yml"
       run: yarn build:agent:instructions
+      stage_fixed: true
     # Auto-fix markdown formatting for instruction and README files (like prettier).
     # The wrapper at .ci/remark/remark.sh runs the local Node install when present
     # and falls back to the Compose remark-lint service when Node isn't available.
@@ -60,8 +65,13 @@ pre-commit:
       glob:
         - "README.md"
         - "[A-Z]*.md"
+        - ".agents/**/*.md"
         - ".github/**/*.md"
         - ".claude/**/*.md"
+        - "api-docs/AGENTS.md"
+        - "assets/AGENTS.md"
+        - "content/AGENTS.md"
+        - "layouts/AGENTS.md"
       run: |
         # Shortcode .md files contain Hugo template syntax that remark-lint would
         # escape, so filter content/ and layouts/ paths before running remark.
@@ -74,7 +84,7 @@ pre-commit:
     # Lint instruction and repository documentation files with generic Vale config
     lint-instructions:
       tags: lint
-      glob: "{[A-Z]*.md,.github/**/*.md,.claude/**/*.md,api-docs/README.md}"
+      glob: "{[A-Z]*.md,.agents/**/*.md,.github/**/*.md,.claude/**/*.md,api-docs/README.md,api-docs/AGENTS.md,assets/AGENTS.md,content/AGENTS.md,layouts/AGENTS.md}"
       run: '.ci/vale/vale.sh
         --config=.vale-instructions.ini
         --minAlertLevel=warning {staged_files}'
@@ -172,6 +182,22 @@ pre-commit:
       fail_text: "ShellCheck found issues in shell scripts. Fix errors before committing."
 pre-push:
   commands:
+    validate-agent-instructions:
+      tags: lint
+      glob:
+        - "AGENTS.md"
+        - ".agents/instructions/**/*.md"
+        - ".agents/skills/**/SKILL.md"
+        - ".github/instructions/**/*.md"
+        - ".claude/rules/**/*.md"
+        - "api-docs/AGENTS.md"
+        - "assets/AGENTS.md"
+        - "content/AGENTS.md"
+        - "layouts/AGENTS.md"
+        - "helper-scripts/build-agent-instructions.js"
+        - "helper-scripts/validate-agent-instructions.js"
+      run: yarn validate:agent-instructions
+
     packages-audit:
       tags: frontend security
       run: |

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "deploy:staging": "sh scripts/deploy-staging.sh",
     "lint": "LEFTHOOK_EXCLUDE=test lefthook run pre-commit && lefthook run pre-push",
     "pre-commit": "lefthook run pre-commit",
-    "test": "echo \"Run 'yarn test:e2e', 'yarn test:links', 'yarn test:codeblocks:all' or a specific test command. e2e and links test commands can take a glob of file paths to test. Some commands run automatically during the git pre-commit and pre-push hooks.\" && exit 0",
+    "test": "echo \"Run 'yarn test:e2e', 'yarn test:codeblocks:all', or a specific test command. For link validation, use the link-checker binary (see DOCS-TESTING.md). The e2e command takes a glob of file paths to test. Some commands run automatically during the git pre-commit and pre-push hooks.\" && exit 0",
     "test:codeblocks": "echo \"Run a specific codeblocks test command (e.g., yarn test:codeblocks:influxdb3_core)\" && exit 0",
     "test:codeblocks:all": "docker compose --profile test up",
     "test:codeblocks:default": "yarn test:codeblocks:influxdb3_core & P1=$! ; yarn test:codeblocks:telegraf & P2=$! ; wait $P1 ; E1=$? ; wait $P2 ; E2=$? ; exit $((E1 | E2))",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "build:api-docs:scripts": "tsc --project api-docs/scripts/tsconfig.json",
     "build:pytest:image": "docker build -t influxdata/docs-pytest:latest -f Dockerfile.pytest .",
     "build:agent:instructions": "node ./helper-scripts/build-agent-instructions.js",
+    "validate:agent-instructions": "node ./helper-scripts/validate-agent-instructions.js",
     "build:ts": "tsc --project tsconfig.json --outDir dist",
     "build:ts:watch": "tsc --project tsconfig.json --outDir dist --watch",
     "build:md": "node scripts/build-llm-markdown.js",

--- a/scripts/docs-cli/commands/create.js
+++ b/scripts/docs-cli/commands/create.js
@@ -487,9 +487,8 @@ async function preparePhase(draftPath, options, stdinContent = null) {
     const context = prepareContext(draft);
 
     // Extract links from draft
-    const { extractLinks, followLocalLinks, fetchExternalLinks } = await import(
-      '../../lib/content-scaffolding.js'
-    );
+    const { extractLinks, followLocalLinks, fetchExternalLinks } =
+      await import('../../lib/content-scaffolding.js');
 
     const links = extractLinks(draft.content);
 

--- a/scripts/docs-cli/commands/create.js
+++ b/scripts/docs-cli/commands/create.js
@@ -1250,7 +1250,7 @@ async function executePhase(options) {
     log('  1. Review generated frontmatter and content');
     log('  2. Test locally: npx hugo server');
     log(
-      `  3. Test links: yarn test:links ${result.created[0].replace(/\/[^/]+$/, '/')}**/*.md`
+      `  3. Test links: link-checker map ${result.created[0].replace(/\/[^/]+$/, '/')}**/*.md | xargs link-checker check`
     );
     log('  4. Commit changes: git add content/ && git commit');
 

--- a/scripts/lib/content-scaffolding.js
+++ b/scripts/lib/content-scaffolding.js
@@ -15,6 +15,7 @@ import {
   writeFrontmatterFile,
   validatePath,
   ensureDirectory,
+  MATTER_OPTIONS,
 } from './file-operations.js';
 import { urlToFilePaths } from './url-parser.js';
 
@@ -297,7 +298,7 @@ export function findSiblingWeights(dirPath) {
       const filePath = join(dirPath, entry);
       try {
         const content = readFileSync(filePath, 'utf8');
-        const parsed = matter(content);
+        const parsed = matter(content, MATTER_OPTIONS);
 
         if (parsed.data && typeof parsed.data.weight === 'number') {
           weights.push(parsed.data.weight);
@@ -618,7 +619,7 @@ export function detectSharedContent(filePath) {
 
   try {
     const content = readFileSync(fullPath, 'utf8');
-    const parsed = matter(content);
+    const parsed = matter(content, MATTER_OPTIONS);
 
     if (parsed.data && parsed.data.source) {
       return parsed.data.source;
@@ -663,7 +664,7 @@ export function findSharedContentVariants(sourcePath) {
         } else if (entry.endsWith('.md')) {
           try {
             const content = readFileSync(fullPath, 'utf8');
-            const parsed = matter(content);
+            const parsed = matter(content, MATTER_OPTIONS);
 
             if (parsed.data && parsed.data.source === sourcePath) {
               // Convert to relative path from repo root
@@ -701,7 +702,7 @@ export function analyzeExistingPage(filePath) {
   }
 
   const content = readFileSync(fullPath, 'utf8');
-  const parsed = matter(content);
+  const parsed = matter(content, MATTER_OPTIONS);
 
   const analysis = {
     path: filePath,
@@ -821,7 +822,7 @@ export function followLocalLinks(links, basePath = REPO_ROOT) {
       // Check if file exists
       if (existsSync(filePath)) {
         const fileContent = readFileSync(filePath, 'utf8');
-        const parsed = matter(fileContent);
+        const parsed = matter(fileContent, MATTER_OPTIONS);
 
         results.push({
           url: link,

--- a/scripts/lib/file-operations.js
+++ b/scripts/lib/file-operations.js
@@ -8,6 +8,18 @@ import { dirname, join, basename } from 'path';
 import matter from 'gray-matter';
 import yaml from 'js-yaml';
 
+// gray-matter 4.0.3 binds its default YAML engine to the removed
+// js-yaml 3 safeLoad/safeDump APIs. js-yaml 4 is safe by default, so point
+// the engine at load/dump to stay compatible with the pinned js-yaml version.
+export const MATTER_OPTIONS = {
+  engines: {
+    yaml: {
+      parse: (input) => yaml.load(input),
+      stringify: (input) => yaml.dump(input),
+    },
+  },
+};
+
 /**
  * Read a markdown file and parse frontmatter
  * @param {string} filePath - Path to the markdown file
@@ -19,7 +31,7 @@ export function readDraft(filePath) {
   }
 
   const raw = readFileSync(filePath, 'utf8');
-  const parsed = matter(raw);
+  const parsed = matter(raw, MATTER_OPTIONS);
 
   return {
     content: parsed.content,
@@ -44,7 +56,7 @@ export async function readDraftFromStdin() {
     process.stdin.on('end', () => {
       try {
         // Parse with gray-matter to extract frontmatter if present
-        const parsed = matter(data);
+        const parsed = matter(data, MATTER_OPTIONS);
         resolve({
           content: parsed.content,
           frontmatter: parsed.data || {},


### PR DESCRIPTION
## Summary

Centralizes agent instructions and skills under `.agents/` as the canonical
source and generates the per-harness adapters from it, so Claude Code, Codex,
and GitHub Copilot read consistent guidance without hand-maintained copies.

What this branch does:

- Adds canonical path-specific instructions in `.agents/instructions/`
  (`content`, `content-review`, `layouts`, `assets`, `api-docs`).
- Moves the shared skills to `.agents/skills/` and points `.claude/skills` at
  them via a symlink.
- Generates harness adapters from the canonical sources with
  `helper-scripts/build-agent-instructions.js`: `.claude/rules/*.md`,
  `.github/instructions/*.instructions.md`, scoped `AGENTS.md` files under
  `content/`, `layouts/`, `assets/`, and `api-docs/`, the Copilot instructions,
  and `PLATFORM_REFERENCE.md`.
- Adds `helper-scripts/validate-agent-instructions.js` and a `lefthook.yml`
  hook to validate the canonical sources and confirm the generated adapters are
  in sync (`yarn build:agent:instructions`, `yarn validate:agent-instructions`).
- Slims the root `AGENTS.md` to startup-level guidance and moves detailed
  guidance into the scoped files.

Accuracy fixes to the skills and contributor docs (verified against the repo):

- Replaces the non-existent `yarn test:links` command with the real
  `link-checker map | check` workflow in `content-editing`, the canonical
  `content` instruction, `DOCS-TESTING.md`, `DOCS-CONTRIBUTING.md`, the
  `docs create` next-steps output, and the `test` script help text.
- Corrects `vale-rule-config`: real `BasedOnStyles` value, real rule filenames
  (`WordList.yml`, not `Terms.yml`/`TechnicalTerms.yml`), the actual single
  `InfluxDataDocs` vocabulary, and abbreviation-expanding swap examples.
- Fixes the Cloud Dedicated `.vale.ini` path (`content/influxdb3/...`) across
  three skills and two docs.
- Fixes `hugo-template-dev` data references (`data/article_data/`, underscore).
- Sharpens the `vale-linting` (run/debug/maintain) vs `vale-rule-config`
  (author rules/regex) boundary and adds "Use when" triggers to the six skill
  descriptions that lacked them.

Background: `docs/superpowers/specs/agent-harness-instructions-skills.md`.

## Checklist

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
- [ ] Local build passes (`npx hugo --quiet`)

***

<details>
<summary><b>Suggested reviewers</b> (click to expand)</summary>

<!--
## Tips:
- Docs team (influxdata/docs-team) is auto-assigned via CODEOWNERS
- Request additional reviewers above when ready for technical review
- Open as Draft until ready for review to avoid notification spam
- Copilot reviews automatically - address suggestions before requesting human review
-->

Based on files changed, consider requesting review from:

### InfluxDB 3

| Content          | Engineering                    | Product                     |
| ---------------- | ------------------------------ | --------------------------- |
| Core, Enterprise | influxdata/monolith-team       | peterbarnett03, garylfowler |
| Clustered        | influxdata/platform-team       | ritwika314, sanderson       |
| Cloud Dedicated  | influxdata/cloud-single-tenant | ritwika314, sanderson       |
| Cloud Serverless | —                              | mavarius, garylfowler       |
| Explorer         | —                              | mavarius, peterbarnett03    |

### InfluxDB v2 / v1 / Enterprise v1

| Content           | Engineering     | Product               |
| ----------------- | --------------- | --------------------- |
| v2, Cloud (TSM)   | influxdata/edge | sanderson, jstirnaman |
| v1, Enterprise v1 | influxdata/edge | sanderson, jstirnaman |

### Other Products

| Content    | Engineering              | Product               |
| ---------- | ------------------------ | --------------------- |
| Telegraf   | influxdata/telegraf-team | sanderson, caterryan  |
| Kapacitor  | influxdata/bonitoo       | sanderson, jstirnaman |
| Chronograf | influxdata/bonitoo       | mavarius, caterryan   |
| Flux       | —                        | sanderson, jstirnaman |

### Shared / Cross-Product

| Content            | Reviewers                   |
| ------------------ | --------------------------- |
| `/content/shared/` | influxdata/product-managers |
| API docs           | Relevant product team above |

</details>
