### PR TITLE
Fix message about connecting to local InfluxDB with ExplorerUI

### DIFF
--- a/content/influxdb3/explorer/get-started.md
+++ b/content/influxdb3/explorer/get-started.md
@@ -43,16 +43,15 @@ InfluxDB 3 Explorer supports the following InfluxDB 3 products:
        > [!Note]
        > #### When to use `host.docker.internal`
        >
-       > If your InfluxDB 3 instance is running in Docker (not the same container as Explorer),
-       > use `host.docker.internal` as your server host to allow the Explorer container to
-       > connect to the InfluxDB container on the host--for example:
+       > If your InfluxDB 3 instance is running in Docker (not the same container as Explorer)
+       > or locally, use `host.docker.internal` as your server host to allow the Explorer container
+       > to connect to the InfluxDB container on the host--for example:
        >
        > ```txt
        > "DEFAULT_INFLUX_SERVER": "http://host.docker.internal:8181"
        > ```
        >
        > - If both Explorer and InfluxDB are in the same Docker network, use the container name instead.
-       > - If InfluxDB is running natively on your machine (not in Docker), use `localhost`.
        >
        > For more information, see the [Docker networking documentation](https://docs.docker.com/desktop/features/networking/).
 

--- a/content/influxdb3/explorer/install.md
+++ b/content/influxdb3/explorer/install.md
@@ -329,16 +329,15 @@ Instead of configuring connections through the UI, you can pre-define connection
    > [!Note]
    > #### When to use `host.docker.internal`
    >
-   > If your InfluxDB 3 instance is running in Docker (not the same container as Explorer),
-   > use `host.docker.internal` as your server host to allow the Explorer container to
-   > connect to the InfluxDB container on the host--for example:
+   > If your InfluxDB 3 instance is running in Docker (not the same container as Explorer)
+   > or locally, use `host.docker.internal` as your server host to allow the Explorer container
+   > to connect to the InfluxDB container on the host--for example:
    >
    > ```txt
    > "DEFAULT_INFLUX_SERVER": "http://host.docker.internal:8181"
    > ```
    >
    > - If both Explorer and InfluxDB are in the same Docker network, use the container name instead.
-   > - If InfluxDB is running natively on your machine (not in Docker), use `localhost`.
    >
    > For more information, see the [Docker networking documentation](https://docs.docker.com/desktop/features/networking/).
 


### PR DESCRIPTION
## Summary

Fix issue with docs incorrectly stating to use localhost for Explorer UI w/locally running InfluxDB instance. It needs `host.docker.internal` regardless, which I've tested.

## Checklist

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)

***

<details>
<summary><b>Suggested reviewers</b> (click to expand)</summary>

<!--
## Tips:
- Docs team (influxdata/docs-team) is auto-assigned via CODEOWNERS
- Request additional reviewers above when ready for technical review
- Open as Draft until ready for review to avoid notification spam
- Copilot reviews automatically - address suggestions before requesting human review
-->

Based on files changed, consider requesting review from:

### InfluxDB 3

| Content          | Engineering                    | Product                     |
| ---------------- | ------------------------------ | --------------------------- |
| Core, Enterprise | influxdata/monolith-team       | peterbarnett03, garylfowler |
| Clustered        | influxdata/platform-team       | ritwika314, sanderson       |
| Cloud Dedicated  | influxdata/cloud-single-tenant | ritwika314, sanderson       |
| Cloud Serverless | —                              | mavarius, garylfowler       |
| Explorer         | —                              | mavarius, peterbarnett03    |

### InfluxDB v2 / v1 / Enterprise v1

| Content           | Engineering     | Product               |
| ----------------- | --------------- | --------------------- |
| v2, Cloud (TSM)   | influxdata/edge | sanderson, jstirnaman |
| v1, Enterprise v1 | influxdata/edge | sanderson, jstirnaman |

### Other Products

| Content    | Engineering              | Product               |
| ---------- | ------------------------ | --------------------- |
| Telegraf   | influxdata/telegraf-team | sanderson, caterryan  |
| Kapacitor  | influxdata/bonitoo       | sanderson, jstirnaman |
| Chronograf | influxdata/bonitoo       | mavarius, caterryan   |
| Flux       | —                        | sanderson, jstirnaman |

### Shared / Cross-Product

| Content            | Reviewers                   |
| ------------------ | --------------------------- |
| `/content/shared/` | influxdata/product-managers |
| API docs           | Relevant product team above |

</details>
