### PR TITLE
docs(influxdb3-cli): add debug, import command pages; fix serve and c…

### DIFF
--- a/content/influxdb3/core/reference/cli/influxdb3/_index.md
+++ b/content/influxdb3/core/reference/cli/influxdb3/_index.md
@@ -25,6 +25,7 @@ influxdb3 [GLOBAL-OPTIONS] [COMMAND]
 | Command                                                     | Description                         |
 | :---------------------------------------------------------- | :---------------------------------- |
 | [create](/influxdb3/core/reference/cli/influxdb3/create/)   | Create resources                    |
+| [debug](/influxdb3/core/reference/cli/influxdb3/debug/)     | Diagnostic tools                    |
 | [delete](/influxdb3/core/reference/cli/influxdb3/delete/)   | Delete resources                    |
 | [disable](/influxdb3/core/reference/cli/influxdb3/disable/) | Disable resources                   |
 | [enable](/influxdb3/core/reference/cli/influxdb3/enable/)   | Enable resources                    |

--- a/content/influxdb3/core/reference/cli/influxdb3/debug/_index.md
+++ b/content/influxdb3/core/reference/cli/influxdb3/debug/_index.md
@@ -1,0 +1,17 @@
+---
+title: influxdb3 debug
+description: >
+  The `influxdb3 debug` command includes diagnostic tools for troubleshooting
+  your InfluxDB 3 Core deployment.
+menu:
+  influxdb3_core:
+    parent: influxdb3
+    name: influxdb3 debug
+weight: 300
+source: /shared/influxdb3-cli/debug/_index.md
+---
+
+<!--
+The content of this file is at
+// SOURCE content/shared/influxdb3-cli/debug/_index.md
+-->

--- a/content/influxdb3/core/reference/cli/influxdb3/debug/object-store-check.md
+++ b/content/influxdb3/core/reference/cli/influxdb3/debug/object-store-check.md
@@ -1,0 +1,17 @@
+---
+title: influxdb3 debug object-store-check
+description: >
+  The `influxdb3 debug object-store-check` command validates that an object store
+  correctly implements the semantic operations that InfluxDB 3 Core relies on.
+menu:
+  influxdb3_core:
+    parent: influxdb3 debug
+    name: object-store-check
+weight: 301
+source: /shared/influxdb3-cli/debug/object-store-check.md
+---
+
+<!--
+The content of this file is at
+// SOURCE content/shared/influxdb3-cli/debug/object-store-check.md
+-->

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/_index.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/_index.md
@@ -25,9 +25,12 @@ influxdb3 [GLOBAL-OPTIONS] [COMMAND]
 | Command                                                           | Description                         |
 | :---------------------------------------------------------------- | :---------------------------------- |
 | [create](/influxdb3/enterprise/reference/cli/influxdb3/create/)   | Create resources                    |
+| [debug](/influxdb3/enterprise/reference/cli/influxdb3/debug/)     | Diagnostic tools                    |
 | [delete](/influxdb3/enterprise/reference/cli/influxdb3/delete/)   | Delete resources                    |
 | [disable](/influxdb3/enterprise/reference/cli/influxdb3/disable/) | Disable resources                   |
 | [enable](/influxdb3/enterprise/reference/cli/influxdb3/enable/)   | Enable resources                    |
