### PR TITLE
Fix CLI config table formatting

### DIFF
--- a/content/shared/influxdb-v2/reference/cli/influx/config/create.md
+++ b/content/shared/influxdb-v2/reference/cli/influx/config/create.md
@@ -34,8 +34,7 @@ influx config create [flags]
 |      | `--json`              | Output data as JSON (default `false`)                                      |            | `INFLUX_OUTPUT_JSON`  |
 | `-o` | `--org`               | Organization name                                                          |   string   |                       |
 | `-t` | `--token`             | API token                                                                  |   string   | `INFLUX_TOKEN`        |
-| `-p` | `--username-password` | **(OSS only)** Username (and optionally password) to use for authentication.
-Include `username:password` to ensure a session is automatically authenticated. Include `username` (without password) to prompt for a password before creating the session.                                                                       |   string   |
+| `-p` | `--username-password` | **(OSS only)** Username (and optionally password) to use for authentication.<br>Include `username:password` to ensure a session is automatically authenticated. Include `username` (without password) to prompt for a password before creating the session. |   string   |                       |
 
 ## Examples
 

--- a/content/shared/influxdb-v2/reference/cli/influx/config/set.md
+++ b/content/shared/influxdb-v2/reference/cli/influx/config/set.md
@@ -21,8 +21,7 @@ influx config set [flags]
 |      | `--json`         | Output data as JSON (default `false`)                           |            | `INFLUX_OUTPUT_JSON`  |
 | `-o` | `--org`          | Organization name for the connection configuration              |   string   |                       |
 | `-t` | `--token`        | API token                                                       |   string   | `INFLUX_TOKEN`        |
-| `-p` | `--username-password` | **(OSS only)** Username (and optionally password) to use for authentication.
-Include `username:password` to ensure a session is automatically authenticated. Include `username` (without password) to prompt for a password before creating the session.                                                                       |   string   |
+| `-p` | `--username-password` | **(OSS only)** Username (and optionally password) to use for authentication.<br>Include `username:password` to ensure a session is automatically authenticated. Include `username` (without password) to prompt for a password before creating the session. |   string   |                       |
 
 ## Examples
 


### PR DESCRIPTION
## What changed

- Fixed the malformed `--username-password` row in the shared `influx config set` flags table.
- Fixed the same table formatting issue in the adjacent shared `influx config create` flags table.

## Why

- Closes #5832.
- The row was split across two Markdown lines, which caused the rendered flags table to break near the bottom.

## Impact

- The affected CLI reference pages now render the `--username-password` flag as a normal five-column table row across sourced Cloud, v2, and Cloud Serverless pages.

## Validation

- `npx hugo --quiet`
- `yarn lint-codeblocks content/shared/influxdb-v2/reference/cli/influx/config/create.md content/shared/influxdb-v2/reference/cli/influx/config/set.md`
- Pre-commit hooks
- Pre-push hooks
- Confirmed rendered HTML contains the corrected table row.

## Preview pages

- /influxdb/v2/reference/cli/influx/config/set/
  Expected: The `--username-password` flag appears inside the Flags table with its description, input type, and mapped environment variable columns aligned.

- /influxdb/v2/reference/cli/influx/config/create/
  Expected: The `--username-password` flag appears inside the Flags table with its description, input type, and mapped environment variable columns aligned.

## Checklist

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)

***

<details>
<summary><b>Suggested reviewers</b> (click to expand)</summary>

<!--
## Tips:
- Docs team (influxdata/docs-team) is auto-assigned via CODEOWNERS
- Request additional reviewers above when ready for technical review
- Open as Draft until ready for review to avoid notification spam
- Copilot reviews automatically - address suggestions before requesting human review
-->

Based on files changed, consider requesting review from:

### InfluxDB 3

| Content          | Engineering                    | Product                     |
| ---------------- | ------------------------------ | --------------------------- |
| Core, Enterprise | influxdata/monolith-team       | peterbarnett03, garylfowler |
| Clustered        | influxdata/platform-team       | ritwika314, sanderson       |
| Cloud Dedicated  | influxdata/cloud-single-tenant | ritwika314, sanderson       |
| Cloud Serverless | -                              | mavarius, garylfowler       |
| Explorer         | -                              | mavarius, peterbarnett03    |

### InfluxDB v2 / v1 / Enterprise v1

| Content           | Engineering     | Product               |
| ----------------- | --------------- | --------------------- |
| v2, Cloud (TSM)   | influxdata/edge | sanderson, jstirnaman |
| v1, Enterprise v1 | influxdata/edge | sanderson, jstirnaman |

### Other Products

| Content    | Engineering              | Product               |
| ---------- | ------------------------ | --------------------- |
| Telegraf   | influxdata/telegraf-team | sanderson, caterryan  |
| Kapacitor  | influxdata/bonitoo       | sanderson, jstirnaman |
| Chronograf | influxdata/bonitoo       | mavarius, caterryan   |
| Flux       | -                        | sanderson, jstirnaman |

### Shared / Cross-Product

| Content            | Reviewers                   |
| ------------------ | --------------------------- |
| `/content/shared/` | influxdata/product-managers |
| API docs           | Relevant product team above |

</details>
