### PR TITLE
docs(release-notes): add v3.10.3 and v3.9.8 release notes

### DIFF
--- a/content/shared/influxdb3-cli/config-options.md
+++ b/content/shared/influxdb3-cli/config-options.md
@@ -1561,6 +1561,7 @@ The default is dynamically determined.
 - [compaction-multipliers](#compaction-multipliers)
 - [compaction-cleanup-wait](#compaction-cleanup-wait)
 - [compaction-check-interval](#compaction-check-interval)
+- [compacted-data-load-concurrency-limit](#compacted-data-load-concurrency-limit)
   {{% /show-in %}}
 - [gen1-duration](#gen1-duration)
 
@@ -1646,6 +1647,31 @@ Specifies how often the compactor checks for new compaction work to perform.
 | influxdb3 serve option        | Environment variable                             |
 | :---------------------------- | :----------------------------------------------- |
 | `--compaction-check-interval` | `INFLUXDB3_ENTERPRISE_COMPACTION_CHECK_INTERVAL` |
+
+***
+
+#### compacted-data-load-concurrency-limit
+
+Specifies the maximum number of concurrent object store fetches while a node
+loads compacted data (compaction detail and generation detail files), both at
+startup and when a consumer picks up new compaction summaries.
+
+The default bounds the transient memory used by in-flight downloads and is
+sized so the load saturates neither a 10 GbE network interface nor the shared
+object store connection pool (see
+[object-store-connection-limit](#object-store-connection-limit)).
+Increase the limit for faster startup when the compaction index is large and
+the host has network headroom; decrease it if the object store throttles the
+load or memory is tight during startup.
+
+This option isn't supported in the TOML configuration file; use the command
+option or environment variable.
+
+**Default:** `20`
+
+| influxdb3 serve option                    | Environment variable                                         |
+| :---------------------------------------- | :----------------------------------------------------------- |
+| `--compacted-data-load-concurrency-limit` | `INFLUXDB3_ENTERPRISE_COMPACTED_DATA_LOAD_CONCURRENCY_LIMIT` |
 
 ***
 

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -19,6 +19,51 @@
 > All updates to Core are automatically included in Enterprise.
 > The Enterprise sections below only list updates exclusive to Enterprise.
 
+## v3.10.3 {date="2026-07-07"}
+
+### Core
+
+#### Bug fixes
+
+- **Duplicate tag key rejection**: Writes that repeat a tag key (for example, `m,t=a,t=a f=1i`) are now rejected with a clear error, the same way duplicate field keys are rejected. Previously, a point with a repeated tag key was accepted into the WAL and later caused a panic during snapshotting that crash-looped the node on WAL replay.
+- **Processing engine trigger cancellation**: Disabling or deleting a trigger now cancels its in-flight plugin run in Core, extending the Enterprise fix from v3.10.2. Previously, a synchronous scheduled trigger whose plugin run was still executing could block trigger `disable` and `delete --force` operations until the run finished.
+
+### Enterprise
+
+All Core updates are included in Enterprise.
+Additional Enterprise-specific updates:
+
+#### Features
+
+- **Compacted data load concurrency limit**: The new `--compacted-data-load-concurrency-limit` option (`INFLUXDB3_ENTERPRISE_COMPACTED_DATA_LOAD_CONCURRENCY_LIMIT` environment variable, default `20`) bounds concurrent object store reads when a node loads compacted data at startup. Previously, nodes with large compaction indexes issued unbounded concurrent reads at startup, which could saturate the network, cause object store timeouts, and starve other subsystems of object store connections.
+
+#### Bug fixes
+
+- **Corrupt peer WAL and snapshot handling**: A durably corrupt WAL or snapshot file from a peer node is now logged, counted, and skipped so replication continues with later files. Previously, a corrupt peer WAL file stalled replication from that node—or prevented server startup—and a corrupt snapshot manifest silently halted snapshot replication from that peer. Transient errors, such as network failures, still retry as before.
+- Other bug fixes and performance improvements
+
+## v3.9.8 {date="2026-07-07"}
+
+### Core
+
+#### Bug fixes
+
+- **Duplicate tag key rejection**: Writes that repeat a tag key (for example, `m,t=a,t=a f=1i`) are now rejected with a clear error, the same way duplicate field keys are rejected. Previously, a point with a repeated tag key was accepted into the WAL and later caused a panic during snapshotting that crash-looped the node on WAL replay.
+- **Processing engine trigger cancellation**: Disabling or deleting a trigger now cancels its in-flight plugin run in Core, extending the Enterprise fix from v3.9.7. Previously, a synchronous scheduled trigger (the default, created without `--run-asynchronous`) whose plugin run was still executing could block trigger `disable`, `delete --force`, and database deletion until the run finished.
+
+### Enterprise
+
+All Core updates are included in Enterprise.
+Additional Enterprise-specific updates:
+
+#### Features
+
+- **Compacted data load concurrency limit**: The new `--compacted-data-load-concurrency-limit` option (`INFLUXDB3_ENTERPRISE_COMPACTED_DATA_LOAD_CONCURRENCY_LIMIT` environment variable, default `20`) bounds concurrent object store reads when a node loads compacted data at startup. Previously, nodes with large compaction indexes issued unbounded concurrent reads at startup, which could saturate the network, cause object store timeouts, and starve other subsystems of object store connections.
+
+#### Bug fixes
+
+- Other bug fixes and performance improvements
+
 ## v3.10.2 {date="2026-06-30"}
 
 ### Core


### PR DESCRIPTION
Both releases ship the duplicate tag key write rejection (Core) and the Core port of the processing engine trigger cancellation fix that shipped for Enterprise in 3.10.2/3.9.7. Enterprise adds the bounded compacted-data load concurrency flag (EAR #6976) on both lines; the corrupt peer WAL/snapshot skip fix (EAR #6916) landed on 3.10 only.