### PR TITLE
refactor(layouts): clean up header/javascript.html partial

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <link rel="shortcut icon" href="/img/favicon.png" type="image/png" sizes="32x32">
 
-    {{ partial "header/javascript.html" }}
+    {{ partialCached "header/javascript.html" . hugo.IsProduction hugo.IsServer }}
     {{ partial "header/stylesheets.html" }}
     {{ partial "header/google-fonts.html" }}
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -15,7 +15,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <link rel="shortcut icon" href="/img/favicon.png" type="image/png" sizes="32x32">
 
-    {{ partial "header/javascript.html" . }}
+    {{ partialCached "header/javascript.html" . hugo.IsProduction hugo.IsServer }}
     {{ partial "header/canonical.html" . }}
     {{ partial "header/faq-jsonld.html" . }}
     {{ partial "header/techarticle-jsonld.html" . }}

--- a/layouts/partials/header/javascript.html
+++ b/layouts/partials/header/javascript.html
@@ -1,9 +1,3 @@
-<!-- $productPathData here is buggy - it might not return the current page path due to the context in which .RelPermalink is called -->
-{{ $productPathData := findRE "[^/]+.*?" .RelPermalink }}
-{{ $product := index $productPathData 0 }}
-{{ $currentVersion := index $productPathData 1 }}
-<!-- Get site data -->
-<!-- Load cloudUrls array -->
 {{ $cloudUrls := slice }}
 {{- range .Site.Data.influxdb_urls.cloud.providers }}
   {{- range .regions }}
@@ -13,7 +7,6 @@
 {{ $products := .Site.Data.products }}
 {{ $influxdb_urls := .Site.Data.influxdb_urls }}
 
-<!-- Build main.js -->
 {{ $isDevelopment := false }}
 {{ $isTesting := false }}
 
@@ -37,14 +30,12 @@
     "minify" hugo.IsProduction
     "sourceMap" (cond $isDevelopmentOrTesting "inline" "")
     "format" (cond $isDevelopmentOrTesting "esm" "iife")
-    "bundle" true 
+    "bundle" true
     "targetPath" "js/main.js"
-    "params" (dict 
-      "product" $product 
-      "currentVersion" $currentVersion 
-      "isServer" hugo.IsServer 
-      "products" $products 
-      "influxdb_urls" $influxdb_urls 
+    "params" (dict
+      "isServer" hugo.IsServer
+      "products" $products
+      "influxdb_urls" $influxdb_urls
       "cloudUrls" $cloudUrls
       "isDevelopment" $isDevelopmentOrTesting
     )


### PR DESCRIPTION
## Summary

Remove a buggy `findRE` extraction from `layouts/partials/header/javascript.html` that was already flagged as incorrect in a code comment. The regex extracted `product` and `currentVersion` from `.RelPermalink`, but neither value is imported by any JS module — only `products` and `influxdb_urls` (both from `.Site.Data`) are consumed via `@params`. Removing those dead params has no effect on the emitted bundle or its integrity hash.

Switch both call sites (`layouts/partials/header.html` and `layouts/404.html`) from `partial` to `partialCached`, keyed on `hugo.IsProduction` and `hugo.IsServer`. Fix the missing-context invocation in `layouts/404.html`, which previously called `{{ partial "header/javascript.html" }}` with no argument.

## Verification

Built with `--environment production --templateMetrics` before and after the change. The `<script>` tag `src` and `integrity` values are identical across all pages in both builds.

Visual test against local Hugo server.

Please review:
- https://docs.influxdata.com/influxdb3/core/get-started/
- /telegraf/v1/plugins/

## Notes for review

The performance gain from `partialCached` is small (approximately 0.4 s wall-clock). Hugo's internal resource pipeline already cached the `js.Build` result across calls, so `js.Build` was running once per build even before this change. The main value of this commit is removing the dead params and fixing the missing-context call in `404.html`.
