### PR TITLE
feat(client-libs): collapse CI changelog sections to a bullet instead of dropping them

### DIFF
--- a/content/shared/influxdb-client-libraries-reference/v3/release-notes/csharp.md
+++ b/content/shared/influxdb-client-libraries-reference/v3/release-notes/csharp.md
@@ -21,10 +21,7 @@
 
 1. [#220](https://github.com/InfluxCommunity/influxdb3-csharp/pull/220): Add InfluxDB 3 Core/Enterprise structured errors handling.
 
-### CI
-
-1. [#213](https://github.com/InfluxCommunity/influxdb3-csharp/pull/213): Turn off deploy workflow for Nighly builds.
-1. [#219](https://github.com/InfluxCommunity/influxdb3-csharp/pull/219): Add support for .NET 10.0.
+- CI updates
 
 ## v1.6.0 {date="2026-01-08"}
 
@@ -44,9 +41,7 @@
 1. [#175](https://github.com/InfluxCommunity/influxdb3-csharp/pull/175): Add QueryTimeout and WriteTimeout to ClientConfig.
 1. [#179](https://github.com/InfluxCommunity/influxdb3-csharp/pull/179): Allows create ClientConfig from ClientConfig(string connectionString) and ClientConfig(IDictionary env)
 
-### CI
-
-1. [#181](https://github.com/InfluxCommunity/influxdb3-csharp/pull/181): Fix CI executors parameters.
+- CI updates
 
 ## v1.4.0 {date="2025-09-15"}
 
@@ -54,9 +49,7 @@
 
 1. [#174](https://github.com/InfluxCommunity/influxdb3-csharp/pull/174): Support passing HttpClient to InfluxDBClient.
 
-### CI
-
-1. [#170](https://github.com/InfluxCommunity/influxdb3-csharp/pull/170) Add tests for arm64 CircleCI.
+- CI updates
 
 ## v1.3.0 {date="2025-08-12"}
 

--- a/content/shared/influxdb-client-libraries-reference/v3/release-notes/go.md
+++ b/content/shared/influxdb-client-libraries-reference/v3/release-notes/go.md
@@ -2,11 +2,7 @@
 
 ## v2.17.0 {date="2026-07-01"}
 
-### CI
-
-1. [#262](https://github.com/InfluxCommunity/influxdb3-go/pull/262): Update GPG support.
-2. [#263](https://github.com/InfluxCommunity/influxdb3-go/pull/263): Start automated releasing.
-3. [#264](https://github.com/InfluxCommunity/influxdb3-go/pull/264): Upgrade GitHub actions checkout.
+- CI updates
 
 ### Dependencies
 
@@ -70,9 +66,7 @@
 
 ## v2.11.0 {date="2025-11-18"}
 
-### CI
-
-1. [#195](https://github.com/InfluxCommunity/influxdb3-go/pull/195): Fix pipelines not downloading the correct go images.
+- CI updates
 
 ### Features
 
@@ -92,11 +86,7 @@
 
 1. [#189](https://github.com/InfluxCommunity/influxdb3-go/pull/189): Add transparent gRPC compression support.
 
-### CI
-
-1. [#180](https://github.com/InfluxCommunity/influxdb3-go/pull/180):
-   - Add tests for arm64 CircleCI.
-   - Add tests for go v1.24 and v1.25.
+- CI updates
 
 ## v2.9.0 {date="2025-08-12"}
 
@@ -271,9 +261,7 @@ Update steps:
 1. [#97](https://github.com/InfluxCommunity/influxdb3-go/pull/97): Style and performance improvements discovered by `golangci-lint`
 1. [#98](https://github.com/InfluxCommunity/influxdb3-go/pull/98): Cloud Dedicated database creation ignores the name given by an argument
 
-### CI
-
-1. [#95](https://github.com/InfluxCommunity/influxdb3-go/pull/95): Add `golangci-lint` to CI
+- CI updates
 
 ## v0.9.0 {date="2024-08-12"}
 

--- a/content/shared/influxdb-client-libraries-reference/v3/release-notes/java.md
+++ b/content/shared/influxdb-client-libraries-reference/v3/release-notes/java.md
@@ -32,10 +32,7 @@
 
 1. [#351](https://github.com/InfluxCommunity/influxdb3-java/pull/351): Enterprise/Core structured errors handling.
 
-### CI
-
-1. [#313](https://github.com/InfluxCommunity/influxdb3-java/pull/313): Clarify JDK 25+ requirements.
-1. [#340](https://github.com/InfluxCommunity/influxdb3-java/pull/340): Turn off deploy workflow for Nighly builds.
+- CI updates
 
 ## v1.7.0 {date="2025-11-21"}
 
@@ -60,9 +57,7 @@
 
 1. [#289](https://github.com/InfluxCommunity/influxdb3-java/pull/289) Add the possibility to disable gRPC compression via the `disableGRPCCompression` parameter in the `ClientConfig`.
 
-### CI
-
-1. [#283](https://github.com/InfluxCommunity/influxdb3-java/pull/283) Fix pipeline not downloading the correct java images.
+- CI updates
 
 ## v1.4.0 {date="2025-09-15"}
 
@@ -80,9 +75,7 @@
       1. `influx.writeTimeout` - a positive integer.  The time unit is in seconds.
       2. `influx.queryTimeout` - a positive integer.  The time unit is in seconds.
 
-### CI
-
-1. [#266](https://github.com/InfluxCommunity/influxdb3-java/pull/266) Add tests for arm64 CircleCI.
+- CI updates
 
 ## v1.3.0 {date="2025-08-13"}
 

--- a/content/shared/influxdb-client-libraries-reference/v3/release-notes/javascript.md
+++ b/content/shared/influxdb-client-libraries-reference/v3/release-notes/javascript.md
@@ -40,9 +40,7 @@
    - Added QueryOptions.timeout and WriteOptions.timeout.
    - Users can pass timeout directly to the query and write functions.
 
-### CI
-
-1. [#626](https://github.com/InfluxCommunity/influxdb3-js/pull/626) Fix pipelines not downloading the correct node images.
+- CI updates
 
 ### Docs
 
@@ -50,9 +48,7 @@
 
 ## v1.4.0 {date="2025-09-15"}
 
-### CI
-
-1. [#607](https://github.com/InfluxCommunity/influxdb3-js/pull/607) Add tests for arm64 CircleCI.
+- CI updates
 
 ## v1.3.0 {date="2025-08-12"}
 

--- a/content/shared/influxdb-client-libraries-reference/v3/release-notes/python.md
+++ b/content/shared/influxdb-client-libraries-reference/v3/release-notes/python.md
@@ -58,14 +58,7 @@
 
 1. [#177](https://github.com/InfluxCommunity/influxdb3-python/pull/177): Fix `TypeError` when writing DataFrames. Serializer-specific kwargs (e.g., `data_frame_measurement_name`) are now filtered before being passed to the HTTP layer.
 
-### CI
-
-1. [#164](https://github.com/InfluxCommunity/influxdb3-python/pull/164): Fix pipelines not downloading the correct python images.
-1. [#167](https://github.com/InfluxCommunity/influxdb3-python/pull/167):
-    - Remove incorrect symbol `>>` for config.yml.
-    - Added spacing for `<<` and `>>` just for consistency.
-1. [#176](https://github.com/InfluxCommunity/influxdb3-python/pull/176): Use `ConstantFlightServerDelayed` for timeout tests.
-1. [#183](https://github.com/InfluxCommunity/influxdb3-python/pull/183): Temporarily add annotation to support Python 3.8.
+- CI updates
 
 ## v0.16.0 {date="2025-09-15"}
 
@@ -80,9 +73,7 @@
          even in batching mode.
       - `client.query()` now propagates the argument `timeout` as a `float` in seconds on the call stack.
 
-### CI
-
-1. [#153](https://github.com/InfluxCommunity/influxdb3-python/pull/153) Add tests for arm64 CircleCI.
+- CI updates
 
 ## v0.15.0 {date="2025-08-12"}
 

--- a/helper-scripts/client-libraries/README.md
+++ b/helper-scripts/client-libraries/README.md
@@ -7,6 +7,26 @@ Hugo-flavored release notes pages under `content/shared/`.
 Driven by `.github/workflows/sync-client-library-release-notes.yml`
 (nightly cron + manual dispatch).
 
+## Excluded sections
+
+Some upstream CHANGELOG sections (for example `### CI`) are maintenance
+detail that's noise for docs readers. Rather than drop them outright — which
+can leave a release with no visible content and read as "the sync forgot
+this release" — a matching heading and everything under it (list items,
+paragraph text, nested subheadings) collapses to a single bullet, for
+example `- CI updates`.
+
+The default exclude list is `DEFAULT_EXCLUDE_HEADINGS` in
+[`transform-changelog.js`](transform-changelog.js) (currently just `CI`).
+Matching is case-insensitive and tolerates `#` markers, so `CI` and `### CI`
+both match a `### CI` heading.
+
+Override the list for a run with `--exclude-headings` (comma-separated
+heading labels), for example `--exclude-headings "CI,Dependencies"`. Each
+label collapses to `<label> updates`; pass `{ heading, replacement }` objects
+to `transformChangelog`'s `excludeHeadings` option directly (not available
+via the CLI flag) for a custom bullet.
+
 ## Local usage
 
 ```sh

--- a/helper-scripts/client-libraries/sync-release-notes.js
+++ b/helper-scripts/client-libraries/sync-release-notes.js
@@ -73,6 +73,9 @@ function parseCliArgs() {
       'source-path': { type: 'string' },
       'source-root': { type: 'string' },
       'docs-root': { type: 'string', default: process.cwd() },
+      // Comma-separated heading labels to collapse to a bullet (for example
+      // `CI,Dependencies`). Defaults to DEFAULT_EXCLUDE_HEADINGS when omitted.
+      'exclude-headings': { type: 'string' },
     },
   });
 
@@ -92,7 +95,7 @@ function parseCliArgs() {
   return values;
 }
 
-function syncOne(client, sourcePath, docsRoot) {
+function syncOne(client, sourcePath, docsRoot, excludeHeadings) {
   const changelogPath = join(sourcePath, client.sourceFile);
   if (!existsSync(changelogPath)) {
     return {
@@ -103,11 +106,15 @@ function syncOne(client, sourcePath, docsRoot) {
   }
 
   const raw = readFileSync(changelogPath, 'utf8');
-  const { page, latestVersion, latestReleaseDate } = transformChangelog(raw, {
-    displayName: client.displayName,
-    language: client.language,
-    repo: client.repo,
-  });
+  const { page, latestVersion, latestReleaseDate } = transformChangelog(
+    raw,
+    {
+      displayName: client.displayName,
+      language: client.language,
+      repo: client.repo,
+    },
+    excludeHeadings ? { excludeHeadings } : undefined
+  );
 
   if (latestVersion === null) {
     return {
@@ -196,11 +203,9 @@ function formatSummary(results) {
           : sanitizeTableCell(r.reason ?? '');
     return `| \`${r.client}\` | ${r.status} | ${detail} |`;
   });
-  return [
-    '| Client | Status | Detail |',
-    '| --- | --- | --- |',
-    ...rows,
-  ].join('\n');
+  return ['| Client | Status | Detail |', '| --- | --- | --- |', ...rows].join(
+    '\n'
+  );
 }
 
 function emitAnnotations(results) {
@@ -242,6 +247,13 @@ function main() {
   const args = parseCliArgs();
   const results = [];
 
+  const excludeHeadings = args['exclude-headings']
+    ? args['exclude-headings']
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : undefined;
+
   const targets = args.all
     ? CLIENTS.map((c) => ({
         client: c,
@@ -251,7 +263,9 @@ function main() {
 
   for (const { client, sourcePath } of targets) {
     try {
-      results.push(syncOne(client, sourcePath, args['docs-root']));
+      results.push(
+        syncOne(client, sourcePath, args['docs-root'], excludeHeadings)
+      );
     } catch (err) {
       results.push({
         client: client.slug,

--- a/helper-scripts/client-libraries/test/fixtures/exclude-CHANGELOG.txt
+++ b/helper-scripts/client-libraries/test/fixtures/exclude-CHANGELOG.txt
@@ -1,0 +1,18 @@
+# Changelog
+
+## [0.17.0] - 2026-01-08
+
+### Features
+- New feature.
+
+### Bug Fixes
+- A fix.
+
+### CI
+- Pipeline tweak.
+- Another CI item.
+
+## [0.16.0] - 2025-09-15
+
+### CI
+- Old CI note.

--- a/helper-scripts/client-libraries/test/fixtures/exclude-expected.txt
+++ b/helper-scripts/client-libraries/test/fixtures/exclude-expected.txt
@@ -1,0 +1,15 @@
+<!-- Generated from CHANGELOG.md. Edit upstream and re-sync; do not edit here. -->
+
+## v0.17.0 {date="2026-01-08"}
+
+### Features
+- New feature.
+
+### Bug Fixes
+- A fix.
+
+- CI updates
+
+## v0.16.0 {date="2025-09-15"}
+
+- CI updates

--- a/helper-scripts/client-libraries/test/transform-changelog.test.js
+++ b/helper-scripts/client-libraries/test/transform-changelog.test.js
@@ -3,7 +3,10 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { transformChangelog } from '../transform-changelog.js';
+import {
+  transformChangelog,
+  DEFAULT_EXCLUDE_HEADINGS,
+} from '../transform-changelog.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURES = join(__dirname, 'fixtures');
@@ -101,6 +104,165 @@ test('strips `## <version> [unreleased]` section through to next version heading
   assert.doesNotMatch(result.body, /Speculative feature/);
   assert.match(result.body, /## v0\.19\.0 \{date="2026-04-23"\}/);
   assert.match(result.body, /Real feature/);
+});
+
+test('collapses `### CI` heading and its items to a single bullet by default', () => {
+  const input = [
+    '## [0.19.0] - 2026-04-23',
+    '',
+    '### Features',
+    '- Real feature.',
+    '',
+    '### CI',
+    '- Pipeline tweak.',
+    '- Another CI item.',
+    '',
+  ].join('\n');
+  const result = transformChangelog(input);
+  assert.doesNotMatch(result.body, /### CI/);
+  assert.doesNotMatch(result.body, /Pipeline tweak/);
+  assert.doesNotMatch(result.body, /Another CI item/);
+  assert.match(result.body, /### Features/);
+  assert.match(result.body, /Real feature/);
+  assert.match(result.body, /^- CI updates$/m);
+});
+
+test('collapsed bullet keeps blank-line separation from the next heading', () => {
+  const input = [
+    '## [0.19.0] - 2026-04-23',
+    '',
+    '### CI',
+    '- Pipeline tweak.',
+    '',
+    '### Docs',
+    '- Real docs change.',
+    '',
+  ].join('\n');
+  const result = transformChangelog(input);
+  assert.match(result.body, /- CI updates\n\n### Docs/);
+  assert.match(result.body, /Real docs change/);
+});
+
+test('collapsed bullet stops at the next version heading', () => {
+  const input = [
+    '## [0.19.0] - 2026-04-23',
+    '',
+    '### CI',
+    '- Pipeline tweak.',
+    '',
+    '## [0.18.0] - 2026-03-10',
+    '',
+    '### Features',
+    '- Older feature.',
+    '',
+  ].join('\n');
+  const result = transformChangelog(input);
+  assert.doesNotMatch(result.body, /Pipeline tweak/);
+  assert.match(
+    result.body,
+    /- CI updates\n\n## v0\.18\.0 \{date="2026-03-10"\}/
+  );
+  assert.match(result.body, /Older feature/);
+});
+
+test('a release with only a CI section still shows a bullet, not an empty release', () => {
+  const input = [
+    '## [1.4.0] - 2025-09-15',
+    '',
+    '### CI',
+    '- Pipeline tweak.',
+    '',
+    '## [1.3.0] - 2025-08-12',
+    '',
+    '### Features',
+    '- Real feature.',
+    '',
+  ].join('\n');
+  const result = transformChangelog(input);
+  assert.match(
+    result.body,
+    /## v1\.4\.0 \{date="2025-09-15"\}\n\n- CI updates\n\n## v1\.3\.0/
+  );
+});
+
+test('drops deeper subheadings nested under a collapsed heading', () => {
+  const input = [
+    '## [0.19.0] - 2026-04-23',
+    '',
+    '### CI',
+    '#### Pipelines',
+    '- Nested CI item.',
+    '',
+    '### Features',
+    '- Real feature.',
+    '',
+  ].join('\n');
+  const result = transformChangelog(input);
+  assert.doesNotMatch(result.body, /#### Pipelines/);
+  assert.doesNotMatch(result.body, /Nested CI item/);
+  assert.match(result.body, /Real feature/);
+});
+
+test('exclude matching is case-insensitive and tolerates `#` markers', () => {
+  const input = [
+    '## [0.19.0] - 2026-04-23',
+    '',
+    '### ci',
+    '- Lowercase heading.',
+    '',
+    '### Features',
+    '- Real feature.',
+    '',
+  ].join('\n');
+  const result = transformChangelog(input, undefined, {
+    excludeHeadings: ['### CI'],
+  });
+  assert.doesNotMatch(result.body, /Lowercase heading/);
+  assert.match(result.body, /- CI updates/);
+  assert.match(result.body, /Real feature/);
+});
+
+test('exclude entries support a custom replacement bullet', () => {
+  const input = [
+    '## [0.19.0] - 2026-04-23',
+    '',
+    '### Deps',
+    '- Bump lodash.',
+    '',
+  ].join('\n');
+  const result = transformChangelog(input, undefined, {
+    excludeHeadings: [{ heading: 'Deps', replacement: 'Dependency bumps' }],
+  });
+  assert.doesNotMatch(result.body, /Bump lodash/);
+  assert.match(result.body, /^- Dependency bumps$/m);
+});
+
+test('empty exclude list keeps all sections', () => {
+  const input = [
+    '## [0.19.0] - 2026-04-23',
+    '',
+    '### CI',
+    '- Pipeline tweak.',
+    '',
+  ].join('\n');
+  const result = transformChangelog(input, undefined, { excludeHeadings: [] });
+  assert.match(result.body, /### CI/);
+  assert.match(result.body, /Pipeline tweak/);
+});
+
+test('exports `CI` as a default excluded heading', () => {
+  assert.ok(DEFAULT_EXCLUDE_HEADINGS.includes('CI'));
+});
+
+test('exclude fixture produces expected full-page output', () => {
+  const input = readFixture('exclude-CHANGELOG.txt');
+  const expected = readFixture('exclude-expected.txt');
+  const { page } = transformChangelog(input, {
+    displayName: 'influxdb3-python',
+    language: 'Python',
+    repo: 'InfluxCommunity/influxdb3-python',
+  });
+  assert.equal(page.trim(), expected.trim());
 });
 
 test('extracts latest version and date to return value', () => {

--- a/helper-scripts/client-libraries/transform-changelog.js
+++ b/helper-scripts/client-libraries/transform-changelog.js
@@ -22,15 +22,59 @@ const RELEASE_HEADING_RES = [
   /^##\s+v?\[?(\d+\.\d+\.\d+(?:[-+][\w.]+)?)\]?\s*\[\s*(\d{4}-\d{2}-\d{2})\s*\]\s*$/,
 ];
 
+// Section headings collapsed to a single bullet in the synced release notes.
+// Upstream CHANGELOGs include maintenance sections (for example `### CI`)
+// whose individual items are noise for docs readers, but dropping the
+// section entirely can leave a release with no visible content at all —
+// which reads as "the sync forgot this release" rather than "this release
+// was maintenance-only". Instead, each matching heading (and everything
+// under it: list items, paragraph text, nested subheadings) is collapsed to
+// one bullet, `- <replacement>`, in place of the section. Matching is
+// case-insensitive and tolerates leading `#` markers, so `'CI'` and
+// `'### CI'` both match a `### CI` heading.
+export const DEFAULT_EXCLUDE_HEADINGS = ['CI'];
+
 function normalizeLine(line) {
   // Avoid trailing whitespace diffs and markdown-formatters drifting output.
   return line.replace(/[\t ]+$/g, '');
 }
 
+// Returns the ATX heading level (number of leading `#`) for a heading line,
+// or null when the line is not a heading.
+function getHeadingLevel(line) {
+  const match = line.match(/^(#{1,6})\s/);
+  return match ? match[1].length : null;
+}
+
+// Normalizes a heading label (from an exclude entry or a heading line) to a
+// comparison key: strips leading `#` markers and surrounding whitespace,
+// then lowercases.
+function normalizeHeadingKey(value) {
+  return String(value).replace(/^#+/, '').trim().toLowerCase();
+}
+
+// Builds a lookup from normalized heading key to replacement bullet text.
+// Entries may be plain strings (heading label; replacement defaults to
+// `<label> updates`) or `{ heading, replacement }` objects for a custom
+// bullet.
+function buildExcludeMap(excludeHeadings) {
+  const map = new Map();
+  for (const entry of excludeHeadings) {
+    const heading = typeof entry === 'string' ? entry : entry.heading;
+    const label = heading.replace(/^#+/, '').trim();
+    const replacement =
+      typeof entry === 'string'
+        ? `${label} updates`
+        : (entry.replacement ?? `${label} updates`);
+    const key = normalizeHeadingKey(heading);
+    if (key) map.set(key, replacement);
+  }
+  return map;
+}
+
 function isUnreleasedHeading(line) {
   return (
-    UNRELEASED_HEADING_RE.test(line) ||
-    UNRELEASED_VERSION_HEADING_RE.test(line)
+    UNRELEASED_HEADING_RE.test(line) || UNRELEASED_VERSION_HEADING_RE.test(line)
   );
 }
 
@@ -45,11 +89,16 @@ function parseReleaseHeading(line) {
   return null;
 }
 
-export function transformChangelog(rawChangelog, meta) {
+export function transformChangelog(rawChangelog, meta, options = {}) {
+  const excludeHeadings = options.excludeHeadings ?? DEFAULT_EXCLUDE_HEADINGS;
+  const excludeMap = buildExcludeMap(excludeHeadings);
+
   const lines = rawChangelog.split('\n');
   const outLines = [];
 
   let skippingUnreleased = false;
+  let skippingExcluded = false;
+  let excludedLevel = 0;
   let seenFirstLine = false;
   let latestVersion = null;
   let latestReleaseDate = null;
@@ -69,8 +118,35 @@ export function transformChangelog(rawChangelog, meta) {
       }
     }
 
+    if (skippingExcluded) {
+      const level = getHeadingLevel(line);
+      // A heading at the same or higher level (fewer or equal `#`) ends the
+      // excluded section; deeper headings and body text stay collapsed into
+      // the replacement bullet already emitted.
+      if (level !== null && level <= excludedLevel) {
+        skippingExcluded = false;
+        // The replacement bullet isn't a heading, so restore the blank-line
+        // separator markdown expects before the next heading.
+        if (outLines[outLines.length - 1] !== '') {
+          outLines.push('');
+        }
+      } else {
+        continue;
+      }
+    }
+
     if (isUnreleasedHeading(line)) {
       skippingUnreleased = true;
+      continue;
+    }
+
+    const headingLevel = getHeadingLevel(line);
+    const replacement =
+      headingLevel !== null ? excludeMap.get(normalizeHeadingKey(line)) : null;
+    if (replacement) {
+      outLines.push(`- ${replacement}`);
+      skippingExcluded = true;
+      excludedLevel = headingLevel;
       continue;
     }
 


### PR DESCRIPTION
## What changed

- `DEFAULT_EXCLUDE_HEADINGS` (default `['CI']`) in transform-changelog.js
  collapses a matching heading and everything under it (list items,
  paragraph text, nested subheadings) into a single bullet, `- CI
  updates`, in place of the section. Matching is case-insensitive and
  tolerates `#` markers.
- `transformChangelog` accepts an `excludeHeadings` option (strings, or
  `{ heading, replacement }` for a custom bullet); sync-release-notes.js
  exposes it via a `--exclude-headings` CLI flag (comma-separated).
- Regenerate the currently synced release notes so
- Add unit tests and an end-to-end fixture covering the collapse
  behavior

## Why

The sync-client-library-release-notes action copied every CHANGELOG
section into the docs verbatim, including maintenance sections like
`### CI` that are noise for docs readers.

Dropping those sections can leave a release with no visible
content at all (some releases are CI-only), which reads as "the sync
forgot this release" rather than "this release was maintenance-only".
