### PR TITLE
fix(influxdb3): correct broken anchors and cross-plugin README links

### DIFF
--- a/content/shared/influxdb3-get-started/setup.md
+++ b/content/shared/influxdb3-get-started/setup.md
@@ -179,7 +179,7 @@ influxdb3 serve \
 {{% /expand %}}
 {{% expand "Docker with a mounted file system object store" %}}
 
-To run the [Docker image](/influxdb3/version/install/#docker-image) and persist
+To run the [Docker image](/influxdb3/version/install/#pull-the-docker-image) and persist
 data to the local file system, mount a volume for the object store--for example,
 provide the following options with your `docker run` command:
 

--- a/content/shared/influxdb3-plugins/extended-plugin-api.md
+++ b/content/shared/influxdb3-plugins/extended-plugin-api.md
@@ -5,7 +5,7 @@ The plugin API lets you:
 - [Write data](#write-data)
 - [Query data](#query-data)
 - [Log messages for monitoring and debugging](#log-messages-for-monitoring-and-debugging)
-- [Maintain state with the in-memory cache](#maintain-state-with-in-memory-cache)
+- [Maintain state with the in-memory cache](#maintain-state-with-the-in-memory-cache)
   - [Store and retrieve cached data](#store-and-retrieve-cached-data)
   - [Use TTL appropriately](#use-ttl-appropriately)
   - [Share data across plugins](#share-data-across-plugins)
@@ -221,7 +221,7 @@ The cache system offers two distinct namespaces:
 - [Store and retrieve cached data](#store-and-retrieve-cached-data)
 - [Store cached data with expiration](#store-cached-data-with-expiration)
 - [Share data across plugins](#share-data-across-plugins)
-- [Build a counter](#build-a-counter)
+- [Build a counter](#building-a-counter)
 
 ### Store and retrieve cached data
 

--- a/content/shared/influxdb3-plugins/plugins-library/official/CLAUDE.md
+++ b/content/shared/influxdb3-plugins/plugins-library/official/CLAUDE.md
@@ -14,6 +14,23 @@ The plugin documentation files in this directory are **generated from source REA
 2. Run `yarn sync-plugins` from the docs-v2 root to port changes
 3. Commit changes in both repositories
 
+## Cross-Plugin Links
+
+Upstream READMEs link to other plugins with a GitHub-relative path, for
+example `[influxdata/notifier plugin](../notifier/README.md)`. That path is
+valid on GitHub but doesn't resolve on the built docs site (Hugo doesn't
+publish `README.md` files). `port_to_docs.js`'s `convertRelativeLinks()`
+rewrites these to the sibling plugin's docs-v2 page —
+`/influxdb3/version/plugins/library/official/notifier/` — converting the
+upstream folder's underscore_case to the docs-v2 hyphen-case slug. This
+keeps readers on the docs site instead of bouncing to GitHub.
+
+If you see a broken `../<plugin>/README.md`-style link in one of these
+files, the sync script didn't run after the upstream link was added — don't
+hand-fix only the generated file; re-run `yarn sync-plugins`, and if the
+link still isn't rewritten, check `convertRelativeLinks()` in
+`helper-scripts/influxdb3-plugins/port_to_docs.js` for a pattern gap.
+
 ## Documentation
 
 See [helper-scripts/influxdb3-plugins/README.md](/helper-scripts/influxdb3-plugins/README.md) for the complete sync workflow documentation.

--- a/content/shared/influxdb3-plugins/plugins-library/official/forecast-error-evaluator.md
+++ b/content/shared/influxdb3-plugins/plugins-library/official/forecast-error-evaluator.md
@@ -94,7 +94,7 @@ For more information on using TOML configuration files, see the Using TOML Confi
 ## Software Requirements
 
 - **{{% product-name %}}**: with the Processing Engine enabled.
-- **Notification Sender Plugin for {{% product-name %}}**: Required for sending notifications. See the [influxdata/notifier plugin](../notifier/README.md).
+- **Notification Sender Plugin for {{% product-name %}}**: Required for sending notifications. See the [influxdata/notifier plugin](/influxdb3/version/plugins/library/official/notifier/).
 - **Python packages**:
  	- `pandas` (for data processing)
  	- `requests` (for HTTP notifications)
@@ -116,7 +116,7 @@ For more information on using TOML configuration files, see the Using TOML Confi
    influxdb3 install package pandas
    influxdb3 install package requests
    ```
-3. Install the [influxdata/notifier plugin](../notifier/README.md) (required)
+3. Install the [influxdata/notifier plugin](/influxdb3/version/plugins/library/official/notifier/) (required)
 
 ## Trigger setup
 

--- a/content/shared/influxdb3-plugins/plugins-library/official/mad-check.md
+++ b/content/shared/influxdb3-plugins/plugins-library/official/mad-check.md
@@ -97,7 +97,7 @@ For more information on using TOML configuration files, see the Using TOML Confi
 - **{{% product-name %}}**: with the Processing Engine enabled.
 - **Python packages**:
   - `requests` (for notification delivery)
-- **Notification Sender Plugin** *(optional)*: Required if using the `senders` parameter. See the [influxdata/notifier plugin](../notifier/README.md).
+- **Notification Sender Plugin** *(optional)*: Required if using the `senders` parameter. See the [influxdata/notifier plugin](/influxdb3/version/plugins/library/official/notifier/).
 
 ### Installation steps
 
@@ -115,7 +115,7 @@ For more information on using TOML configuration files, see the Using TOML Confi
    ```bash
    influxdb3 install package requests
    ```
-3. *(Optional)* For notifications, install the [influxdata/notifier plugin](../notifier/README.md) and create an HTTP trigger for it.
+3. *(Optional)* For notifications, install the [influxdata/notifier plugin](/influxdb3/version/plugins/library/official/notifier/) and create an HTTP trigger for it.
 
 ## Schema requirement
 

--- a/content/shared/influxdb3-plugins/plugins-library/official/prophet-forecasting.md
+++ b/content/shared/influxdb3-plugins/plugins-library/official/prophet-forecasting.md
@@ -95,7 +95,7 @@ For more information on using TOML configuration files, see the Using TOML Confi
   - `numpy` (for numerical operations)
   - `requests` (for HTTP requests)
   - `prophet` (for time series forecasting)
-- **Notification Sender Plugin** *(optional)*: Required if using the `senders` parameter. See the [influxdata/notifier plugin](../notifier/README.md).
+- **Notification Sender Plugin** *(optional)*: Required if using the `senders` parameter. See the [influxdata/notifier plugin](/influxdb3/version/plugins/library/official/notifier/).
 
 ### Installation steps
 
@@ -116,7 +116,7 @@ For more information on using TOML configuration files, see the Using TOML Confi
    influxdb3 install package requests
    influxdb3 install package prophet
    ```
-3. *(Optional)* For notifications, install the [influxdata/notifier plugin](../notifier/README.md) and create an HTTP trigger for it.
+3. *(Optional)* For notifications, install the [influxdata/notifier plugin](/influxdb3/version/plugins/library/official/notifier/) and create an HTTP trigger for it.
 
 ## Trigger setup
 

--- a/content/shared/influxdb3-plugins/plugins-library/official/state-change.md
+++ b/content/shared/influxdb3-plugins/plugins-library/official/state-change.md
@@ -63,7 +63,7 @@ For more information on using TOML configuration files, see the Using TOML Confi
 
 ### Channel-specific configuration
 
-Notification channels require additional parameters based on the sender type (same as the [influxdata/notifier plugin](../notifier/README.md)).
+Notification channels require additional parameters based on the sender type (same as the [influxdata/notifier plugin](/influxdb3/version/plugins/library/official/notifier/)).
 
 ## Schema requirement
 
@@ -72,7 +72,7 @@ The plugin assumes that the table schema is already defined in the database, as 
 ## Software Requirements
 
 - **{{% product-name %}}**: with the Processing Engine enabled.
-- **Notification Sender Plugin for {{% product-name %}}**: Required for sending notifications. See the [influxdata/notifier plugin](../notifier/README.md).
+- **Notification Sender Plugin for {{% product-name %}}**: Required for sending notifications. See the [influxdata/notifier plugin](/influxdb3/version/plugins/library/official/notifier/).
 - **Python packages**:
  	- `requests` (for HTTP notifications)
 
@@ -92,7 +92,7 @@ The plugin assumes that the table schema is already defined in the database, as 
    ```bash
    influxdb3 install package requests
    ```
-3. *Optional*: For notifications, install and configure the [influxdata/notifier plugin](../notifier/README.md)
+3. *Optional*: For notifications, install and configure the [influxdata/notifier plugin](/influxdb3/version/plugins/library/official/notifier/)
 
 ## Trigger setup
 

--- a/content/shared/influxdb3-plugins/plugins-library/official/stateless-adtk-detector.md
+++ b/content/shared/influxdb3-plugins/plugins-library/official/stateless-adtk-detector.md
@@ -72,7 +72,7 @@ For more information on using TOML configuration files, see the Using TOML Confi
   - `adtk` (for anomaly detection)
   - `pandas` (for data manipulation)
   - `requests` (for HTTP notifications)
-- **Notification Sender Plugin** *(optional)*: Required if using the `senders` parameter. See the [influxdata/notifier plugin](../notifier/README.md).
+- **Notification Sender Plugin** *(optional)*: Required if using the `senders` parameter. See the [influxdata/notifier plugin](/influxdb3/version/plugins/library/official/notifier/).
 
 ### Installation steps
 
@@ -92,7 +92,7 @@ For more information on using TOML configuration files, see the Using TOML Confi
    influxdb3 install package adtk
    influxdb3 install package pandas
    ```
-3. *(Optional)* For notifications, install the [influxdata/notifier plugin](../notifier/README.md) and create an HTTP trigger for it.
+3. *(Optional)* For notifications, install the [influxdata/notifier plugin](/influxdb3/version/plugins/library/official/notifier/) and create an HTTP trigger for it.
 
 ## Trigger setup
 

--- a/content/shared/influxdb3-plugins/plugins-library/official/threshold-deadman-checks.md
+++ b/content/shared/influxdb3-plugins/plugins-library/official/threshold-deadman-checks.md
@@ -62,7 +62,7 @@ For more information on using TOML configuration files, see the Using TOML Confi
 
 ### Channel-specific configuration
 
-Notification channels require additional parameters based on the sender type (same as the [influxdata/notifier plugin](../notifier/README.md)).
+Notification channels require additional parameters based on the sender type (same as the [influxdata/notifier plugin](/influxdb3/version/plugins/library/official/notifier/)).
 
 ## Schema requirement
 
@@ -71,7 +71,7 @@ The plugin assumes that the table schema is already defined in the database, as 
 ## Software requirements
 
 - **InfluxDB v3 Core/Enterprise**: with the Processing Engine enabled.
-- **Notification Sender Plugin for {{% product-name %}}**: This plugin is required for sending notifications. See the [influxdata/notifier plugin](../notifier/README.md).
+- **Notification Sender Plugin for {{% product-name %}}**: This plugin is required for sending notifications. See the [influxdata/notifier plugin](/influxdb3/version/plugins/library/official/notifier/).
 
 ## Installation steps
 
@@ -89,7 +89,7 @@ The plugin assumes that the table schema is already defined in the database, as 
    ```bash
    influxdb3 install package requests
    ```
-3. **Optional**: For notifications, install and configure the [influxdata/notifier plugin](../notifier/README.md)
+3. **Optional**: For notifications, install and configure the [influxdata/notifier plugin](/influxdb3/version/plugins/library/official/notifier/)
 
 ## Trigger setup
 

--- a/helper-scripts/influxdb3-plugins/README.md
+++ b/helper-scripts/influxdb3-plugins/README.md
@@ -275,9 +275,12 @@ When porting content from `influxdb3_plugins` to `docs-v2`:
 
 1. **Remove emoji metadata line** (already in plugin metadata)
 
-2. **Convert relative links to GitHub URLs**:
+2. **Convert relative links to GitHub URLs or sibling docs-v2 pages**:
    - `[file.toml](file.toml)` → `[file.toml](https://github.com/influxdata/influxdb3_plugins/blob/master/influxdata/[plugin]/file.toml)`
    - `/README.md` → `https://github.com/influxdata/influxdb3_plugins/blob/master/README.md`
+   - `../[plugin]/README.md` (a link to a *different* plugin's README) →
+     `/influxdb3/version/plugins/library/official/[plugin]/` (the sibling
+     plugin's docs-v2 page, with underscores converted to hyphens)
 
 3. **Add product shortcodes**:
    - Replace "InfluxDB 3" with `{{% product-name %}}`

--- a/helper-scripts/influxdb3-plugins/port_to_docs.js
+++ b/helper-scripts/influxdb3-plugins/port_to_docs.js
@@ -89,6 +89,16 @@ function convertRelativeLinks(content, pluginName) {
   const rootUrl =
     'https://github.com/influxdata/influxdb3_plugins/blob/master/';
 
+  // Convert cross-plugin README links to the sibling plugin's docs-v2 page.
+  // e.g. [influxdata/notifier plugin](../notifier/README.md) ->
+  //      [influxdata/notifier plugin](/influxdb3/version/plugins/library/official/notifier/)
+  // Upstream plugin folders use underscore_case; docs-v2 slugs use hyphens.
+  content = content.replace(
+    /\[([^\]]+)\]\(\.\.\/([a-z0-9_]+)\/README\.md\)/g,
+    (match, linkText, pluginDir) =>
+      `[${linkText}](/influxdb3/version/plugins/library/official/${pluginDir.replace(/_/g, '-')}/)`
+  );
+
   // Convert relative README links (../../README.md, ../README.md, etc.)
   content = content.replace(
     /\[([^\]]+)\]\((\.\.\/)+README\.md\)/g,


### PR DESCRIPTION
Split out of #7469 (canonical rubric work) — these are pre-existing content/tooling bugs CI surfaced there, unrelated to that PR's canonical fix, so they're landing separately.

## What changed

**Broken anchors (2 fixes):**
- `content/shared/influxdb3-get-started/setup.md`: Docker image link pointed
  to `#docker-image`; the actual heading (`content/shared/influxdb3/install.md`)
  is "Pull the Docker image", slugging to `#pull-the-docker-image`.
- `content/shared/influxdb3-plugins/extended-plugin-api.md`: two TOC entries
  pointed at wrong anchors — `#maintain-state-with-in-memory-cache` (missing
  "the") and `#build-a-counter` (should be `#building-a-counter`, matching
  the actual heading and a correct TOC entry elsewhere in the same file).

**Cross-plugin README links (generator fix + regenerated content):**

Six shared official-plugin docs link to the notifier plugin via
`[influxdata/notifier plugin](../notifier/README.md)` — a GitHub-relative
path that's valid when browsing `influxdata/influxdb3_plugins` on GitHub,
but doesn't resolve on the built docs site (Hugo doesn't publish `README.md`
files).

Root cause: these files are generated from upstream READMEs by
`helper-scripts/influxdb3-plugins/port_to_docs.js`. Its
`convertRelativeLinks()` only rewrote a plugin's link to its *own* README
(`../README.md`); links to a *sibling* plugin's README
(`../<plugin>/README.md`) passed through unchanged.

Fix:
- `port_to_docs.js`: rewrite `../<plugin>/README.md` to the sibling
  plugin's docs-v2 page, `/influxdb3/version/plugins/library/official/<plugin>/`
  (converting the upstream `underscore_case` folder to the docs-v2
  `hyphen-case` slug), so future syncs from upstream don't reintroduce this.
- `helper-scripts/influxdb3-plugins/README.md`: document the new rule.
- Hand-patch the 6 currently-affected generated files (`state-change.md`,
  `prophet-forecasting.md`, `mad-check.md`, `threshold-deadman-checks.md`,
  `stateless-adtk-detector.md`, `forecast-error-evaluator.md`) so the fix
  is live now, ahead of the next real sync from upstream.
- `content/shared/influxdb3-plugins/plugins-library/official/CLAUDE.md`:
  document the cross-plugin link rewrite behavior and what to do if this
  class of broken link recurs, since this directory is otherwise
  "generated, do not edit directly."

## Why

Both were caught by CI's "Check links in affected files" job running on
#7469 (which only touches `canonical:` frontmatter, so neither bug is
related to that PR's actual change) — confirmed via direct inspection that
both are pre-existing.

## Impact

- 9 previously-broken links now resolve; no new links introduced.
- No frontmatter, template, or canonical-routing changes — purely link/anchor
  text and the generator script.
- The generator fix prevents regression on the next real sync from
  `influxdata/influxdb3_plugins`, so this isn't a one-time patch that erodes.

## Verification

- `npx hugo --quiet` — build passes.
- Confirmed in built HTML that all 6 plugin pages (Core and Enterprise) now
  link to the notifier page's actual site URL.
- Verified the new `port_to_docs.js` regex against both the broken pattern
  (correctly rewrites) and the pre-existing own-README pattern (unaffected,
  no double-matching).
- Same 9 broken links were confirmed fixed via #7469's CI link-check run
  once these commits landed there (prior to being split into this PR).

## Checklist

- [x] Rebased/mergeable (branches directly off current `master`)
- [x] Local build passes (`npx hugo --quiet`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LeZSXxL9tXjMN331aKYBbG)_