### PR TITLE
fix(influxdb3): render URL scheme in host placeholders

### DIFF
--- a/DOCS-SHORTCODES.md
+++ b/DOCS-SHORTCODES.md
@@ -1248,6 +1248,31 @@ of `http://{{< influxdb/host >}}`.
 {{< influxdb/host-url >}}
 ```
 
+##### Choose between influxdb/host and influxdb/host-url
+
+`influxdb/host` renders the host only (no scheme).
+`influxdb/host-url` renders `scheme://host`.
+Choosing the wrong one produces broken examples, so match the shortcode to the
+context.
+
+Use `influxdb/host-url` where the value is a full base URL:
+
+- A `curl` request URL, for example `curl "{{< influxdb/host-url >}}/api/v3/query_sql"`.
+- An `api-endpoint` `endpoint=` value.
+- An environment variable or code assignment that expects a full URL, for
+  example `INFLUXDB3_HOST_URL={{< influxdb/host-url >}}`.
+
+Use `influxdb/host` (bare host) where the field expects a hostname, not a URL,
+and the scheme is set separately. Converting these to a full URL breaks the
+example:
+
+- A client `host` field paired with a separate scheme, for example node-influx
+  (`host:` with `protocol:` and `port:`) or influxdb-python (`host=` with
+  `ssl=True`).
+- `InfluxDBClient3(host="{{< influxdb/host >}}")`, where the client adds the
+  scheme.
+- Server or CLI configuration that expects a hostname.
+
 ***
 
 **For working examples**: Test all shortcodes in [content/example.md](content/example.md)

--- a/content/shared/influxdb3-admin/databases/create.md
+++ b/content/shared/influxdb3-admin/databases/create.md
@@ -53,7 +53,7 @@ Replace the following:
 
 To create a database using the HTTP API, send a `POST` request to the `/api/v3/configure/database` endpoint:
 
-{{% api-endpoint method="POST" endpoint="{{< influxdb/host >}}/api/v3/configure/database" %}}
+{{% api-endpoint method="POST" endpoint="{{< influxdb/host-url >}}/api/v3/configure/database" %}}
 
 Include the following in your request:
 
@@ -75,7 +75,7 @@ Include the following in your request:
 
 ```bash{placeholders="DATABASE_NAME|AUTH_TOKEN"}
 # Create a database with a 30-day retention period
-curl --request POST "{{< influxdb/host >}}/api/v3/configure/database" \
+curl --request POST "{{< influxdb/host-url >}}/api/v3/configure/database" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{
@@ -84,7 +84,7 @@ curl --request POST "{{< influxdb/host >}}/api/v3/configure/database" \
   }'
 
 # Create a database with a 90-day retention period
-curl --request POST "{{< influxdb/host >}}/api/v3/configure/database" \
+curl --request POST "{{< influxdb/host-url >}}/api/v3/configure/database" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{
@@ -93,7 +93,7 @@ curl --request POST "{{< influxdb/host >}}/api/v3/configure/database" \
   }'
 
 # Create a database with infinite retention (default)
-curl --request POST "{{< influxdb/host >}}/api/v3/configure/database" \
+curl --request POST "{{< influxdb/host-url >}}/api/v3/configure/database" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{

--- a/content/shared/influxdb3-admin/databases/delete.md
+++ b/content/shared/influxdb3-admin/databases/delete.md
@@ -34,7 +34,7 @@ Enter `yes` to confirm that you want to delete the database.
 
 To delete a database using the HTTP API, send a `DELETE` request to the `/api/v3/configure/database` endpoint:
 
-{{% api-endpoint method="DELETE" endpoint="{{< influxdb/host >}}/api/v3/configure/database" %}}
+{{% api-endpoint method="DELETE" endpoint="{{< influxdb/host-url >}}/api/v3/configure/database" %}}
 
 Include the following in your request:
 
@@ -44,7 +44,7 @@ Include the following in your request:
   - `Authorization: Bearer` with your {{% token-link "admin" %}}
 
 ```bash{placeholders="DATABASE_NAME|AUTH_TOKEN"}
-curl --request DELETE "{{< influxdb/host >}}/api/v3/configure/database?db=DATABASE_NAME" \
+curl --request DELETE "{{< influxdb/host-url >}}/api/v3/configure/database?db=DATABASE_NAME" \
   --header "Authorization: Bearer AUTH_TOKEN"
 ```
 
@@ -120,7 +120,7 @@ But removes:
 To delete only data using the HTTP API, include the `data_only=true` query parameter:
 
 ```bash{placeholders="DATABASE_NAME|AUTH_TOKEN"}
