### PR TITLE
docs(influxdb3-test): missing and incorrect arguments for `test/{schedule,wal}_plugin.md`

### DIFF
--- a/content/shared/influxdb3-cli/test/schedule_plugin.md
+++ b/content/shared/influxdb3-cli/test/schedule_plugin.md
@@ -20,7 +20,7 @@ influxdb3 test schedule_plugin [OPTIONS] --database <DATABASE_NAME> <FILENAME>
 | `-H`   | `--host`              | URL of the running {{< product-name >}} server <br>(default: `http://127.0.0.1:8181`)         |
 | `-d`   | `--database`          | _({{< req >}})_ Name of the database you want to test the plugin against                      |
 |        | `--token`             | _({{< req >}})_ Authentication token                                                          |
-|        | `--input-arguments`   | JSON map of key/value pairs to pass as plugin input arguments (for example, `'{"key":"val"}'`)|
+|        | `--input-arguments`   | Comma-separated list of `key=value` pairs to pass as plugin input arguments (for example, `key1=val1,key2=val2`) |
 |        | `--schedule`          | Cron schedule to simulate when testing the plugin <br>(default: `* * * * *`)                  |
 |        | `--cache-name`        | Optional cache name to associate with the test                                                |
 |        | `--tls-ca`            | Path to a custom TLS certificate authority for self-signed certs                              |

--- a/content/shared/influxdb3-cli/test/wal_plugin.md
+++ b/content/shared/influxdb3-cli/test/wal_plugin.md
@@ -23,7 +23,8 @@ influxdb3 test wal_plugin [OPTIONS] --database <DATABASE_NAME> <PLUGIN_NAME>
 |        | `--token`           | _({{< req >}})_ Authentication token                                                     |
 |        | `--lp`              | Line protocol to use as input                                                            |
 |        | `--file`            | Line protocol file to use as input                                                       |
-|        | `--input-arguments` | Map of string key-value pairs as to use as plugin input arguments                        |
+|        | `--input-arguments` | Comma-separated list of `key=value` pairs to pass as plugin input arguments               |
+|        | `--cache-name`      | Name of the cache to use in the test                                                      |
 |        | `--tls-ca`          | Path to a custom TLS certificate authority (for testing or self-signed certificates)     |
 |        | `--tls-no-verify`   | Disable TLS certificate verification (**Not recommended in production**, useful for self-signed certificates) |
 | `-h`   | `--help`            | Print help information                                                                   |
@@ -39,6 +40,7 @@ You can use the following environment variables to set command options:
 | `INFLUXDB3_HOST_URL`      | `--host`     |
 | `INFLUXDB3_DATABASE_NAME` | `--database` |
 | `INFLUXDB3_AUTH_TOKEN`    | `--token`    |
+| `INFLUXDB3_TLS_CA`        | `--tls-ca`   |
 | `INFLUXDB3_TLS_NO_VERIFY` | `--tls-no-verify` |
 
 ## Examples


### PR DESCRIPTION
## What changed

- add `--cache-name` argument for `influxdb3-cli/test/wal_plugin/`
- add `INFLUXDB3_TLS_CA` env var for `influxdb3-cli/test/wal_plugin/`
- fix `--input-arguments` syntax for `influxdb3-cli/test/schedule_plugin/`

## Why

Missing and incorrect arguments and env var in test plugin documentation.

## Impact

Improves user experience.
Incidentally exposed gaps in `derive` for extracting CLI arguments - addressed in influxdata/docs-tooling#196

## Verification

Cross-verified using docs-tooling `derive` extraction, the live influxdb3 API, and CLI.