### PR TITLE
chore(resources): suppress /resources/ from AI crawlers and site search

### DIFF
--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -2,6 +2,8 @@
 title: Additional InfluxData resources
 description: >
   View additional resources related to InfluxDB and other InfluxData products and services.
+cascade:
+  noindex: true
 ---
 
 {{< children >}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -272,12 +272,6 @@
           <p><a href="https://awesome.influxdata.com/" target="_blank">View the book</a></p>
         </div>
         <div class="item">
-          <div class="icon">{{ partial "svgs/video-arrow.svg" }}</div>
-          <h4>InfluxData Videos</h4>
-          <p>Videos about time series data and InfluxData projects.</p>
-          <p><a href="/resources/videos/">View videos</a></p>
-        </div>
-        <div class="item">
           <div class="icon">{{ partial "svgs/hatch.svg" }}</div>
           <h4>Case Studies</h4>
           <p>Learn about real world use cases and InfluxDB in the wild.</p>

--- a/layouts/partials/header/search-attributes.html
+++ b/layouts/partials/header/search-attributes.html
@@ -7,7 +7,7 @@
 {{ $searchTag := print $product "-" $version }}
 
 {{ if not .IsHome }}
-  {{ if or (eq $version (replaceRE `\.[0-9x]+$` "" (index $.Site.Data.products $product).latest)) (or (eq $product "platform") (eq $product "resources")) (in (slice "cloud" "core" "enterprise" "cloud-serverless" "cloud-dedicated" "clustered" "explorer" "controller") $version ) }}
+  {{ if or (eq $version (replaceRE `\.[0-9x]+$` "" (index $.Site.Data.products $product).latest)) (eq $product "platform") (in (slice "cloud" "core" "enterprise" "cloud-serverless" "cloud-dedicated" "clustered" "explorer" "controller") $version ) }}
     <meta name="docsearch:latest" content="true">
   {{ end }}
   {{ if and (ne $product "platform") (ne $product "resources") (ne $version "") }}
@@ -19,6 +19,3 @@
   <meta name="docsearch:flux" content="true">
 {{ end }}
 
-{{ if $isResources }}
-  <meta name="docsearch:resources" content="true">
-{{ end }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -110,15 +110,6 @@
     {{ partialCached "sidebar/nested-menu" (dict "menu" $platformMenu "siteData" .Site.Data) "platform" }}
   {{ end }}
 
-  <!-- Additional resources for all docs -->
-  {{ $resourcesProductWhitelist := slice "platform" "influxdb" "enterprise_influxdb" "telegraf" "chronograf" "kapacitor" "flux" }}
-  {{ $resourcesVersionWhitelist := `(?:v\d\.(?:\d{1,2}|x))|cloud$` }}
-  {{ if and (in $resourcesProductWhitelist $product) (gt (len (findRE $resourcesVersionWhitelist $currentVersion)) 0) }}
-    <h4 class="resources">Additional resources</h4>
-    <li class="nav-category"><a href="/resources/videos/">Videos</a></li>
-    <li class="nav-category"><a href="/resources/how-to-guides/">How-to Guides</a></li>
-  {{ end }}
-
   </ul>
   <script>
   (function(){


### PR DESCRIPTION
## Summary

Closes #7435 (phase 1)

The `/resources/` section is a 54-page set of Flux/v2-era content that was
fully exposed to AI crawlers and polluted in-site search results with
non-product content. This change suppresses the section without deleting
any files.

- Add `cascade: noindex: true` to `content/resources/_index.md`. Every
  page under `/resources/` now inherits `noindex: true`, which causes
  `robots.txt` to emit `Disallow` lines for all AI bots and Googlebot and
  drops `.md` twins from `sitemap-md.xml`.
- Remove `docsearch:resources` and `docsearch:latest` meta tags from
  resources pages in `search-attributes.html`. Resources pages no longer
  appear in Algolia in-site search results.
- Remove the homepage "InfluxData Videos" card (`layouts/index.html`).
- Remove the "Additional resources" sidebar block from
  `layouts/partials/sidebar.html` (links to `/resources/videos/` and
  `/resources/how-to-guides/` that appeared on all v1/v2/Flux pages).

## Test plan

- [ ] Local Hugo build passes (`npx hugo --quiet`)
- [ ] Verify `robots.txt` on staging contains `Disallow` lines for
  `/resources/` pages after deploy
- [ ] Confirm resources pages no longer appear in Algolia search results
  after next crawler run