### PR TITLE
docs(influxdb3): add one-way migration caution to v3.10 release notes

### DIFF
--- a/content/shared/influxdb3-admin/upgrade.md
+++ b/content/shared/influxdb3-admin/upgrade.md
@@ -19,7 +19,7 @@ Before upgrading your {{% product-name %}} instance, review the [release notes](
 Before upgrading your {{% product-name %}} cluster, review the [release notes](/influxdb3/version/release-notes/) for compatibility requirements and then plan your upgrade strategy.
 {{% /show-in %}}
 
-> [!Warning]
+> [!Important]
 > #### Upgrading to InfluxDB 3.10 is a one-way migration
 >
 > The first time you start InfluxDB 3.10, it automatically upgrades the on-disk

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -1,3 +1,16 @@
+> [!Warning]
+> #### Upgrading to InfluxDB 3.10 is a one-way migration
+>
+> The first time you start InfluxDB 3.10, it automatically upgrades the on-disk
+> catalog format from v2 to v3. After migration, 3.9.x and older
+> binaries are unable to read the new catalog, and fail to start on the same
+> cluster data.
+>
+> Before upgrading, back up `{prefix}/catalogs/` and `{prefix}/_catalog_checkpoint`.
+> Restoring these objects is the only way to roll back to 3.9.x.
+>
+> {{% show-in "enterprise" %}}If you have enabled the storage engine upgrade (`--use-pacha-tree`), data written in the new `.pt` file format is also unreadable by 3.9.x.{{% /show-in %}}
+
 > \[!Note]
 >
 > #### InfluxDB 3 Core and Enterprise relationship
@@ -12,7 +25,7 @@
 
 #### Features
 
-- **Catalog format upgrade (catalog v2 → v3)**: InfluxDB 3.10 automatically migrates the on-disk catalog to v3 format on first startup. The v3 catalog uses a compact binary record format (~5–6x smaller than v2). Migration is automatic, idempotent, and crash-safe. Back up `{prefix}/catalogs/` and `{prefix}/_catalog_checkpoint` before upgrading — the migration is one-way and 3.9.x binaries cannot read a v3 catalog.
+- **Catalog format upgrade (catalog v2 → v3)**: InfluxDB 3.10 automatically migrates the on-disk catalog to v3 format on first startup. The v3 catalog uses a compact binary record format (~5–6x smaller than v2). Migration is automatic, idempotent, and crash-safe. **Back up `{prefix}/catalogs/` and `{prefix}/_catalog_checkpoint` before upgrading — the migration is one-way and 3.9.x binaries cannot read a v3 catalog.**
 
 - **`influxdb3 debug catalog` command**: Inspect catalog state offline directly from object storage — no running server required. Subcommands: `list`, `snapshot`, `sequence`. Available in both Core and Enterprise.
 

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -1,4 +1,4 @@
-> [!Warning]
+> [!Important]
 > #### Upgrading to InfluxDB 3.10 is a one-way migration
 >
 > The first time you start InfluxDB 3.10, it automatically upgrades the on-disk


### PR DESCRIPTION
## Summary

Prepends the InfluxDB 3.10 one-way catalog migration warning to the shared Core/Enterprise release notes, and bolds the related backup/migration sentence in the v3.10.0 catalog feature entry.

The callout is copied verbatim from the upgrade guide (`/influxdb3/{core,enterprise}/admin/upgrade/`). The catalog v2 → v3 migration applies to **both** Core and Enterprise, so the callout lives in the shared release-notes source file. The Enterprise-only `--use-pacha-tree` note is scoped with `{{% show-in "enterprise" %}}`.

## Changes

- One file: `content/shared/v3-core-enterprise-release-notes/_index.md`
  - Prepend `[!Warning]` "one-way migration" callout above the existing Core/Enterprise relationship note.
  - Bold the backup/one-way-migration sentence in the v3.10.0 Core "Catalog format upgrade" feature entry.

## Preview URLs

- /influxdb3/core/release-notes/
- /influxdb3/enterprise/release-notes/
- /influxdb3/enterprise/admin/upgrade/

## Verification

- `npx hugo --quiet` builds clean (exit 0).
- Rendered HTML confirmed for both products:
  - Core: callout shows, `--use-pacha-tree` line correctly hidden.
  - Enterprise: callout shows, `--use-pacha-tree` line shown.
- Vale pre-commit lint: 0 errors, 0 warnings, 0 suggestions.