### PR TITLE
fix(shortcodes): resolve influxdb/host-url in api-endpoint shortcode

### DIFF
--- a/layouts/shortcodes/api-endpoint.html
+++ b/layouts/shortcodes/api-endpoint.html
@@ -1,11 +1,13 @@
 {{- $productData := partial "product/get-data.html" . -}}
 {{- $hostOverride := .Get "influxdb_host" | default "" -}}
 {{- $placeholderHost := cond (gt (len $hostOverride) 0) $hostOverride ($productData.placeholder_host | default "localhost:8086") -}}
+{{- $scheme := $productData.scheme | default "https" -}}
+{{- $hostUrl := printf "%s://%s" $scheme $placeholderHost -}}
 {{- $endpoint := .Get "endpoint" -}}
 {{- $method := .Get "method" | upper -}}
 {{- $methodStyle := .Get "method" | lower -}}
 {{- $apiRef := .Get "api-ref" | default "" -}}
-{{- $renderedEndpoint := $endpoint | replaceRE `\{\{[<%] influxdb/host .*[>%]\}\}` $placeholderHost -}}
+{{- $renderedEndpoint := $endpoint | replaceRE `\{\{[<%] influxdb/host-url .*[>%]\}\}` $hostUrl | replaceRE `\{\{[<%] influxdb/host .*[>%]\}\}` $placeholderHost -}}
 <pre class="api-endpoint">
   {{- if ne $apiRef "" -}}
   <a href="{{ $apiRef }}" target="_blank"><span class="api {{ $methodStyle }}">{{ $method }}</span> {{ $renderedEndpoint }}</a>


### PR DESCRIPTION
## What changed

The `api-endpoint` shortcode now resolves the `influxdb/host-url` shortcode
(to `scheme://host`) in addition to `influxdb/host` (bare host).

## Why

`api-endpoint` substituted only `{{< influxdb/host >}}` and left
`{{< influxdb/host-url >}}` untouched. When shared content passed an endpoint
containing `host-url`, the shortcode rendered the literal text
`{{< influxdb/host-url >}}/query` instead of a URL.

`content/shared/influxdb3-query-guides/execute-queries/influxdb-v1-api.md`
uses `host-url` inside `api-endpoint`, so the broken output appeared on every
product that renders that shared file (Core, Enterprise, and others).

## Impact

- Core, Enterprise: `GET http://localhost:8181/query`
- Managed products render the `https` scheme.
- No literal `{{< influxdb/host-url >}}` remains in rendered output.

## Verification

Local Hugo build (`npx hugo`), exit 0. Checked the rendered `api-endpoint`
output for Core and Enterprise and grepped the full `public/` output for
literal `host-url` leaks (zero).

## PR Preview URLS

- /influxdb3/cloud/query-data/execute-queries/influxdb-v1-api/