### PR TITLE
docs(influxdb3-cloud): draft release announcement notification

### DIFF
--- a/data/notifications.yaml
+++ b/data/notifications.yaml
@@ -219,3 +219,36 @@
     ```sh
     docker pull influxdb:2
     ```
+
+# DRAFT — InfluxDB 3 Cloud release announcement.
+# Stub to edit before release. Kept commented so it does not render until ready.
+# Before uncommenting to go live, confirm:
+#   - Final title, slug, and message copy
+#   - scope/exclude paths (where the banner should appear)
+#   - The announcement blog URL (replace the placeholder below)
+#   - Any launch date or availability wording
+# - id: influxdb3-cloud-ga
+#   level: note
+#   scope:
+#     - /influxdb3/
+#   exclude:
+#     - /influxdb3/cloud/
+#   title: 'InfluxDB 3 Cloud is now available'
+#   slug: |
+#     InfluxDB 3 Cloud is a fully managed, single-tenant InfluxDB 3 service
+#     that InfluxData operates for you.
+#
+#     <a class="btn" href="/influxdb3/cloud/">Explore InfluxDB 3 Cloud</a>
+#   message: |
+#     **InfluxDB 3 Cloud** brings InfluxDB 3 to a fully managed, single-tenant
+#     service. InfluxData runs the cluster; you write, query, and administer
+#     your data.
+#
+#     **Highlights:**
+#
+#     - Fully managed and single-tenant
+#     - SQL and InfluxQL support
+#     - Native v3 write and query APIs
+#
+#     For more information, see the
+#     [InfluxDB 3 Cloud documentation](/influxdb3/cloud/).


### PR DESCRIPTION
## What changed

Adds a **draft** InfluxDB 3 Cloud release notification to `data/notifications.yaml`. The entry is **commented out** and carries a starting `title` / `slug` / `message` plus inline notes on what to confirm (final copy, `scope`/`exclude`, announcement blog URL, launch/availability wording).

## Why

Stages the launch banner ahead of time as a **stub for @ritwika314 to edit**. Follows the repo convention of keeping draft notifications commented until ready, so the copy can be reviewed now without going live.

## Impact

- **No rendered output.** The entry is commented, so Hugo and the link checker do not see it — nothing appears on the site yet.
- Goes live only when someone uncomments it after filling in the details.
- **Stacked** on `ritwika/cloud3_init` (#7338) so the diff is just this one file; retargets to `master` when #7338 merges.

## Verification

- `data/notifications.yaml` change is comment-only; active notification data is unchanged.
- Diff is a single file.