### PR TITLE
docs(influxdb3): document Enterprise load capture

### DIFF
--- a/api-docs/influxdb3/core/influxdb3-core-openapi.yaml
+++ b/api-docs/influxdb3/core/influxdb3-core-openapi.yaml
@@ -26,7 +26,7 @@ info:
     name: InfluxData
     url: https://www.influxdata.com
     email: support@influxdata.com
-  x-source-hash: sha256:59e0d108505b9909361470ccdd95015b6ea1bffcf2c5a9892e7217eabff5b994
+  x-source-hash: sha256:b2f4a4da437fb5797a2908f6ed642a7ef9d2f59e75e2383341e2929f8ff404e1
   x-influxdata-download-url: /openapi/influxdb3-core-openapi.yaml
 servers:
   - url: https://{baseurl}
@@ -846,9 +846,9 @@ paths:
                   trigger_name: all_tables_trigger
                   trigger_specification: all_tables
                   disabled: false
-                  trigger_settings:
-                    run_async: false
-                    error_behavior: log
+                trigger_settings:
+                  run_async: false
+                  error_behavior: log
               github_plugin:
                 summary: Trigger using a plugin fetched from GitHub
                 description: |
@@ -2776,28 +2776,9 @@ components:
           description: |
             The path and filename of the plugin to execute--for example,
             `schedule.py` or `endpoints/report.py`.
-            The path can be absolute or relative to the `--plugin-dir` directory configured when starting InfluxDB 3.
+            The path can be absolute or relative to the `--plugins-dir` directory configured when starting InfluxDB 3.
 
             The plugin file must implement the trigger interface associated with the trigger's specification.
-
-            #### Reference a plugin from GitHub
-
-            Prefix the path with `gh:` to fetch the plugin from a GitHub repository instead of the local `--plugin-dir`--for example, `gh:examples/wal_plugin/wal_plugin.py`.
-            The path after `gh:` is appended to the configured `--plugin-repo`. This does not require GitHub or a Git repository--`--plugin-repo` accepts any HTTP/HTTPS URL that serves raw plugin files.
-
-            By default, InfluxDB fetches `gh:`-prefixed plugins from `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/`.
-            To use a different repository, set the `--plugin-repo` server option or the `INFLUXDB3_PLUGIN_REPO` environment variable to a raw content URL base path--for example, `https://raw.githubusercontent.com/myorg/my-plugins/main/`.
-
-            InfluxDB fetches the plugin when the trigger is created (to validate it) and again each time the trigger starts--for example, on server startup or when re-enabled.
-            Unlike local plugins, `gh:`-prefixed plugins aren't automatically reloaded when the source changes. Disable and re-enable the trigger to fetch updates.
-
-            Only single-file plugins are supported with the `gh:` prefix. Multi-file plugin directories must be uploaded locally.
-
-            If the fetch fails, the API returns an error with the HTTP status code and URL--for example:
-
-            ```
-            error fetching plugin from repository: 404 Not Found https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/not_found.py
-            ```
         trigger_name:
           type: string
         trigger_settings:

--- a/api-docs/influxdb3/core/influxdb3-core-openapi.yaml
+++ b/api-docs/influxdb3/core/influxdb3-core-openapi.yaml
@@ -2780,24 +2780,9 @@ components:
 
             The plugin file must implement the trigger interface associated with the trigger's specification.
 
