### PR TITLE
fix(release-notes): mark /ready endpoint as Enterprise-only in v3.10.0

### DIFF
--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -114,10 +114,7 @@ All Core updates are included in Enterprise.
 
 - **Processing engine: trigger lockdown flags**: Two new serve flags restrict plugin behavior. `--restrict-plugin-triggers-to` limits triggers to one or more of `wal`, `schedule`, or `request`. `--plugin-dir-only` (Enterprise) blocks plugin installation from any source other than the configured plugin directory.
 
-- **`GET /ready` endpoint** (Enterprise-only):
-  Returns `200 OK` when the server can reach object storage, or `503 Service Unavailable` when it cannot.
-  Use this endpoint for readiness probes in load balancers and orchestration systems.
-  Core support is planned; contact InfluxData Support if you need it in Core.
+- **`GET /ready` endpoint** (Enterprise): Returns `200 OK` when the server can reach object storage, or `503 Service Unavailable` when it cannot. Use this endpoint for readiness probes in load balancers and orchestration systems.
 
 - **Observability: always-on heap profiling**: Heap profiling is now enabled at startup with negligible overhead (~<1% CPU). Access profiles at the existing pprof endpoint. To disable, set `MALLOC_CONF=prof:false` before starting the server.
 

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -114,10 +114,10 @@ All Core updates are included in Enterprise.
 
 - **Processing engine: trigger lockdown flags**: Two new serve flags restrict plugin behavior. `--restrict-plugin-triggers-to` limits triggers to one or more of `wal`, `schedule`, or `request`. `--plugin-dir-only` (Enterprise) blocks plugin installation from any source other than the configured plugin directory.
 