-curl --request DELETE "{{< influxdb/host >}}/api/v3/configure/database?db=DATABASE_NAME&data_only=true" \
+curl --request DELETE "{{< influxdb/host-url >}}/api/v3/configure/database?db=DATABASE_NAME&data_only=true" \
   --header "Authorization: Bearer AUTH_TOKEN"
 ```
 
@@ -134,7 +134,7 @@ Replace the following:
 To also remove table schemas, add the `remove_tables=true` parameter:
 
 ```bash{placeholders="DATABASE_NAME|AUTH_TOKEN"}
-curl --request DELETE "{{< influxdb/host >}}/api/v3/configure/database?db=DATABASE_NAME&data_only=true&remove_tables=true" \
+curl --request DELETE "{{< influxdb/host-url >}}/api/v3/configure/database?db=DATABASE_NAME&data_only=true&remove_tables=true" \
   --header "Authorization: Bearer AUTH_TOKEN"
 ```
 {{% /show-in %}}

--- a/content/shared/influxdb3-admin/databases/list.md
+++ b/content/shared/influxdb3-admin/databases/list.md
@@ -113,7 +113,7 @@ influxdb3 show databases --show-deleted
 
 To list databases using the HTTP API, send a `GET` request to the `/api/v3/configure/database` endpoint.
 
-{{% api-endpoint method="GET" endpoint="{{< influxdb/host >}}/api/v3/configure/database?format=pretty" %}}
+{{% api-endpoint method="GET" endpoint="{{< influxdb/host-url >}}/api/v3/configure/database?format=pretty" %}}
 
 Include the `format` query parameter and specify one of the following formats:
 
@@ -139,7 +139,7 @@ Include the following in your request:
   - `format=pretty`
 
 ```bash{placeholders="AUTH_TOKEN"}
-curl --request GET "{{< influxdb/host >}}/api/v3/configure/database?format=pretty" \
+curl --request GET "{{< influxdb/host-url >}}/api/v3/configure/database?format=pretty" \
   --header "Authorization: Bearer AUTH_TOKEN"
 ```
 
@@ -168,7 +168,7 @@ Include the following in your request:
   - `format=json`
 
 ```bash{placeholders="AUTH_TOKEN"}
-curl --request GET "{{< influxdb/host >}}/api/v3/configure/database?format=json" \
+curl --request GET "{{< influxdb/host-url >}}/api/v3/configure/database?format=json" \
   --header "Authorization: Bearer AUTH_TOKEN"
 ```
 
@@ -200,7 +200,7 @@ Include the following in your request:
 - An output destination for the Parquet file
 
 ```bash{placeholders="AUTH_TOKEN"}
-curl "{{< influxdb/host >}}/api/v3/configure/database?format=parquet" \
+curl "{{< influxdb/host-url >}}/api/v3/configure/database?format=parquet" \
   -o databases.parquet \
   --header "Authorization: Bearer AUTH_TOKEN"
 ```

--- a/content/shared/influxdb3-admin/tables/create.md
+++ b/content/shared/influxdb3-admin/tables/create.md
@@ -87,7 +87,7 @@ Replace the following:
 
 To create a table using the HTTP API, send a `POST` request to the `/api/v3/configure/table` endpoint:
 
-{{% api-endpoint method="POST" endpoint="{{< influxdb/host >}}/api/v3/configure/table" %}}
+{{% api-endpoint method="POST" endpoint="{{< influxdb/host-url >}}/api/v3/configure/table" %}}
 
 Include the following in your request:
 
@@ -105,7 +105,7 @@ Include the following in your request:
 
 ```bash{placeholders="DATABASE_NAME|TABLE_NAME|AUTH_TOKEN"}
 # Create a table with tag columns
-curl -X POST "{{< influxdb/host >}}/api/v3/configure/table" \
+curl -X POST "{{< influxdb/host-url >}}/api/v3/configure/table" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
@@ -116,7 +116,7 @@ curl -X POST "{{< influxdb/host >}}/api/v3/configure/table" \
   }'
 
 # Create a table with tag and field columns
