### PR TITLE
docs(mcp): expand MCP acronym, add /mcp/server/ aliases and platform hub

### DIFF
--- a/content/platform/mcp/server.md
+++ b/content/platform/mcp/server.md
@@ -11,6 +11,7 @@ weight: 10
 tags: [MCP, LLM, AI]
 aliases:
   - /platform/mcp-server/
+  - /platform/mcp/
 source: /shared/influxdb3-admin/mcp-server-docs-only.md
 ---
 


### PR DESCRIPTION
## Summary

- Add `/mcp/server/` and `/platform/mcp/server/` aliases across all product MCP server pages so short URLs resolve.
- Expand \"MCP\" to \"Model Context Protocol (MCP)\" in page descriptions and add matching \`seotitle\` values for search visibility.
- Add a new \`/platform/mcp/server/\` hub page linking to each product's MCP server documentation.

## Why

Users searching for \"MCP server\" or hitting shortened URLs from external references (blog posts, docs.influxdata.com/mcp/server/) were not landing on the right pages. Expanding the acronym in descriptions and seotitles improves SEO and disambiguates the term for readers unfamiliar with the abbreviation.

## Reviewer notes

- Alias-only changes for most product pages; content untouched.
- New hub page at [content/platform/mcp/server.md](content/platform/mcp/server.md) is a link index.