-- **`GET /ready` endpoint** (Enterprise only):
-Returns `200 OK` when the server can reach object storage, or `503 Service Unavailable` when it cannot.
-Use this endpoint for readiness probes in load balancers and orchestration systems.
-Core support is tracked in [influxdb_pro#3240](https://github.com/influxdata/influxdb_pro/issues/3240).
+- **`GET /ready` endpoint** (Enterprise-only):
+  Returns `200 OK` when the server can reach object storage, or `503 Service Unavailable` when it cannot.
+  Use this endpoint for readiness probes in load balancers and orchestration systems.
+  Core support is planned; contact InfluxData Support if you need it in Core.
 
 - **Observability: always-on heap profiling**: Heap profiling is now enabled at startup with negligible overhead (~<1% CPU). Access profiles at the existing pprof endpoint. To disable, set `MALLOC_CONF=prof:false` before starting the server.
 

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -114,8 +114,6 @@ All Core updates are included in Enterprise.
 
 - **Processing engine: trigger lockdown flags**: Two new serve flags restrict plugin behavior. `--restrict-plugin-triggers-to` limits triggers to one or more of `wal`, `schedule`, or `request`. `--plugin-dir-only` (Enterprise) blocks plugin installation from any source other than the configured plugin directory.
 
-- **`GET /ready` endpoint** (Enterprise): Returns `200 OK` when the server can reach object storage, or `503 Service Unavailable` when it cannot. Use this endpoint for readiness probes in load balancers and orchestration systems.
-
 - **Observability: always-on heap profiling**: Heap profiling is now enabled at startup with negligible overhead (~<1% CPU). Access profiles at the existing pprof endpoint. To disable, set `MALLOC_CONF=prof:false` before starting the server.
 
 - **Observability: per-request query traces**: Query tracing is now opt-in per request rather than enabled for all queries. This reduces trace volume for high-throughput deployments. See the monitoring documentation for how to enable tracing on individual requests.
@@ -159,6 +157,8 @@ All Core updates are included in Enterprise. The following updates are exclusive
 - **Row-level deletion**: Delete rows by time range and tag predicates using `influxdb3 delete rows` and `influxdb3 cancel row-delete`. Deletion is asynchronous — requests persist to object storage and the compactor applies them when rewriting run sets. Requires `--use-pacha-tree`. Monitor pending deletes with the `system.row_deletes` system table and 9 new `influxdb3_compactor_row_delete_*` metrics.
 
 - **Runtime query-concurrency limit**: Adjust the maximum number of concurrent queries at runtime via the `/api/v3/configure/query_concurrency_limit` API — `GET` to read the current limit, `PUT` to set it, and `DELETE` to reset it to the startup default.
+
+- **`GET /ready` endpoint**: Returns `200 OK` when the server can reach object storage, or `503 Service Unavailable` when it cannot. Use this endpoint for readiness probes in load balancers and orchestration systems.
 
 - **Backup and restore**: Create and manage full backups of Enterprise data with `influxdb3 create backup`, `influxdb3 status backup`, `influxdb3 show backups`, `influxdb3 delete backup`, and `influxdb3 cancel backup`. Initiate restore operations with `influxdb3 create restore`, `influxdb3 status restore`, `influxdb3 show restores`, and `influxdb3 cancel restore`. Backup and restore require `--use-pacha-tree` and a compactor node with an admin token. `create backup` refuses to overwrite an existing backup. Only one restore runs at a time across the cluster. After a restore completes, restart the node(s) for the in-memory view to update. API: `POST|GET|DELETE /api/v3/enterprise/backup[/{name}]` and `/api/v3/enterprise/restore[/{id}]`.
 

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -114,7 +114,10 @@ All Core updates are included in Enterprise.
 
 - **Processing engine: trigger lockdown flags**: Two new serve flags restrict plugin behavior. `--restrict-plugin-triggers-to` limits triggers to one or more of `wal`, `schedule`, or `request`. `--plugin-dir-only` (Enterprise) blocks plugin installation from any source other than the configured plugin directory.
 
-- **`GET /ready` endpoint**: Returns `200 OK` when the server can reach object storage, or `503 Service Unavailable` when it cannot. Use this endpoint for readiness probes in load balancers and orchestration systems.
+- **`GET /ready` endpoint** (Enterprise only):
+Returns `200 OK` when the server can reach object storage, or `503 Service Unavailable` when it cannot.
+Use this endpoint for readiness probes in load balancers and orchestration systems.
+Core support is tracked in [influxdb_pro#3240](https://github.com/influxdata/influxdb_pro/issues/3240).
 
 - **Observability: always-on heap profiling**: Heap profiling is now enabled at startup with negligible overhead (~<1% CPU). Access profiles at the existing pprof endpoint. To disable, set `MALLOC_CONF=prof:false` before starting the server.
 


### PR DESCRIPTION
## Summary

Corrects the [v3.10.0 Core release notes](https://docs.influxdata.com/influxdb3/core/release-notes/#core-5) bullet for `GET /ready`, which appears under the **Core** heading but the endpoint was only wired into **Enterprise**.

## Why

The `/ready` endpoint shipped in [influxdb_pro#3185](https://github.com/influxdata/influxdb_pro/pull/3185) as an Enterprise-only feature. The PR's "Deliberately deferred" section explicitly notes:

> **OSS wiring of the `/ready` handler** — the `ObjectStoreHealth` and `ObservedObjectStore` types live in `oss/influxdb3_server` for potential reuse, but only the enterprise `HttpApi` wires them up. OSS can add the handler later if needed.

The shared types live in `oss/object_store_utils` so Core can adopt the feature later, but the Core `HttpApi` route table currently only handles `/health`. A `GET /ready` request against Core in v3.10.0, v3.10.1, v3.10.2, and current `main` returns not-found.

Core support is tracked in [influxdb_pro#3240](https://github.com/influxdata/influxdb_pro/issues/3240).

## What changed

- Marked the `/ready` bullet as **Enterprise only**.
- Linked the tracking issue so readers know when Core support is expected.
- Kept the bullet under the shared Core/Enterprise release notes (rather than moving it into a separate Enterprise section) to preserve historical continuity — this is a labeling fix, not a restructure.

## Test plan

- [ ] Hugo build succeeds
- [ ] Callout renders as expected in the published release notes page
- [ ] Link to influxdb_pro#3240 resolves