### PR TITLE
chore(perf): split Mermaid from docs JS bundle

### DIFF
--- a/assets/js/components/diagram.js
+++ b/assets/js/components/diagram.js
@@ -1,15 +1,20 @@
-// Memoize the mermaid module import
-let mermaidPromise = null;
+import { diagramRendererModuleUrl } from '@params';
+
+// Memoize the renderer module import.
+let rendererPromise = null;
 
 export default function Diagram({ component }) {
-  // Import mermaid.js module (memoized)
-  if (!mermaidPromise) {
-    mermaidPromise = import('mermaid');
+  if (!rendererPromise) {
+    if (!diagramRendererModuleUrl) {
+      console.error('Diagram renderer module URL is not configured.');
+      return;
+    }
+    rendererPromise = import(diagramRendererModuleUrl);
   }
-  mermaidPromise
-    .then(({ default: mermaid }) => {
+  rendererPromise
+    .then(({ default: renderer }) => {
       // Configure mermaid with InfluxData theming
-      mermaid.initialize({
+      renderer.initialize({
         startOnLoad: false, // We'll manually call run()
         theme: document.body.classList.contains('dark-theme')
           ? 'dark'
@@ -29,16 +34,16 @@ export default function Diagram({ component }) {
 
       // Process the specific diagram component
       try {
-        mermaid.run({ nodes: [component] });
+        renderer.run({ nodes: [component] });
       } catch (error) {
-        console.error('Mermaid diagram rendering error:', error);
+        console.error('Diagram rendering error:', error);
       }
 
-      // Store reference to mermaid for theme switching
-      if (!window.mermaidInstances) {
-        window.mermaidInstances = new Map();
+      // Store reference to the renderer for theme switching.
+      if (!window.diagramRendererInstances) {
+        window.diagramRendererInstances = new Map();
       }
-      window.mermaidInstances.set(component, mermaid);
+      window.diagramRendererInstances.set(component, renderer);
     })
     .catch((error) => {
       console.error('Failed to load Mermaid library:', error);
@@ -54,12 +59,12 @@ export default function Diagram({ component }) {
         window.isDarkTheme = document.body.classList.contains('dark-theme');
 
         // Reload this specific diagram with new theme
-        if (window.mermaidInstances?.has(component)) {
-          const mermaid = window.mermaidInstances.get(component);
-          mermaid.initialize({
+        if (window.diagramRendererInstances?.has(component)) {
+          const renderer = window.diagramRendererInstances.get(component);
+          renderer.initialize({
             theme: window.isDarkTheme ? 'dark' : 'default',
           });
-          mermaid.run({ nodes: [component] });
+          renderer.run({ nodes: [component] });
         }
       }
     });
@@ -71,8 +76,8 @@ export default function Diagram({ component }) {
   // Return cleanup function to be called when component is destroyed
   return () => {
     observer.disconnect();
-    if (window.mermaidInstances?.has(component)) {
-      window.mermaidInstances.delete(component);
+    if (window.diagramRendererInstances?.has(component)) {
+      window.diagramRendererInstances.delete(component);
     }
   };
 }

--- a/assets/js/diagram-renderer.js
+++ b/assets/js/diagram-renderer.js
@@ -1,0 +1,3 @@
+import mermaid from 'mermaid';
+
+export default mermaid;

--- a/assets/styles/tools/_fonts.scss
+++ b/assets/styles/tools/_fonts.scss
@@ -17,21 +17,25 @@ body {
   font-family: "Proxima Nova";
   src: url("fonts/proxima-nova.otf") format("opentype");
   font-weight: 300;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Proxima Nova';
   src: url('fonts/proxima-nova-medium.otf') format('opentype');
   font-weight: 400;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Proxima Nova';
   src: url('fonts/proxima-nova-semibold.otf') format('opentype');
   font-weight: 500 600;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Proxima Nova';
   src: url('fonts/proxima-nova-bold.otf') format('opentype');
   font-weight: 700;
+  font-display: swap;
 }
 
 @import "tools/icon-fonts/icomoon-v2";

--- a/layouts/partials/header/javascript.html
+++ b/layouts/partials/header/javascript.html
@@ -24,12 +24,32 @@
 {{ end }}
 
 {{ $isDevelopmentOrTesting := or $isDevelopment $isTesting }}
+{{ $diagramRendererModuleURL := "" }}
+
+{{ with resources.Get "js/diagram-renderer.js" }}
+  {{ $diagramRendererOpts := dict
+    "minify" hugo.IsProduction
+    "sourceMap" (cond $isDevelopmentOrTesting "inline" "")
+    "format" "esm"
+    "bundle" true
+    "targetPath" "js/diagram-renderer.js"
+  }}
+  {{ with . | js.Build $diagramRendererOpts }}
+    {{ if hugo.IsProduction }}
+      {{ with . | fingerprint }}
+        {{ $diagramRendererModuleURL = .RelPermalink }}
+      {{ end }}
+    {{ else }}
+      {{ $diagramRendererModuleURL = .RelPermalink }}
+    {{ end }}
+  {{ end }}
+{{ end }}
 
 {{ with resources.Get "js/main.js" }}
   {{ $opts := dict
     "minify" hugo.IsProduction
     "sourceMap" (cond $isDevelopmentOrTesting "inline" "")
-    "format" (cond $isDevelopmentOrTesting "esm" "iife")
+    "format" "esm"
     "bundle" true
     "targetPath" "js/main.js"
     "params" (dict
@@ -38,12 +58,13 @@
       "influxdb_urls" $influxdb_urls
       "cloudUrls" $cloudUrls
       "isDevelopment" $isDevelopmentOrTesting
+      "diagramRendererModuleUrl" $diagramRendererModuleURL
     )
   }}
   {{ with . | js.Build $opts }}
     {{ if hugo.IsProduction }}
       {{ with . | fingerprint }}
-        <script src="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous"></script>
+        <script type="module" src="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous"></script>
       {{ end }}
     {{ else }}
       <script type="module" src="{{ .RelPermalink }}"></script>


### PR DESCRIPTION
## What changed

- Split the Mermaid renderer out of the always-loaded docs JavaScript bundle.
- Load the diagram renderer only when a page includes a diagram component.
- Ship the production entry script as an ES module so the browser can load the diagram renderer on demand.
- Add `font-display: swap` to the four Proxima Nova font faces.

## Why

The docs site loaded Mermaid on every page, even when a page had no diagrams.
Mermaid is one of the largest JavaScript dependencies in the site bundle, so this increased initial page weight and delayed rendering for common docs pages.
The previous production bundle format also prevented the existing dynamic import from becoming a separate browser-loaded module.

This change moves diagram rendering cost to the pages that need it and reduces the always-loaded JavaScript entry.
The font-display update lets body text render with a fallback font while Proxima Nova loads, which avoids blocking text rendering on slower connections.

## Impact

Pages without diagrams no longer download the Mermaid renderer during initial page load.
Diagram pages still render Mermaid diagrams after loading the separate renderer module.
Body text can paint before Proxima Nova finishes loading.

**This changes the JS baseline to browsers with ES module support. Older browsers still receive static docs content but lose enhanced interactivity.**

## Validation

- Ran `npx hugo --minify --quiet`.
- Verified the production `main` entry is `264K`, contains no `mermaid` string, and references the separate `diagram-renderer` module.
- Verified compiled light-theme CSS includes 4 `font-display:swap` declarations.
- Verified in headless Chrome that `/influxdb3/core/` loads only `main`, while `/telegraf/controller/reference/architecture/` loads `main` and `diagram-renderer` and renders a diagram SVG with no console errors.
- Ran targeted Cypress JS regression specs: `219/219` tests passed.
- Attempted the full Cypress spec glob. It ran `452` tests with `404` passing and failed in existing broad-suite areas that require separate setup or external services: `topnav`, API generated content, Algolia search, and markdown validation prerequisites.

## Preview pages

| Page | Expected |
| --- | --- |
| `/influxdb3/core/` | Loads the main JavaScript entry without loading the diagram renderer. Core docs content and standard UI controls render normally. |
| `/telegraf/controller/reference/architecture/` | Loads the diagram renderer only on demand and renders the Mermaid diagram. |
| `/` | Home page renders normally with theme switching and search UI available in module-capable browsers. |
| /enterprise_influxdb/v1/ | |
| /influxdb3/enterprise/get-started/ | |
| /influxdb3/enterprise/api | |
| /influxdb/v2/ | |
| /telegraf/v1/plugins/ | |