### PR TITLE
Replace prompt hook with deterministic script for InfluxDB 3 shared content

### DIFF
--- a/.claude/hooks/suggest-shared-content.sh
+++ b/.claude/hooks/suggest-shared-content.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# PostToolUse hook: nudge toward shared content for InfluxDB 3 searches.
+#
+# Most InfluxDB 3 prose lives in content/shared/influxdb3-*/; the product
+# directories (content/influxdb3/core/, .../enterprise/) are usually thin
+# stubs with `source:` references. When a Grep/Glob targets only those
+# product directories, results can look incomplete (frontmatter stubs only).
+#
+# This hook is deterministic and scoped: it stays silent unless a search
+# genuinely targeted core/ or enterprise/ WITHOUT also covering shared
+# content. It never blocks — it only adds context for Claude.
+#
+# Exit codes:
+#   0 = always (PostToolUse cannot block; the tool already ran)
+
+set -euo pipefail
+
+# Read hook input JSON from stdin
+INPUT=$(cat)
+
+# Collect the search-target fields: path, glob, and pattern cover both
+# Grep (path/glob/pattern) and Glob (path/pattern).
+TARGETS=$(echo "$INPUT" | jq -r '
+  [.tool_input.path, .tool_input.glob, .tool_input.pattern]
+  | map(select(. and . != "")) | join(" ")
+' 2>/dev/null) || exit 0
+
+[[ -z "$TARGETS" ]] && exit 0
+
+# Did the search reference an InfluxDB 3 product directory?
+if [[ "$TARGETS" != *content/influxdb3/core/* \
+   && "$TARGETS" != *content/influxdb3/enterprise/* ]]; then
+  exit 0
+fi
+
+# Did it already cover shared content? Then no reminder is needed.
+if [[ "$TARGETS" == *content/shared/influxdb3* ]]; then
+  exit 0
+fi
+
+# Relevant search that skipped shared content — surface a gentle reminder
+# as additional context rather than an error.
+REMINDER="Most InfluxDB 3 prose lives in content/shared/influxdb3-*/; \
+content/influxdb3/core/ and .../enterprise/ are usually thin stubs with \
+source: references. If these results look incomplete or only contain \
+frontmatter, search content/shared/influxdb3-*/ as well."
+
+jq -n --arg ctx "$REMINDER" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: $ctx
+  }
+}'
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -121,8 +121,9 @@
         "matcher": "Grep|Glob",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "If this search targeted content/influxdb3/core/ or content/influxdb3/enterprise/ but did NOT also search content/shared/influxdb3-*/, note that most InfluxDB 3 prose lives in shared content files. Suggest a follow-up search in content/shared/ if results look incomplete or only contain frontmatter stubs."
+            "type": "command",
+            "command": "bash .claude/hooks/suggest-shared-content.sh",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
## Summary

Replaces the manual prompt-based hook for InfluxDB 3 shared content suggestions with a deterministic bash script that automatically detects when a search targets product directories (`content/influxdb3/core/` or `.../enterprise/`) without also covering shared content (`content/shared/influxdb3-*/`), and surfaces a contextual reminder.

**Why:** The previous prompt-based approach relied on Claude to manually evaluate search targets and decide whether to suggest shared content. This new script makes the detection deterministic and automatic—it runs after every Grep/Glob tool use and only surfaces a reminder when genuinely needed, reducing cognitive overhead and ensuring consistent behavior.

**Key changes:**
- Added `.claude/hooks/suggest-shared-content.sh`: A scoped, deterministic PostToolUse hook that parses tool input JSON, checks search targets, and outputs additional context only when appropriate
- Updated `.claude/settings.json`: Changed the hook from `type: prompt` to `type: command`, pointing to the new script with a 5-second timeout
- The hook is silent by default and never blocks tool execution—it only adds context when a search genuinely skipped shared content

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)

https://claude.ai/code/session_01TeJXNLTKFoKWNEQTMG5KvP