### PR TITLE
docs(influxdb3): document gh: plugin prefix for processing engine tri…

### DIFF
--- a/api-docs/influxdb3/core/influxdb3-core-openapi.yaml
+++ b/api-docs/influxdb3/core/influxdb3-core-openapi.yaml
@@ -855,7 +855,7 @@ paths:
                   Trigger that uses a plugin referenced with the `gh:` prefix.
                   InfluxDB fetches the plugin from the default `influxdata/influxdb3_plugins`
                   repository (or the repository configured with `--plugin-repo`)
-                  instead of the local `--plugins-dir`.
+                  instead of the local `--plugin-dir`.
                 value:
                   db: mydb
                   plugin_filename: gh:examples/wal_plugin/wal_plugin.py
@@ -2776,14 +2776,14 @@ components:
           description: |
             The path and filename of the plugin to execute--for example,
             `schedule.py` or `endpoints/report.py`.
-            The path can be absolute or relative to the `--plugins-dir` directory configured when starting InfluxDB 3.
+            The path can be absolute or relative to the `--plugin-dir` directory configured when starting InfluxDB 3.
 
             The plugin file must implement the trigger interface associated with the trigger's specification.
 
             #### Reference a plugin from GitHub
 
-            Prefix the path with `gh:` to fetch the plugin from a GitHub repository instead of the local `--plugins-dir`--for example, `gh:examples/wal_plugin/wal_plugin.py`.
-            The path after `gh:` is relative to the repository root.
+            Prefix the path with `gh:` to fetch the plugin from a GitHub repository instead of the local `--plugin-dir`--for example, `gh:examples/wal_plugin/wal_plugin.py`.
+            The path after `gh:` is appended to the configured `--plugin-repo`. This does not require GitHub or a Git repository--`--plugin-repo` accepts any HTTP/HTTPS URL that serves raw plugin files.
 
             By default, InfluxDB fetches `gh:`-prefixed plugins from `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/`.
             To use a different repository, set the `--plugin-repo` server option or the `INFLUXDB3_PLUGIN_REPO` environment variable to a raw content URL base path--for example, `https://raw.githubusercontent.com/myorg/my-plugins/main/`.

--- a/api-docs/influxdb3/core/influxdb3-core-openapi.yaml
+++ b/api-docs/influxdb3/core/influxdb3-core-openapi.yaml
@@ -849,6 +849,20 @@ paths:
                   trigger_settings:
                     run_async: false
                     error_behavior: log
+              github_plugin:
+                summary: Trigger using a plugin fetched from GitHub
+                description: |
+                  Trigger that uses a plugin referenced with the `gh:` prefix.
+                  InfluxDB fetches the plugin from the default `influxdata/influxdb3_plugins`
+                  repository (or the repository configured with `--plugin-repo`)
+                  instead of the local `--plugins-dir`.
+                value:
+                  db: mydb
+                  plugin_filename: gh:examples/wal_plugin/wal_plugin.py
+                  trigger_name: my_trigger
+                  trigger_specification: all_tables
+                  disabled: false
+                  trigger_settings: {}
               table_specific:
                 summary: Table-specific trigger example
                 description: |
@@ -2765,6 +2779,25 @@ components:
             The path can be absolute or relative to the `--plugins-dir` directory configured when starting InfluxDB 3.
 
             The plugin file must implement the trigger interface associated with the trigger's specification.
+
+            #### Reference a plugin from GitHub
+
+            Prefix the path with `gh:` to fetch the plugin from a GitHub repository instead of the local `--plugins-dir`--for example, `gh:examples/wal_plugin/wal_plugin.py`.
+            The path after `gh:` is relative to the repository root.
+
+            By default, InfluxDB fetches `gh:`-prefixed plugins from `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/`.
+            To use a different repository, set the `--plugin-repo` server option or the `INFLUXDB3_PLUGIN_REPO` environment variable to a raw content URL base path--for example, `https://raw.githubusercontent.com/myorg/my-plugins/main/`.
+
+            InfluxDB fetches the plugin when the trigger is created (to validate it) and again each time the trigger starts--for example, on server startup or when re-enabled.
+            Unlike local plugins, `gh:`-prefixed plugins aren't automatically reloaded when the source changes. Disable and re-enable the trigger to fetch updates.
+
+            Only single-file plugins are supported with the `gh:` prefix. Multi-file plugin directories must be uploaded locally.
+
+            If the fetch fails, the API returns an error with the HTTP status code and URL--for example:
+
+            ```
+            error fetching plugin from repository: 404 Not Found https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/not_found.py
+            ```
         trigger_name:
           type: string
         trigger_settings:

