### PR TITLE
test(shortcodes): cover host-url in api endpoint

### DIFF
--- a/content/example.md
+++ b/content/example.md
@@ -1660,6 +1660,10 @@ curl "{{< influxdb/host-url >}}/api/v3/query_sql?db=DATABASE_NAME" \
   --header "Authorization: Bearer DATABASE_TOKEN"
 ```
 
+In an API endpoint:
+
+{{< api-endpoint endpoint="{{< influxdb/host-url >}}/query" method="get" >}}
+
 > [!Note]
 > This page has no `product` frontmatter, so the shortcodes above fall back to
 > their defaults: `localhost:8086` for the host and `https` for the scheme.
@@ -1668,4 +1672,3 @@ curl "{{< influxdb/host-url >}}/api/v3/query_sql?db=DATABASE_NAME" \
 > On real product pages, `influxdb/host-url` renders the product-correct scheme
 > and host--for example, `http://localhost:8181` for Core and Enterprise or
 > `https://cluster-host.com` for Clustered.
-

--- a/cypress/e2e/content/host-url-shortcode.cy.js
+++ b/cypress/e2e/content/host-url-shortcode.cy.js
@@ -27,6 +27,7 @@ const PAGES = {
     '/influxdb3/cloud-dedicated/reference/sample-data/',
   influxdb3_clustered: '/influxdb3/clustered/reference/sample-data/',
 };
+const EXAMPLE_PAGE = '/example/';
 
 // Visit with cleared URL storage so the customizer renders default placeholders.
 function visitClean(path) {
@@ -72,5 +73,12 @@ describe('influxdb/host-url shortcode', function () {
           .and('not.contain', `http://${placeholder_host}`);
       });
     });
+  });
+
+  it('renders host-url when nested in api-endpoint', function () {
+    visitClean(EXAMPLE_PAGE);
+    cy.get('pre.api-endpoint')
+      .should('contain.text', 'https://localhost:8086/query')
+      .and('not.contain.text', '{{< influxdb/host-url >}}');
   });
 });


### PR DESCRIPTION
## What changed

  - Added an `api-endpoint` fixture in `content/example.md` using `{{< influxdb/host-url >}}/query`.
  - Extended `host-url-shortcode.cy.js` to assert the nested shortcode renders `https://localhost:8086/
  query` rather than literal shortcode text.

  ## Why

  PR 7503's host-url tests exercised only ordinary article content. They did not cover the `api-
  endpoint` shortcode, whose substitution logic currently recognizes `influxdb/host` but not `influxdb/
  host-url`.

  ## Impact

  This regression test covers the same nested-shortcode path used by shared InfluxDB 3 query content,
  so a literal `{{< influxdb/host-url >}}` can no longer go undetected.

  ## Verification

  - Pre-commit hooks passed, including automatic Prettier formatting.
  - `git diff --check` passed.
  - `node --check cypress/e2e/content/host-url-shortcode.cy.js` passed.
  - `yarn audit` passed with 0 vulnerabilities.