### PR TITLE
docs(influxdb3): fix broken anchor links in upgrade page

### DIFF
--- a/content/shared/influxdb3-admin/upgrade.md
+++ b/content/shared/influxdb3-admin/upgrade.md
@@ -150,12 +150,10 @@ Start-Service influxdb3
 Upgrade {{% product-name %}} instances to newer versions using rolling upgrades to minimize downtime.
 When upgrading multi-node clusters, you need to understand catalog version constraints and the recommended upgrade order for different node modes.
 
-- [Upgrade a single {{% product-name %}} instance](#upgrade-a-single--product-name--instance)
-- [Upgrade a multi-node cluster](#upgrade-a-multi-node-cluster)
-  - [Before you upgrade](#before-you-upgrade)
-  - [Multi-node upgrade procedure](#multi-node-upgrade-procedure)
-  - [Upgrade constraints](#upgrade-constraints)
-  - [Troubleshooting](#troubleshooting)
+- [Catalog version compatibility](#catalog-version-compatibility)
+- [Multi-node upgrade procedure](#multi-node-upgrade-procedure)
+- [Rolling upgrade constraints](#rolling-upgrade-constraints)
+- [Troubleshooting cluster upgrades](#troubleshooting-cluster-upgrades)
 
 ### Catalog version compatibility
 


### PR DESCRIPTION
## Summary

Fixes three broken anchor links in the InfluxDB 3 upgrade page reported on PR #7397.

The multi-node section TOC in `content/shared/influxdb3-admin/upgrade.md` referenced anchors that did not match any heading:

- `#upgrade-a-single--product-name--instance` — no such heading (a literal unrendered shortcode in a hand-typed anchor)
- `#upgrade-constraints` → corrected to `#rolling-upgrade-constraints`
- `#troubleshooting` → corrected to `#troubleshooting-cluster-upgrades`

The list now points at the section's four real subsections:

- `#catalog-version-compatibility`
- `#multi-node-upgrade-procedure`
- `#rolling-upgrade-constraints`
- `#troubleshooting-cluster-upgrades`

## Verification

- `npx hugo --quiet` builds without errors
- Link checker on the enterprise upgrade page reports `error_count: 0` and "0 broken fragments found"