-            #### Fetch a plugin remotely
-
-            Prefix the path with `gh:` to fetch the plugin remotely instead of reading it from the local `--plugin-dir`--for example, `gh:examples/wal_plugin/wal_plugin.py`.
-            The path after `gh:` is appended to the configured `--plugin-repo`. Despite the name, `gh:` doesn't require GitHub or a Git repository--`--plugin-repo` accepts any HTTP/HTTPS URL that serves raw plugin files.
-
-            By default, `gh:`-prefixed plugins resolve against the [`influxdata/influxdb3_plugins`](https://github.com/influxdata/influxdb3_plugins) repository at `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/`.
-            To use a different repository, set the `--plugin-repo` server option or the `INFLUXDB3_PLUGIN_REPO` environment variable to a raw content URL base path--for example, `https://raw.githubusercontent.com/myorg/my-plugins/main/`.
-
-            InfluxDB fetches the plugin when the trigger is created (to validate it) and again each time the trigger starts--for example, on server startup or when re-enabled.
-            Unlike local plugins, `gh:`-prefixed plugins aren't automatically reloaded when the source changes. Disable and re-enable the trigger to fetch updates.
-
-            Only single-file plugins are supported with the `gh:` prefix. Multi-file plugin directories must be uploaded locally.
-
-            If the fetch fails, the API returns an error with the HTTP status code and URL--for example:
-
-            ```
-            error fetching plugin from repository: 404 Not Found https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/not_found.py
-            ```
+            Prefix the path with `gh:` to fetch the plugin remotely from the configured `--plugin-repo` instead of reading it from the local `--plugin-dir`--for example, `gh:examples/wal_plugin/wal_plugin.py`.
+            Despite the name, `gh:` doesn't require GitHub--`--plugin-repo` accepts any HTTP/HTTPS URL that serves raw plugin files.
+            For defaults, fetch behavior, and limitations, see [Use example plugins](/influxdb3/core/plugins/#use-example-plugins).
         trigger_name:
           type: string
         trigger_settings:

--- a/api-docs/influxdb3/core/influxdb3-core-openapi.yaml
+++ b/api-docs/influxdb3/core/influxdb3-core-openapi.yaml
@@ -850,7 +850,7 @@ paths:
                   run_async: false
                   error_behavior: log
               github_plugin:
-                summary: Trigger using a plugin fetched from GitHub
+                summary: Trigger using a remotely fetched plugin
                 description: |
                   Trigger that uses a plugin referenced with the `gh:` prefix.
                   InfluxDB fetches the plugin from the default `influxdata/influxdb3_plugins`
@@ -2776,9 +2776,28 @@ components:
           description: |
             The path and filename of the plugin to execute--for example,
             `schedule.py` or `endpoints/report.py`.
-            The path can be absolute or relative to the `--plugins-dir` directory configured when starting InfluxDB 3.
+            The path can be absolute or relative to the `--plugin-dir` directory configured when starting InfluxDB 3.
 
             The plugin file must implement the trigger interface associated with the trigger's specification.
+
+            #### Fetch a plugin remotely
+
+            Prefix the path with `gh:` to fetch the plugin remotely instead of reading it from the local `--plugin-dir`--for example, `gh:examples/wal_plugin/wal_plugin.py`.
+            The path after `gh:` is appended to the configured `--plugin-repo`. Despite the name, `gh:` doesn't require GitHub or a Git repository--`--plugin-repo` accepts any HTTP/HTTPS URL that serves raw plugin files.
+
+            By default, `gh:`-prefixed plugins resolve against the [`influxdata/influxdb3_plugins`](https://github.com/influxdata/influxdb3_plugins) repository at `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/`.
+            To use a different repository, set the `--plugin-repo` server option or the `INFLUXDB3_PLUGIN_REPO` environment variable to a raw content URL base path--for example, `https://raw.githubusercontent.com/myorg/my-plugins/main/`.
+
+            InfluxDB fetches the plugin when the trigger is created (to validate it) and again each time the trigger starts--for example, on server startup or when re-enabled.
+            Unlike local plugins, `gh:`-prefixed plugins aren't automatically reloaded when the source changes. Disable and re-enable the trigger to fetch updates.
+
+            Only single-file plugins are supported with the `gh:` prefix. Multi-file plugin directories must be uploaded locally.
+
+            If the fetch fails, the API returns an error with the HTTP status code and URL--for example:
+
+            ```
+            error fetching plugin from repository: 404 Not Found https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/not_found.py
+            ```
         trigger_name:
           type: string
         trigger_settings:

--- a/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
+++ b/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
@@ -968,7 +968,7 @@ paths:
                   run_async: false
                   error_behavior: log
               github_plugin:
-                summary: Trigger using a plugin fetched from GitHub
+                summary: Trigger using a remotely fetched plugin
                 description: |
                   Trigger that uses a plugin referenced with the `gh:` prefix.
                   InfluxDB fetches the plugin from the default `influxdata/influxdb3_plugins`
@@ -4456,9 +4456,28 @@ components:
           description: |
             The path and filename of the plugin to execute--for example,
             `schedule.py` or `endpoints/report.py`.
-            The path can be absolute or relative to the `--plugins-dir` directory configured when starting InfluxDB 3.
+            The path can be absolute or relative to the `--plugin-dir` directory configured when starting InfluxDB 3.
 
             The plugin file must implement the trigger interface associated with the trigger's specification.
+
+            #### Fetch a plugin remotely
+
+            Prefix the path with `gh:` to fetch the plugin remotely instead of reading it from the local `--plugin-dir`--for example, `gh:examples/wal_plugin/wal_plugin.py`.
+            The path after `gh:` is appended to the configured `--plugin-repo`. Despite the name, `gh:` doesn't require GitHub or a Git repository--`--plugin-repo` accepts any HTTP/HTTPS URL that serves raw plugin files.
+
+            By default, `gh:`-prefixed plugins resolve against the [`influxdata/influxdb3_plugins`](https://github.com/influxdata/influxdb3_plugins) repository at `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/`.
+            To use a different repository, set the `--plugin-repo` server option or the `INFLUXDB3_PLUGIN_REPO` environment variable to a raw content URL base path--for example, `https://raw.githubusercontent.com/myorg/my-plugins/main/`.
+
+            InfluxDB fetches the plugin when the trigger is created (to validate it) and again each time the trigger starts--for example, on server startup or when re-enabled.
+            Unlike local plugins, `gh:`-prefixed plugins aren't automatically reloaded when the source changes. Disable and re-enable the trigger to fetch updates.
+
+            Only single-file plugins are supported with the `gh:` prefix. Multi-file plugin directories must be uploaded locally.
+
+            If the fetch fails, the API returns an error with the HTTP status code and URL--for example:
+
+            ```
+            error fetching plugin from repository: 404 Not Found https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/not_found.py
+            ```
         node_spec:
           $ref: "#/components/schemas/ApiNodeSpec"
         trigger_name:

--- a/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
+++ b/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
@@ -26,7 +26,7 @@ info:
     name: InfluxData
     url: https://www.influxdata.com
     email: support@influxdata.com
-  x-source-hash: sha256:59e0d108505b9909361470ccdd95015b6ea1bffcf2c5a9892e7217eabff5b994
+  x-source-hash: sha256:b2f4a4da437fb5797a2908f6ed642a7ef9d2f59e75e2383341e2929f8ff404e1
   x-influxdata-download-url: /openapi/influxdb3-enterprise-openapi.yaml
 servers:
   - url: https://{baseurl}
@@ -322,6 +322,14 @@ tags:
       Bulk import endpoints require the upgraded storage engine, enabled with the `--use-pacha-tree` flag, and a
       compactor node that runs the bulk import scheduler to complete the import. All endpoints require an admin
       (operator) token.
+  - name: Load capture
+    description: |
+      Capture a timed, anonymized profile of write requests, query requests, or both on a query-capable node.
+
+      Load capture endpoints require an admin token. Only one capture can run at a time on a node.
+    x-related:
+      - title: Capture workload data
+        href: /influxdb3/enterprise/admin/load-capture/
   - name: Data deletion
     description: |
       Manage row-delete requests.
@@ -956,9 +964,9 @@ paths:
                   trigger_name: all_tables_trigger
                   trigger_specification: all_tables
                   disabled: false
-                  trigger_settings:
-                    run_async: false
-                    error_behavior: log
+                trigger_settings:
+                  run_async: false
+                  error_behavior: log
               github_plugin:
                 summary: Trigger using a plugin fetched from GitHub
                 description: |
@@ -2392,6 +2400,78 @@ paths:
       tags:
         - Export data (beta)
         - Enterprise
+  /api/v3/loadcap/profiles:
+    get:
+      operationId: GetLoadcapProfiles
+      summary: List load capture profiles
+      description: >
+        Returns load capture profiles stored by a query-capable Enterprise node that has the performance upgrade preview
+        enabled and an explicit `--mode` setting that includes `query`.
+
+
+        This endpoint requires an admin token.
+      responses:
+        "200":
+          description: Load capture profiles.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/LoadCaptureProfile"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Forbidden. An admin token is required.
+        "404":
+          description: >-
+            Load capture is unavailable because this node does not use the performance upgrade preview with an explicit
+            `--mode` setting that includes `query`.
+      tags:
+        - Load capture
+        - Enterprise
+      x-enterprise-only: true
+      x-influxdb-introduced-in: v3.10.0
+  /api/v3/loadcap/start:
+    post:
+      operationId: PostLoadcapStart
+      summary: Start a load capture
+      description: >
+        Starts a timed capture of write requests, query requests, or both on a query-capable Enterprise node that has
+        the performance upgrade preview enabled and an explicit `--mode` setting that includes `query`.
+
+
+        Only one capture can run at a time on a node. This endpoint requires an admin token.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoadCaptureStartRequest"
+      responses:
+        "200":
+          description: Load capture started.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LoadCaptureStartResponse"
+        "400":
+          description: Invalid capture type or duration.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Forbidden. An admin token is required.
+        "404":
+          description: >-
+            Load capture is unavailable because this node does not use the performance upgrade preview with an explicit
+            `--mode` setting that includes `query`.
+        "409":
+          description: A load capture is already running on this node.
+      tags:
+        - Load capture
+        - Enterprise
+      x-enterprise-only: true
+      x-influxdb-introduced-in: v3.10.0
   /api/v3/plugin_test/schedule:
     post:
       operationId: PostTestSchedulingPlugin
@@ -4376,28 +4456,9 @@ components:
           description: |
             The path and filename of the plugin to execute--for example,
             `schedule.py` or `endpoints/report.py`.
-            The path can be absolute or relative to the `--plugin-dir` directory configured when starting InfluxDB 3.
+            The path can be absolute or relative to the `--plugins-dir` directory configured when starting InfluxDB 3.
 
             The plugin file must implement the trigger interface associated with the trigger's specification.
-
-            #### Reference a plugin from GitHub
-
-            Prefix the path with `gh:` to fetch the plugin from a GitHub repository instead of the local `--plugin-dir`--for example, `gh:examples/wal_plugin/wal_plugin.py`.
-            The path after `gh:` is appended to the configured `--plugin-repo`. This does not require GitHub or a Git repository--`--plugin-repo` accepts any HTTP/HTTPS URL that serves raw plugin files.
-
-            By default, InfluxDB fetches `gh:`-prefixed plugins from `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/`.
-            To use a different repository, set the `--plugin-repo` server option or the `INFLUXDB3_PLUGIN_REPO` environment variable to a raw content URL base path--for example, `https://raw.githubusercontent.com/myorg/my-plugins/main/`.
-
-            InfluxDB fetches the plugin when the trigger is created (to validate it) and again each time the trigger starts--for example, on server startup or when re-enabled.
-            Unlike local plugins, `gh:`-prefixed plugins aren't automatically reloaded when the source changes. Disable and re-enable the trigger to fetch updates.
-
-            Only single-file plugins are supported with the `gh:` prefix. Multi-file plugin directories must be uploaded locally.
-
-            If the fetch fails, the API returns an error with the HTTP status code and URL--for example:
-
-            ```
-            error fetching plugin from repository: 404 Not Found https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/not_found.py
-            ```
         node_spec:
           $ref: "#/components/schemas/ApiNodeSpec"
         trigger_name:
@@ -4776,6 +4837,78 @@ components:
         - db
         - table
       description: Request schema for updating table configuration.
+    LoadCaptureStartRequest:
+      type: object
+      description: Request body for starting a timed load capture.
+      properties:
+        type:
+          type: string
+          description: The request types to capture.
+          enum:
+            - write
+            - query
+            - both
+        duration:
+          type: string
+          description: Capture duration using seconds, minutes, or hours. The maximum duration is one hour.
+          example: 5m
+      required:
+        - type
+        - duration
+    LoadCaptureStartResponse:
+      type: object
+      description: Response returned after a load capture starts.
+      properties:
+        profile_id:
+          type: string
+          format: uuid
+          description: Identifier of the new load capture profile.
+      required:
+        - profile_id
+    LoadCaptureProfile:
+      type: object
+      description: Metadata for a load capture profile.
+      properties:
+        profile_id:
+          type: string
+          format: uuid
+          description: Identifier of the load capture profile.
+        created_at:
+          type: string
+          format: date-time
+          description: Time when the capture started.
+        capture_type:
+          type: string
+          enum:
+            - write
+            - query
+            - both
+          description: The request types captured by the profile.
+        duration:
+          type: string
+          description: Requested capture duration.
+        node_id:
+          type: string
+          description: Identifier of the node that owns the profile.
+        status:
+          type: string
+          enum:
+            - running
+            - complete
+            - aborted
+          description: Current capture status.
+        wal_dropped:
+          type: integer
+          minimum: 0
+          description: Number of write-ahead log files that could not be captured.
+        query_dropped:
+          type: integer
+          minimum: 0
+          description: Number of queries that could not be captured.
+        unparseable_queries:
+          type: integer
+          minimum: 0
+          description: Number of queries replaced because they could not be parsed safely.
     LicenseResponse:
       type: object
       properties:

--- a/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
+++ b/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
@@ -4460,24 +4460,9 @@ components:
 
             The plugin file must implement the trigger interface associated with the trigger's specification.
 
-            #### Fetch a plugin remotely
-
-            Prefix the path with `gh:` to fetch the plugin remotely instead of reading it from the local `--plugin-dir`--for example, `gh:examples/wal_plugin/wal_plugin.py`.
-            The path after `gh:` is appended to the configured `--plugin-repo`. Despite the name, `gh:` doesn't require GitHub or a Git repository--`--plugin-repo` accepts any HTTP/HTTPS URL that serves raw plugin files.
-
-            By default, `gh:`-prefixed plugins resolve against the [`influxdata/influxdb3_plugins`](https://github.com/influxdata/influxdb3_plugins) repository at `https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/`.
-            To use a different repository, set the `--plugin-repo` server option or the `INFLUXDB3_PLUGIN_REPO` environment variable to a raw content URL base path--for example, `https://raw.githubusercontent.com/myorg/my-plugins/main/`.
-
-            InfluxDB fetches the plugin when the trigger is created (to validate it) and again each time the trigger starts--for example, on server startup or when re-enabled.
-            Unlike local plugins, `gh:`-prefixed plugins aren't automatically reloaded when the source changes. Disable and re-enable the trigger to fetch updates.
-
-            Only single-file plugins are supported with the `gh:` prefix. Multi-file plugin directories must be uploaded locally.
-
-            If the fetch fails, the API returns an error with the HTTP status code and URL--for example:
-
-            ```
-            error fetching plugin from repository: 404 Not Found https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/not_found.py
-            ```
+            Prefix the path with `gh:` to fetch the plugin remotely from the configured `--plugin-repo` instead of reading it from the local `--plugin-dir`--for example, `gh:examples/wal_plugin/wal_plugin.py`.
+            Despite the name, `gh:` doesn't require GitHub--`--plugin-repo` accepts any HTTP/HTTPS URL that serves raw plugin files.
+            For defaults, fetch behavior, and limitations, see [Use example plugins](/influxdb3/enterprise/plugins/#use-example-plugins).
         node_spec:
           $ref: "#/components/schemas/ApiNodeSpec"
         trigger_name:

--- a/api-docs/influxdb3/enterprise/tags.yml
+++ b/api-docs/influxdb3/enterprise/tags.yml
@@ -9,6 +9,16 @@ tags:
     x-related:
       - title: Export data
         href: /influxdb3/enterprise/admin/export/
+  Load capture:
+    description: >
+      Capture an anonymized profile of write requests, query requests, or both on a
+      query-capable node.
+    externalDocs:
+      description: Capture workload data
+      url: /influxdb3/enterprise/admin/load-capture/
+    x-related:
+      - title: Capture workload data
+        href: /influxdb3/enterprise/admin/load-capture/
   Authentication:
     x-traitTag: true
     description: |

--- a/content/influxdb3/enterprise/admin/load-capture.md
+++ b/content/influxdb3/enterprise/admin/load-capture.md
@@ -1,0 +1,65 @@
+---
+title: Capture workload data
+introduced: v3.10.0
+description: >
+  Capture a time-limited, anonymized profile of write and query requests in
+  InfluxDB 3 Enterprise.
+weight: 207
+menu:
+  influxdb3_enterprise:
+    parent: Administer InfluxDB
+    name: Capture workload data
+related:
+  - /influxdb3/enterprise/admin/tokens/admin/
+  - /influxdb3/enterprise/api/
+---
+
+Use load capture to record a short, anonymized profile of requests handled by a query-capable InfluxDB 3 Enterprise node.
+The profile preserves workload characteristics that can help you analyze or reproduce a workload.
+
+> [!Important]
+> Inspect a capture before sharing it.
+> Anonymization does not remove all operational characteristics from a profile.
+
+> [!Note]
+> Load capture requires the [performance upgrade preview](/influxdb3/enterprise/performance-preview/), which uses the storage engine upgrade.
+> Enable the preview with `--use-pacha-tree` and send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
+> Load capture isn't available on a node that uses the default `--mode all` configuration.
+
+Load capture requires an [admin token](/influxdb3/enterprise/admin/tokens/admin/).
+Only one capture can run on a node at a time.
+
+## Start a capture
+
+Send a `POST` request to `/api/v3/loadcap/start`.
+Set `type` to `write`, `query`, or `both` and specify a duration with seconds, minutes, or hours.
+The maximum duration is one hour.
+
+```sh { placeholders="INFLUXDB3_HOST_URL|ADMIN_TOKEN" }
+curl --request POST "$INFLUXDB3_HOST_URL/api/v3/loadcap/start" \
+  --header "Authorization: Bearer ADMIN_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data '{"type":"both","duration":"5m"}'
+```
+
+The response contains the capture profile identifier:
+
+```json
+{
+  "profile_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+If another capture is running on the node, the endpoint returns `409 Conflict`.
+
+## List capture profiles
+
+Send a `GET` request to `/api/v3/loadcap/profiles` to list profiles stored by the query-capable node.
+
+```sh { placeholders="INFLUXDB3_HOST_URL|ADMIN_TOKEN" }
+curl --request GET "$INFLUXDB3_HOST_URL/api/v3/loadcap/profiles" \
+  --header "Authorization: Bearer ADMIN_TOKEN"
+```
+
+Each profile includes its identifier, creation time, capture type, requested duration, owning node, and status.
+The status is `running`, `complete`, or `aborted`.

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/_index.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/_index.md
@@ -31,6 +31,7 @@ influxdb3 [GLOBAL-OPTIONS] [COMMAND]
 | [enable](/influxdb3/enterprise/reference/cli/influxdb3/enable/)   | Enable resources                    |
 | [import](/influxdb3/enterprise/reference/cli/influxdb3/import/)   | Manage bulk Parquet imports         |
 | [install](/influxdb3/enterprise/reference/cli/influxdb3/install/) | Install plugins                     |
+| [loadcap](/influxdb3/enterprise/reference/cli/influxdb3/loadcap/) | Capture and manage workload profiles |
 | [query](/influxdb3/enterprise/reference/cli/influxdb3/query/)     | Query {{% product-name %}}          |
 | [serve](/influxdb3/enterprise/reference/cli/influxdb3/serve/)     | Run the {{% product-name %}} server |
 | [show](/influxdb3/enterprise/reference/cli/influxdb3/show/)       | List resources                      |

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/_index.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/_index.md
@@ -1,0 +1,48 @@
+---
+title: influxdb3 loadcap
+introduced: v3.10.0
+description: >
+  The `influxdb3 loadcap` command captures and manages anonymized workload
+  profiles in InfluxDB 3 Enterprise.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3
+    name: influxdb3 loadcap
+weight: 300
+related:
+  - /influxdb3/enterprise/admin/load-capture/
+---
+
+Use `influxdb3 loadcap` to capture and manage anonymized workload profiles on a query-capable InfluxDB 3 Enterprise node.
+
+> [!Note]
+> Load capture requires the [performance upgrade preview](/influxdb3/enterprise/performance-preview/), which uses the storage engine upgrade.
+> Enable the preview with `--use-pacha-tree` and send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
+> Load capture isn't available on a node that uses the default `--mode all` configuration.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 loadcap <SUBCOMMAND>
+```
+
+## Subcommands
+
+| Subcommand | Description |
+| :--------- | :---------- |
+| [start](/influxdb3/enterprise/reference/cli/influxdb3/loadcap/start/) | Start a timed capture |
+| [list](/influxdb3/enterprise/reference/cli/influxdb3/loadcap/list/) | List capture profiles |
+| [files](/influxdb3/enterprise/reference/cli/influxdb3/loadcap/files/) | List files in a profile |
+| [preview](/influxdb3/enterprise/reference/cli/influxdb3/loadcap/preview/) | Preview a profile |
+| [download](/influxdb3/enterprise/reference/cli/influxdb3/loadcap/download/) | Download a profile archive |
+| [delete](/influxdb3/enterprise/reference/cli/influxdb3/loadcap/delete/) | Delete a profile |
+| help | Print command help or the help of a subcommand |
+
+## Options
+
+| Option |              | Description                     |
+| :----- | :----------- | :------------------------------ |
+| `-h`   | `--help`     | Print help information          |
+|        | `--help-all` | Print detailed help information |

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/delete.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/delete.md
@@ -1,0 +1,40 @@
+---
+title: influxdb3 loadcap delete
+introduced: v3.10.0
+description: >
+  The `influxdb3 loadcap delete` command deletes an InfluxDB 3 Enterprise
+  workload capture profile.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 loadcap
+    name: delete
+weight: 306
+related:
+  - /influxdb3/enterprise/admin/load-capture/
+---
+
+Use `influxdb3 loadcap delete` to delete a workload capture profile.
+
+> [!Note]
+> Load capture requires the [performance upgrade preview](/influxdb3/enterprise/performance-preview/), which uses the storage engine upgrade.
+> Enable the preview with `--use-pacha-tree` and send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
+> Load capture isn't available on a node that uses the default `--mode all` configuration.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 loadcap delete --profile-id <PROFILE_ID> [OPTIONS]
+```
+
+## Options
+
+| Option | | Description | Default | Environment variable |
+| :----- | :-- | :---------- | :------ | :------------------- |
+| | `--profile-id <PROFILE_ID>` | Capture profile identifier | | |
+| `-H` | `--host <HOST_URL>` | InfluxDB 3 Enterprise server URL | `http://127.0.0.1:8181` | `INFLUXDB3_HOST_URL` |
+| | `--token <AUTH_TOKEN>` | Authentication token | | `INFLUXDB3_AUTH_TOKEN` |
+| | `--tls-ca <CA_CERT>` | Path to a custom TLS certificate authority | | `INFLUXDB3_TLS_CA` |
+| | `--tls-no-verify` | Disable TLS certificate verification | | `INFLUXDB3_TLS_NO_VERIFY` |
+| `-h` | `--help` | Print help information | | |

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/download.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/download.md
@@ -1,0 +1,42 @@
+---
+title: influxdb3 loadcap download
+introduced: v3.10.0
+description: >
+  The `influxdb3 loadcap download` command downloads an InfluxDB 3 Enterprise
+  workload capture profile as a tar.gz archive.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 loadcap
+    name: download
+weight: 305
+related:
+  - /influxdb3/enterprise/admin/load-capture/
+---
+
+Use `influxdb3 loadcap download` to download a workload capture profile.
+If you omit `--output`, the command writes `<PROFILE_ID>.tar.gz` to the current directory.
+
+> [!Note]
+> Load capture requires the [performance upgrade preview](/influxdb3/enterprise/performance-preview/), which uses the storage engine upgrade.
+> Enable the preview with `--use-pacha-tree` and send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
+> Load capture isn't available on a node that uses the default `--mode all` configuration.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 loadcap download --profile-id <PROFILE_ID> [OPTIONS]
+```
+
+## Options
+
+| Option | | Description | Default | Environment variable |
+| :----- | :-- | :---------- | :------ | :------------------- |
+| | `--profile-id <PROFILE_ID>` | Capture profile identifier | | |
+| `-o` | `--output <OUTPUT>` | Output archive path | `<PROFILE_ID>.tar.gz` | |
+| `-H` | `--host <HOST_URL>` | InfluxDB 3 Enterprise server URL | `http://127.0.0.1:8181` | `INFLUXDB3_HOST_URL` |
+| | `--token <AUTH_TOKEN>` | Authentication token | | `INFLUXDB3_AUTH_TOKEN` |
+| | `--tls-ca <CA_CERT>` | Path to a custom TLS certificate authority | | `INFLUXDB3_TLS_CA` |
+| | `--tls-no-verify` | Disable TLS certificate verification | | `INFLUXDB3_TLS_NO_VERIFY` |
+| `-h` | `--help` | Print help information | | |

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/files.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/files.md
@@ -1,0 +1,40 @@
+---
+title: influxdb3 loadcap files
+introduced: v3.10.0
+description: >
+  The `influxdb3 loadcap files` command lists files in an InfluxDB 3 Enterprise
+  workload capture profile.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 loadcap
+    name: files
+weight: 303
+related:
+  - /influxdb3/enterprise/admin/load-capture/
+---
+
+Use `influxdb3 loadcap files` to list files in a workload capture profile.
+
+> [!Note]
+> Load capture requires the [performance upgrade preview](/influxdb3/enterprise/performance-preview/), which uses the storage engine upgrade.
+> Enable the preview with `--use-pacha-tree` and send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
+> Load capture isn't available on a node that uses the default `--mode all` configuration.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 loadcap files --profile-id <PROFILE_ID> [OPTIONS]
+```
+
+## Options
+
+| Option | | Description | Default | Environment variable |
+| :----- | :-- | :---------- | :------ | :------------------- |
+| | `--profile-id <PROFILE_ID>` | Capture profile identifier | | |
+| `-H` | `--host <HOST_URL>` | InfluxDB 3 Enterprise server URL | `http://127.0.0.1:8181` | `INFLUXDB3_HOST_URL` |
+| | `--token <AUTH_TOKEN>` | Authentication token | | `INFLUXDB3_AUTH_TOKEN` |
+| | `--tls-ca <CA_CERT>` | Path to a custom TLS certificate authority | | `INFLUXDB3_TLS_CA` |
+| | `--tls-no-verify` | Disable TLS certificate verification | | `INFLUXDB3_TLS_NO_VERIFY` |
+| `-h` | `--help` | Print help information | | |

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/list.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/list.md
@@ -1,0 +1,40 @@
+---
+title: influxdb3 loadcap list
+introduced: v3.10.0
+description: >
+  The `influxdb3 loadcap list` command lists workload capture profiles in
+  InfluxDB 3 Enterprise.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 loadcap
+    identifier: influxdb3 loadcap list
+    name: list
+weight: 302
+related:
+  - /influxdb3/enterprise/admin/load-capture/
+---
+
+Use `influxdb3 loadcap list` to list capture profiles stored by a query-capable InfluxDB 3 Enterprise node.
+
+> [!Note]
+> Load capture requires the [performance upgrade preview](/influxdb3/enterprise/performance-preview/), which uses the storage engine upgrade.
+> Enable the preview with `--use-pacha-tree` and send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
+> Load capture isn't available on a node that uses the default `--mode all` configuration.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 loadcap list [OPTIONS]
+```
+
+## Options
+
+| Option | | Description | Default | Environment variable |
+| :----- | :-- | :---------- | :------ | :------------------- |
+| `-H` | `--host <HOST_URL>` | InfluxDB 3 Enterprise server URL | `http://127.0.0.1:8181` | `INFLUXDB3_HOST_URL` |
+| | `--token <AUTH_TOKEN>` | Authentication token | | `INFLUXDB3_AUTH_TOKEN` |
+| | `--tls-ca <CA_CERT>` | Path to a custom TLS certificate authority | | `INFLUXDB3_TLS_CA` |
+| | `--tls-no-verify` | Disable TLS certificate verification | | `INFLUXDB3_TLS_NO_VERIFY` |
+| `-h` | `--help` | Print help information | | |

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/preview.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/preview.md
@@ -1,0 +1,40 @@
+---
+title: influxdb3 loadcap preview
+introduced: v3.10.0
+description: >
+  The `influxdb3 loadcap preview` command previews an InfluxDB 3 Enterprise
+  workload capture profile.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 loadcap
+    name: preview
+weight: 304
+related:
+  - /influxdb3/enterprise/admin/load-capture/
+---
+
+Use `influxdb3 loadcap preview` to inspect a workload capture profile without downloading it.
+
+> [!Note]
+> Load capture requires the [performance upgrade preview](/influxdb3/enterprise/performance-preview/), which uses the storage engine upgrade.
+> Enable the preview with `--use-pacha-tree` and send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
+> Load capture isn't available on a node that uses the default `--mode all` configuration.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 loadcap preview --profile-id <PROFILE_ID> [OPTIONS]
+```
+
+## Options
+
+| Option | | Description | Default | Environment variable |
+| :----- | :-- | :---------- | :------ | :------------------- |
+| | `--profile-id <PROFILE_ID>` | Capture profile identifier | | |
+| `-H` | `--host <HOST_URL>` | InfluxDB 3 Enterprise server URL | `http://127.0.0.1:8181` | `INFLUXDB3_HOST_URL` |
+| | `--token <AUTH_TOKEN>` | Authentication token | | `INFLUXDB3_AUTH_TOKEN` |
+| | `--tls-ca <CA_CERT>` | Path to a custom TLS certificate authority | | `INFLUXDB3_TLS_CA` |
+| | `--tls-no-verify` | Disable TLS certificate verification | | `INFLUXDB3_TLS_NO_VERIFY` |
+| `-h` | `--help` | Print help information | | |

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/start.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/start.md
@@ -1,0 +1,54 @@
+---
+title: influxdb3 loadcap start
+introduced: v3.10.0
+description: >
+  The `influxdb3 loadcap start` command starts a timed workload capture in
+  InfluxDB 3 Enterprise.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 loadcap
+    name: start
+weight: 301
+related:
+  - /influxdb3/enterprise/admin/load-capture/
+---
+
+Use `influxdb3 loadcap start` to capture write requests, query requests, or both on a query-capable InfluxDB 3 Enterprise node.
+Only one capture can run on a node at a time.
+
+> [!Note]
+> Load capture requires the [performance upgrade preview](/influxdb3/enterprise/performance-preview/), which uses the storage engine upgrade.
+> Enable the preview with `--use-pacha-tree` and send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
+> Load capture isn't available on a node that uses the default `--mode all` configuration.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 loadcap start --type <TYPE> --duration <DURATION> [OPTIONS]
+```
+
+## Options
+
+| Option | | Description | Default | Environment variable |
+| :----- | :-- | :---------- | :------ | :------------------- |
+| | `--type <TYPE>` | Request types to capture: `write`, `query`, or `both` | | |
+| | `--duration <DURATION>` | Capture duration, for example, `30s`, `5m`, or `1h`. The maximum is one hour. | | |
+| `-H` | `--host <HOST_URL>` | InfluxDB 3 Enterprise server URL | `http://127.0.0.1:8181` | `INFLUXDB3_HOST_URL` |
+| | `--token <AUTH_TOKEN>` | Authentication token | | `INFLUXDB3_AUTH_TOKEN` |
+| | `--tls-ca <CA_CERT>` | Path to a custom TLS certificate authority | | `INFLUXDB3_TLS_CA` |
+| | `--tls-no-verify` | Disable TLS certificate verification | | `INFLUXDB3_TLS_NO_VERIFY` |
+| `-h` | `--help` | Print help information | | |
+
+## Example
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="AUTH_TOKEN" }
+influxdb3 loadcap start \
+  --host http://localhost:8181 \
+  --token AUTH_TOKEN \
+  --type both \
+  --duration 5m
+```


### PR DESCRIPTION
## What changed
Added InfluxDB 3 Enterprise load capture admin and CLI reference pages, v3.10.0 version metadata, storage-engine prerequisite notes, and synchronized public OpenAPI specifications.

## Why
Operators need accurate guidance for the load capture endpoints and CLI commands introduced in v3.10.0. Closes #7466 

## Impact
Enterprise documentation and API reference now expose load capture and its availability requirements; Core remains free of Enterprise-only endpoints.

## Verification
- `npx hugo --quiet --environment development --destination /tmp/docs-v2-loadcap-note-verify --cleanDestinationDir --noBuildLock`
- `yarn lint-codeblocks content/influxdb3/enterprise/admin/load-capture.md content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/*.md`
- docs-tooling OpenAPI generation, tests, and downstream drift check