--- a/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
+++ b/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
@@ -959,6 +959,20 @@ paths:
                   trigger_settings:
                     run_async: false
                     error_behavior: log
+              github_plugin:
+                summary: Trigger using a plugin fetched from GitHub
+                description: |
+                  Trigger that uses a plugin referenced with the `gh:` prefix.
+                  InfluxDB fetches the plugin from the default `influxdata/influxdb3_plugins`
+                  repository (or the repository configured with `--plugin-repo`)
+                  instead of the local `--plugins-dir`.
+                value:
+                  db: mydb
+                  plugin_filename: gh:examples/wal_plugin/wal_plugin.py
+                  trigger_name: my_trigger
+                  trigger_specification: all_tables
+                  disabled: false
+                  trigger_settings: {}
               table_specific:
                 summary: Table-specific trigger example
                 description: |
@@ -4365,6 +4379,25 @@ components:
             The path can be absolute or relative to the `--plugins-dir` directory configured when starting InfluxDB 3.
 
             The plugin file must implement the trigger interface associated with the trigger's specification.
+
+            #### Reference a plugin from GitHub
+
+            Prefix the path with `gh:` to fetch the plugin from a GitHub repository instead of the local `--plugins-dir`--for example, `gh:examples/wal_plugin/wal_plugin.py`.
+            The path after `gh:` is relative to the repository root.
+
+            By default, InfluxDB fetches `gh:`-prefixed plugins from `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/`.
+            To use a different repository, set the `--plugin-repo` server option or the `INFLUXDB3_PLUGIN_REPO` environment variable to a raw content URL base path--for example, `https://raw.githubusercontent.com/myorg/my-plugins/main/`.
+
+            InfluxDB fetches the plugin when the trigger is created (to validate it) and again each time the trigger starts--for example, on server startup or when re-enabled.
+            Unlike local plugins, `gh:`-prefixed plugins aren't automatically reloaded when the source changes. Disable and re-enable the trigger to fetch updates.
+
+            Only single-file plugins are supported with the `gh:` prefix. Multi-file plugin directories must be uploaded locally.
+
+            If the fetch fails, the API returns an error with the HTTP status code and URL--for example:
+
+            ```
+            error fetching plugin from repository: 404 Not Found https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/not_found.py
+            ```
         node_spec:
           $ref: "#/components/schemas/ApiNodeSpec"
         trigger_name:

--- a/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
+++ b/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
@@ -965,7 +965,7 @@ paths:
                   Trigger that uses a plugin referenced with the `gh:` prefix.
                   InfluxDB fetches the plugin from the default `influxdata/influxdb3_plugins`
                   repository (or the repository configured with `--plugin-repo`)
-                  instead of the local `--plugins-dir`.
+                  instead of the local `--plugin-dir`.
                 value:
                   db: mydb
                   plugin_filename: gh:examples/wal_plugin/wal_plugin.py
@@ -4376,14 +4376,14 @@ components:
           description: |
             The path and filename of the plugin to execute--for example,
             `schedule.py` or `endpoints/report.py`.
-            The path can be absolute or relative to the `--plugins-dir` directory configured when starting InfluxDB 3.
+            The path can be absolute or relative to the `--plugin-dir` directory configured when starting InfluxDB 3.
 
             The plugin file must implement the trigger interface associated with the trigger's specification.
 
             #### Reference a plugin from GitHub
 