-curl -X POST "{{< influxdb/host >}}/api/v3/configure/table" \
+curl -X POST "{{< influxdb/host-url >}}/api/v3/configure/table" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
@@ -134,7 +134,7 @@ curl -X POST "{{< influxdb/host >}}/api/v3/configure/table" \
 {{% show-in "enterprise" %}}
 ```bash{placeholders="DATABASE_NAME|TABLE_NAME|AUTH_TOKEN"}
 # Create a table with a 7-day retention period
-curl -X POST "{{< influxdb/host >}}/api/v3/configure/table" \
+curl -X POST "{{< influxdb/host-url >}}/api/v3/configure/table" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
@@ -149,7 +149,7 @@ curl -X POST "{{< influxdb/host >}}/api/v3/configure/table" \
   }'
 
 # Create a table with database default retention (omit retention_period)
-curl -X POST "{{< influxdb/host >}}/api/v3/configure/table" \
+curl -X POST "{{< influxdb/host-url >}}/api/v3/configure/table" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{

--- a/content/shared/influxdb3-admin/tables/delete.md
+++ b/content/shared/influxdb3-admin/tables/delete.md
@@ -60,7 +60,7 @@ influxdb3 delete table \
 
 To delete a table using the HTTP API, send a `DELETE` request to the `/api/v3/configure/table` endpoint:
 
-{{% api-endpoint method="DELETE" endpoint="{{< influxdb/host >}}/api/v3/configure/table" %}}
+{{% api-endpoint method="DELETE" endpoint="{{< influxdb/host-url >}}/api/v3/configure/table" %}}
 
 Include the following in your request:
 
@@ -74,7 +74,7 @@ Include the following in your request:
 ### Soft delete a table
 
 ```bash{placeholders="DATABASE_NAME|TABLE_NAME|AUTH_TOKEN"}
-curl -X DELETE "{{< influxdb/host >}}/api/v3/configure/table?db=DATABASE_NAME&table=TABLE_NAME" \
+curl -X DELETE "{{< influxdb/host-url >}}/api/v3/configure/table?db=DATABASE_NAME&table=TABLE_NAME" \
   --header "Authorization: Bearer AUTH_TOKEN"
 ```
 
@@ -89,7 +89,7 @@ Replace the following:
 To schedule a hard deletion at a specific time, include the `hard_delete_at` parameter with an ISO 8601 timestamp:
 
 ```bash{placeholders="DATABASE_NAME|TABLE_NAME|AUTH_TOKEN"}
-curl -X DELETE "{{< influxdb/host >}}/api/v3/configure/table?db=DATABASE_NAME&table=TABLE_NAME&hard_delete_at=2025-12-31T23:59:59Z" \
+curl -X DELETE "{{< influxdb/host-url >}}/api/v3/configure/table?db=DATABASE_NAME&table=TABLE_NAME&hard_delete_at=2025-12-31T23:59:59Z" \
   --header "Authorization: Bearer AUTH_TOKEN"
 ```
 
@@ -143,7 +143,7 @@ Replace the following:
 To delete only data using the HTTP API, include the `data_only=true` query parameter:
 
 ```bash{placeholders="DATABASE_NAME|TABLE_NAME|AUTH_TOKEN"}
-curl -X DELETE "{{< influxdb/host >}}/api/v3/configure/table?db=DATABASE_NAME&table=TABLE_NAME&data_only=true" \
+curl -X DELETE "{{< influxdb/host-url >}}/api/v3/configure/table?db=DATABASE_NAME&table=TABLE_NAME&data_only=true" \
   --header "Authorization: Bearer AUTH_TOKEN"
 ```
 

--- a/content/shared/influxdb3-admin/tables/list.md
+++ b/content/shared/influxdb3-admin/tables/list.md
@@ -50,7 +50,7 @@ influxdb3 query \
 
 To list tables using the HTTP API, send a `GET` request to the `/api/v3/query_sql` endpoint with a `SHOW TABLES` query:
 
-{{% api-endpoint method="GET" endpoint="{{< influxdb/host >}}/api/v3/query_sql" %}}
+{{% api-endpoint method="GET" endpoint="{{< influxdb/host-url >}}/api/v3/query_sql" %}}
 
 Include the following in your request:
 
@@ -62,7 +62,7 @@ Include the following in your request:
   - `Authorization: Bearer` with your authentication token
 
 ```bash { placeholders="DATABASE_NAME|AUTH_TOKEN" }
-curl --get "{{< influxdb/host >}}/api/v3/query_sql" \
+curl --get "{{< influxdb/host-url >}}/api/v3/query_sql" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --data-urlencode "db=DATABASE_NAME" \
   --data-urlencode "q=SHOW TABLES" \
