### PR TITLE
ci(vale): cut suggestion-tier noise from PR style checks

### DIFF
--- a/.github/scripts/vale-check.sh
+++ b/.github/scripts/vale-check.sh
@@ -82,10 +82,14 @@ for config in "${!CONFIG_GROUPS[@]}"; do
 
   # Run Vale via the repo wrapper (.ci/vale/vale.sh),
   # which uses a local binary if available or falls back to Docker.
+  # Surface warning/error in PRs only. Suggestion-level rules (e.g.
+  # Google.Parens, Google.Semicolons, InfluxDataDocs.Acronyms) are editing
+  # hints best left to the Vale editor extension; in PR review they're noise.
+  # This honors MinAlertLevel = warning in .vale.ini rather than overriding it.
   RESULT=$("$VALE_WRAPPER" \
     --config="$config" \
     --output=JSON \
-    --minAlertLevel=suggestion \
+    --minAlertLevel=warning \
     "${file_array[@]}" 2>/dev/null || true)
 
   if [[ -n "$RESULT" && "$RESULT" != "null" ]]; then

--- a/.github/workflows/pr-vale-check.yml
+++ b/.github/workflows/pr-vale-check.yml
@@ -157,7 +157,6 @@ jobs:
 
             const errors = results.errors || 0;
             const warnings = results.warnings || 0;
-            const suggestions = results.suggestions || 0;
             const checkResult = '${{ steps.vale.outputs.check-result }}';
 
             // Build comment body
@@ -166,7 +165,6 @@ jobs:
             body += '|--------|-------|\n';
             body += `| Errors | ${errors} |\n`;
             body += `| Warnings | ${warnings} |\n`;
-            body += `| Suggestions | ${suggestions} |\n\n`;
 
             // List errors (blocking)
             if (errors > 0) {
@@ -250,7 +248,6 @@ jobs:
         run: |
           ERRORS="${{ steps.vale.outputs.error-count }}"
           WARNINGS="${{ steps.vale.outputs.warning-count }}"
-          SUGGESTIONS="${{ steps.vale.outputs.suggestion-count }}"
           RESULT="${{ steps.vale.outputs.check-result }}"
 
           echo "## Vale Style Check Results" >> $GITHUB_STEP_SUMMARY
@@ -259,7 +256,6 @@ jobs:
           echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Errors | ${ERRORS:-0} |" >> $GITHUB_STEP_SUMMARY
           echo "| Warnings | ${WARNINGS:-0} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Suggestions | ${SUGGESTIONS:-0} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           if [[ "$RESULT" == "failed" ]]; then


### PR DESCRIPTION
## What

Stops the Vale CI check from surfacing low-value, suggestion-level rules in pull requests, and tidies the report that remains.

- **Raise the PR alert level to `warning`** (`.github/scripts/vale-check.sh`). CI was running at `--minAlertLevel=suggestion`, which dragged the entire suggestion tier into PR *Files Changed* as `::notice::` annotations. This now honors `MinAlertLevel = warning` already declared in `.vale.ini` instead of overriding it.
- **Drop the always-zero Suggestions row** from the PR comment table and the step summary (`.github/workflows/pr-vale-check.yml`), so the report shows only actionable Errors/Warnings.

## Why

The only suggestion-level rules currently active are `Google.Parens`, `Google.Semicolons`, and `InfluxDataDocs.Acronyms` — none encode a decision a reviewer can act on:

- `Google.Parens` / `Google.Semicolons` match *every* parenthetical/semicolon and defer the judgment to a human.
- `InfluxDataDocs.Acronyms` approximates "define acronyms on first use" with a regex that needs a ~150-entry denylist to suppress SQL/InfluxQL keywords, and still leaks.

Suggestion-level hints remain available live in the Vale editor extension for writers; they just no longer add noise to PR review. The deterministic `warning`/`error` policy (branding, capitalization, wordlist, spelling) is unaffected.

## Verification

Smoke-tested both alert levels against a sample file with Vale 3.14.2:

- `--minAlertLevel=suggestion`: 3 suggestions fired (`Google.Parens`, `Google.Semicolons`, `InfluxDataDocs.Acronyms`)
- `--minAlertLevel=warning`: 0 suggestions; warning/error rules unaffected

Counting plumbing in the Run Vale step is left intact so the uploaded `vale-results.json` artifact schema stays stable.