### PR TITLE
docs(controller): use AUDIT_ENABLED env var name

### DIFF
--- a/content/telegraf/controller/audit-logs/_index.md
+++ b/content/telegraf/controller/audit-logs/_index.md
@@ -76,7 +76,7 @@ Audit logging is part of [Telegraf Enterprise](/telegraf/enterprise/)
 and is unavailable in the free tier.
 With a valid license:
 
-- Audit logging is **enabled at startup only** by setting `AUDIT_LOGGING_ENABLED`.
+- Audit logging is **enabled at startup only** by setting `AUDIT_ENABLED`.
   See [Enable and configure audit logging](/telegraf/controller/audit-logs/enable-configure/).
 - Only the retention period is modifiable at runtime, from the **Settings**
   page.

--- a/content/telegraf/controller/audit-logs/enable-configure.md
+++ b/content/telegraf/controller/audit-logs/enable-configure.md
@@ -46,7 +46,7 @@ destinations for long-term storage or SIEM integration.
 
 ## Enable audit logging
 
-Set `AUDIT_LOGGING_ENABLED` to `true` before starting {{% product-name %}}.
+Set `AUDIT_ENABLED` to `true` before starting {{% product-name %}}.
 
 {{< tabs-wrapper >}}
 {{% tabs %}}
@@ -57,12 +57,12 @@ Set `AUDIT_LOGGING_ENABLED` to `true` before starting {{% product-name %}}.
 {{% /tabs %}}
 {{% tab-content %}}
 
-Add `AUDIT_LOGGING_ENABLED=true` to your systemd unit file (typically
+Add `AUDIT_ENABLED=true` to your systemd unit file (typically
 `/etc/systemd/system/telegraf-controller.service`):
 
 ```ini
 [Service]
-Environment=AUDIT_LOGGING_ENABLED=true
+Environment=AUDIT_ENABLED=true
 ```
 
 Reload systemd and restart the service:
@@ -78,7 +78,7 @@ sudo systemctl restart telegraf-controller
 Set the variable, or pass `--audit-enabled` on the command line:
 
 ```bash
-export AUDIT_LOGGING_ENABLED=true
+export AUDIT_ENABLED=true
 telegraf_controller --no-interactive
 ```
 
@@ -92,7 +92,7 @@ telegraf_controller --audit-enabled --no-interactive
 Set the variable in PowerShell, or pass `--audit-enabled` on the command line:
 
 ```powershell
-$env:AUDIT_LOGGING_ENABLED="true"
+$env:AUDIT_ENABLED="true"
 ./telegraf_controller.exe --no-interactive
 ```
 
@@ -106,11 +106,11 @@ $env:AUDIT_LOGGING_ENABLED="true"
      influxdata/telegraf-controller Docker image is published.
      Restore this tab (and its button above) when the image ships.
 
-Pass `AUDIT_LOGGING_ENABLED=true` when starting the container:
+Pass `AUDIT_ENABLED=true` when starting the container:
 
 ```bash
 docker run \
-  -e AUDIT_LOGGING_ENABLED=true \
+  -e AUDIT_ENABLED=true \
   influxdata/telegraf-controller
 ```
 
@@ -225,7 +225,7 @@ term.
 
 ## Disable audit logging
 
-To turn audit logging off, remove `AUDIT_LOGGING_ENABLED` (or set it to a value
+To turn audit logging off, remove `AUDIT_ENABLED` (or set it to a value
 other than `true`) and restart {{% product-name %}}.
 The startup-only policy applies in both directions: audit logging cannot be
 disabled from the UI.

--- a/content/telegraf/controller/reference/config-options.md
+++ b/content/telegraf/controller/reference/config-options.md
@@ -1001,7 +1001,7 @@ Enterprise license to take effect.
 
 | Command flag      | Environment variable    |
 | :---------------- | :---------------------- |
-| `--audit-enabled` | `AUDIT_LOGGING_ENABLED` |
+| `--audit-enabled` | `AUDIT_ENABLED` |
 
 ---
 


### PR DESCRIPTION
## Summary

The binary reads `AUDIT_ENABLED` (matching the `-audit-enabled` flag), not `AUDIT_LOGGING_ENABLED`. Update all references in the configuration options and audit logging pages to the correct variable name.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
