### PR TITLE
fix(vale): skip gracefully when no Vale binary and no Docker daemon

### DIFF
--- a/.agents/skills/vale-linting/SKILL.md
+++ b/.agents/skills/vale-linting/SKILL.md
@@ -40,7 +40,10 @@ This skill covers the complete Vale linting workflow for InfluxData documentatio
 The wrapper script `.ci/vale/vale.sh` runs Vale using:
 
 1. **Local binary** (preferred) — if `vale` is installed and version >= 3.x
-2. **Docker fallback** — `jdkato/vale:v${VALE_VERSION}` (pinned version)
+2. **Docker fallback** — `jdkato/vale:v${VALE_VERSION}` (pinned version),
+   only if the Docker daemon is running
+3. **Graceful skip** — if neither is available, the wrapper prints a warning
+   and exits 0 so other pre-commit hooks still run
 
 ```bash
 # The wrapper handles binary vs Docker automatically
@@ -49,6 +52,16 @@ The wrapper script `.ci/vale/vale.sh` runs Vale using:
 # In CI, the pr-vale-check.yml workflow installs the Vale binary
 # directly (reads version from vale.sh), so Docker is not needed.
 ```
+
+**Sandboxed agent sessions (no Docker daemon, GitHub release downloads
+blocked):** Vale can't run locally, so the wrapper skips it (exit 0) with a
+warning. Do NOT use `git commit --no-verify` — that bypasses all hooks, not
+just Vale. Let the commit proceed normally; the `pr-vale-check.yml` workflow
+is the authoritative gate and blocks merge on errors. It sets `VALE_STRICT=1`,
+which makes the wrapper fail instead of skip if Vale is ever unavailable in
+CI. To run Vale in a sandbox anyway, ask an environment admin to allowlist
+the Vale release host (`github.com/vale-cli/vale`) in the environment's
+network policy.
 
 **Critical limitation:** Only files inside the repository are accessible when using Docker fallback. Files in `/tmp` or other external paths will silently fail.
 

--- a/.ci/vale/vale.sh
+++ b/.ci/vale/vale.sh
@@ -4,6 +4,14 @@ set -euo pipefail
 # Run Vale to lint files for writing style and consistency.
 # Uses a local vale binary if available, otherwise falls back to Docker.
 #
+# If neither a compatible local binary nor a running Docker daemon is
+# available (for example, in sandboxed agent sessions where the Docker daemon
+# and GitHub release downloads are both unavailable), the check is skipped
+# with a warning and exits 0 so pre-commit hooks don't force a full
+# `git commit --no-verify` bypass. The pr-vale-check.yml workflow remains the
+# authoritative gate and sets VALE_STRICT=1, which turns the skip into a
+# failure instead.
+#
 # Example usage:
 #
 # Lint all added and modified files in the cloud-dedicated directory:
@@ -30,12 +38,26 @@ if command -v vale &>/dev/null; then
   fi
 fi
 
-docker run \
-  --rm \
-  --label tag=influxdata-docs \
-  --label stage=lint \
-  --mount type=bind,src="$(pwd)",dst=/workdir \
-  -w /workdir \
-  --entrypoint /bin/vale \
-  "jdkato/vale:v${VALE_VERSION}" \
-  "$@"
+if command -v docker &>/dev/null && docker info &>/dev/null; then
+  docker run \
+    --rm \
+    --label tag=influxdata-docs \
+    --label stage=lint \
+    --mount type=bind,src="$(pwd)",dst=/workdir \
+    -w /workdir \
+    --entrypoint /bin/vale \
+    "jdkato/vale:v${VALE_VERSION}" \
+    "$@"
+  exit $?
+fi
+
+if [[ "${VALE_STRICT:-0}" == "1" ]]; then
+  echo "ERROR: Vale is unavailable (no local binary >= v${VALE_MAJOR_MIN} and no Docker daemon) and VALE_STRICT=1 is set." >&2
+  echo "  Install Vale: see https://vale.sh/docs/install/" >&2
+  exit 1
+fi
+
+echo "WARNING: Skipping Vale — no local binary (>= v${VALE_MAJOR_MIN}) and no Docker daemon available." >&2
+echo "  Style checks still run in CI (pr-vale-check.yml) and block merge on errors." >&2
+echo "  To run Vale locally, install it: see https://vale.sh/docs/install/" >&2
+exit 0

