### PR TITLE
fix(products): set InfluxDB 3 Core latest_patch to 3.10.3

### DIFF
--- a/data/products.yml
+++ b/data/products.yml
@@ -12,7 +12,7 @@ influxdb3_core:
   versions: [core]
   list_order: 2
   latest: core
-  latest_patch: 3.10.0
+  latest_patch: 3.10.3
   placeholder_host: localhost:8181
   limits:
     database: 5


### PR DESCRIPTION
## What changed

`data/products.yml` — InfluxDB 3 Core `latest_patch`: `3.10.0` → `3.10.3`.

## Why

The documented latest Core release is 3.10.3, matching Enterprise. Core
`latest_patch` was stale at 3.10.0.

v3.10.x facts:
- v3.10.1 — Core changes, build published
- v3.10.2 — no Core changes, no build
- v3.10.3 — Core changes, no separate Core binary build (docs still report it as Core's latest)

## Impact

Pages driven by `products.yml` (version references, release-note headers,
install snippets) now show 3.10.3 as the latest Core patch. Shared
`v3-core-enterprise-release-notes` already document v3.10.3 with its Core
changes — no release-note edits needed.

## Verification

- Confirmed v3.10.3 `### Core` section lists the Core bug fixes.
- Diff limited to a single YAML scalar; no other files changed.
- Hugo build not run locally (no hugo binary in this environment); CI build validates.

## Preview URLs

- https://docs.influxdata.com/influxdb3/core/install/