### PR TITLE
ci(link-checker): close the feedback loop on broken-link reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/broken-link.yml
+++ b/.github/ISSUE_TEMPLATE/broken-link.yml
@@ -1,0 +1,45 @@
+name: Broken link
+description: Report a broken link found in the InfluxData documentation.
+title: "Broken link: [URL]"
+labels:
+  - area:links
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## About this template
+
+        Report a broken link so it can be tracked and fixed. Open issues with
+        this label are matched by the PR link checker: a broken URL that
+        appears in an open `area:links` issue is downgraded to a warning so
+        it stops blocking unrelated pull requests.
+
+  - type: input
+    id: broken-url
+    attributes:
+      label: Broken URL
+      description: The exact URL that is broken (include scheme for external links).
+      placeholder: "https://example.com/page or /influxdb3/core/missing-page/"
+    validations:
+      required: true
+
+  - type: textarea
+    id: source-pages
+    attributes:
+      label: Source page(s) or content file(s)
+      description: Where the broken link appears (content/ paths or published URLs).
+      placeholder: |
+        - content/influxdb3/core/get-started/_index.md
+
+  - type: input
+    id: error-status
+    attributes:
+      label: Error or status
+      placeholder: "e.g. 404 Not Found, Cannot find file, Timeout"
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: How the link was found and anything useful for fixing it.
+      placeholder: "Found by link-checker on PR #1234"

--- a/.github/LABEL_GUIDE.md
+++ b/.github/LABEL_GUIDE.md
@@ -46,6 +46,8 @@ Human approval uses GitHub's native PR review system (CODEOWNERS), not labels.
 1. Read issue → identify product(s) → apply `product:*` labels
 2. Apply `source:*` label if applicable
 3. Determine readiness → apply `agent-ready` or `waiting:*`
+4. Applying `copilot:fix` triggers automated assignment of the Copilot
+   coding agent (see [assign-copilot-on-label](workflows/assign-copilot-on-label.yml))
 
 ### PR review pipeline
 

--- a/.github/LABEL_GUIDE.md
+++ b/.github/LABEL_GUIDE.md
@@ -23,21 +23,21 @@ Human approval uses GitHub's native PR review system (CODEOWNERS), not labels.
 
 ## Renamed Labels
 
-| Old Name | New Name |
-|----------|----------|
-| `AI assistant tooling` | `ai:tooling` |
-| `ci:testing-and-validation` | `ci:testing` |
-| `design` | `area:site-ui` |
-| `InfluxDB Cloud` | `product:v2-cloud` |
-| `user feedback` | `source:feedback` |
-| `ai:tooling` | `area:agents` |
+| Old Name                    | New Name           |
+| --------------------------- | ------------------ |
+| `AI assistant tooling`      | `ai:tooling`       |
+| `ci:testing-and-validation` | `ci:testing`       |
+| `design`                    | `area:site-ui`     |
+| `InfluxDB Cloud`            | `product:v2-cloud` |
+| `user feedback`             | `source:feedback`  |
+| `ai:tooling`                | `area:agents`      |
 
 ## Deleted Labels
 
-| Label | Replacement | Reason |
-|-------|-------------|--------|
+| Label        | Replacement  | Reason                                 |
+| ------------ | ------------ | -------------------------------------- |
 | `Pending PR` | `waiting:pr` | Consolidated into `waiting:` namespace |
-| `broke-link` | `area:links` | Consolidated into `area:` namespace |
+| `broke-link` | `area:links` | Consolidated into `area:` namespace    |
 
 ## Common Workflows
 

