### PR TITLE
docs(controller): note agent list column sorting

### DIFF
--- a/content/telegraf/controller/agents/_index.md
+++ b/content/telegraf/controller/agents/_index.md
@@ -24,5 +24,7 @@ Controller can distinguish one agent from another.
   also automatically delete agents that haven't reported in a specified amount
   of time.
 - You can assign a reporting rule from the agent list or an agent details page.
+- Sort the agent list by **Agent Details**, **Status**, or **Last Reported** by
+  clicking a column header. Click the header again to reverse the sort order.
 
 {{< children hlevel="h2" >}}


### PR DESCRIPTION
## Summary

Document that the agent list can be sorted by the Agent Details, Status, and Last Reported columns by clicking the column header.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
