### PR TITLE
[codex] Update general PR template checklist

### DIFF
--- a/.github/pull_request_template/general.md
+++ b/.github/pull_request_template/general.md
@@ -1,0 +1,23 @@
+## What changed
+
+-
+
+## Why
+
+-
+
+## Impact
+
+-
+
+## Validation
+
+-
+
+## Preview pages
+
+- /path/to/page/
+  Expected:
+
+- /another/path/
+  Expected:

--- a/.github/pull_request_template/general.md
+++ b/.github/pull_request_template/general.md
@@ -21,3 +21,59 @@
 
 - /another/path/
   Expected:
+
+## Checklist
+
+- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
+- [ ] Rebased/mergeable
+- [ ] Local build passes (`npx hugo --quiet`)
+
+***
+
+<details>
+<summary><b>Suggested reviewers</b> (click to expand)</summary>
+
+<!--
+## Tips:
+- Docs team (influxdata/docs-team) is auto-assigned via CODEOWNERS
+- Request additional reviewers above when ready for technical review
+- Open as Draft until ready for review to avoid notification spam
+- Copilot reviews automatically - address suggestions before requesting human review
+-->
+
+Based on files changed, consider requesting review from:
+
+### InfluxDB 3
+
+| Content          | Engineering                    | Product                     |
+| ---------------- | ------------------------------ | --------------------------- |
+| Core, Enterprise | influxdata/monolith-team       | peterbarnett03, garylfowler |
+| Clustered        | influxdata/platform-team       | ritwika314, sanderson       |
+| Cloud Dedicated  | influxdata/cloud-single-tenant | ritwika314, sanderson       |
+| Cloud Serverless | -                              | mavarius, garylfowler       |
+| Explorer         | -                              | mavarius, peterbarnett03    |
+
+### InfluxDB v2 / v1 / Enterprise v1
+
+| Content           | Engineering     | Product               |
+| ----------------- | --------------- | --------------------- |
+| v2, Cloud (TSM)   | influxdata/edge | sanderson, jstirnaman |
+| v1, Enterprise v1 | influxdata/edge | sanderson, jstirnaman |
+
+### Other Products
+
+| Content    | Engineering              | Product               |
+| ---------- | ------------------------ | --------------------- |
+| Telegraf   | influxdata/telegraf-team | sanderson, caterryan  |
+| Kapacitor  | influxdata/bonitoo       | sanderson, jstirnaman |
+| Chronograf | influxdata/bonitoo       | mavarius, caterryan   |
+| Flux       | -                        | sanderson, jstirnaman |
+
+### Shared / Cross-Product
+
+| Content            | Reviewers                   |
+| ------------------ | --------------------------- |
+| `/content/shared/` | influxdata/product-managers |
+| API docs           | Relevant product team above |
+
+</details>


### PR DESCRIPTION
## What changed

- Added the default PR template checklist to the general PR template.
- Added the suggested reviewers details block and template comments from the default PR template.

## Why

- Keeps the new general PR template aligned with the default PR template guidance.

## Impact

- Pull requests opened with the general template now include CLA, mergeability, build checklist items, and reviewer guidance.

## Validation

- Pre-commit hook passed during commit.
- Pre-push hook passed during push.
- Did not run a Hugo build; this is a Markdown PR template-only change.

## Preview pages

- None
  Expected: No rendered documentation pages affected.

## Checklist

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
- [ ] Local build passes (`npx hugo --quiet`)

***

<details>
<summary><b>Suggested reviewers</b> (click to expand)</summary>

<!--
## Tips:
- Docs team (influxdata/docs-team) is auto-assigned via CODEOWNERS
- Request additional reviewers above when ready for technical review
- Open as Draft until ready for review to avoid notification spam
- Copilot reviews automatically - address suggestions before requesting human review
-->

Based on files changed, consider requesting review from:

### InfluxDB 3

| Content          | Engineering                    | Product                     |
| ---------------- | ------------------------------ | --------------------------- |
| Core, Enterprise | influxdata/monolith-team       | peterbarnett03, garylfowler |
| Clustered        | influxdata/platform-team       | ritwika314, sanderson       |
| Cloud Dedicated  | influxdata/cloud-single-tenant | ritwika314, sanderson       |
| Cloud Serverless | -                              | mavarius, garylfowler       |
| Explorer         | -                              | mavarius, peterbarnett03    |

### InfluxDB v2 / v1 / Enterprise v1

| Content           | Engineering     | Product               |
| ----------------- | --------------- | --------------------- |
| v2, Cloud (TSM)   | influxdata/edge | sanderson, jstirnaman |
| v1, Enterprise v1 | influxdata/edge | sanderson, jstirnaman |

### Other Products

| Content    | Engineering              | Product               |
| ---------- | ------------------------ | --------------------- |
| Telegraf   | influxdata/telegraf-team | sanderson, caterryan  |
| Kapacitor  | influxdata/bonitoo       | sanderson, jstirnaman |
| Chronograf | influxdata/bonitoo       | mavarius, caterryan   |
| Flux       | -                        | sanderson, jstirnaman |

### Shared / Cross-Product

| Content            | Reviewers                   |
| ------------------ | --------------------------- |
| `/content/shared/` | influxdata/product-managers |
| API docs           | Relevant product team above |

</details>