### PR TITLE
ci(actions): add build-docs-site composite action for PR/prod parity

### DIFF
--- a/.github/actions/build-docs-site/action.yml
+++ b/.github/actions/build-docs-site/action.yml
@@ -1,0 +1,102 @@
+name: 'Build Documentation Site'
+description: >
+  Canonical build definition for docs-v2. Builds the Rust markdown converter,
+  API documentation, and Hugo site. Use in every job that builds the site so
+  PR and production steps stay in parity by construction rather than by
+  discipline. Mirrors the CircleCI build job steps (see .circleci/config.yml).
+
+inputs:
+  build-rust:
+    description: >
+      Install Rust toolchain and build the markdown converter.
+      Disabled by default to avoid slow uncached builds.
+      Enable for full production parity; add an actions/cache step for
+      ~/.cargo, ~/.rustup, and scripts/rust-markdown-converter/target
+      keyed on rust-toolchain.toml + Cargo.lock before calling this action.
+    default: 'false'
+  build-api-docs:
+    description: 'Build API documentation before Hugo'
+    default: 'true'
+  hugo-environment:
+    description: 'Hugo environment flag (production, pr-preview, development, …)'
+    default: 'production'
+  hugo-destination:
+    description: 'Hugo output directory'
+    default: 'public'
+  hugo-base-url:
+    description: 'Hugo --baseURL override (empty = use config default)'
+    default: ''
+  hugo-minify:
+    description: 'Pass --minify to Hugo'
+    default: 'false'
+  hugo-quiet:
+    description: 'Pass --quiet to Hugo'
+    default: 'false'
+  hugo-gc:
+    description: 'Pass --gc to Hugo (remove unused cache files)'
+    default: 'false'
+  hugo-log-level:
+    description: 'Hugo --logLevel value (debug, info, warn, error)'
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    # ------------------------------------------------------------------ Rust --
+    # Mirrors the CircleCI "Install Rust toolchain" step. Reads the pinned
+    # channel from scripts/rust-markdown-converter/rust-toolchain.toml.
+    # If build-rust is false, both Rust steps are skipped and Hugo falls back
+    # to the pure-JS markdown converter.
+    - name: Install Rust toolchain
+      if: inputs.build-rust == 'true'
+      shell: bash
+      run: |
+        if [ ! -x "$HOME/.cargo/bin/rustup" ]; then
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --profile minimal --default-toolchain none
+        fi
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        RUST_CHANNEL=$(grep '^channel' scripts/rust-markdown-converter/rust-toolchain.toml \
+          | sed 's/.*= *"\([^"]*\)".*/\1/')
+        "$HOME/.cargo/bin/rustup" toolchain install \
+          --profile minimal --no-self-update "$RUST_CHANNEL"
+        "$HOME/.cargo/bin/rustup" default "$RUST_CHANNEL"
+
+    - name: Build Rust markdown converter
+      if: inputs.build-rust == 'true'
+      shell: bash
+      run: node scripts/build-rust-converter.js
+
+    # ------------------------------------------------------------ API docs --
+    # Mirrors the CircleCI "Build API documentation" step. Skipped when
+    # build-api-docs is false (e.g., render-artifact checks that don't test
+    # API pages).
+    - name: Build API documentation
+      if: inputs.build-api-docs == 'true'
+      shell: bash
+      run: yarn build:api-docs
+
+    # --------------------------------------------------------------- Hugo --
+    # Mirrors the CircleCI "Hugo Build" step. All flag inputs are optional;
+    # omitted flags fall back to Hugo/config defaults.
+    - name: Build Hugo site
+      shell: bash
+      run: |
+        HUGO_ARGS="--environment ${{ inputs.hugo-environment }}"
+        HUGO_ARGS="$HUGO_ARGS --destination ${{ inputs.hugo-destination }}"
+        if [ -n "${{ inputs.hugo-base-url }}" ]; then
+          HUGO_ARGS="$HUGO_ARGS --baseURL ${{ inputs.hugo-base-url }}"
+        fi
+        if [ "${{ inputs.hugo-minify }}" = "true" ]; then
+          HUGO_ARGS="$HUGO_ARGS --minify"
+        fi
+        if [ "${{ inputs.hugo-quiet }}" = "true" ]; then
+          HUGO_ARGS="$HUGO_ARGS --quiet"
+        fi
+        if [ "${{ inputs.hugo-gc }}" = "true" ]; then
+          HUGO_ARGS="$HUGO_ARGS --gc"
+        fi
+        if [ -n "${{ inputs.hugo-log-level }}" ]; then
+          HUGO_ARGS="$HUGO_ARGS --logLevel ${{ inputs.hugo-log-level }}"
+        fi
+        npx hugo $HUGO_ARGS

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -153,14 +153,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version-file: .nvmrc
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - name: Setup docs environment
+        uses: ./.github/actions/setup-docs-env
 
       - name: Fetch current PR body
         id: fetch-pr-body
@@ -201,27 +195,30 @@ jobs:
           echo "No pages to deploy - skipping preview"
           echo "Reason: ${{ steps.detect.outputs.skip-reason || steps.detect.outputs.change-summary }}"
 
