### PR TITLE
docs(controller): document UI_PORT for separate web interface port

### DIFF
--- a/content/telegraf/controller/install/_index.md
+++ b/content/telegraf/controller/install/_index.md
@@ -30,7 +30,9 @@ configurations, monitoring agents, and organizing plugins.
 - **Operating Systems**: Linux, macOS, Windows
 - **Architecture**: x64 (Intel/AMD) or ARM64 (Apple Silicon/ARM)
 - **Database**: SQLite (default), PostgreSQL, or PostgreSQL-compatible
-- **Ports**: 8888 (web interface), 8000 (heartbeat service)
+- **Ports**: 8888 (web interface and API), 8000 (heartbeat service).
+  Optionally, serve the web interface on a separate
+  [`ui-port`](/telegraf/controller/reference/config-options/#ui-port).
 
 
 ## Review the EULA
@@ -373,6 +375,7 @@ Use the following command line options to configure {{% product-name %}}.
 | Command Flag                | Environment Variable       | Description                                  | Default              |
 | :-------------------------- | :------------------------- | :------------------------------------------- | :------------------- |
 | `--port`                    | `APP_PORT`                 | Web interface and API port                   | `8888`               |
+| `--ui-port`                 | `UI_PORT`                  | Optional separate web interface port         | Served on API port   |
 | `--heartbeat-port`          | `HEARTBEAT_PORT`           | Agent heartbeat service port                 | `8000`               |
 | `--database`                | `DATABASE_URL`             | Database connection string                   | Auto-detected SQLite |
 | `--logs-dir`                | `LOGS_DIR`                 | Absolute path for agent logs                 | System temp dir      |
@@ -640,4 +643,6 @@ comparison.
 ## Access {{% product-name %}}
 
 Once started, access the {{% product-name %}} web interface at
-<http://localhost:8888> _(or using your custom port)_.
+<http://localhost:8888> _(or using your custom port)_. If you set
+[`ui-port`](/telegraf/controller/reference/config-options/#ui-port) to serve the
+web interface on a separate port, use that port instead.

--- a/content/telegraf/controller/install/secure-tls.md
+++ b/content/telegraf/controller/install/secure-tls.md
@@ -42,6 +42,12 @@ client that connects. Agents interact with two listeners, and both use the
 - **Heartbeat service** on port `8000` (default): agents send heartbeats to this
   listener.
 
+> [!Note]
+> If you serve the web interface on a separate port
+> ([`ui-port`](/telegraf/controller/reference/config-options/#ui-port)), that
+> listener uses the same certificate and key. Browsers that connect to the web
+> interface must also trust the CA that signed the certificate.
+
 Before an agent trusts a connection, it verifies that the certificate was signed
 by a CA it already trusts. Agents (through Telegraf) ship with the same list of
 public CAs as a web browser. A certificate signed by a private or internal CA, or

--- a/content/telegraf/controller/install/troubleshoot.md
+++ b/content/telegraf/controller/install/troubleshoot.md
@@ -29,6 +29,7 @@ configuration options to specify alternative ports:
 | Description           | Environment Variable | Command Flag       |
 | :-------------------- | -------------------- | ------------------ |
 | Web Interface and API | `APP_PORT`           | `--port`           |
+| Web Interface (separate port) | `UI_PORT`    | `--ui-port`        |
 | Heartbeat server      | `HEARTBEAT_PORT`     | `--heartbeat-port` |
 
 _For more information, see the
@@ -155,6 +156,9 @@ database you're using:
 Ensure the following ports are open in your network Firewall configuration:
 
 - **Web Interface and API**: TCP `8888` (or custom port)
+- **Web Interface (separate port)**: the
+  [`ui-port`](/telegraf/controller/reference/config-options/#ui-port) value, if
+  configured
 - **Heartbeat server**: TCP `8000` (or custom heartbeat port)
 
 ## Security considerations

--- a/content/telegraf/controller/reference/architecture.md
+++ b/content/telegraf/controller/reference/architecture.md
@@ -22,9 +22,10 @@ heartbeat server for agent monitoring.
 
 When you run the Telegraf Controller binary, it starts four main subsystems:
 
-- **Web Server**: Serves the management interface (default port: `8888`)
+- **Web Server**: Serves the management interface (default port: `8888`). Can
+  optionally be served on a separate port from the API using `UI_PORT`.
 - **API Server**: Handles configuration management and administrative requests
-  (served on the same port as the web server)
+  (served on the API port, `8888` by default)
 - **Heartbeat Server**: Dedicated high-performance server for agent heartbeats
   (default port: `8000`)
 - **Background Scheduler**: Monitors agent health every 60 seconds
@@ -55,9 +56,10 @@ environment variables.
 | :----------------- | :------------------- | :--------------------------------------------------------------------------------------------------------------- |
 | `--port`           | `APP_PORT`           | API server port (default is `8888`)                                                                              |
 | `--heartbeat-port` | `HEARTBEAT_PORT`     | Heartbeat service port (default: `8000`)                                                                         |
+| `--ui-port`        | `UI_PORT`            | Optional separate port for the web interface (default: served on the API port)                                  |
 | `--database`       | `DATABASE_URL`       | Database filepath or URL (default is [SQLite path](/telegraf/controller/install/#default-sqlite-data-locations)) |
-| _(none)_           | `SSL_CERT_PATH`      | Path to SSL certificate                                                                                          |
-| _(none)_           | `SSL_KEY_PATH`       | Path to SSL private key                                                                                          |
+| `--ssl-cert`       | `SSL_CERT_PATH`      | Path to SSL certificate                                                                                          |
+| `--ssl-key`        | `SSL_KEY_PATH`       | Path to SSL private key                                                                                          |
 
 _For a full list of options, see the
 [{{% product-name %}} configuration options reference](/telegraf/controller/reference/config-options/)._

--- a/content/telegraf/controller/reference/config-options.md
+++ b/content/telegraf/controller/reference/config-options.md
@@ -76,6 +76,7 @@ telegraf_controller --no-interactive
 - [General](#general)
   - [port](#port)
   - [heartbeat-port](#heartbeat-port)
+  - [ui-port](#ui-port)
   - [database](#database)
 - [TLS](#tls)
   - [ssl-cert-path](#ssl-cert-path)
@@ -150,6 +151,7 @@ telegraf_controller --no-interactive
 
 - [port](#port)
 - [heartbeat-port](#heartbeat-port)
+- [ui-port](#ui-port)
 - [database](#database)
 
 #### port
@@ -173,6 +175,26 @@ Agent heartbeat service port.
 | Command flag       | Environment variable |
 | :----------------- | :------------------- |
 | `--heartbeat-port` | `HEARTBEAT_PORT`     |
+
+---
+
+#### ui-port
+
+Serve the web interface on a separate port from the API. By default,
+{{% product-name %}} serves the web interface and the API together on
+[`port`](#port). Set `ui-port` to serve the web interface on its own port.
+
+In separate-port mode, the browser loads the web interface from `ui-port` and
+calls the API on [`port`](#port), so web clients must be able to reach both
+ports. {{% product-name %}} automatically allows the web interface origin to
+call the API. When set, `ui-port` must differ from [`port`](#port) and
+[`heartbeat-port`](#heartbeat-port).
+
+**Default:** Not set (the web interface is served on [`port`](#port))
+
+| Command flag | Environment variable |
+| :----------- | :------------------- |
+| `--ui-port`  | `UI_PORT`            |
 
 ---
 


### PR DESCRIPTION
## Summary

Document the `UI_PORT` option for serving the web interface on a separate port from the API. Add the ui-port reference entry, the architecture configuration table row and component notes, and mentions across the install and troubleshoot pages (system requirements, config table, access, port conflicts, firewall) and the TLS guide.

Also fix the architecture configuration table, which incorrectly listed no command flags for `SSL_CERT_PATH` and `SSL_KEY_PATH`; both have `--ssl-cert` and `--ssl-key flags`.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
