### PR TITLE
fix(docs): complete replication-factor glossary anchors

### DIFF
--- a/content/enterprise_influxdb/v1/concepts/glossary.md
+++ b/content/enterprise_influxdb/v1/concepts/glossary.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Glossary
 description: Terms related to InfluxDB Enterprise.
 aliases:
@@ -52,7 +52,7 @@ query capacity within the cluster.
 Data node sizes will depend on your needs.
 The Amazon EC2 m4.large or m4.xlarge are good starting points.
 
-Related entries: [data service](#data-service), [replication factor](#replication-factor)
+Related entries: [data service](#data-service), [replication factor](#replication-factor-rf)
 
 ## data service
 
@@ -245,7 +245,7 @@ Describes how long InfluxDB keeps data (duration), how many copies of the data t
 When you create a database, InfluxDB creates a retention policy called `autogen` with an infinite duration, a replication factor set to one, and a shard group duration set to seven days.
 For more information, see [Retention policy management](/enterprise_influxdb/v1/query_language/manage-database/#retention-policy-management).
 
-Related entries: [duration](#duration), [measurement](#measurement), [replication factor](#replication-factor), [series](#series), [shard duration](#shard-duration), [tag set](#tag-set)
+Related entries: [duration](#duration), [measurement](#measurement), [replication factor](#replication-factor-rf), [series](#series), [shard duration](#shard-duration), [tag set](#tag-set)
 
 <!--
 ## role

--- a/content/enterprise_influxdb/v1/guides/hardware_sizing.md
+++ b/content/enterprise_influxdb/v1/guides/hardware_sizing.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Hardware sizing guidelines
 Description: >
   Review configuration and hardware guidelines for InfluxDB OSS (open source) and InfluxDB Enterprise v1.
@@ -31,7 +31,7 @@ InfluxDB Enterprise supports the following:
 - more than 10,000,000 [series cardinality](/influxdb/v1/concepts/glossary/#series-cardinality)
 
 InfluxDB Enterprise distributes multiple copies of your data across a cluster,
-providing high-availability and redundancy, so an unavailable node doesn’t significantly impact the cluster.
+providing high-availability and redundancy, so an unavailable node doesnâ€™t significantly impact the cluster.
 Please [contact us](https://www.influxdata.com/contact-sales/) for assistance tuning your system.
 
 If you want a single node instance of InfluxDB that's fully open source, requires fewer writes, queries, and unique series than listed above, and do **not require** redundancy, we recommend InfluxDB OSS.
@@ -60,7 +60,7 @@ For **simple** or **complex** queries, we recommend testing and adjusting the su
 
 ### Meta nodes
 
-> Set up clusters with an odd number of meta nodes─an even number may cause issues in certain configurations.
+> Set up clusters with an odd number of meta nodesâ”€an even number may cause issues in certain configurations.
 
 A cluster must have a **minimum of three** independent meta nodes for data redundancy and availability. A cluster with `2n + 1` meta nodes can tolerate the loss of `n` meta nodes.
 
@@ -72,7 +72,7 @@ Meta nodes do not need very much computing power. Regardless of the cluster load
 
 ### Data nodes
 
-A cluster with one data node is valid but has no data redundancy. Redundancy is set by the [replication factor](/influxdb/v1/concepts/glossary/#replication-factor) on the retention policy the data is written to. Where `n` is the replication factor, a cluster can lose `n - 1` data nodes and return complete query results.
+A cluster with one data node is valid but has no data redundancy. Redundancy is set by the [replication factor](/influxdb/v1/concepts/glossary/#replication-factor-rf) on the retention policy the data is written to. Where `n` is the replication factor, a cluster can lose `n - 1` data nodes and return complete query results.
 
 >**Note:** For optimal data distribution within the cluster, use an even number of data nodes.
 
@@ -340,4 +340,4 @@ Non-string values require approximately three bytes. String values require varia
 
 ### Separate `wal` and `data` directories
 
-When running InfluxDB in a production environment, store the `wal` directory and the `data` directory on separate storage devices. This optimization significantly reduces disk contention under heavy write load──an important consideration if the write load is highly variable. If the write load does not vary by more than 15%, the optimization is probably not necessary.
+When running InfluxDB in a production environment, store the `wal` directory and the `data` directory on separate storage devices. This optimization significantly reduces disk contention under heavy write loadâ”€â”€an important consideration if the write load is highly variable. If the write load does not vary by more than 15%, the optimization is probably not necessary.

--- a/content/influxdb/v1/concepts/glossary.md
+++ b/content/influxdb/v1/concepts/glossary.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: InfluxDB glossary
 description: Terms related to InfluxDB OSS.
 menu:
@@ -180,7 +180,7 @@ Describes how long InfluxDB keeps data (duration), how many copies of the data t
 When you create a database, InfluxDB creates a retention policy called `autogen` with an infinite duration, a replication factor set to one, and a shard group duration set to seven days.
 For more information, see [Retention policy management](/influxdb/v1/query_language/manage-database/#retention-policy-management).
 
-Related entries: [duration](/influxdb/v1/concepts/glossary/#duration), [measurement](/influxdb/v1/concepts/glossary/#measurement), [replication factor](/influxdb/v1/concepts/glossary/#replication-factor), [series](/influxdb/v1/concepts/glossary/#series), [shard duration](/influxdb/v1/concepts/glossary/#shard-duration), [tag set](/influxdb/v1/concepts/glossary/#tag-set)
+Related entries: [duration](/influxdb/v1/concepts/glossary/#duration), [measurement](/influxdb/v1/concepts/glossary/#measurement), [replication factor](/influxdb/v1/concepts/glossary/#replication-factor-rf), [series](/influxdb/v1/concepts/glossary/#series), [shard duration](/influxdb/v1/concepts/glossary/#shard-duration), [tag set](/influxdb/v1/concepts/glossary/#tag-set)
 
 ## schema
 

--- a/content/influxdb/v1/query_language/explore-schema.md
+++ b/content/influxdb/v1/query_language/explore-schema.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Explore your schema using InfluxQL
 description: Useful query syntax for exploring schema in InfluxQL.
 menu:
@@ -107,7 +107,7 @@ database in tabular format.
 The database has one retention policy called `autogen`.
 The `autogen` retention policy has an infinite [duration](/influxdb/v1/concepts/glossary/#duration),
 a seven-day [shard group duration](/influxdb/v1/concepts/glossary/#shard-group),
-a [replication factor](/influxdb/v1/concepts/glossary/#replication-factor)
+a [replication factor](/influxdb/v1/concepts/glossary/#replication-factor-rf)
 of one, and it is the `DEFAULT` retention policy for the database.
 
 #### Run a `SHOW RETENTION POLICIES` query without the `ON` clause

--- a/content/influxdb/v1/query_language/manage-database.md
+++ b/content/influxdb/v1/query_language/manage-database.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Manage your database using InfluxQL
 description: >
   Use InfluxQL to administer your InfluxDB server and work with InfluxDB databases, retention policies, series, measurements, and shards.
@@ -102,7 +102,7 @@ CREATE DATABASE "NOAA_water_database" WITH DURATION 3d REPLICATION 1 SHARD DURAT
 ```
 
 The query creates a database called `NOAA_water_database`.
-It also creates a default retention policy for `NOAA_water_database` with a `DURATION` of three days, a [replication factor](/influxdb/v1/concepts/glossary/#replication-factor) of one, a [shard group](/influxdb/v1/concepts/glossary/#shard-group) duration of one hour, and with the name `liquid`.
+It also creates a default retention policy for `NOAA_water_database` with a `DURATION` of three days, a [replication factor](/influxdb/v1/concepts/glossary/#replication-factor-rf) of one, a [shard group](/influxdb/v1/concepts/glossary/#shard-group) duration of one hour, and with the name `liquid`.
 
 ### Delete a database with DROP DATABASE
 

--- a/content/shared/influxdb-v2/reference/glossary.md
+++ b/content/shared/influxdb-v2/reference/glossary.md
@@ -1,4 +1,4 @@
-
+﻿
 [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) | [H](#h) | [I](#i) | [J](#j) | [K](#k) | [L](#l) | [M](#m) | [N](#n) | [O](#o) | [P](#p) | [Q](#q) | [R](#r) | [S](#s) | [T](#t) | [U](#u) | [V](#v) | [W](#w) | <span style="opacity:.35;font-weight:500">X</span> | <span style="opacity:.35;font-weight:500">Y</span> | <span style="opacity:.35;font-weight:500">Z</span>
 
 ## A
@@ -238,7 +238,7 @@ For high availability in InfluxDB, a cluster must have at least two data nodes. 
 
 Data node sizes will depend on your needs. The Amazon EC2 m4.large or m4.xlarge are good starting points.
 
-Related entries: [data service](#data-service), [replication factor](#replication-factor)
+Related entries: [data service](#data-service), [replication factor](#replication-factor-rf)
 -->
 
 ### data service
@@ -287,7 +287,7 @@ Related entries: [continuous query](#continuous-query-cq), [retention policy](#r
 
 InfluxDB stores the date-time format for each data point in a timestamp with nanosecond-precision Unix time.
 Specifying a timestamp is options.
-If a timestamp isn't specified for a data point, InfluxDB uses the server’s local nanosecond timestamp in UTC.
+If a timestamp isn't specified for a data point, InfluxDB uses the serverâ€™s local nanosecond timestamp in UTC.
 
 ### downsample
 
@@ -534,7 +534,7 @@ Open source tracing used in distributed systems to monitor and troubleshoot tran
 
 ### JSON
 
-JavaScript Object Notation (JSON) is an open-standard file format that uses human-readable text to transmit data objects consisting of attribute–value pairs and array data types.
+JavaScript Object Notation (JSON) is an open-standard file format that uses human-readable text to transmit data objects consisting of attributeâ€“value pairs and array data types.
 
 ## K
 
@@ -761,7 +761,7 @@ Rows are uniquely identified by their timestamp and tag set.
 
 The precision configuration setting determines the timestamp precision retained for input data points.
 All incoming timestamps are truncated to the specified precision.
-Valid precisions are `ns`, `us` or `µs`, `ms`, and `s`.
+Valid precisions are `ns`, `us` or `Âµs`, `ms`, and `s`.
 
 In Telegraf, truncated timestamps are padded with zeros to create a nanosecond timestamp.
 Telegraf output plugins emit timestamps in nanoseconds.
@@ -916,7 +916,7 @@ For example, assume that an InfluxDB bucket has one measurement.
 The single measurement has two tag keys: `email` and `status`.
 If the data contains three different `email` values, and each email address is associated with two
 different `status` values, the series cardinality for the measurement is `6`
-(3 × 2 = 6):
+(3 Ã— 2 = 6):
 
 | email                 | status |
 | :-------------------- | :----- |
@@ -930,7 +930,7 @@ different `status` values, the series cardinality for the measurement is `6`
 In some cases, this calculation may overestimate series cardinality
 because of the presence of _dependent tags_--tags scoped by another tag.
 Dependent tags do not increase series cardinality.
-Adding the tag `firstname` to the preceding example would not increase the series cardinality to `18` (3 × 2 × 3 = 18).
+Adding the tag `firstname` to the preceding example would not increase the series cardinality to `18` (3 Ã— 2 Ã— 3 = 18).
 The series cardinality would remain unchanged at `6`, as `firstname` is already scoped by the `email` tag:
 
 | email                | status | firstname |
@@ -1252,7 +1252,7 @@ per second by the number of values stored per point.
 For example, if the points have four fields each, and a batch of 5000 points is
 written 10 times per second, the values per second rate is:
 
-**4 field values per point** × **5000 points per batch** × **10 batches per second** = **200,000 values per second**  
+**4 field values per point** Ã— **5000 points per batch** Ã— **10 batches per second** = **200,000 values per second**  
 
 Related entries: [batch](#batch), [field](#field), [point](#point)
 


### PR DESCRIPTION
Links to RF glossary entry use full #replication-factor-rf anchor. Fixes #5799.