-      - name: Build API docs
+      - name: Start build timer
+        if: steps.detect.outputs.pages-to-deploy != '[]'
+        id: timer-start
+        run: echo "ts=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Build docs site
         # API reference pages under content/{product}/api/ are gitignored
         # and generated at build time from OpenAPI specs. Without this
         # step, Hugo builds a site with no API pages and preview URLs for
         # any /api/ route 404 (see #7123 for the symptom).
+        # Uses the canonical build-docs-site action for PR/prod parity.
         if: steps.detect.outputs.pages-to-deploy != '[]'
-        run: yarn build:api-docs
+        uses: ./.github/actions/build-docs-site
+        with:
+          hugo-environment: pr-preview
+          hugo-minify: 'true'
+          hugo-base-url: https://influxdata.github.io/docs-v2/pr-preview/pr-${{ github.event.number }}/
 
-      - name: Build Hugo site
+      - name: Record build time
         if: steps.detect.outputs.pages-to-deploy != '[]'
         id: build
-        env:
-          # Set baseURL for GitHub Pages preview subdirectory
-          PREVIEW_BASE_URL: https://influxdata.github.io/docs-v2/pr-preview/pr-${{ github.event.number }}/
         run: |
-          START_TIME=$(date +%s)
-          # Use pr-preview environment for path offset config
-          npx hugo --minify --baseURL "$PREVIEW_BASE_URL" -e pr-preview
-          END_TIME=$(date +%s)
-          DURATION=$((END_TIME - START_TIME))
-          echo "build-time=${DURATION}s" >> $GITHUB_OUTPUT
+          DURATION=$(( $(date +%s) - ${{ steps.timer-start.outputs.ts }} ))
+          echo "build-time=${DURATION}s" >> "$GITHUB_OUTPUT"
 
       - name: Prepare preview files
         if: steps.detect.outputs.pages-to-deploy != '[]'

--- a/.github/workflows/pr-render-check.yml
+++ b/.github/workflows/pr-render-check.yml
@@ -32,19 +32,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version-file: .nvmrc
-          cache: 'yarn'
-
-      - name: Install dependencies
+      - name: Setup docs environment
         env:
           CYPRESS_INSTALL_BINARY: 0
-        run: yarn install --frozen-lockfile
+        uses: ./.github/actions/setup-docs-env
 
       - name: Build Hugo site
-        run: npx hugo --quiet
+        uses: ./.github/actions/build-docs-site
+        with:
+          build-rust: 'false'
+          build-api-docs: 'false'
+          hugo-quiet: 'true'
 
       - name: Scan built HTML for render artifacts
         run: .ci/scripts/check-render-artifacts.sh public
@@ -88,16 +86,9 @@ jobs:
             echo "ℹ️  No layout/asset/render-check file changed — skipping Cypress"
           fi
 
-      - name: Setup Node.js
+      - name: Setup docs environment
         if: steps.detect.outputs.should-run == 'true'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version-file: .nvmrc
-          cache: 'yarn'
-
-      - name: Install dependencies
-        if: steps.detect.outputs.should-run == 'true'
-        run: yarn install --frozen-lockfile
+        uses: ./.github/actions/setup-docs-env
 
       - name: Run render-regression and canonical specs
         if: steps.detect.outputs.should-run == 'true'


### PR DESCRIPTION
  ## Summary

  - Adds `.github/actions/build-docs-site/action.yml` — the canonical build definition for docs-v2. This is Phase 1 §4.5 of the CI/CD modernization plan: a single
  shared composite action that both PR and production jobs call, so parity holds by construction.
  - Updates `pr-preview.yml` to use `setup-docs-env` (replacing inline Node setup) and `build-docs-site` (replacing inline `yarn build:api-docs` + `npx hugo`).
  - Updates `pr-render-check.yml` to use `setup-docs-env` in both jobs; uses `build-docs-site` in the `check-artifacts` job.

  ## What the action encapsulates

  | Step | Input to disable | CircleCI mirror |
  |------|-----------------|-----------------|
  | Rust toolchain + converter build | `build-rust: 'false'` (default) | Install Rust toolchain + Build Rust markdown converter |
  | API doc generation | `build-api-docs: 'false'` | Build API documentation scripts + Generate API documentation |
  | Hugo build | — | Hugo Build |

  Rust is off by default until Rust caching (`actions/cache` keyed on `rust-toolchain.toml` + `Cargo.lock`) is wired in — Phase 2 follow-up.

  ## Completes Phase 1

  Together with PR #7414 (Node unification, frozen installs, lockfile-aware caches, Rust toolchain pin, SHA-pinned actions), this finishes all Phase 1 items from
  `issue-169-cicd-plan.md`.

  ## Test plan

  - [ ] `pr-preview` workflow runs on a content/layout PR and produces a preview URL
  - [ ] `check-artifacts` job builds the site and scans HTML without error
  - [ ] `cypress-render` job installs deps and runs Cypress specs when layout files change