--- a/.github/scripts/assign-copilot.js
+++ b/.github/scripts/assign-copilot.js
@@ -1,0 +1,120 @@
+/**
+ * Assign Copilot to Issue
+ * Assigns the GitHub Copilot coding agent to an issue via GraphQL, triggered
+ * by applying the `copilot:fix` label.
+ *
+ * Usage: Called from GitHub Actions via actions/github-script
+ * (see .github/workflows/assign-copilot-on-label.yml)
+ */
+
+export const COPILOT_LOGIN = 'copilot-swe-agent';
+
+const SUGGESTED_ACTORS_QUERY = `
+  query($owner: String!, $name: String!) {
+    repository(owner: $owner, name: $name) {
+      suggestedActors(capabilities: [CAN_BE_ASSIGNED], first: 100) {
+        nodes {
+          login
+          __typename
+          ... on Bot { id }
+          ... on User { id }
+        }
+      }
+    }
+  }
+`;
+
+const ISSUE_ASSIGNEES_QUERY = `
+  query($owner: String!, $name: String!, $number: Int!) {
+    repository(owner: $owner, name: $name) {
+      issue(number: $number) {
+        id
+        assignees(first: 20) {
+          nodes { id login }
+        }
+      }
+    }
+  }
+`;
+
+const REPLACE_ASSIGNEES_MUTATION = `
+  mutation($assignableId: ID!, $actorIds: [ID!]!) {
+    replaceActorsForAssignable(input: { assignableId: $assignableId, actorIds: $actorIds }) {
+      assignable {
+        ... on Issue {
+          assignees(first: 20) { nodes { login } }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Find the Copilot coding agent actor for a repo, if assignable.
+ * @param {Object} github - GitHub API client (must expose .graphql)
+ * @param {string} owner
+ * @param {string} name
+ * @returns {Promise<{id:string, login:string}|null>}
+ */
+export async function findCopilotActor(github, owner, name) {
+  const result = await github.graphql(SUGGESTED_ACTORS_QUERY, { owner, name });
+  const nodes = result.repository?.suggestedActors?.nodes || [];
+  const copilot = nodes.find((node) => node.login === COPILOT_LOGIN);
+  return copilot ? { id: copilot.id, login: copilot.login } : null;
+}
+
+/**
+ * Assign the Copilot coding agent to the issue in the current context,
+ * preserving any existing assignees. Never throws on Copilot unavailability
+ * — posts an explanatory comment instead. Only throws on unexpected API
+ * errors so the workflow step can surface them.
+ * @param {Object} github - GitHub API client
+ * @param {Object} context - GitHub Actions context (issues.labeled event)
+ * @returns {Promise<{assigned:boolean, reason?:string}>}
+ */
+export async function assignCopilotToIssue(github, context) {
+  const owner = context.repo.owner;
+  const name = context.repo.repo;
+  const issueNumber = context.issue.number;
+
+  const copilot = await findCopilotActor(github, owner, name);
+
+  if (!copilot) {
+    const message =
+      '⚠️ Could not assign Copilot: the Copilot coding agent is not available ' +
+      'on this repository (not found in `suggestedActors`). Remove and ' +
+      're-add the `copilot:fix` label to retry after enabling it.';
+    await github.rest.issues.createComment({
+      owner,
+      repo: name,
+      issue_number: issueNumber,
+      body: message,
+    });
+    return { assigned: false, reason: 'copilot-unavailable' };
+  }
+
+  const issueResult = await github.graphql(ISSUE_ASSIGNEES_QUERY, {
+    owner,
+    name,
+    number: issueNumber,
+  });
+  const issue = issueResult.repository?.issue;
+  const existingAssigneeIds = (issue?.assignees?.nodes || []).map((n) => n.id);
+  const actorIds = Array.from(new Set([...existingAssigneeIds, copilot.id]));
+
+  await github.graphql(REPLACE_ASSIGNEES_MUTATION, {
+    assignableId: issue.id,
+    actorIds,
+  });
+
+  await github.rest.issues.createComment({
+    owner,
+    repo: name,
+    issue_number: issueNumber,
+    body:
+      '🤖 Assigned the Copilot coding agent to fix this broken link ' +
+      '(triggered by the `copilot:fix` label).',
+  });
+
+  return { assigned: true };
+}

--- a/.github/scripts/fetch-known-link-issues.js
+++ b/.github/scripts/fetch-known-link-issues.js
@@ -1,0 +1,58 @@
+/**
+ * Fetch Known Link Issues
+ * Loads open issues labeled area:links so the link checker can downgrade
+ * errors that are already tracked.
+ *
+ * Usage: Called from GitHub Actions via actions/github-script
+ * (see .github/workflows/pr-link-check.yml)
+ */
+
+import fs from 'fs';
+
+export const KNOWN_ISSUES_LABEL = 'area:links';
+
+/**
+ * Fetch open issues labeled area:links, excluding pull requests.
+ * @param {Object} github - GitHub API client
+ * @param {Object} context - GitHub Actions context
+ * @returns {Promise<Array<{number:number,title:string,text:string,url:string}>>}
+ */
+export async function fetchKnownLinkIssues(github, context) {
+  const issues = await github.paginate(github.rest.issues.listForRepo, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    labels: KNOWN_ISSUES_LABEL,
+    state: 'open',
+    per_page: 100,
+  });
+
+  return issues
+    .filter((issue) => !issue.pull_request)
+    .map((issue) => ({
+      number: issue.number,
+      title: issue.title || '',
+      text: `${issue.title || ''}\n${issue.body || ''}`,
+      url: issue.html_url,
+    }));
+}
+
+/**
+ * Fetch known link issues and write them to disk. Never throws — on
+ * failure, logs a warning and writes an empty list so the classify step
+ * behaves as if no issues were tracked.
+ * @param {Object} github - GitHub API client
+ * @param {Object} context - GitHub Actions context
+ * @param {string} outputPath - Path to write known-link-issues.json
+ * @returns {Promise<number>} - Number of known issues written
+ */
+export async function writeKnownLinkIssues(github, context, outputPath) {
+  let knownIssues = [];
+  try {
+    knownIssues = await fetchKnownLinkIssues(github, context);
+  } catch (error) {
+    console.warn(`Could not fetch known link issues: ${error.message}`);
+  }
+
+  fs.writeFileSync(outputPath, JSON.stringify(knownIssues, null, 2));
+  return knownIssues.length;
+}

--- a/.github/scripts/link-check-classify.js
+++ b/.github/scripts/link-check-classify.js
@@ -1,0 +1,190 @@
+/**
+ * Link Check Result Classifier
+ * Reclassifies link-checker results before they reach CI's pass/fail logic:
+ *
+ *   1. "Cannot find file" warnings become errors (missing local files are
+ *      genuinely broken links, but the checker reports them as warnings
+ *      since they carry no HTTP status code).
+ *   2. Errors whose URL matches an open `area:links` issue are downgraded
+ *      to warnings, so a tracked, already-reported broken link doesn't
+ *      block unrelated PRs.
+ *
+ * Usage: node link-check-classify.js <results.json> [known-issues.json]
+ * Rewrites <results.json> in place.
+ */
+
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const FILE_NOT_FOUND_PATTERN = /Cannot find file/;
+// Characters that may legitimately follow a matched URL inside issue text;
+// prevents 'https://a/b' from matching an occurrence of 'https://a/bc'.
+const BOUNDARY_CHARS = new Set(['/', ')', '"', "'", '>', '`', ',']);
+
+/**
+ * Strip surrounding whitespace and a single trailing slash.
+ * @param {string} url
+ * @returns {string}
+ */
+export function normalizeUrl(url) {
+  if (!url) return '';
+  return url.trim().replace(/\/+$/, '');
+}
+
+/**
+ * Check whether a normalized URL occurs in issue text at a word boundary.
+ * @param {string} url - Broken link URL (will be normalized)
+ * @param {string} issueText - Issue title + body
+ * @returns {boolean}
+ */
+export function urlMatchesIssueText(url, issueText) {
+  const needle = normalizeUrl(url);
+  if (!needle || !issueText) return false;
+
+  let fromIndex = 0;
+  while (true) {
+    const index = issueText.indexOf(needle, fromIndex);
+    if (index === -1) return false;
+
+    const nextChar = issueText[index + needle.length];
+    const isBoundary =
+      nextChar === undefined ||
+      BOUNDARY_CHARS.has(nextChar) ||
+      /\s/.test(nextChar);
+
+    if (isBoundary) return true;
+    fromIndex = index + 1;
+  }
+}
+
+/**
+ * Find the first known issue whose title/body mentions this URL.
+ * @param {string} url
+ * @param {Array<{number:number,title:string,text:string,url:string}>} knownIssues
+ * @returns {{number:number,title:string,url:string}|null}
+ */
+export function matchKnownIssue(url, knownIssues) {
+  if (!url || !Array.isArray(knownIssues)) return null;
+  const match = knownIssues.find((issue) =>
+    urlMatchesIssueText(url, issue.text)
+  );
+  if (!match) return null;
+  return { number: match.number, title: match.title, url: match.url };
+}
+
+function recomputeSummary(results) {
+  results.summary = results.summary || {};
+  results.summary.error_count = results.errors.length;
+  results.summary.warning_count = results.warnings.length;
+  results.summary.known_issue_count = results.warnings.filter(
+    (w) => w.knownIssue
+  ).length;
+}
+
+/**
+ * Move "Cannot find file" warnings into errors (port of the previous
+ * inline jq reclassification).
+ * @param {Object} results - Parsed link-check-results.json
+ * @returns {Object} - New results object (input is not mutated)
+ */
+export function reclassifyFileNotFound(results) {
+  const errors = [...(results.errors || [])];
+  const warnings = [];
+
+  for (const entry of results.warnings || []) {
+    if (FILE_NOT_FOUND_PATTERN.test(entry.error || '')) {
+      errors.push({ ...entry, severity: 'error' });
+    } else {
+      warnings.push(entry);
+    }
+  }
+
+  const next = { ...results, errors, warnings };
+  recomputeSummary(next);
+  return next;
+}
+
+/**
+ * Downgrade errors matching an open area:links issue to warnings.
+ * @param {Object} results - Parsed link-check-results.json
+ * @param {Array} knownIssues - Known issue records (see fetch-known-link-issues.js)
+ * @returns {Object} - New results object (input is not mutated)
+ */
+export function applyKnownIssueDowngrade(results, knownIssues) {
+  if (!Array.isArray(knownIssues) || knownIssues.length === 0) {
+    return { ...results, warnings: [...(results.warnings || [])] };
+  }
+
+  const errors = [];
+  const warnings = [...(results.warnings || [])];
+
+  for (const entry of results.errors || []) {
+    const knownIssue = matchKnownIssue(entry.url, knownIssues);
+    if (knownIssue) {
+      warnings.push({ ...entry, severity: 'warning', knownIssue });
+    } else {
+      errors.push(entry);
+    }
+  }
+
+  const next = { ...results, errors, warnings };
+  recomputeSummary(next);
+  return next;
+}
+
+/**
+ * Full classification pipeline: reclassify file-not-found, then downgrade
+ * known issues (so a known internal broken link is downgradable too).
+ * @param {Object} results
+ * @param {Array} knownIssues
+ * @returns {Object}
+ */
+export function classify(results, knownIssues) {
+  return applyKnownIssueDowngrade(reclassifyFileNotFound(results), knownIssues);
+}
+
+function loadJson(path, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(path, 'utf8'));
+  } catch (error) {
+    console.warn(`Could not load ${path}: ${error.message}`);
+    return fallback;
+  }
+}
+
+function main() {
+  const [resultsPath, knownIssuesPath] = process.argv.slice(2);
+
+  if (!resultsPath) {
+    console.error(
+      'Usage: node link-check-classify.js <results.json> [known-issues.json]'
+    );
+    process.exit(1);
+  }
+
+  const results = loadJson(resultsPath, null);
+  if (!results) {
+    console.error(`No results to classify at ${resultsPath}`);
+    process.exit(1);
+  }
+
+  const knownIssues = knownIssuesPath ? loadJson(knownIssuesPath, []) : [];
+  const classified = classify(results, knownIssues);
+
+  const downgraded = classified.warnings.filter((w) => w.knownIssue);
+  for (const entry of downgraded) {
+    console.log(
+      `⤵ Downgraded (known issue #${entry.knownIssue.number}): ${entry.url}`
+    );
+  }
+
+  fs.writeFileSync(resultsPath, JSON.stringify(classified, null, 2));
+  console.log(
+    `Classified: ${classified.errors.length} error(s), ${classified.warnings.length} warning(s), ` +
+      `${downgraded.length} known issue(s)`
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/.github/scripts/link-check-comment.js
+++ b/.github/scripts/link-check-comment.js
@@ -21,6 +21,11 @@ const MAX_WARNINGS_SHOWN = 20;
 const MAX_URL_LENGTH = 100;
 const MAX_ERROR_LENGTH = 80;
 
+const REPORT_TEMPLATE = 'broken-link.yml';
+const REPORT_REPO = 'influxdata/docs-v2';
+const MAX_REPORT_URL_LENGTH = 400;
+const MAX_REPORT_FIELD_LENGTH = 150;
+
 /**
  * Map a built public HTML path back to its content source path.
  * Mirrors the sed mapping used for workflow annotations: strip everything
@@ -56,8 +61,8 @@ export function escapeTableCell(text, maxLength = MAX_ERROR_LENGTH) {
  * Load and normalize link-check-results.json
  * @param {string} resultsPath - Path to the results JSON file
  * @returns {Object} - { status?, errors, warnings, totalLinks, errorCount,
- *   warningCount, successRate }; status 'error' when the file is missing or
- *   unreadable
+ *   warningCount, knownIssueCount, successRate }; status 'error' when the
+ *   file is missing or unreadable
  */
 export function loadResults(resultsPath) {
   try {
@@ -70,6 +75,7 @@ export function loadResults(resultsPath) {
       totalLinks: summary.total_checked ?? 0,
       errorCount: summary.error_count ?? 0,
       warningCount: summary.warning_count ?? 0,
+      knownIssueCount: summary.known_issue_count ?? 0,
       successRate: summary.success_rate ?? 0,
     };
   } catch (error) {
@@ -81,22 +87,87 @@ export function loadResults(resultsPath) {
       totalLinks: 0,
       errorCount: 0,
       warningCount: 0,
+      knownIssueCount: 0,
       successRate: 0,
     };
   }
 }
 
-function renderErrorTable(errors, maxShown, runUrl) {
+/**
+ * Build a prefilled new-issue URL for an unmatched broken link, using the
+ * broken-link.yml issue form. Field ids double as the query param names
+ * GitHub uses to prefill issue-form fields.
+ * @param {{url:string, error:string, file:string}} entry
+ * @param {number|string} [prNumber] - PR number the link was found on
+ * @returns {string}
+ */
+function buildReportUrl(
+  url,
+  errorStatus,
+  sourcePages,
+  context,
+  includeSourcePages
+) {
+  const fields = {
+    template: REPORT_TEMPLATE,
+    title: `Broken link: ${url}`,
+    'broken-url': url,
+    'error-status': errorStatus,
+    context,
+  };
+  if (includeSourcePages) fields['source-pages'] = sourcePages;
+
+  const params = new URLSearchParams(fields);
+  return `https://github.com/${REPORT_REPO}/issues/new?${params.toString()}`;
+}
+
+export function generateReportUrl(entry, prNumber) {
+  const sourcePages = mapPublicToContentPath(entry.file);
+  const context = prNumber
+    ? `Found by link-checker on PR #${prNumber}`
+    : 'Found by link-checker';
+
+  // The URL appears twice (title + broken-url), so shrink progressively:
+  // full fields -> drop source-pages -> shorter url/error -> minimal fields.
+  const attempts = [
+    [MAX_REPORT_FIELD_LENGTH, MAX_ERROR_LENGTH, true],
+    [MAX_REPORT_FIELD_LENGTH, MAX_ERROR_LENGTH, false],
+    [60, 40, false],
+    [30, 20, false],
+  ];
+
+  let reportUrl;
+  for (const [urlLen, errorLen, includeSourcePages] of attempts) {
+    const url = String(entry.url || 'unknown').substring(0, urlLen);
+    const errorStatus = String(entry.error || 'Unknown error').substring(
+      0,
+      errorLen
+    );
+    reportUrl = buildReportUrl(
+      url,
+      errorStatus,
+      sourcePages,
+      context,
+      includeSourcePages
+    );
+    if (reportUrl.length <= MAX_REPORT_URL_LENGTH) break;
+  }
+
+  return reportUrl;
+}
+
+function renderErrorTable(errors, maxShown, runUrl, prNumber) {
   let section = `### Broken Links\n\n`;
-  section += `| Source File | Broken URL | Error |\n`;
-  section += `|------------|------------|-------|\n`;
+  section += `| Source File | Broken URL | Error | Report |\n`;
+  section += `|------------|------------|-------|--------|\n`;
 
   const displayErrors = errors.slice(0, maxShown);
   displayErrors.forEach((entry) => {
     const contentFile = mapPublicToContentPath(entry.file);
     const url = escapeTableCell(entry.url || 'unknown', MAX_URL_LENGTH);
     const message = escapeTableCell(entry.error || 'Unknown error');
-    section += `| \`${contentFile}\` | ${url} | ${message} |\n`;
+    const reportUrl = generateReportUrl(entry, prNumber);
+    section += `| \`${contentFile}\` | ${url} | ${message} | [Report](${reportUrl}) |\n`;
   });
 
   if (errors.length > maxShown) {
@@ -105,6 +176,26 @@ function renderErrorTable(errors, maxShown, runUrl) {
   }
 
   return section + '\n';
+}
+
+function renderKnownIssuesSection(knownWarnings) {
+  let section = `### ⚠️ Known Issues (downgraded to warnings)\n\n`;
+  section += `| Source File | URL | Error | Issue |\n`;
+  section += `|------------|-----|-------|-------|\n`;
+
+  knownWarnings.forEach((entry) => {
+    const contentFile = mapPublicToContentPath(entry.file);
+    const url = escapeTableCell(entry.url || 'unknown', MAX_URL_LENGTH);
+    const message = escapeTableCell(entry.error || 'Unknown');
+    const issueUrl =
+      entry.knownIssue.url ||
+      `https://github.com/${REPORT_REPO}/issues/${entry.knownIssue.number}`;
+    section += `| \`${contentFile}\` | ${url} | ${message} | [#${entry.knownIssue.number}](${issueUrl}) |\n`;
+  });
+
+  section += `\n_These match open \`area:links\` issues, so they don't fail CI. `;
+  section += `If a link is actually fixed, close the issue._\n\n`;
+  return section;
 }
 
 function renderWarningDetails(warnings, runUrl) {
@@ -138,10 +229,12 @@ function renderWarningDetails(warnings, runUrl) {
  * @param {string|number} [options.totalLinks] - Total links checked
  * @param {string|number} [options.errorCount] - Number of broken links
  * @param {string|number} [options.warningCount] - Number of warnings
+ * @param {string|number} [options.knownIssueCount] - Warnings downgraded from errors
  * @param {string|number} [options.successRate] - Success rate percentage
  * @param {Array} [options.errors] - Error entries from results JSON
  * @param {Array} [options.warnings] - Warning entries from results JSON
  * @param {string} [options.runUrl] - URL of the workflow run
+ * @param {number|string} [options.prNumber] - PR number, used in Report links
  * @returns {string} - Markdown comment body
  */
 export function generateLinkCheckComment(options) {
@@ -151,14 +244,19 @@ export function generateLinkCheckComment(options) {
     totalLinks = 0,
     errorCount = 0,
     warningCount = 0,
+    knownIssueCount = 0,
     successRate = 0,
     errors = [],
     warnings = [],
     runUrl = 'https://github.com/influxdata/docs-v2/actions',
+    prNumber,
   } = options;
 
   const timestamp =
     new Date().toISOString().replace('T', ' ').split('.')[0] + ' UTC';
+
+  const knownWarnings = warnings.filter((w) => w.knownIssue);
+  const plainWarnings = warnings.filter((w) => !w.knownIssue);
 
   const build = (maxErrors, includeWarnings) => {
     let body = `${COMMENT_MARKER}\n## 🔗 Link Check Results — Link Check Bot\n\n`;
@@ -185,14 +283,21 @@ export function generateLinkCheckComment(options) {
       body += `| Total Links | ${totalLinks} |\n`;
       body += `| Errors | ${errorCount} |\n`;
       body += `| Warnings | ${warningCount} |\n`;
+      if (Number(knownIssueCount) > 0) {
+        body += `| Known Issues | ${knownIssueCount} |\n`;
+      }
       body += `| Success Rate | ${successRate}% |\n\n`;
 
       if (status === 'failed' && errors.length > 0) {
-        body += renderErrorTable(errors, maxErrors, runUrl);
+        body += renderErrorTable(errors, maxErrors, runUrl, prNumber);
       }
 
-      if (includeWarnings && warnings.length > 0) {
-        body += renderWarningDetails(warnings, runUrl);
+      if (knownWarnings.length > 0) {
+        body += renderKnownIssuesSection(knownWarnings);
+      }
+
+      if (includeWarnings && plainWarnings.length > 0) {
+        body += renderWarningDetails(plainWarnings, runUrl);
       }
     }
 

--- a/.github/scripts/test-assign-copilot.js
+++ b/.github/scripts/test-assign-copilot.js
@@ -1,0 +1,162 @@
+/**
+ * Test Suite for assign-copilot.js
+ * Run with: node .github/scripts/test-assign-copilot.js
+ */
+
+import {
+  COPILOT_LOGIN,
+  findCopilotActor,
+  assignCopilotToIssue,
+} from './assign-copilot.js';
+
+let totalTests = 0;
+let passedTests = 0;
+let failedTests = 0;
+
+function test(name, fn) {
+  totalTests++;
+  return Promise.resolve()
+    .then(fn)
+    .then(() => {
+      passedTests++;
+      console.log(`✓ ${name}`);
+    })
+    .catch((error) => {
+      failedTests++;
+      console.error(`✗ ${name}`);
+      console.error(`  ${error.message}`);
+    });
+}
+
+function assertEquals(actual, expected, message = '') {
+  const actualStr = JSON.stringify(actual);
+  const expectedStr = JSON.stringify(expected);
+  if (actualStr !== expectedStr) {
+    throw new Error(
+      `${message}\n  Expected: ${expectedStr}\n  Actual: ${actualStr}`
+    );
+  }
+}
+
+const context = {
+  repo: { owner: 'influxdata', repo: 'docs-v2' },
+  issue: { number: 55 },
+};
+
+async function run() {
+  console.log('\n=== Testing assign-copilot.js ===\n');
+
+  await test('findCopilotActor: finds the coding agent by login', async () => {
+    const github = {
+      graphql: async () => ({
+        repository: {
+          suggestedActors: {
+            nodes: [
+              { login: 'some-user', __typename: 'User', id: 'U_1' },
+              { login: COPILOT_LOGIN, __typename: 'Bot', id: 'BOT_1' },
+            ],
+          },
+        },
+      }),
+    };
+    const actor = await findCopilotActor(github, 'influxdata', 'docs-v2');
+    assertEquals(actor, { id: 'BOT_1', login: COPILOT_LOGIN });
+  });
+
+  await test('findCopilotActor: returns null when not suggested', async () => {
+    const github = {
+      graphql: async () => ({
+        repository: { suggestedActors: { nodes: [] } },
+      }),
+    };
+    const actor = await findCopilotActor(github, 'influxdata', 'docs-v2');
+    assertEquals(actor, null);
+  });
+
+  await test('assignCopilotToIssue: assigns and comments on success', async () => {
+    const calls = [];
+    const github = {
+      graphql: async (query, vars) => {
+        if (query.includes('suggestedActors')) {
+          return {
+            repository: {
+              suggestedActors: {
+                nodes: [
+                  { login: COPILOT_LOGIN, __typename: 'Bot', id: 'BOT_1' },
+                ],
+              },
+            },
+          };
+        }
+        if (
+          query.includes('assignees(first: 20)') &&
+          query.includes('issue(number')
+        ) {
+          return {
+            repository: {
+              issue: {
+                id: 'ISSUE_1',
+                assignees: { nodes: [{ id: 'U_EXISTING', login: 'someone' }] },
+              },
+            },
+          };
+        }
+        if (query.includes('replaceActorsForAssignable')) {
+          calls.push(vars);
+          return {
+            replaceActorsForAssignable: {
+              assignable: { assignees: { nodes: [{ login: COPILOT_LOGIN }] } },
+            },
+          };
+        }
+        throw new Error(`Unexpected query: ${query}`);
+      },
+      rest: {
+        issues: {
+          createComment: async (params) => {
+            calls.push({ comment: params.body });
+          },
+        },
+      },
+    };
+
+    const result = await assignCopilotToIssue(github, context);
+    assertEquals(result, { assigned: true });
+    assertEquals(calls[0].assignableId, 'ISSUE_1');
+    assertEquals(calls[0].actorIds.sort(), ['BOT_1', 'U_EXISTING'].sort());
+    assertEquals(
+      calls[1].comment.includes('Assigned the Copilot coding agent'),
+      true
+    );
+  });
+
+  await test('assignCopilotToIssue: graceful comment when Copilot unavailable', async () => {
+    const comments = [];
+    const github = {
+      graphql: async () => ({
+        repository: { suggestedActors: { nodes: [] } },
+      }),
+      rest: {
+        issues: {
+          createComment: async (params) => comments.push(params.body),
+        },
+      },
+    };
+
+    const result = await assignCopilotToIssue(github, context);
+    assertEquals(result, { assigned: false, reason: 'copilot-unavailable' });
+    assertEquals(comments.length, 1);
+    assertEquals(comments[0].includes('not available'), true);
+  });
+
+  console.log('\n=== Test Summary ===');
+  console.log(`Total: ${totalTests}`);
+  console.log(`Passed: ${passedTests}`);
+  console.log(`Failed: ${failedTests}`);
+
+  if (failedTests > 0) {
+    process.exit(1);
+  }
+}
+
+run();

--- a/.github/scripts/test-fetch-known-link-issues.js
+++ b/.github/scripts/test-fetch-known-link-issues.js
@@ -1,0 +1,143 @@
+/**
+ * Test Suite for fetch-known-link-issues.js
+ * Run with: node .github/scripts/test-fetch-known-link-issues.js
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  fetchKnownLinkIssues,
+  writeKnownLinkIssues,
+} from './fetch-known-link-issues.js';
+
+let totalTests = 0;
+let passedTests = 0;
+let failedTests = 0;
+
+function test(name, fn) {
+  totalTests++;
+  return Promise.resolve()
+    .then(fn)
+    .then(() => {
+      passedTests++;
+      console.log(`✓ ${name}`);
+    })
+    .catch((error) => {
+      failedTests++;
+      console.error(`✗ ${name}`);
+      console.error(`  ${error.message}`);
+    });
+}
+
+function assertEquals(actual, expected, message = '') {
+  const actualStr = JSON.stringify(actual);
+  const expectedStr = JSON.stringify(expected);
+  if (actualStr !== expectedStr) {
+    throw new Error(
+      `${message}\n  Expected: ${expectedStr}\n  Actual: ${actualStr}`
+    );
+  }
+}
+
+const context = { repo: { owner: 'influxdata', repo: 'docs-v2' } };
+
+function fakeGithub(issues) {
+  return {
+    rest: { issues: { listForRepo: () => {} } },
+    paginate: async (_fn, params) => {
+      assertEquals(
+        params.labels,
+        'area:links',
+        'Should query area:links label'
+      );
+      assertEquals(params.state, 'open', 'Should query only open issues');
+      return issues;
+    },
+  };
+}
+
+async function run() {
+  console.log('\n=== Testing fetch-known-link-issues.js ===\n');
+
+  await test('fetchKnownLinkIssues: maps issue fields', async () => {
+    const github = fakeGithub([
+      {
+        number: 42,
+        title: 'Broken link: /influxdb3/core/missing/',
+        body: 'Found on PR #1',
+        html_url: 'https://github.com/influxdata/docs-v2/issues/42',
+      },
+    ]);
+    const result = await fetchKnownLinkIssues(github, context);
+    assertEquals(result, [
+      {
+        number: 42,
+        title: 'Broken link: /influxdb3/core/missing/',
+        text: 'Broken link: /influxdb3/core/missing/\nFound on PR #1',
+        url: 'https://github.com/influxdata/docs-v2/issues/42',
+      },
+    ]);
+  });
+
+  await test('fetchKnownLinkIssues: filters out pull requests', async () => {
+    const github = fakeGithub([
+      { number: 1, title: 'A PR', body: '', html_url: 'x', pull_request: {} },
+      { number: 2, title: 'An issue', body: '', html_url: 'y' },
+    ]);
+    const result = await fetchKnownLinkIssues(github, context);
+    assertEquals(result.length, 1);
+    assertEquals(result[0].number, 2);
+  });
+
+  await test('fetchKnownLinkIssues: handles missing body', async () => {
+    const github = fakeGithub([
+      { number: 3, title: 'No body', body: null, html_url: 'z' },
+    ]);
+    const result = await fetchKnownLinkIssues(github, context);
+    assertEquals(result[0].text, 'No body\n');
+  });
+
+  await test('writeKnownLinkIssues: writes results to disk', async () => {
+    const github = fakeGithub([
+      { number: 5, title: 'Issue', body: 'body', html_url: 'u' },
+    ]);
+    const outputPath = path.join(
+      os.tmpdir(),
+      `known-issues-${Date.now()}.json`
+    );
+    const count = await writeKnownLinkIssues(github, context, outputPath);
+    assertEquals(count, 1);
+    const written = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+    assertEquals(written.length, 1);
+    fs.unlinkSync(outputPath);
+  });
+
+  await test('writeKnownLinkIssues: writes empty list on API failure', async () => {
+    const github = {
+      paginate: async () => {
+        throw new Error('API rate limited');
+      },
+    };
+    const outputPath = path.join(
+      os.tmpdir(),
+      `known-issues-fail-${Date.now()}.json`
+    );
+    const count = await writeKnownLinkIssues(github, context, outputPath);
+    assertEquals(count, 0);
+    const written = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+    assertEquals(written, []);
+    fs.unlinkSync(outputPath);
+  });
+
+  console.log('\n=== Test Summary ===');
+  console.log(`Total: ${totalTests}`);
+  console.log(`Passed: ${passedTests}`);
+  console.log(`Failed: ${failedTests}`);
+
+  if (failedTests > 0) {
+    process.exit(1);
+  }
+}
+
+run();

--- a/.github/scripts/test-link-check-classify.js
+++ b/.github/scripts/test-link-check-classify.js
@@ -1,0 +1,355 @@
+/**
+ * Test Suite for link-check-classify.js
+ * Run with: node .github/scripts/test-link-check-classify.js
+ */
+
+import {
+  normalizeUrl,
+  urlMatchesIssueText,
+  matchKnownIssue,
+  reclassifyFileNotFound,
+  applyKnownIssueDowngrade,
+  classify,
+} from './link-check-classify.js';
+
+let totalTests = 0;
+let passedTests = 0;
+let failedTests = 0;
+
+function test(name, fn) {
+  totalTests++;
+  try {
+    fn();
+    passedTests++;
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    failedTests++;
+    console.error(`✗ ${name}`);
+    console.error(`  ${error.message}`);
+  }
+}
+
+function assertEquals(actual, expected, message = '') {
+  const actualStr = JSON.stringify(actual);
+  const expectedStr = JSON.stringify(expected);
+  if (actualStr !== expectedStr) {
+    throw new Error(
+      `${message}\n  Expected: ${expectedStr}\n  Actual: ${actualStr}`
+    );
+  }
+}
+
+function assertTrue(value, message = '') {
+  if (!value) throw new Error(`${message}\n  Expected truthy value`);
+}
+
+function assertFalse(value, message = '') {
+  if (value) throw new Error(`${message}\n  Expected falsy value`);
+}
+
+console.log('\n=== Testing link-check-classify.js ===\n');
+
+// normalizeUrl
+
+test('normalizeUrl: strips trailing slash', () => {
+  assertEquals(
+    normalizeUrl('https://example.com/page/'),
+    'https://example.com/page'
+  );
+});
+
+test('normalizeUrl: strips multiple trailing slashes', () => {
+  assertEquals(
+    normalizeUrl('https://example.com/page///'),
+    'https://example.com/page'
+  );
+});
+
+test('normalizeUrl: trims whitespace', () => {
+  assertEquals(normalizeUrl('  /influxdb3/core/  '), '/influxdb3/core');
+});
+
+test('normalizeUrl: empty/null input', () => {
+  assertEquals(normalizeUrl(''), '');
+  assertEquals(normalizeUrl(null), '');
+  assertEquals(normalizeUrl(undefined), '');
+});
+
+// urlMatchesIssueText
+
+test('urlMatchesIssueText: exact match in title', () => {
+  assertTrue(
+    urlMatchesIssueText(
+      'https://example.com/missing',
+      'Broken link: https://example.com/missing'
+    )
+  );
+});
+
+test('urlMatchesIssueText: match in body text', () => {
+  assertTrue(
+    urlMatchesIssueText(
+      '/influxdb3/core/missing-page/',
+      'Title line\nSee /influxdb3/core/missing-page/ for the 404.'
+    )
+  );
+});
+
+test('urlMatchesIssueText: trailing-slash asymmetry (URL has slash, text does not)', () => {
+  assertTrue(
+    urlMatchesIssueText(
+      '/influxdb3/core/missing/',
+      'Broken URL: /influxdb3/core/missing'
+    )
+  );
+});
+
+test('urlMatchesIssueText: trailing-slash asymmetry (text has slash, URL does not)', () => {
+  assertTrue(
+    urlMatchesIssueText(
+      '/influxdb3/core/missing',
+      'Broken URL: /influxdb3/core/missing/'
+    )
+  );
+});
+
+test('urlMatchesIssueText: rejects prefix collision', () => {
+  assertFalse(
+    urlMatchesIssueText(
+      'https://example.com/b',
+      'See https://example.com/bc for details'
+    )
+  );
+});
+
+test('urlMatchesIssueText: accepts when followed by slash', () => {
+  assertTrue(
+    urlMatchesIssueText(
+      'https://example.com/b',
+      'See https://example.com/b/extra for details'
+    )
+  );
+});
+
+test('urlMatchesIssueText: accepts when followed by closing paren', () => {
+  assertTrue(
+    urlMatchesIssueText(
+      'https://example.com/b',
+      '[link](https://example.com/b)'
+    )
+  );
+});
+
+test('urlMatchesIssueText: accepts when followed by newline or end of text', () => {
+  assertTrue(
+    urlMatchesIssueText(
+      'https://example.com/b',
+      'https://example.com/b\nmore text'
+    )
+  );
+  assertTrue(
+    urlMatchesIssueText('https://example.com/b', 'https://example.com/b')
+  );
+});
+
+test('urlMatchesIssueText: markdown-wrapped URL in backticks', () => {
+  assertTrue(
+    urlMatchesIssueText('/influxdb3/core/', 'Path: `/influxdb3/core/`')
+  );
+});
+
+test('urlMatchesIssueText: no match when URL absent', () => {
+  assertFalse(
+    urlMatchesIssueText('https://example.com/x', 'Nothing relevant here')
+  );
+});
+
+test('urlMatchesIssueText: empty inputs', () => {
+  assertFalse(urlMatchesIssueText('', 'some text'));
+  assertFalse(urlMatchesIssueText('https://example.com/x', ''));
+});
+
+// matchKnownIssue
+
+const knownIssues = [
+  {
+    number: 101,
+    title: 'Broken link: /flux/v0/release-notes/#v0-104-0',
+    text: 'Broken link: /flux/v0/release-notes/#v0-104-0\nFragment not found.',
+    url: 'https://github.com/influxdata/docs-v2/issues/101',
+  },
+  {
+    number: 102,
+    title: 'Broken link: https://example.com/gone',
+    text: 'Broken link: https://example.com/gone\nSource: content/influxdb3/core/foo.md',
+    url: 'https://github.com/influxdata/docs-v2/issues/102',
+  },
+];
+
+test('matchKnownIssue: finds matching issue', () => {
+  const result = matchKnownIssue(
+    '/flux/v0/release-notes/#v0-104-0',
+    knownIssues
+  );
+  assertEquals(result, {
+    number: 101,
+    title: 'Broken link: /flux/v0/release-notes/#v0-104-0',
+    url: 'https://github.com/influxdata/docs-v2/issues/101',
+  });
+});
+
+test('matchKnownIssue: returns null when no match', () => {
+  assertEquals(
+    matchKnownIssue('https://example.com/unrelated', knownIssues),
+    null
+  );
+});
+
+test('matchKnownIssue: returns null for empty/invalid known issues', () => {
+  assertEquals(matchKnownIssue('https://example.com/gone', []), null);
+  assertEquals(matchKnownIssue('https://example.com/gone', null), null);
+  assertEquals(matchKnownIssue('', knownIssues), null);
+});
+
+// reclassifyFileNotFound
+
+test('reclassifyFileNotFound: moves file-not-found warnings to errors', () => {
+  const results = {
+    errors: [{ url: 'https://example.com/404', error: '404 Not Found' }],
+    warnings: [
+      {
+        url: '/missing/page/',
+        error: 'Cannot find file: missing/page/index.html',
+      },
+      { url: 'https://flaky.example.com/', error: 'Timeout' },
+    ],
+    summary: { error_count: 1, warning_count: 2 },
+  };
+  const result = reclassifyFileNotFound(results);
+  assertEquals(result.errors.length, 2);
+  assertEquals(result.warnings.length, 1);
+  assertEquals(result.warnings[0].url, 'https://flaky.example.com/');
+  assertEquals(
+    result.errors.find((e) => e.url === '/missing/page/').severity,
+    'error'
+  );
+  assertEquals(result.summary.error_count, 2);
+  assertEquals(result.summary.warning_count, 1);
+});
+
+test('reclassifyFileNotFound: no-op when no file-not-found warnings', () => {
+  const results = {
+    errors: [{ url: 'https://example.com/404', error: '404 Not Found' }],
+    warnings: [{ url: 'https://flaky.example.com/', error: 'Timeout' }],
+    summary: { error_count: 1, warning_count: 1 },
+  };
+  const result = reclassifyFileNotFound(results);
+  assertEquals(result.errors.length, 1);
+  assertEquals(result.warnings.length, 1);
+});
+
+test('reclassifyFileNotFound: does not mutate input', () => {
+  const results = {
+    errors: [],
+    warnings: [{ url: '/missing/', error: 'Cannot find file' }],
+    summary: {},
+  };
+  reclassifyFileNotFound(results);
+  assertEquals(
+    results.errors.length,
+    0,
+    'Original errors array should be untouched'
+  );
+});
+
+// applyKnownIssueDowngrade
+
+test('applyKnownIssueDowngrade: downgrades matching error to warning', () => {
+  const results = {
+    errors: [
+      { url: '/flux/v0/release-notes/#v0-104-0', error: 'Fragment not found' },
+      { url: 'https://example.com/unrelated', error: '404 Not Found' },
+    ],
+    warnings: [],
+    summary: { error_count: 2, warning_count: 0 },
+  };
+  const result = applyKnownIssueDowngrade(results, knownIssues);
+  assertEquals(result.errors.length, 1);
+  assertEquals(result.errors[0].url, 'https://example.com/unrelated');
+  assertEquals(result.warnings.length, 1);
+  assertEquals(result.warnings[0].severity, 'warning');
+  assertEquals(result.warnings[0].knownIssue.number, 101);
+  assertEquals(result.summary.error_count, 1);
+  assertEquals(result.summary.warning_count, 1);
+  assertEquals(result.summary.known_issue_count, 1);
+});
+
+test('applyKnownIssueDowngrade: no-op with empty known issues', () => {
+  const results = {
+    errors: [{ url: 'https://example.com/x', error: '404' }],
+    warnings: [{ url: 'https://y.com', error: 'Timeout' }],
+    summary: { error_count: 1, warning_count: 1 },
+  };
+  const result = applyKnownIssueDowngrade(results, []);
+  assertEquals(result.errors.length, 1);
+  assertEquals(result.warnings.length, 1);
+});
+
+test('applyKnownIssueDowngrade: preserves unmatched errors untouched', () => {
+  const results = {
+    errors: [{ url: 'https://example.com/unrelated', error: '404 Not Found' }],
+    warnings: [],
+    summary: { error_count: 1, warning_count: 0 },
+  };
+  const result = applyKnownIssueDowngrade(results, knownIssues);
+  assertEquals(result.errors.length, 1);
+  assertEquals(result.warnings.length, 0);
+  assertEquals(result.summary.known_issue_count, 0);
+});
+
+// classify (ordering)
+
+test('classify: file-not-found error becomes downgradable when known', () => {
+  const results = {
+    errors: [],
+    warnings: [
+      {
+        url: 'https://example.com/gone',
+        error: 'Cannot find file: public/gone/index.html',
+      },
+    ],
+    summary: { error_count: 0, warning_count: 1 },
+  };
+  const result = classify(results, knownIssues);
+  assertEquals(result.errors.length, 0);
+  assertEquals(result.warnings.length, 1);
+  assertEquals(result.warnings[0].knownIssue.number, 102);
+  assertEquals(result.warnings[0].severity, 'warning');
+  assertEquals(result.summary.known_issue_count, 1);
+});
+
+test('classify: unrelated file-not-found stays an error', () => {
+  const results = {
+    errors: [],
+    warnings: [
+      {
+        url: '/unrelated/missing/',
+        error: 'Cannot find file: missing/index.html',
+      },
+    ],
+    summary: { error_count: 0, warning_count: 1 },
+  };
+  const result = classify(results, knownIssues);
+  assertEquals(result.errors.length, 1);
+  assertEquals(result.warnings.length, 0);
+});
+
+// Print summary
+console.log('\n=== Test Summary ===');
+console.log(`Total: ${totalTests}`);
+console.log(`Passed: ${passedTests}`);
+console.log(`Failed: ${failedTests}`);
+
+if (failedTests > 0) {
+  process.exit(1);
+}

--- a/.github/scripts/test-link-check-comment.js
+++ b/.github/scripts/test-link-check-comment.js
@@ -8,6 +8,7 @@ import {
   mapPublicToContentPath,
   escapeTableCell,
   generateLinkCheckComment,
+  generateReportUrl,
 } from './link-check-comment.js';
 
 let totalTests = 0;
@@ -47,6 +48,10 @@ function assertNotIncludes(haystack, needle, message = '') {
   if (haystack.includes(needle)) {
     throw new Error(`${message}\n  Expected NOT to include: ${needle}`);
   }
+}
+
+function assertTrue(value, message = '') {
+  if (!value) throw new Error(`${message}\n  Expected truthy value`);
 }
 
 console.log('\n=== Testing link-check-comment.js ===\n');
@@ -274,6 +279,153 @@ test('table safety: pipes in URLs and errors are escaped', () => {
   });
   assertIncludes(body, 'https://example.com/a\\|b');
   assertIncludes(body, 'weird \\| message');
+});
+
+// generateReportUrl
+
+test('generateReportUrl: includes template and encoded fields', () => {
+  const url = generateReportUrl(
+    {
+      url: 'https://example.com/missing?x=1&y=2',
+      error: '404 Not Found',
+      file: '/work/public/influxdb3/core/get-started/index.html',
+    },
+    42
+  );
+  assertIncludes(url, 'template=broken-link.yml');
+  assertIncludes(url, 'title=Broken+link%3A');
+  assertIncludes(
+    url,
+    'broken-url=https%3A%2F%2Fexample.com%2Fmissing%3Fx%3D1%26y%3D2'
+  );
+  assertIncludes(url, 'error-status=404+Not+Found');
+  assertIncludes(url, 'context=Found+by+link-checker+on+PR+%2342');
+  assertIncludes(
+    url,
+    'source-pages=content%2Finfluxdb3%2Fcore%2Fget-started%2F_index.md'
+  );
+});
+
+test('generateReportUrl: omits PR fragment when prNumber is undefined', () => {
+  const url = generateReportUrl({
+    url: 'https://example.com/x',
+    error: '404',
+    file: '/work/public/x/index.html',
+  });
+  assertIncludes(url, 'context=Found+by+link-checker');
+  assertNotIncludes(url, 'PR');
+});
+
+test('generateReportUrl: stays under length cap for pathological input', () => {
+  const url = generateReportUrl(
+    {
+      url: 'https://example.com/' + 'x'.repeat(1000),
+      error: 'y'.repeat(1000),
+      file: '/work/public/' + 'z'.repeat(1000) + '/index.html',
+    },
+    999999
+  );
+  if (url.length > 500) {
+    throw new Error(`Report URL too long: ${url.length} chars`);
+  }
+});
+
+// Known Issues section
+
+const knownIssueOptions = {
+  ...failedOptions,
+  errorCount: 1,
+  errors: [
+    {
+      url: 'https://example.com/unrelated',
+      error: '404 Not Found',
+      file: '/work/public/influxdb3/core/index.html',
+    },
+  ],
+  warningCount: 2,
+  knownIssueCount: 1,
+  warnings: [
+    {
+      url: '/flux/v0/release-notes/#v0-104-0',
+      error: 'Fragment not found',
+      file: '/work/public/influxdb/v2/reference/release-notes/influxdb/index.html',
+      knownIssue: {
+        number: 101,
+        title: 'Broken link: /flux/v0/release-notes/#v0-104-0',
+        url: 'https://github.com/influxdata/docs-v2/issues/101',
+      },
+    },
+    {
+      url: 'https://flaky.example.com/',
+      error: 'Timeout',
+      file: '/work/public/influxdb3/core/get-started/index.html',
+    },
+  ],
+};
+
+test('Known Issues section: renders outside <details>, with #NNN link', () => {
+  const body = generateLinkCheckComment(knownIssueOptions);
+  assertIncludes(body, '### ⚠️ Known Issues (downgraded to warnings)');
+  assertIncludes(
+    body,
+    '[#101](https://github.com/influxdata/docs-v2/issues/101)'
+  );
+  assertIncludes(body, '| Known Issues | 1 |');
+
+  const knownIndex = body.indexOf('### ⚠️ Known Issues');
+  const detailsIndex = body.indexOf('<details>');
+  assertTrue(
+    knownIndex < detailsIndex,
+    'Known Issues section should render before the collapsed warnings details'
+  );
+});
+
+test('Known Issues section: excluded from plain warnings details', () => {
+  const body = generateLinkCheckComment(knownIssueOptions);
+  const detailsSection = body.slice(body.indexOf('<details>'));
+  assertNotIncludes(
+    detailsSection,
+    '/flux/v0/release-notes/#v0-104-0',
+    'Known-issue warning should not duplicate into the plain warnings details'
+  );
+  assertIncludes(detailsSection, 'https://flaky.example.com/');
+});
+
+test('Known Issues section: still renders when status is passed', () => {
+  const body = generateLinkCheckComment({
+    ...knownIssueOptions,
+    status: 'passed',
+    errorCount: 0,
+    errors: [],
+  });
+  assertIncludes(body, '✅ **All links are valid**');
+  assertIncludes(body, '### ⚠️ Known Issues (downgraded to warnings)');
+});
+
+test('Known Issues section: errors table has Report column', () => {
+  const body = generateLinkCheckComment(knownIssueOptions);
+  assertIncludes(body, '| Source File | Broken URL | Error | Report |');
+  assertIncludes(
+    body,
+    '[Report](https://github.com/influxdata/docs-v2/issues/new?'
+  );
+});
+
+test('oversized comment with report links: stays under GitHub limit', () => {
+  const errors = Array.from({ length: 500 }, (_, i) => ({
+    url: `https://example.com/some/long/path/segment/${i}?query=value`,
+    error: 'x'.repeat(300),
+    file: `/work/public/influxdb3/core/a-fairly-long-page-name-${i}/index.html`,
+  }));
+  const body = generateLinkCheckComment({
+    ...failedOptions,
+    errorCount: errors.length,
+    errors,
+    prNumber: 42,
+  });
+  if (body.length > 65536) {
+    throw new Error(`Body too long: ${body.length} chars`);
+  }
 });
 
 // Print summary

--- a/.github/workflows/assign-copilot-on-label.yml
+++ b/.github/workflows/assign-copilot-on-label.yml
@@ -1,0 +1,30 @@
+name: Assign Copilot on label
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  assign-copilot:
+    name: Assign Copilot coding agent
+    if: github.event.label.name == 'copilot:fix'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          sparse-checkout: .github/scripts
+
+      - name: Assign Copilot via GraphQL
+        # Requires the Copilot coding agent to be enabled on this repository.
+        # Falls back to a comment (not a failure) if Copilot isn't assignable.
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const { assignCopilotToIssue } =
+              await import('${{ github.workspace }}/.github/scripts/assign-copilot.js');
+            await assignCopilotToIssue(github, context);

--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -149,6 +149,22 @@ jobs:
           fi
           echo "✅ Using configuration: .ci/link-checker/production.lycherc.toml"
 
+      - name: Fetch known link issues
+        # Open issues labeled area:links; broken URLs matching one are
+        # downgraded to warnings so CI passes. Read-only API call, safe
+        # on fork PRs. On failure the classify step treats the list as
+        # empty and behavior is unchanged.
+        if: steps.detect.outputs.has-changes == 'true'
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const { writeKnownLinkIssues } =
+              await import('${{ github.workspace }}/.github/scripts/fetch-known-link-issues.js');
+            const count = await writeKnownLinkIssues(github, context,
+              '${{ github.workspace }}/known-link-issues.json');
+            core.info(`Loaded ${count} open area:links issue(s)`);
+
       - name: Map changed content to public files
         if: steps.detect.outputs.has-changes == 'true'
         id: mapping
@@ -203,27 +219,19 @@ jobs:
             TOTAL_COUNT=$(jq -r '.summary.total_checked // 0' link-check-results.json)
             SUCCESS_RATE=$(jq -r '.summary.success_rate // 0' link-check-results.json)
 
-            # Reclassify file-not-found warnings as errors
-            # link-checker classifies missing local files as warnings (no HTTP status code),
-            # but these represent genuinely broken internal links and should fail CI.
-            FILE_NOT_FOUND_COUNT=$(jq '[.warnings[] | select(.error | test("Cannot find file"))] | length' link-check-results.json 2>/dev/null || echo 0)
-            if [[ $FILE_NOT_FOUND_COUNT -gt 0 ]]; then
-              echo "⚠️ Found $FILE_NOT_FOUND_COUNT missing local file(s) — reclassifying as errors"
-              # Move file-not-found entries from warnings to errors
-              jq '
-                .errors += [.warnings[] | select(.error | test("Cannot find file")) | .severity = "error"]
-                | .warnings = [.warnings[] | select(.error | test("Cannot find file") | not)]
-                | .summary.error_count = (.errors | length)
-                | .summary.warning_count = (.warnings | length)
-              ' link-check-results.json > link-check-results-fixed.json
-              mv link-check-results-fixed.json link-check-results.json
+            # Reclassify file-not-found warnings as errors, and downgrade
+            # errors matching open area:links issues (known issues) back to
+            # warnings so tracked, already-reported links don't fail CI.
+            node .github/scripts/link-check-classify.js \
+              link-check-results.json known-link-issues.json
 
-              ERROR_COUNT=$(jq -r '.summary.error_count // 0' link-check-results.json)
-              WARNING_COUNT=$(jq -r '.summary.warning_count // 0' link-check-results.json)
-            fi
+            ERROR_COUNT=$(jq -r '.summary.error_count // 0' link-check-results.json)
+            WARNING_COUNT=$(jq -r '.summary.warning_count // 0' link-check-results.json)
+            KNOWN_COUNT=$(jq -r '.summary.known_issue_count // 0' link-check-results.json)
 
             echo "error-count=$ERROR_COUNT" >> $GITHUB_OUTPUT
             echo "warning-count=$WARNING_COUNT" >> $GITHUB_OUTPUT
+            echo "known-count=$KNOWN_COUNT" >> $GITHUB_OUTPUT
             echo "total-count=$TOTAL_COUNT" >> $GITHUB_OUTPUT
             echo "success-rate=$SUCCESS_RATE" >> $GITHUB_OUTPUT
 
@@ -231,15 +239,23 @@ jobs:
               echo "❌ Found $ERROR_COUNT broken links out of $TOTAL_COUNT total links"
               echo "check-result=failed" >> $GITHUB_OUTPUT
             else
-              echo "✅ All $TOTAL_COUNT links are valid ($WARNING_COUNT warnings)"
+              echo "✅ All $TOTAL_COUNT links are valid ($WARNING_COUNT warnings, $KNOWN_COUNT known issue(s))"
               echo "check-result=passed" >> $GITHUB_OUTPUT
+            fi
+
+            # Pass/fail is driven by the classified error count (post-downgrade),
+            # not the checker's raw exit code, so a known-issue downgrade can
+            # actually let CI pass.
+            if [[ $ERROR_COUNT -gt 0 ]]; then
+              exit 1
+            else
+              exit 0
             fi
           else
             echo "❌ Link check failed to generate results"
             echo "check-result=error" >> $GITHUB_OUTPUT
+            exit $EXIT_CODE
           fi
-
-          exit $EXIT_CODE
 
       - name: Process and report results
         if: always() && steps.detect.outputs.has-changes == 'true' && steps.mapping.outputs.public-files != ''
@@ -248,6 +264,7 @@ jobs:
           TOTAL_COUNT: ${{ steps.link-check.outputs.total-count }}
           ERROR_COUNT: ${{ steps.link-check.outputs.error-count }}
           WARNING_COUNT: ${{ steps.link-check.outputs.warning-count }}
+          KNOWN_COUNT: ${{ steps.link-check.outputs.known-count }}
           SUCCESS_RATE: ${{ steps.link-check.outputs.success-rate }}
           CHECK_RESULT: ${{ steps.link-check.outputs.check-result }}
         run: |
@@ -261,6 +278,9 @@ jobs:
             echo "| Total Links | ${TOTAL_COUNT} |" >> $GITHUB_STEP_SUMMARY
             echo "| Errors | ${ERROR_COUNT} |" >> $GITHUB_STEP_SUMMARY
             echo "| Warnings | ${WARNING_COUNT} |" >> $GITHUB_STEP_SUMMARY
+            if [[ "${KNOWN_COUNT}" -gt 0 ]]; then
+              echo "| Known Issues | ${KNOWN_COUNT} |" >> $GITHUB_STEP_SUMMARY
+            fi
             echo "| Success Rate | ${SUCCESS_RATE}% |" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
 
@@ -301,8 +321,34 @@ jobs:
               echo "✅ **All links are valid**" >> $GITHUB_STEP_SUMMARY
             fi
 
+            # Report known issues (downgraded from errors; don't fail CI)
+            KNOWN_ARRAY_LEN=$(jq '[.warnings[]? | select(.knownIssue)] | length' link-check-results.json 2>/dev/null || echo 0)
+            if [[ "$KNOWN_ARRAY_LEN" -gt 0 ]]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "### Known Issues (downgraded — do not fail CI)" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "| Source File | URL | Error | Known Issue |" >> $GITHUB_STEP_SUMMARY
+              echo "|------------|-----|-------|-------------|" >> $GITHUB_STEP_SUMMARY
+
+              jq -c '.warnings[]? | select(.knownIssue)' link-check-results.json 2>/dev/null | while read -r entry; do
+                URL=$(echo "$entry" | jq -r '.url // "unknown"')
+                ERROR=$(echo "$entry" | jq -r '.error // "Unknown"')
+                FILE=$(echo "$entry" | jq -r '.file // "unknown"')
+                ISSUE_NUM=$(echo "$entry" | jq -r '.knownIssue.number')
+                CONTENT_FILE=$(echo "$FILE" | sed 's|.*/public/|content/|' | sed 's|/index\.html$|/_index.md|')
+                SAFE_URL=$(echo "$URL" | sed 's/|/\\|/g')
+                SAFE_ERROR=$(echo "$ERROR" | sed 's/|/\\|/g' | cut -c1-80)
+
+                echo "::notice file=${CONTENT_FILE}::Known broken link (issue #${ISSUE_NUM}): ${URL}"
+                echo "| \`${CONTENT_FILE}\` | ${SAFE_URL} | ${SAFE_ERROR} | [#${ISSUE_NUM}](https://github.com/${{ github.repository }}/issues/${ISSUE_NUM}) |" >> $GITHUB_STEP_SUMMARY
+              done
+
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "_These broken links match open \`area:links\` issues and were downgraded to warnings so CI passes. Fix them via the linked issues._" >> $GITHUB_STEP_SUMMARY
+            fi
+
             # Report warnings (don't fail CI, but useful context)
-            WARNING_ARRAY_LEN=$(jq '.warnings | length' link-check-results.json 2>/dev/null || echo 0)
+            WARNING_ARRAY_LEN=$(jq '[.warnings[]? | select(.knownIssue | not)] | length' link-check-results.json 2>/dev/null || echo 0)
             if [[ "$WARNING_ARRAY_LEN" -gt 0 ]]; then
               echo "" >> $GITHUB_STEP_SUMMARY
               echo "<details>" >> $GITHUB_STEP_SUMMARY
@@ -311,7 +357,7 @@ jobs:
               echo "| Source File | URL | Issue |" >> $GITHUB_STEP_SUMMARY
               echo "|------------|-----|-------|" >> $GITHUB_STEP_SUMMARY
 
-              jq -c '.warnings[]?' link-check-results.json 2>/dev/null | head -20 | while read -r entry; do
+              jq -c '.warnings[]? | select(.knownIssue | not)' link-check-results.json 2>/dev/null | head -20 | while read -r entry; do
                 URL=$(echo "$entry" | jq -r '.url // "unknown"')
                 ERROR=$(echo "$entry" | jq -r '.error // "Unknown"')
                 FILE=$(echo "$entry" | jq -r '.file // "unknown"')
@@ -379,6 +425,7 @@ jobs:
               warningCount: process.env.WARNING_COUNT || results.warningCount,
               successRate: process.env.SUCCESS_RATE || results.successRate,
               runUrl: process.env.RUN_URL,
+              prNumber: context.issue.number,
             });
 
       - name: Refresh stale comment when nothing was checked

--- a/data/labels.yml
+++ b/data/labels.yml
@@ -42,6 +42,9 @@ workflow:
     skip-review:
       color: "#1E90FF"
       description: PR skips the automated doc review pipeline
+    copilot:fix:
+      color: "#8250DF"
+      description: Assign the Copilot coding agent to fix this issue
 
 area:
   color: "#a89129"


### PR DESCRIPTION
## Summary

Follow-up to #6393 and the sticky-comment reporting shipped in #7450. This PR closes the feedback loop so broken links aren't just reported — they connect to tracked work and don't repeatedly block unrelated PRs:

- **Known-issue matching + CI downgrade**: broken URLs matching an open `area:links` issue are downgraded from errors to warnings, so CI passes once a link is tracked. Rendered as a "Known Issues" section (with `#NNN` links) in both the step summary and the PR comment.
- **Broken-link issue form + prefilled Report links**: new `.github/ISSUE_TEMPLATE/broken-link.yml`. Untracked broken links in the PR comment get a one-click, prefilled "Report" link (URL, source page, error, and PR context pre-filled). No auto-created issues — a human decides.
- **Label-gated Copilot assignment**: applying the `copilot:fix` label to any issue assigns the GitHub Copilot coding agent via GraphQL (`suggestedActors` + `replaceActorsForAssignable`), with a graceful fallback comment if Copilot isn't enabled on the repo.

### Key files

- `.github/scripts/fetch-known-link-issues.js` / `link-check-classify.js` — fetch open `area:links` issues and reclassify/downgrade matching errors (replaces the previous inline jq reclassification; CI pass/fail now follows the classified count instead of the checker's raw exit code)
- `.github/scripts/link-check-comment.js` — Known Issues section, Report column, `generateReportUrl`
- `.github/ISSUE_TEMPLATE/broken-link.yml` — new issue form
- `.github/scripts/assign-copilot.js` + `.github/workflows/assign-copilot-on-label.yml` — Copilot assignment on `copilot:fix`
- `data/labels.yml`, `.github/LABEL_GUIDE.md` — new `copilot:fix` label definition (label itself has been created on GitHub already)

## Checklist

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
- [x] Rebased/mergeable
- [ ] Local build passes (`npx hugo --quiet`) — no content changes in this PR, only `.github/` automation
- [x] All new scripts covered by plain-node test suites (62 tests total, run via `node .github/scripts/test-*.js`)

## Test plan

- [x] `node .github/scripts/test-link-check-classify.js` (26 tests)
- [x] `node .github/scripts/test-link-check-comment.js` (27 tests)
- [x] `node .github/scripts/test-fetch-known-link-issues.js` (5 tests)
- [x] `node .github/scripts/test-assign-copilot.js` (4 tests)
- [x] YAML validated for all new/changed workflow, issue-template, and label files
- [ ] End-to-end verification on a real PR touching `content/influxdb/v2/reference/release-notes/influxdb.md` (has real pre-existing broken links, confirmed via #7450's own CI run): confirm Report links work, filing an issue downgrades the link to "known issue" on the next run, and `copilot:fix` triggers assignment

***

<details>
<summary><b>Suggested reviewers</b> (click to expand)</summary>

This PR only touches `.github/` CI automation and `data/labels.yml` — no product content changes.

</details>