+| [import](/influxdb3/enterprise/reference/cli/influxdb3/import/)   | Manage bulk Parquet imports         |
+| [install](/influxdb3/enterprise/reference/cli/influxdb3/install/) | Install plugins                     |
 | [query](/influxdb3/enterprise/reference/cli/influxdb3/query/)     | Query {{% product-name %}}          |
 | [serve](/influxdb3/enterprise/reference/cli/influxdb3/serve/)     | Run the {{% product-name %}} server |
 | [show](/influxdb3/enterprise/reference/cli/influxdb3/show/)       | List resources                      |

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/debug/_index.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/debug/_index.md
@@ -1,0 +1,17 @@
+---
+title: influxdb3 debug
+description: >
+  The `influxdb3 debug` command includes diagnostic tools for troubleshooting
+  your InfluxDB 3 Enterprise deployment.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3
+    name: influxdb3 debug
+weight: 300
+source: /shared/influxdb3-cli/debug/_index.md
+---
+
+<!--
+The content of this file is at
+// SOURCE content/shared/influxdb3-cli/debug/_index.md
+-->

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/debug/object-store-check.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/debug/object-store-check.md
@@ -1,0 +1,17 @@
+---
+title: influxdb3 debug object-store-check
+description: >
+  The `influxdb3 debug object-store-check` command validates that an object store
+  correctly implements the semantic operations that InfluxDB 3 Enterprise relies on.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 debug
+    name: object-store-check
+weight: 301
+source: /shared/influxdb3-cli/debug/object-store-check.md
+---
+
+<!--
+The content of this file is at
+// SOURCE content/shared/influxdb3-cli/debug/object-store-check.md
+-->

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/import/_index.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/import/_index.md
@@ -1,0 +1,44 @@
+---
+title: influxdb3 import
+description: >
+  The `influxdb3 import` command manages bulk imports of Parquet data into
+  InfluxDB 3 Enterprise databases and tables.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3
+    name: influxdb3 import
+weight: 300
+related:
+  - /influxdb3/enterprise/admin/import-data/
+---
+
+The `influxdb3 import` command manages bulk imports of Parquet data into
+{{< product-name >}} databases and tables.
+
+> [!Note]
+> Bulk import requires the [storage engine upgrade](/influxdb3/enterprise/reference/config-options/)
+> (`--use-pacha-tree`).
+> The target database and table must exist before importing.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 import <SUBCOMMAND>
+```
+
+## Subcommands
+
+| Subcommand | Description |
+| :--------- | :---------- |
+| [upload](/influxdb3/enterprise/reference/cli/influxdb3/import/upload/) | Upload Parquet files into a database and table |
+| [list](/influxdb3/enterprise/reference/cli/influxdb3/import/list/) | List import jobs |
+| help | Print command help or the help of a subcommand |
+
+## Options
+
+| Option |              | Description                     |
+| :----- | :----------- | :------------------------------ |
+| `-h`   | `--help`     | Print help information          |
+|        | `--help-all` | Print detailed help information |

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/import/_index.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/import/_index.md
@@ -15,7 +15,7 @@ related:
 The `influxdb3 import` command manages bulk imports of Parquet data into
 {{< product-name >}} databases and tables.
 
-> [!Note]
+> [!Important]
 > Bulk import requires the [storage engine upgrade](/influxdb3/enterprise/reference/config-options/)
 > (`--use-pacha-tree`).
 > The target database and table must exist before importing.

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/import/list.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/import/list.md
@@ -1,0 +1,54 @@
+---
+title: influxdb3 import list
+description: >
+  The `influxdb3 import list` command lists bulk import jobs in an
+  InfluxDB 3 Enterprise database.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 import
+    name: list
+weight: 302
+related:
+  - /influxdb3/enterprise/admin/import-data/
+---
+
+The `influxdb3 import list` command lists bulk import jobs for a
+{{< product-name >}} database.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 import list [OPTIONS]
+```
+
+## Options
+
+| Option |                         | Description                                                          | Default                 | Environment variable      |
+| :----- | :---------------------- | :------------------------------------------------------------------- | :---------------------- | :------------------------ |
+|        | `--host <HOST_URL>`     | Host URL of the InfluxDB 3 Enterprise server                         | `http://127.0.0.1:8181` | `INFLUXDB3_HOST_URL`      |
+|        | `--token <AUTH_TOKEN>`  | Authentication token                                                 |                         | `INFLUXDB3_AUTH_TOKEN`    |
+|        | `--database <DATABASE>` | Database name to list jobs for                                       |                         | `INFLUXDB3_DATABASE_NAME` |
+|        | `--tls-ca <CA_CERT>`    | Path to a custom TLS certificate authority                           |                         | `INFLUXDB3_TLS_CA`        |
+|        | `--tls-no-verify`       | Disable TLS certificate verification (not recommended in production) |                         | `INFLUXDB3_TLS_NO_VERIFY` |
+| `-h`   | `--help`                | Print help information                                               |                         |                           |
+|        | `--help-all`            | Print detailed help information                                      |                         |                           |
+
+## Examples
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
+  the name of the database to list import jobs for
+- {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}}:
+  your authentication token
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="DATABASE_NAME|AUTH_TOKEN" }
+influxdb3 import list \
+  --host http://localhost:8181 \
+  --token AUTH_TOKEN \
+  --database DATABASE_NAME
+```

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/import/upload.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/import/upload.md
@@ -1,0 +1,116 @@
+---
+title: influxdb3 import upload
+description: >
+  The `influxdb3 import upload` command uploads one or more Parquet files into
+  an InfluxDB 3 Enterprise database and table.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 import
+    name: upload
+weight: 301
+related:
+  - /influxdb3/enterprise/admin/import-data/
+---
+
+The `influxdb3 import upload` command uploads one or more Parquet files into
+an existing {{< product-name >}} database and table.
+Each file becomes a separate import job.
+Imported data is written to your object storage and becomes queryable after
+the compactor processes it.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 import upload [OPTIONS] [PATH]
+```
+
+## Arguments
+
+| Argument | Description |
+| :------- | :---------- |
+| `[PATH]` | Path to a Parquet file or a directory. If a directory, all `*.parquet` files are processed recursively and one import job is created per file. |
+
+## Options
+
+| Option |                                   | Description                                                                                                                                                                                  | Default                   | Environment variable        |
+| :----- | :-------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------ | :-------------------------- |
+|        | `--host <HOST_URL>`               | Host URL of the InfluxDB 3 Enterprise server                                                                                                                                                 | `http://127.0.0.1:8181`   | `INFLUXDB3_HOST_URL`        |
+|        | `--token <AUTH_TOKEN>`            | Authentication token                                                                                                                                                                         |                           | `INFLUXDB3_AUTH_TOKEN`      |
+|        | `--database <DATABASE>`           | Target database name                                                                                                                                                                         |                           | `INFLUXDB3_DATABASE_NAME`   |
+|        | `--table <TABLE>`                 | Target table name                                                                                                                                                                            |                           |                             |
+|        | `--column <COLUMN>`               | Map a Parquet column to an InfluxDB type: `<column>:<type>`. Supported types: `i64`, `u64`, `f64`, `bool`, `string`, `time`, `tag`. Can be specified multiple times. Unmapped columns default to field values. | |                             |
+|        | `--tls-ca <CA_CERT>`              | Path to a custom TLS certificate authority                                                                                                                                                   |                           | `INFLUXDB3_TLS_CA`          |
+|        | `--tls-no-verify`                 | Disable TLS certificate verification (not recommended in production)                                                                                                                         |                           | `INFLUXDB3_TLS_NO_VERIFY`   |
+| `-h`   | `--help`                          | Print help information                                                                                                                                                                       |                           |                             |
+|        | `--help-all`                      | Print detailed help information                                                                                                                                                              |                           |                             |
+
+## Column type mapping
+
+The `--column` option maps Parquet columns to InfluxDB data types.
+Specify the option multiple times to map multiple columns.
+Unmapped columns default to field values.
+
+| Type     | Description                  |
+| :------- | :--------------------------- |
+| `i64`    | Signed 64-bit integer field  |
+| `u64`    | Unsigned 64-bit integer field |
+| `f64`    | 64-bit float field           |
+| `bool`   | Boolean field                |
+| `string` | String field                 |
+| `time`   | Timestamp column             |
+| `tag`    | Tag column                   |
+
+## Examples
+
+In the examples below, replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
+  the name of the target database
+- {{% code-placeholder-key %}}`TABLE_NAME`{{% /code-placeholder-key %}}:
+  the name of the target table
+- {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}}:
+  your authentication token
+
+### Upload a single Parquet file
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="DATABASE_NAME|TABLE_NAME|AUTH_TOKEN" }
+influxdb3 import upload \
+  --host http://localhost:8181 \
+  --token AUTH_TOKEN \
+  --database DATABASE_NAME \
+  --table TABLE_NAME \
+  /path/to/data.parquet
+```
+
+### Upload all Parquet files in a directory
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="DATABASE_NAME|TABLE_NAME|AUTH_TOKEN" }
+influxdb3 import upload \
+  --host http://localhost:8181 \
+  --token AUTH_TOKEN \
+  --database DATABASE_NAME \
+  --table TABLE_NAME \
+  /path/to/parquet-directory/
+```
+
+### Upload with column type mapping
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="DATABASE_NAME|TABLE_NAME|AUTH_TOKEN" }
+influxdb3 import upload \
+  --host http://localhost:8181 \
+  --token AUTH_TOKEN \
+  --database DATABASE_NAME \
+  --table TABLE_NAME \
+  --column timestamp:time \
+  --column host:tag \
+  --column cpu_usage:f64 \
+  /path/to/metrics.parquet
+```

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/serve.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/serve.md
@@ -75,6 +75,7 @@ influxdb3 serve [OPTIONS]
 |                  | `--compaction-gen2-duration`                         | _See [configuration options](/influxdb3/enterprise/reference/config-options/#compaction-gen2-duration)_                         |
 |                  | `--compaction-max-num-files-per-plan`                | _See [configuration options](/influxdb3/enterprise/reference/config-options/#compaction-max-num-files-per-plan)_                |
 |                  | `--compaction-multipliers`                           | _See [configuration options](/influxdb3/enterprise/reference/config-options/#compaction-multipliers)_                           |
+|                  | `--compaction-row-limit`                             | _See [configuration options](/influxdb3/enterprise/reference/config-options/#compaction-row-limit)_                             |
 |                  | `--conn-info` | _See [configuration options](/influxdb3/enterprise/reference/config-options/#conn-info)_ |
 |                  | `--data-dir`                                         | _See [configuration options](/influxdb3/enterprise/reference/config-options/#data-dir)_                                         |
 |                  | `--datafusion-config`                                | _See [configuration options](/influxdb3/enterprise/reference/config-options/#datafusion-config)_                                |

--- a/content/shared/influxdb3-admin/object-storage/minio.md
+++ b/content/shared/influxdb3-admin/object-storage/minio.md
@@ -86,8 +86,9 @@ reads on node startup, and unexpected node-state warnings.
 
 ### Verify your object store
 
-{{% product-name %}} 3.10.0 and later includes a debug subcommand that
-validates an object store against the preceding semantic requirements.
+{{% product-name %}} 3.10.0 and later includes the
+[`influxdb3 debug object-store-check`](/influxdb3/version/reference/cli/influxdb3/debug/object-store-check/)
+command that validates an object store against the preceding semantic requirements.
 Run it against your MinIO endpoint before putting the deployment into
 production, and again after any change to the MinIO topology or backing
 storage:
@@ -108,7 +109,8 @@ any semantic violation it finds.
 If the synthetic checks pass but a real catalog is still failing to load,
 pass `--probe-prefix <your-catalog-prefix>` to replay the loader's object
 store operations against your real catalog in read-only mode.
-Run `influxdb3 debug object-store-check --help` for the full flag reference.
+See [`influxdb3 debug object-store-check`](/influxdb3/version/reference/cli/influxdb3/debug/object-store-check/)
+for the full flag reference.
 
 ## Set up MinIO
 

--- a/content/shared/influxdb3-cli/config-options.md
+++ b/content/shared/influxdb3-cli/config-options.md
@@ -1554,8 +1554,7 @@ The default is dynamically determined.
 
 {{% show-in "enterprise" %}}
 
-<!--- [compaction-row-limit](#compaction-row-limit) - NOT YET RELEASED in v3.5.0 -->
-
+- [compaction-row-limit](#compaction-row-limit)
 - [compaction-max-num-files-per-plan](#compaction-max-num-files-per-plan)
 - [compaction-gen2-duration](#compaction-gen2-duration)
 - [compaction-multipliers](#compaction-multipliers)
@@ -1566,13 +1565,11 @@ The default is dynamically determined.
 
 {{% show-in "enterprise" %}}
 
-<!---
 #### compaction-row-limit
 
-NOTE: This option is not yet released in v3.5.0. Uncomment when available in a future release.
-
 Specifies the soft limit for the number of rows per file that the compactor
-writes. The compactor may write more rows than this limit.
+writes.
+The compactor may write more rows than this limit.
 
 **Default:** `1000000`
 
@@ -1580,8 +1577,7 @@ writes. The compactor may write more rows than this limit.
 | :----------------------- | :------------------------------------------ |
 | `--compaction-row-limit` | `INFLUXDB3_ENTERPRISE_COMPACTION_ROW_LIMIT` |
 
----
--->
+***
 
 #### compaction-max-num-files-per-plan
 

--- a/content/shared/influxdb3-cli/debug/_index.md
+++ b/content/shared/influxdb3-cli/debug/_index.md
@@ -1,20 +1,20 @@
-The `influxdb3 install` command and its subcommands manage Python package
-installations for the {{< product-name >}} processing engine.
+The `influxdb3 debug` command includes diagnostic tools for troubleshooting
+your {{< product-name >}} deployment.
 
 ## Usage
 
 <!--pytest.mark.skip-->
 
 ```bash