@@ -100,7 +100,7 @@ Replace the following:
 To get the response in CSV format, set the `format` parameter to `csv`:
 
 ```bash { placeholders="DATABASE_NAME|AUTH_TOKEN" }
-curl --get "{{< influxdb/host >}}/api/v3/query_sql" \
+curl --get "{{< influxdb/host-url >}}/api/v3/query_sql" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --data-urlencode "db=DATABASE_NAME" \
   --data-urlencode "q=SHOW TABLES" \

--- a/content/shared/influxdb3-internals/data-retention.md
+++ b/content/shared/influxdb3-internals/data-retention.md
@@ -125,7 +125,7 @@ influxdb3 create database \
 
 ```bash{placeholders="DATABASE_NAME|AUTH_TOKEN"}
 # Create a database with a 30-day retention period
-curl --request POST "{{< influxdb/host >}}/api/v3/configure/database" \
+curl --request POST "{{< influxdb/host-url >}}/api/v3/configure/database" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{
@@ -134,7 +134,7 @@ curl --request POST "{{< influxdb/host >}}/api/v3/configure/database" \
   }'
 
 # Create a database with infinite retention
-curl --request POST "{{< influxdb/host >}}/api/v3/configure/database" \
+curl --request POST "{{< influxdb/host-url >}}/api/v3/configure/database" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{
@@ -143,7 +143,7 @@ curl --request POST "{{< influxdb/host >}}/api/v3/configure/database" \
   }'
 
 # Create a database with a 90-day retention period
