### PR TITLE
fix(layouts): lazy-evaluate .Summary in techarticle-jsonld

### DIFF
--- a/layouts/partials/header/techarticle-jsonld.html
+++ b/layouts/partials/header/techarticle-jsonld.html
@@ -26,7 +26,7 @@
       "dateModified" (.Lastmod.Format "2006-01-02T15:04:05Z07:00")
       "inLanguage" "en"
   -}}
-  {{- with .Description | default .Summary -}}
+  {{- with or .Description .Summary -}}
     {{- $article = merge $article (dict "description" (. | plainify | strings.TrimSpace)) -}}
   {{- end -}}
   {{- with partial "product/landing.html" . -}}


### PR DESCRIPTION
## Summary

Go evaluates function arguments eagerly before calling the function, so `.Description | default .Summary` always computes `.Summary` even when `.Description` is non-empty. When Hugo's `render-codeblock` hook for `callout=` fenced code attributes runs concurrently with summary computation, a partially-processed HAHAHUGOSHORTCODE token can appear in .Summary and cause:

  error calling Summary: unknown shortcode token "HAHAHUGOSHORTCODE2..."

As seen on during a CircleCI build of #7417.

Replace with `or .Description .Summary`: Go's `or` built-in is lazy and short-circuits on the first truthy value, so .Summary is never computed on pages that have a description in frontmatter.

header.html:14 already uses the correct if/else pattern for the same reason; this aligns techarticle-jsonld.html with that precedent.

## Verification

All tests pass against live pages:

  /influxdb3/core/ (landing page) — TechArticle with description populated, isPartOf → #software, SoftwareApplication also present. articleSection is absent (correct
  — it's the landing itself).

  /influxdb3/core/reference/cli/ (deep reference page) — TechArticle with articleSection: "Reference", no SoftwareApplication. Correct.

  /influxdb3/core/tags/ — No JSON-LD at all. Correct (Kind=taxonomy excluded by gate).

  /telegraf/v1/ (versioned landing) — TechArticle + SoftwareApplication with @id: .../telegraf/v1/#software and softwareVersion: "1.39.0". Correct.

  /telegraf/v1/install/ (child of versioned landing) — articleSection: "Install", isPartOf → /telegraf/v1/#software (not a dangling /telegraf/#software). Correct.

  /influxdb/v2/ (multi-version product) — SoftwareApplication scoped to /influxdb/v2/#software with softwareVersion: "2.9.1". Correct.