### PR TITLE
[codex] fix deploy archive checksum path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,8 +202,10 @@ jobs:
               exit 0
             fi
             tar -czf workspace/archive/public.tar.gz -C workspace public
-            sha256sum workspace/archive/public.tar.gz \
-              > workspace/archive/public.SHA256SUMS
+            (
+              cd workspace/archive
+              sha256sum public.tar.gz > public.SHA256SUMS
+            )
             HUGO_VERSION=$(yarn --silent hugo version 2>/dev/null | head -1)
             RUST_CHANNEL=$(grep '^channel' scripts/rust-markdown-converter/rust-toolchain.toml \
               | sed 's/.*= *"\([^"]*\)".*/\1/')


### PR DESCRIPTION
## Summary

Fixes the CircleCI deploy archive checksum verification path.

The build job creates `workspace/archive/public.tar.gz`, but the deploy job runs `sha256sum -c public.SHA256SUMS` after changing into `workspace/archive`. The checksum file previously recorded `workspace/archive/public.tar.gz`, causing verification to look for `workspace/archive/workspace/archive/public.tar.gz` relative to the current directory. This updates checksum generation to run from `workspace/archive` and record `public.tar.gz`.

## Checklist

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
- [ ] Local build passes (`npx hugo --quiet`)

## Validation

- Scratch archive/checksum simulation: `public.tar.gz: OK`
- YAML parse check: `YAML OK`
- Pre-push hook: `packages-audit` passed
- Pre-push hook: `validate-agent-instructions` passed

## Preview pages

Not applicable; CI configuration only.