-curl --request POST "{{< influxdb/host >}}/api/v3/configure/database" \
+curl --request POST "{{< influxdb/host-url >}}/api/v3/configure/database" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{
@@ -213,7 +213,7 @@ influxdb3 create table \
 
 ```bash{placeholders="DATABASE_NAME|TABLE_NAME|AUTH_TOKEN"}
 # Create a table with a 7-day retention period
-curl --request POST "{{< influxdb/host >}}/api/v3/configure/table" \
+curl --request POST "{{< influxdb/host-url >}}/api/v3/configure/table" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{
@@ -224,7 +224,7 @@ curl --request POST "{{< influxdb/host >}}/api/v3/configure/table" \
   }'
 
 # Create a table with field definitions and retention period
-curl --request POST "{{< influxdb/host >}}/api/v3/configure/table" \
+curl --request POST "{{< influxdb/host-url >}}/api/v3/configure/table" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{
@@ -281,7 +281,7 @@ influxdb3 update database \
 
 ```bash{placeholders="DATABASE_NAME|AUTH_TOKEN"}
 # Update a database retention period to 60 days
-curl --request PATCH "{{< influxdb/host >}}/api/v3/configure/database/DATABASE_NAME" \
+curl --request PATCH "{{< influxdb/host-url >}}/api/v3/configure/database/DATABASE_NAME" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{
@@ -289,7 +289,7 @@ curl --request PATCH "{{< influxdb/host >}}/api/v3/configure/database/DATABASE_N
   }'
 
 # Clear a database retention period (set to infinite)
-curl --request PATCH "{{< influxdb/host >}}/api/v3/configure/database/DATABASE_NAME" \
+curl --request PATCH "{{< influxdb/host-url >}}/api/v3/configure/database/DATABASE_NAME" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{
@@ -297,7 +297,7 @@ curl --request PATCH "{{< influxdb/host >}}/api/v3/configure/database/DATABASE_N
   }'
 
 # Update a database retention period to 90 days
-curl --request PATCH "{{< influxdb/host >}}/api/v3/configure/database/DATABASE_NAME" \
+curl --request PATCH "{{< influxdb/host-url >}}/api/v3/configure/database/DATABASE_NAME" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --data '{

--- a/content/shared/influxdb3-plugins/_index.md
+++ b/content/shared/influxdb3-plugins/_index.md
@@ -444,7 +444,7 @@ For more information, see the [`influxdb3 create trigger` CLI reference](/influx
 
 To upload a plugin file using the HTTP API, send a `PUT` request to the `/api/v3/plugins/files` endpoint:
 
-{{% api-endpoint method="PUT" endpoint="{{< influxdb/host >}}/api/v3/plugins/files" api-ref="/influxdb3/version/api/v3/#operation/PutPluginFile" %}}
+{{% api-endpoint method="PUT" endpoint="{{< influxdb/host-url >}}/api/v3/plugins/files" api-ref="/influxdb3/version/api/v3/#operation/PutPluginFile" %}}
 
 Include the following in your request:
 
@@ -456,7 +456,7 @@ Include the following in your request:
 
 ```bash{placeholders="AUTH_TOKEN"}
 # Upload a single-file plugin
-curl -X PUT "{{< influxdb/host >}}/api/v3/plugins/files?path=plugin.py" \
+curl -X PUT "{{< influxdb/host-url >}}/api/v3/plugins/files?path=plugin.py" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/octet-stream" \
   --data-binary "@/local/path/to/plugin.py"
@@ -506,7 +506,7 @@ For complete reference, see [`influxdb3 update trigger`](/influxdb3/version/refe
 
 To update a plugin file using the HTTP API, send a `PUT` request to the `/api/v3/plugins/files` endpoint:
 
-{{% api-endpoint method="PUT" endpoint="{{< influxdb/host >}}/api/v3/plugins/files" api-ref="/influxdb3/version/api/v3/#operation/PutPluginFile" %}}
+{{% api-endpoint method="PUT" endpoint="{{< influxdb/host-url >}}/api/v3/plugins/files" api-ref="/influxdb3/version/api/v3/#operation/PutPluginFile" %}}
 
 Include the following in your request:
 
@@ -518,7 +518,7 @@ Include the following in your request:
 
 ```bash{placeholders="AUTH_TOKEN"}
 # Update a plugin file
-curl -X PUT "{{< influxdb/host >}}/api/v3/plugins/files?path=plugin.py" \
+curl -X PUT "{{< influxdb/host-url >}}/api/v3/plugins/files?path=plugin.py" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/octet-stream" \
   --data-binary "@/path/to/updated/plugin.py"
@@ -634,7 +634,7 @@ For complete reference, see [`influxdb3 create trigger`](/influxdb3/version/refe
 
 To create a trigger using the HTTP API, send a `POST` request to the `/api/v3/configure/processing_engine_trigger` endpoint:
 
-{{% api-endpoint method="POST" endpoint="{{< influxdb/host >}}/api/v3/configure/processing_engine_trigger" api-ref="/influxdb3/version/api/v3/#operation/PostConfigureProcessingEngineTrigger" %}}
+{{% api-endpoint method="POST" endpoint="{{< influxdb/host-url >}}/api/v3/configure/processing_engine_trigger" api-ref="/influxdb3/version/api/v3/#operation/PostConfigureProcessingEngineTrigger" %}}
 
 Include the following in your request:
 
@@ -654,7 +654,7 @@ Include the following in your request:
 
 ```bash {placeholders="DATABASE_NAME|PLUGIN_FILE|TRIGGER_NAME|TRIGGER_SPEC|AUTH_TOKEN"}
 # Create a basic trigger
-curl -X POST "{{< influxdb/host >}}/api/v3/configure/processing_engine_trigger" \
+curl -X POST "{{< influxdb/host-url >}}/api/v3/configure/processing_engine_trigger" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
@@ -714,7 +714,7 @@ influxdb3 create trigger \
 
 ```bash {placeholders="DATABASE_NAME|AUTH_TOKEN"}
 # Trigger on writes to a specific table
-curl -X POST "{{< influxdb/host >}}/api/v3/configure/processing_engine_trigger" \
+curl -X POST "{{< influxdb/host-url >}}/api/v3/configure/processing_engine_trigger" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
@@ -730,7 +730,7 @@ curl -X POST "{{< influxdb/host >}}/api/v3/configure/processing_engine_trigger" 
   }'
 
 # Trigger on writes to all tables
-curl -X POST "{{< influxdb/host >}}/api/v3/configure/processing_engine_trigger" \
+curl -X POST "{{< influxdb/host-url >}}/api/v3/configure/processing_engine_trigger" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
@@ -834,7 +834,7 @@ influxdb3 create trigger \
 
 ```bash {placeholders="DATABASE_NAME|AUTH_TOKEN"}
 # Run every 5 minutes
-curl -X POST "{{< influxdb/host >}}/api/v3/configure/processing_engine_trigger" \
+curl -X POST "{{< influxdb/host-url >}}/api/v3/configure/processing_engine_trigger" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
@@ -851,7 +851,7 @@ curl -X POST "{{< influxdb/host >}}/api/v3/configure/processing_engine_trigger" 
 
 # Run on a cron schedule (8am daily)
 # Supports extended cron format with seconds
-curl -X POST "{{< influxdb/host >}}/api/v3/configure/processing_engine_trigger" \
+curl -X POST "{{< influxdb/host-url >}}/api/v3/configure/processing_engine_trigger" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
@@ -900,7 +900,7 @@ influxdb3 create trigger \
 
 ```bash {placeholders="DATABASE_NAME|AUTH_TOKEN"}
 # Create an endpoint at /api/v3/engine/webhook
-curl -X POST "{{< influxdb/host >}}/api/v3/configure/processing_engine_trigger" \
+curl -X POST "{{< influxdb/host-url >}}/api/v3/configure/processing_engine_trigger" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
@@ -969,7 +969,7 @@ influxdb3 create trigger \
 {{% code-tab-content %}}
 
 ```bash {placeholders="DATABASE_NAME|AUTH_TOKEN"}
-curl -X POST "{{< influxdb/host >}}/api/v3/configure/processing_engine_trigger" \
+curl -X POST "{{< influxdb/host-url >}}/api/v3/configure/processing_engine_trigger" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
@@ -1037,7 +1037,7 @@ influxdb3 create trigger \
 
 ```bash {placeholders="DATABASE_NAME|AUTH_TOKEN"}
 # Allow multiple trigger instances to run simultaneously
-curl -X POST "{{< influxdb/host >}}/api/v3/configure/processing_engine_trigger" \
+curl -X POST "{{< influxdb/host-url >}}/api/v3/configure/processing_engine_trigger" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
@@ -1101,7 +1101,7 @@ influxdb3 create trigger \
 
 ```bash {placeholders="DATABASE_NAME|AUTH_TOKEN"}
 # Automatically retry on error
-curl -X POST "{{< influxdb/host >}}/api/v3/configure/processing_engine_trigger" \
+curl -X POST "{{< influxdb/host-url >}}/api/v3/configure/processing_engine_trigger" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
@@ -1117,7 +1117,7 @@ curl -X POST "{{< influxdb/host >}}/api/v3/configure/processing_engine_trigger" 
   }'
 
 # Disable the trigger on error
-curl -X POST "{{< influxdb/host >}}/api/v3/configure/processing_engine_trigger" \
+curl -X POST "{{< influxdb/host-url >}}/api/v3/configure/processing_engine_trigger" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
@@ -1179,7 +1179,7 @@ docker exec -it CONTAINER_NAME influxdb3 install package pandas
 
 ```bash {placeholders="AUTH_TOKEN"}
 # Use the HTTP API to install Python packages
-curl -X POST "{{< influxdb/host >}}/api/v3/configure/plugin_environment/install_packages" \
+curl -X POST "{{< influxdb/host-url >}}/api/v3/configure/plugin_environment/install_packages" \
   --header "Authorization: Bearer AUTH_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{


### PR DESCRIPTION
## What changed

Replaced `{{< influxdb/host >}}` with `{{< influxdb/host-url >}}` in URL
contexts across InfluxDB 3 shared content (48 occurrences in 8 files):

- `curl` request URLs (39)
- `api-endpoint` `endpoint=` values (9)

Client `host` fields that take a hostname and set the scheme separately are
left unchanged. Added a "Choose between influxdb/host and influxdb/host-url"
subsection to `DOCS-SHORTCODES.md`.

## Why

`influxdb/host` renders the host only, with no scheme. The author of these
examples assumed it included a scheme. The result was schemeless URLs like
`curl "instance-id.enterprise.influxdb.io/api/v3/..."`, which are wrong for
managed products because curl defaults to `http` against an `https` host.

PR #7503 fixed the scheme-prefixed subset (`http://{{< influxdb/host >}}`).
These bare-host occurrences were never touched. `host-url` renders the
product-correct scheme (`http` for Core/Enterprise localhost, `https` for
managed).

## Impact

- Core, Enterprise: `http://localhost:8181/...`
- Managed products (Cloud Serverless, Cloud Dedicated, Clustered, Cloud):
  `https://.../...`
- Client `host` fields unchanged, for example node-influx (`host:` with
  `protocol:`/`port:`), influxdb-python (`host=` with `ssl=True`), and
  `InfluxDBClient3(host=...)`.

Depends on #7503 (the `host-url` shortcode) and #7513 (which taught the
`api-endpoint` shortcode to resolve `host-url`), both merged.

## Verification

Local Hugo build (`npx hugo`), exit 0. Verified rendered output: Core and
Enterprise render `http://localhost:8181`, managed products render `https://`,
no literal `{{< influxdb/host-url >}}` remains, and the three client `host`
fields stay bare.