-influxdb3 install <SUBCOMMAND>
+influxdb3 debug <SUBCOMMAND>
 ```
 
 ## Subcommands
 
 | Subcommand | Description |
 | :--------- | :---------- |
-| [`package`](/influxdb3/version/reference/cli/influxdb3/install/package/) | Install Python packages for processing engine plugins |
-| `help` | Print command help or the help of a subcommand |
+| [object-store-check](/influxdb3/version/reference/cli/influxdb3/debug/object-store-check/) | Validate object store compatibility |
+| help | Print command help or the help of a subcommand |
 
 ## Options
 

--- a/content/shared/influxdb3-cli/debug/object-store-check.md
+++ b/content/shared/influxdb3-cli/debug/object-store-check.md
@@ -1,0 +1,72 @@
+The `influxdb3 debug object-store-check` command validates that an object store
+correctly implements the semantic operations that {{< product-name >}} relies on.
+It writes synthetic test objects to `<CHECK_PREFIX>/oscheck-<uuid>/` and reports
+any compatibility violations.
+This command connects directly to the object store and does not require a running
+{{< product-name >}} server.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 debug object-store-check [OPTIONS]
+```
+
+## Options
+
+| Option |                                         | Description                                                                                                                                         | Required |
+| :----- | :-------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
+|        | `--object-store <OBJECT_STORE>`         | Object store type. Valid values: `s3`, `google`, `azure`, `file`, `memory`                                                                          | Yes      |
+|        | `--bucket <BUCKET>`                     | Object store bucket name. Required for `s3`, `google`, and `azure` object store types.                                                              | Varies   |
+|        | `--aws-endpoint <AWS_ENDPOINT>`         | Custom AWS or S3-compatible endpoint URL                                                                                                            | No       |
+|        | `--aws-access-key-id <AWS_ACCESS_KEY_ID>` | AWS access key ID                                                                                                                                 | No       |
+|        | `--aws-secret-access-key <AWS_SECRET_ACCESS_KEY>` | AWS secret access key                                                                                                                   | No       |
+|        | `--aws-allow-http`                      | Allow non-HTTPS connections to the object store                                                                                                     | No       |
+|        | `--aws-default-region <AWS_DEFAULT_REGION>` | AWS region                                                                                                                                      | No       |
+|        | `--check-prefix <CHECK_PREFIX>`         | Prefix for synthetic test objects. The command writes to `<CHECK_PREFIX>/oscheck-<uuid>/`.                                                          | No       |
+|        | `--probe-prefix <PROBE_PREFIX>`         | Read-only prefix to replay catalog loader operations against. Use this option to diagnose failures with an existing catalog without writing new data. | No       |
+| `-h`   | `--help`                                | Print help information                                                                                                                              | No       |
+|        | `--help-all`                            | Print detailed help information                                                                                                                     | No       |
+
+## Examples
+
+### Check a MinIO (S3-compatible) object store
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`MINIO_USERNAME`{{% /code-placeholder-key %}}:
+  your MinIO username
+- {{% code-placeholder-key %}}`MINIO_PASSWORD`{{% /code-placeholder-key %}}:
+  your MinIO password
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="http://localhost:9000|MINIO_(USERNAME|PASSWORD)" }
+influxdb3 debug object-store-check \
+  --object-store s3 \
+  --bucket influxdb3 \
+  --aws-endpoint http://localhost:9000 \
+  --aws-access-key-id MINIO_USERNAME \
+  --aws-secret-access-key MINIO_PASSWORD \
+  --aws-allow-http \
+  --check-prefix oscheck
+```
+
+### Probe an existing catalog prefix (read-only)
+
+Use `--probe-prefix` with your actual cluster ID to diagnose catalog load
+failures without writing any data to the object store.
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="MINIO_USERNAME|MINIO_PASSWORD|my-cluster-id" }
+influxdb3 debug object-store-check \
+  --object-store s3 \
+  --bucket influxdb3 \
+  --aws-endpoint http://localhost:9000 \
+  --aws-access-key-id MINIO_USERNAME \
+  --aws-secret-access-key MINIO_PASSWORD \
+  --aws-allow-http \
+  --probe-prefix my-cluster-id
+```


### PR DESCRIPTION
…onfig-options gaps

## What changed

Add missing CLI reference pages and fix undocumented flags across InfluxDB 3 Core and Enterprise.


New pages:
- influxdb3 debug (Core + Enterprise, shared content)
- influxdb3 debug object-store-check (Core + Enterprise)
- influxdb3 import, import upload, import list (Enterprise only)

Updated pages:
- influxdb3 _index (Core): add debug command to table
- influxdb3 _index (Enterprise): add debug, import, install to table
- influxdb3 serve (Enterprise): add --compaction-row-limit option
- config-options: uncomment compaction-row-limit (was marked NOT YET RELEASED in v3.5.0; now available in v3.10.0+)
- install _index (shared): add Usage and Options sections
- MinIO object store (Core + Enterprise, shared content): link commands to reference pages

## Why

- The previous docs-tooling `derive` run for v3.10 lacked some source mappings for recently added binaries in influxdb_pro.
- `compaction-row-limit` was previously commented out pending release
- missing global entries

## Impact

Closes influxdata/docs-v2#7447, #7443, #7381
Addresses influxdata/docs-v2#6912, #6016
Opened follow-up #7458 
Related to #7444 