--- a/.github/workflows/pr-vale-check.yml
+++ b/.github/workflows/pr-vale-check.yml
@@ -70,13 +70,18 @@ jobs:
         if: steps.detect.outputs.has-files == 'true'
         run: |
           VALE_VERSION=$(sed -n 's/^VALE_VERSION="\(.*\)"/\1/p' .ci/vale/vale.sh)
-          curl -sfL "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz" \
+          # The Vale org was renamed errata-ai -> vale-cli
+          curl -sfL "https://github.com/vale-cli/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz" \
             | sudo tar xz -C /usr/local/bin vale
           vale --version
 
       - name: Run Vale
         if: steps.detect.outputs.has-files == 'true'
         id: vale
+        env:
+          # Never allow vale.sh to skip silently in CI — this workflow is the
+          # authoritative style gate.
+          VALE_STRICT: '1'
         run: |
           chmod +x .github/scripts/vale-check.sh .ci/vale/vale.sh
 

--- a/DOCS-TESTING.md
+++ b/DOCS-TESTING.md
@@ -184,6 +184,13 @@ Local checks resolve relative links to the local filesystem. CI checks resolve t
 
 Install locally: `brew install vale` (recommended) or use the Docker fallback via `.ci/vale/vale.sh`.
 
+If neither a local Vale binary nor a running Docker daemon is available
+(for example, in sandboxed agent sessions), `.ci/vale/vale.sh` skips the
+check with a warning and exits 0 — don't use `git commit --no-verify`.
+CI (`pr-vale-check.yml`) remains the authoritative gate: it installs the
+pinned Vale binary, runs with `VALE_STRICT=1` so the check can never skip
+silently, and blocks merge on errors.
+
 ```bash
 # Lint specific files
 .ci/vale/vale.sh content/influxdb3/core/**/*.md

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -116,7 +116,7 @@ pre-commit:
         - 'content/influxdb3/clustered/*.md'
         - 'content/shared/*.md'
       run: '.ci/vale/vale.sh
-        --config=content/influxdb3/cloud-serverless/.vale.ini
+        --config=content/influxdb3/clustered/.vale.ini
         --minAlertLevel=error {staged_files}'
     core-lint:
       tags: lint,v3


### PR DESCRIPTION
## Summary

Partially addresses #7470 (Problem 1: Vale can't run in sandboxed agent sessions). Problem 2 (`yarn lint` dirtying `assets/jsconfig.json`) is not addressed here.

In sandboxed agent sessions, neither execution path in `.ci/vale/vale.sh` works: the Docker daemon is unavailable and binary downloads from GitHub releases are blocked by the session proxy. The hard failure forced `git commit --no-verify`, which bypasses **all** pre-commit hooks instead of just Vale. Full evaluation and verification details: [#7470 (comment)](https://github.com/influxdata/docs-v2/issues/7470#issuecomment-4945826113).

Changes:

- **`.ci/vale/vale.sh`** — check for a *running* Docker daemon (`docker info`), not just the CLI. When neither a v3+ binary nor a daemon is available, warn and exit 0 so other hooks still run. `VALE_STRICT=1` turns the skip into a failure.
- **`.github/workflows/pr-vale-check.yml`** — set `VALE_STRICT=1` so CI (the authoritative gate) can never skip silently; update the release download URL to the renamed `vale-cli` org (the `errata-ai` redirect still works today).
- **`lefthook.yml`** — point `clustered-lint` at `content/influxdb3/clustered/.vale.ini` instead of the cloud-serverless config (copy-paste error found during config review).
- **`.agents/skills/vale-linting/SKILL.md`, `DOCS-TESTING.md`** — document the sandbox limitation, the skip behavior, and the "don't use `--no-verify`" guidance.

Verified in an affected sandbox: direct invocation skips with a warning (exit 0), `VALE_STRICT=1` fails (exit 1), and a real commit exercised the new path — `lint-instructions` skipped Vale with a warning while all other hooks ran normally.

## Checklist

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dwz2V5JLtbHjeDhKdusjw2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dwz2V5JLtbHjeDhKdusjw2)_