-            Prefix the path with `gh:` to fetch the plugin from a GitHub repository instead of the local `--plugins-dir`--for example, `gh:examples/wal_plugin/wal_plugin.py`.
-            The path after `gh:` is relative to the repository root.
+            Prefix the path with `gh:` to fetch the plugin from a GitHub repository instead of the local `--plugin-dir`--for example, `gh:examples/wal_plugin/wal_plugin.py`.
+            The path after `gh:` is appended to the configured `--plugin-repo`. This does not require GitHub or a Git repository--`--plugin-repo` accepts any HTTP/HTTPS URL that serves raw plugin files.
 
             By default, InfluxDB fetches `gh:`-prefixed plugins from `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/`.
             To use a different repository, set the `--plugin-repo` server option or the `INFLUXDB3_PLUGIN_REPO` environment variable to a raw content URL base path--for example, `https://raw.githubusercontent.com/myorg/my-plugins/main/`.

--- a/content/shared/influxdb3-cli/create/trigger.md
+++ b/content/shared/influxdb3-cli/create/trigger.md
@@ -54,11 +54,13 @@ Additional {{% product-name %}} option:
 
 ### Reference a plugin from GitHub
 
-To use a plugin directly from a GitHub repository without downloading it locally, prefix the plugin path with `gh:`. The path after the prefix is relative to the repository root--for example:
+To fetch a plugin remotely instead of downloading it locally, prefix the plugin path with `gh:`. The path after the prefix is appended to the configured `--plugin-repo`--for example:
 
 ```
 gh:examples/wal_plugin/wal_plugin.py
 ```
