### PR TITLE
docs(controller): note postgres:// scheme and DATABASE_URL quoting

### DIFF
--- a/content/telegraf/controller/reference/config-options.md
+++ b/content/telegraf/controller/reference/config-options.md
@@ -181,6 +181,12 @@ Agent heartbeat service port.
 Database connection URL or filesystem path. {{% product-name %}} supports
 SQLite and PostgreSQL.
 
+For PostgreSQL, {{% product-name %}} accepts both the `postgresql://` and
+`postgres://` URL schemes. {{% product-name %}} removes surrounding quotes from
+the value before connecting, so quoting the connection string in your shell or
+`.env` file is safe. If the value is not a URL, {{% product-name %}} treats it
+as a SQLite file path and adds the `file:` scheme automatically.
+
 **Default:** `file:./sqlite.db`
 
 ```bash


### PR DESCRIPTION
## Summary

Document that Telegraf Controller accepts both `postgresql://` and `postgres://` URL schemes, strips surrounding quotes from `DATABASE_URL`, and treats a non-URL value as a SQLite file path.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)