### PR TITLE
Update 3ent latest_patch version to 3.10.3

### DIFF
--- a/data/products.yml
+++ b/data/products.yml
@@ -56,7 +56,7 @@ influxdb3_enterprise:
   versions: [enterprise]
   list_order: 2
   latest: enterprise
-  latest_patch: 3.10.0
+  latest_patch: 3.10.3
   placeholder_host: localhost:8181
   limits:
     database: 100


### PR DESCRIPTION
## Summary

Updated latest_patch to the most recent version.  Trying to resolve the problem where download urls in the docs are pointing to an older version.

Closes #

<!-- Brief description: What changed and why? -->

## Checklist

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
- [ ] Local build passes (`npx hugo --quiet`)

***