+
+Despite the name, `gh:` doesn't require GitHub or a Git repository--`--plugin-repo` accepts any HTTP/HTTPS URL that serves raw plugin files.
 
 By default, `gh:`-prefixed plugins resolve against the [`influxdata/influxdb3_plugins`](https://github.com/influxdata/influxdb3_plugins) repository at `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/`.
 For example, `gh:examples/wal_plugin/wal_plugin.py` resolves to `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/examples/wal_plugin/wal_plugin.py`.

--- a/content/shared/influxdb3-cli/create/trigger.md
+++ b/content/shared/influxdb3-cli/create/trigger.md
@@ -45,8 +45,26 @@ influxdb3 create trigger [OPTIONS] \
 | `-h`   | `--help`            | Print help information                                                                                   |
 |        | `--help-all`        | Print detailed help information                                                                          |
 
-If you want to use a plugin from the [Plugin Library](https://github.com/influxdata/influxdb3_plugins) repo, use the URL path with `gh:` specified as the prefix.
-For example, to use the [System Metrics](https://github.com/influxdata/influxdb3_plugins/blob/main/influxdata/system_metrics/system_metrics.py) plugin, the plugin filename is `gh:influxdata/system_metrics/system_metrics.py`.
+### Reference a plugin from GitHub
+
+To use a plugin directly from a GitHub repository without downloading it locally, prefix the plugin path with `gh:`. The path after the prefix is relative to the repository root--for example:
+
+```
+gh:examples/wal_plugin/wal_plugin.py
+```
+
+By default, `gh:`-prefixed plugins resolve against the [`influxdata/influxdb3_plugins`](https://github.com/influxdata/influxdb3_plugins) repository at `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/`.
+For example, `gh:examples/wal_plugin/wal_plugin.py` resolves to `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/examples/wal_plugin/wal_plugin.py`.
+
+To reference plugins from a different repository, set the `--plugin-repo` server option (or the `INFLUXDB3_PLUGIN_REPO` environment variable) to a raw content URL base path. For more information, see the [`plugin-repo` config option](/influxdb3/version/reference/config-options/#plugin-repo).
+
+InfluxDB fetches the plugin over HTTP when the trigger is created (to validate it), and again each time the trigger starts--for example, on server startup or when re-enabled. If the fetch fails, `influxdb3 create trigger` returns an error with the HTTP status code and URL:
+
+```
+error fetching plugin from repository: 404 Not Found https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/not_found.py
+```
+
+Unlike local plugins, `gh:`-prefixed plugins aren't automatically reloaded when the source changes--disable and re-enable the trigger to fetch updates. Only single-file plugins are supported with the `gh:` prefix; multi-file plugin directories must be uploaded locally with `--upload`.
 
 
 ### Option environment variables

--- a/content/shared/influxdb3-cli/create/trigger.md
+++ b/content/shared/influxdb3-cli/create/trigger.md
@@ -39,11 +39,18 @@ influxdb3 create trigger [OPTIONS] \
 |        | `--disabled`        | Create the trigger in disabled state                                                                     |
 |        | `--error-behavior`  | Error handling behavior: `log`, `retry`, or `disable` |
 |        | `--run-asynchronous` | Run the trigger asynchronously, allowing multiple triggers to run simultaneously (default is synchronous)                                                 |
-{{% show-in "enterprise" %}}|        | `--node-spec`       | Which node(s) the trigger should be configured on. Two value formats are supported: `all` (default) - applies to all nodes, or `nodes:<node-id>[,<node-id>..]` - applies only to specified comma-separated list of nodes |{{% /show-in %}}
 |        | `--tls-ca`          | Path to a custom TLS certificate authority (for self-signed or internal certificates)                    |
 |        | `--tls-no-verify`   | Disable TLS certificate verification (**Not recommended in production**, useful for self-signed certificates) |
 | `-h`   | `--help`            | Print help information                                                                                   |
 |        | `--help-all`        | Print detailed help information                                                                          |
+
+{{% show-in "enterprise" %}}
+Additional {{% product-name %}} option:
+
+| Option |               | Description                                                                                                                                                                 |
+| :----- | :------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|        | `--node-spec` | Which node(s) the trigger should be configured on. Two value formats are supported: `all` (default) - applies to all nodes, or `nodes:<node-id>[,<node-id>..]` - applies only to specified comma-separated list of nodes |
+{{% /show-in %}}
 
 ### Reference a plugin from GitHub
 

--- a/content/shared/influxdb3-plugins/_index.md
+++ b/content/shared/influxdb3-plugins/_index.md
@@ -172,6 +172,37 @@ This approach:
 - Simplifies updates and maintenance
 - Reduces local storage requirements
 
+**Syntax:**
+
+```
+gh:<path-to-plugin-file>
+```
+
+The path is relative to the repository root.
+
+By default, `gh:`-prefixed plugins resolve against the official [`influxdata/influxdb3_plugins`](https://github.com/influxdata/influxdb3_plugins) repository at `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/`.
+For example, `gh:examples/wal_plugin/wal_plugin.py` resolves to:
+
+```
+https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/examples/wal_plugin/wal_plugin.py
+```
+
+**How `gh:` plugin resolution works:**
+
+1. {{% product-name %}} detects the `gh:` prefix in the plugin path.
+2. It strips the prefix and appends the remaining path to the configured plugin repository URL.
+3. An HTTP `GET` request fetches the plugin source code.
+4. If the fetch succeeds (HTTP 2xx), {{% product-name %}} validates the plugin and creates the trigger.
+5. If the fetch fails, the command returns an error with the HTTP status code and URL--for example:
+
+   ```
+   error fetching plugin from repository: 404 Not Found https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/not_found.py
+   ```
+
+{{% product-name %}} fetches the plugin at trigger creation time (to validate it), and again each time the trigger starts--for example, on server startup or when you re-enable a disabled trigger.
+Unlike local plugins, GitHub plugins aren't automatically reloaded when the source changes--disable and re-enable the trigger to fetch updates.
+Only single-file plugins are supported through the `gh:` prefix; multi-file plugin directories must be uploaded locally (see [Upload plugins from local machine](#upload-plugins-from-local-machine)).
+
 ##### Option 3: Use a custom plugin repository
 
 For organizations that maintain their own plugin repositories or need to use private/internal plugins,
@@ -205,7 +236,7 @@ influxdb3 create trigger \
 - **Development and staging**: Test plugins from development branches before production deployment
 - **Compliance requirements**: Meet data governance policies requiring internal hosting
 
-The `--plugin-repo` option accepts any HTTP/HTTPS URL that serves raw plugin files.
+The `--plugin-repo` option accepts any HTTP/HTTPS URL that serves raw plugin files. You can also set it with the `INFLUXDB3_PLUGIN_REPO` environment variable.
 See the [plugin-repo configuration option](/influxdb3/version/reference/config-options/#plugin-repo) for more details.
 
 Plugins have various functions such as: 

--- a/content/shared/influxdb3-plugins/_index.md
+++ b/content/shared/influxdb3-plugins/_index.md
@@ -178,7 +178,12 @@ This approach:
 gh:<path-to-plugin-file>
 ```
 
-The path is relative to the repository root.
+The path after `gh:` is appended to the configured `--plugin-repo`.
+
+> [!Note]
+> #### The gh: prefix isn't GitHub-specific
+>
+> Despite the name, `gh:` doesn't require GitHub or a Git repository. `--plugin-repo` accepts any HTTP/HTTPS URL that serves raw plugin files--for example, an internal static file host or object storage endpoint. `gh:` just tells {{% product-name %}} to fetch the plugin remotely from that URL instead of reading it from the local `--plugin-dir`.
 
 By default, `gh:`-prefixed plugins resolve against the official [`influxdata/influxdb3_plugins`](https://github.com/influxdata/influxdb3_plugins) repository at `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/`.
 For example, `gh:examples/wal_plugin/wal_plugin.py` resolves to:


### PR DESCRIPTION
…ggers

## What changed:
- content/shared/influxdb3-plugins/_index.md: expanded the "Reference plugins directly from GitHub" section (Option 2) with the gh: syntax, default repository URL resolution, the 5-step fetch/validate behavior, the error response format, and notes on fetch timing, no-auto-reload, and single-file-only support. Added a mention of `INFLUXDB3_PLUGIN_REPO` alongside `--plugin-repo` in Option 3.
- content/shared/influxdb3-cli/create/trigger.md: replaced the two-line gh: mention with a full "Reference a plugin from GitHub" subsection covering syntax, default/custom repo resolution, fetch timing, the error response, and the single-file limitation.
- api-docs/influxdb3/{core,enterprise}/influxdb3-*-openapi.yaml: added a "Reference a plugin from GitHub" block to the plugin_filename field description on ProcessingEngineTriggerRequest, and a new github_plugin request example under the create-trigger endpoint. Synced verbatim from docs-tooling's 1reports/openapi/public/` output (`reports/openapi/internal/enterprise-openapi-merged.yaml` is the hand-authored source; see companion commit in docs-tooling).

## Why:
Now that recent updates to InfluxDB 3 Core and Enterprise enhanced plugin management and the `gh:` prefix mechanism has settled, users need to know: the default plugin repository, how to point at a private/custom repository, plugins are (re-)fetched, that gh:-prefixed plugins don't hot-reload, or what error they'd see on a bad path.

Addresses part of influxdata/docs-tooling#183
Closes influxdata/docs-v2#7462
Closes influxdata/docs-v2#6968
Supersedes influxdata/docs-v2#6969

## Impact:
- User guide and CLI reference now fully explain gh: resolution, custom repos, fetch/validation timing, and error handling.
- OpenAPI spec's plugin_filename field and request examples now surface the same `gh:` behavior in the interactive API reference
- No behavior change; documentation only, additive to existing pages.
- Paths in examples (gh:examples/wal_plugin/wal_plugin.py) verify against the influxdata/influxdb3_plugins repo layout.

Verification:
- Manually reviewed rendered Markdown for both content pages; confirmed internal anchor links (#plugin-repo, #upload-plugins-from-local-machine) resolve to existing headi
- Confirmed api-docs/influxdb3/{core,enterprise}/*.yaml are byte-identical to docs-tooling's reports/openapi/public/ outp (node scripts/openapi/check-downstream-drift.js --docs-v2 <path>).
- YAML indentation of new schema description/example blocks che by hand (12-space literal block scalar, consistent with surrounding properties); no parser available in this environment to valid automatically--recommend running the OpenAPI spec build/lint in CI before merge.
- Did not run Vale or Hugo build locally (unavailable in this environment)--CI should catch style/build issues.
