### PR TITLE
docs(agents): note org-managed Dependabot in AGENTS and docs-testing skill

### DIFF
--- a/.agents/skills/docs-testing/SKILL.md
+++ b/.agents/skills/docs-testing/SKILL.md
@@ -73,6 +73,19 @@ Code block execution tests are **disabled** in pre-push hooks. Run them manually
 
 Code block **execution** is NOT a PR check. It runs on demand via `workflow_dispatch`.
 
+### Dependency updates (org-managed)
+
+**Dependabot runs org-wide** for all influxdata repos — it is managed by the
+security team, not by a workflow in this repo. Do not add a parallel
+dependency-update mechanism. Two implications for agents:
+
+- When you add or update a third-party GitHub Action, **pin it by full commit
+  SHA** with a version comment (see `.github/workflows/pr-lockfile-lint.yml`) so
+  Dependabot can bump it cleanly.
+- A repo-level `.github/dependabot.yml`, if present, supplements the org config;
+  scheduled `github-actions` version updates require an explicit entry there.
+  Coordinate with the security team before changing dependency automation.
+
 ***
 
 ## Part 3: Running Specific Tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,19 @@ See [README.md](README.md) and the
 - Network-restricted environments may fail on Cypress downloads, Docker builds,
   or Alpine package installs.
 
+## Dependency management
+
+- **Dependabot is managed org-wide by the security team** for all influxdata
+  repos. Do not stand up a parallel dependency-update mechanism, and treat a
+  repo-level `.github/dependabot.yml` (if present) as supplementary to the org
+  config, not the source of truth.
+- Pin third-party GitHub Actions by full commit SHA (with a version comment) so
+  Dependabot can keep the pins current. `.github/workflows/pr-lockfile-lint.yml`
+  is the reference example.
+- Coordinate with the security team before changing dependency automation;
+  org-wide Dependabot security updates do not automatically include scheduled
+  `github-actions` version updates.
+
 ## Documentation style
 
 - Follow the Google Developer Documentation Style Guide.


### PR DESCRIPTION
## Summary

The security team runs **Dependabot org-wide** for all influxdata repos. This records that fact for agent awareness so future agents don't stand up a parallel dependency-update mechanism.

Changes:
- **`AGENTS.md`** — new **Dependency management** section: Dependabot is managed org-wide by the security team; treat any repo-level `.github/dependabot.yml` as supplementary to the org config; SHA-pin third-party GitHub Actions (with version comments) so Dependabot can keep pins current (`pr-lockfile-lint.yml` is the reference example); coordinate with the security team before changing dependency automation, since org-wide security updates don't automatically include scheduled `github-actions` version updates.
- **`.agents/skills/docs-testing/SKILL.md`** — a **Dependency updates (org-managed)** note under *Part 2: Automation Coverage*, pointing agents to SHA-pin Actions and not duplicate the mechanism.

Generated instruction adapters were regenerated (`yarn build:agent:instructions`) and validated (`yarn validate:agent-instructions`) — no adapter output changed, since `AGENTS.md` and the skill are canonical sources.

## Notes
- This is documentation/skill-only; no workflow or build behavior changes.
- The broader CI/CD modernization plan that motivated this note is kept on a separate working branch and intentionally not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dm2kjEK8tyBexwGqmyJdG

---
_Generated by [Claude Code](https://claude.ai/code/session_019Dm2kjEK8tyBexwGqmyJdG)_