### PR TITLE
docs(influxdb3): add Docker version-pinning guidance to install guide

### DIFF
--- a/content/shared/influxdb3/install.md
+++ b/content/shared/influxdb3/install.md
@@ -151,6 +151,21 @@ docker pull \
 influxdb:3-{{< product-key >}}
 ```
 {{% /expand %}}
+{{% expand "Pin to a specific version" %}}
+The `3-{{< product-key >}}` tag always points to the latest 3.x release.
+To keep a deployment on a fixed version, pull a version-specific tag instead:
+
+```bash
+# Pin to a specific patch release
+docker pull influxdb:{{< latest-patch >}}-{{< product-key >}}
+
+# Pin to the latest patch in a minor series--for example, 3.10
+docker pull influxdb:3.10-{{< product-key >}}
+```
+
+To browse recent InfluxDB 3 image tags (Core and Enterprise), newest first, see
+[`influxdb` tags on Docker Hub](https://hub.docker.com/_/influxdb/tags?name=3.&ordering=last_updated).
+{{% /expand %}}
 {{< /expand-wrapper >}}
 
 


### PR DESCRIPTION
## What

Adds a **"Pin to a specific version"** expand block to the shared
InfluxDB 3 Docker install section. It:

- Explains that the `3-<edition>` tag floats to the latest 3.x release.
- Shows version-specific tag examples (pinned patch via `latest-patch`,
  and a minor-series tag).
- Links to a filtered Docker Hub tag list
  (`?name=3.&ordering=last_updated`) so users can find non-`latest`
  releases, which the Docker Hub UI otherwise makes hard to browse.

## Why

Users had trouble finding and pinning to specific (non-`latest`) Docker
image tags on Docker Hub. One link, scoped to 3.x and ordered newest
first, serves both Core and Enterprise.

`name=3.` is used (not `name=core`/`name=enterprise`) because the
edition substrings also match v1-era tags.

## Preview these pages

The change is in shared content (`content/shared/influxdb3/install.md`),
so it renders on both install guides:

- /influxdb3/core/install/
- /influxdb3/enterprise/install/

Check the **Pull the Docker image** section → **Pin to a specific
version** expander.

## Notes / follow-up

This helps users find versions that exist. It does not surface
`3.9.5`/`3.9.6-enterprise`, which are not published to Docker Hub at all
(the Enterprise series jumps 3.9.3 → 3.10.0). If those patches were
actually released, that's a publishing gap to file against the
Enterprise release pipeline — separate from this docs change.