### PR TITLE
docs(controller): add v1.0.1 release notes

### DIFF
--- a/content/telegraf/controller/reference/release-notes.md
+++ b/content/telegraf/controller/reference/release-notes.md
@@ -9,10 +9,28 @@ menu:
 weight: 101
 ---
 
-## v1.0.0 {date="2026-06-23"}
+## v1.0.1 {date="2026-07-01"}
 
 <!-- Link only be on the latest version, update and move with new versions. -->
-[Download Telegraf Controller v1.0.0](/telegraf/controller/install/#download-and-install-telegraf-controller)
+[Download Telegraf Controller v1.0.1](/telegraf/controller/install/#download-and-install-telegraf-controller)
+
+### Features
+
+- Serve the web UI on a separate port from the API using the `UI_PORT` option,
+  for deployments that run the web UI behind a reverse proxy.
+- Sort the agent list by column (Agent Details, Status, Last Reported), backed
+  by `sortBy` and `sortOrder` query parameters on `GET /api/agents`.
+- Accept both `postgresql://` and `postgres://` connection string schemes and
+  tolerate quoted `DATABASE_URL` values.
+
+### Bug fixes
+
+- Sync the agents quota counter with manual refresh and polling.
+- Fix an environment-variable example typo on the add-configuration page.
+
+---
+
+## v1.0.0 {date="2026-06-23"}
 
 > [!Important]
 > #### Telegraf Controller v1.0 (General Availability)

--- a/content/telegraf/controller/reference/release-notes.md
+++ b/content/telegraf/controller/reference/release-notes.md
@@ -11,7 +11,7 @@ weight: 101
 
 ## v1.0.1 {date="2026-07-01"}
 
-<!-- Link only be on the latest version, update and move with new versions. -->
+<!-- Update and move the link to the latest version. -->
 [Download Telegraf Controller v1.0.1](/telegraf/controller/install/#download-and-install-telegraf-controller)
 
 ### Features


### PR DESCRIPTION
## Summary

Add the v1.0.1 release notes (2026-07-01) covering UI port separation, agent list sorting, `DATABASE_URL` scheme/quoting flexibility, and bug fixes. Move the download link to the latest version.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
