### PR TITLE
fix(tooling): stop yarn lint from dirtying assets/jsconfig.json

### DIFF
--- a/.agents/instructions/assets.md
+++ b/.agents/instructions/assets.md
@@ -27,6 +27,10 @@ Project uses TypeScript with ES2020 target:
 - Build: `yarn build:ts`
 - Watch: `yarn build:ts:watch`
 
+`assets/jsconfig.json` is static editor configuration maintained by hand;
+Hugo's jsconfig generation is disabled (`noJSConfigInAssets: true`), so no
+tool should rewrite it.
+
 ## Component Pattern
 
 1. Add `data-component` attribute to HTML element:

--- a/.claude/rules/assets.md
+++ b/.claude/rules/assets.md
@@ -29,6 +29,10 @@ Project uses TypeScript with ES2020 target:
 - Build: `yarn build:ts`
 - Watch: `yarn build:ts:watch`
 
+`assets/jsconfig.json` is static editor configuration maintained by hand;
+Hugo's jsconfig generation is disabled (`noJSConfigInAssets: true`), so no
+tool should rewrite it.
+
 ## Component Pattern
 
 1. Add `data-component` attribute to HTML element:

--- a/.github/instructions/assets.instructions.md
+++ b/.github/instructions/assets.instructions.md
@@ -27,6 +27,10 @@ Project uses TypeScript with ES2020 target:
 - Build: `yarn build:ts`
 - Watch: `yarn build:ts:watch`
 
+`assets/jsconfig.json` is static editor configuration maintained by hand;
+Hugo's jsconfig generation is disabled (`noJSConfigInAssets: true`), so no
+tool should rewrite it.
+
 ## Component Pattern
 
 1. Add `data-component` attribute to HTML element:

--- a/assets/AGENTS.md
+++ b/assets/AGENTS.md
@@ -27,6 +27,10 @@ Project uses TypeScript with ES2020 target:
 - Build: `yarn build:ts`
 - Watch: `yarn build:ts:watch`
 
+`assets/jsconfig.json` is static editor configuration maintained by hand;
+Hugo's jsconfig generation is disabled (`noJSConfigInAssets: true`), so no
+tool should rewrite it.
+
 ### Component Pattern
 
 1. Add `data-component` attribute to HTML element:

--- a/config/_default/hugo.yml
+++ b/config/_default/hugo.yml
@@ -86,13 +86,11 @@ outputs:
 
 # Asset processing configuration for development
 build:
-  # Ensure Hugo correctly processes JavaScript modules
-  jsConfig:
-    nodeEnv: "development"
-# Development asset processing
   writeStats: false
   useResourceCacheWhen: "fallback"
-  noJSConfigInAssets: false
+  # Keep Hugo from regenerating assets/jsconfig.json (editor-only config,
+  # maintained by hand). See influxdata/docs-v2#7470.
+  noJSConfigInAssets: true
 
 # Asset processing configuration
 assetDir: "assets"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "test:markdown-parity": "node --test scripts/__tests__/markdown-parity.test.mjs",
     "test:markdown-completeness": "node --test scripts/__tests__/markdown-completeness.test.mjs",
     "deploy:staging": "sh scripts/deploy-staging.sh",
-    "lint": "LEFTHOOK_EXCLUDE=test lefthook run pre-commit && lefthook run pre-push",
+    "lint": "LEFTHOOK_EXCLUDE=test lefthook run pre-commit && LEFTHOOK_EXCLUDE=test lefthook run pre-push",
     "pre-commit": "lefthook run pre-commit",
     "test": "echo \"Run 'yarn test:e2e', 'yarn test:codeblocks:all', or a specific test command. For link validation, use the link-checker binary (see DOCS-TESTING.md). The e2e command takes a glob of file paths to test. Some commands run automatically during the git pre-commit and pre-push hooks.\" && exit 0",
     "test:codeblocks": "echo \"Run a specific codeblocks test command (e.g., yarn test:codeblocks:influxdb3_core)\" && exit 0",


### PR DESCRIPTION
Two changes address the flappy assets/jsconfig.json noise reported in
issue #7470 (item 2):

- Set build.noJSConfigInAssets: true so Hugo stops regenerating
  assets/jsconfig.json on every build. The file is editor-only config;
  commit 9d193a72 deliberately removed the ../node_modules/* entry as
  redundant (editors resolve node_modules by walking up directories),
  but Hugo kept writing it back. Also remove the jsConfig.nodeEnv lines:
  not a Hugo build option, silently dropped from the merged config.

- Apply LEFTHOOK_EXCLUDE=test to both legs of the yarn lint script.
  Shell env scoping meant only the pre-commit leg excluded test-tagged
  jobs, so the pre-push leg ran e2e-shortcode-examples, which starts a
  Hugo server. On branches with no upstream (fresh cloud-session
  branches), lefthook diffs against the empty tree, so the job's glob
  always matched and every yarn lint run rewrote the file. Real git
  pushes still run the e2e job via the actual pre-push hook.

Also note in the assets instructions that jsconfig.json is static,
hand-maintained editor config (adapters regenerated).

Fixes the jsconfig portion of #7470.