### PR TITLE
fix(explorer): host-gateway

### DIFF
--- a/content/influxdb3/explorer/get-started.md
+++ b/content/influxdb3/explorer/get-started.md
@@ -43,15 +43,19 @@ InfluxDB 3 Explorer supports the following InfluxDB 3 products:
        > [!Note]
        > #### When to use `host.docker.internal`
        >
-       > If your InfluxDB 3 instance is running in Docker (not the same container as Explorer)
-       > or locally, use `host.docker.internal` as your server host to allow the Explorer container
-       > to connect to the InfluxDB container on the host--for example:
+       > If your InfluxDB 3 instance is running on the Docker host, either natively
+       > or in a separate container with port `8181` published, use
+       > `host.docker.internal` as the server host--for example:
        >
        > ```txt
        > "DEFAULT_INFLUX_SERVER": "http://host.docker.internal:8181"
        > ```
        >
        > - If both Explorer and InfluxDB are in the same Docker network, use the container name instead.
+       > - Docker Desktop provides `host.docker.internal` automatically.
+       >   On Linux Docker Engine, map the hostname when you start Explorer:
+       >   `--add-host=host.docker.internal:host-gateway` with `docker run`, or
+       >   `extra_hosts: ["host.docker.internal:host-gateway"]` with Docker Compose.
        >
        > For more information, see the [Docker networking documentation](https://docs.docker.com/desktop/features/networking/).
 

--- a/content/influxdb3/explorer/get-started.md
+++ b/content/influxdb3/explorer/get-started.md
@@ -57,7 +57,8 @@ InfluxDB 3 Explorer supports the following InfluxDB 3 products:
        >   `--add-host=host.docker.internal:host-gateway` with `docker run`, or
        >   `extra_hosts: ["host.docker.internal:host-gateway"]` with Docker Compose.
        >
-       > For more information, see the [Docker networking documentation](https://docs.docker.com/desktop/features/networking/).
+       > For Docker Desktop details, see the [Docker Desktop networking documentation](https://docs.docker.com/desktop/features/networking/).
+       > For Linux Docker Engine details, see the [Docker daemon documentation](https://docs.docker.com/reference/cli/dockerd/#configure-host-gateway-ip).
 
     - **Token**: The authorization token to use to connect to your InfluxDB 3 server.
       We recommend using an InfluxDB 3 _admin_ token.

--- a/content/influxdb3/explorer/get-started.md
+++ b/content/influxdb3/explorer/get-started.md
@@ -43,16 +43,15 @@ InfluxDB 3 Explorer supports the following InfluxDB 3 products:
        > [!Note]
        > #### When to use `host.docker.internal`
        >
-       > If your InfluxDB 3 instance is running in Docker (not the same container as Explorer),
-       > use `host.docker.internal` as your server host to allow the Explorer container to
-       > connect to the InfluxDB container on the host--for example:
+       > If your InfluxDB 3 instance is running in Docker (not the same container as Explorer)
+       > or locally, use `host.docker.internal` as your server host to allow the Explorer container
+       > to connect to the InfluxDB container on the host--for example:
        >
        > ```txt
        > "DEFAULT_INFLUX_SERVER": "http://host.docker.internal:8181"
        > ```
        >
        > - If both Explorer and InfluxDB are in the same Docker network, use the container name instead.
-       > - If InfluxDB is running natively on your machine (not in Docker), use `localhost`.
        >
        > For more information, see the [Docker networking documentation](https://docs.docker.com/desktop/features/networking/).
 

--- a/content/influxdb3/explorer/install.md
+++ b/content/influxdb3/explorer/install.md
@@ -343,7 +343,8 @@ Instead of configuring connections through the UI, you can pre-define connection
    >   `--add-host=host.docker.internal:host-gateway` with `docker run`, or
    >   `extra_hosts: ["host.docker.internal:host-gateway"]` with Docker Compose.
    >
-   > For more information, see the [Docker networking documentation](https://docs.docker.com/desktop/features/networking/).
+   > For Docker Desktop details, see the [Docker Desktop networking documentation](https://docs.docker.com/desktop/features/networking/).
+   > For Linux Docker Engine details, see the [Docker daemon documentation](https://docs.docker.com/reference/cli/dockerd/#configure-host-gateway-ip).
 
 2. **Mount the configuration directory:**
 

--- a/content/influxdb3/explorer/install.md
+++ b/content/influxdb3/explorer/install.md
@@ -329,16 +329,15 @@ Instead of configuring connections through the UI, you can pre-define connection
    > [!Note]
    > #### When to use `host.docker.internal`
    >
-   > If your InfluxDB 3 instance is running in Docker (not the same container as Explorer),
-   > use `host.docker.internal` as your server host to allow the Explorer container to
-   > connect to the InfluxDB container on the host--for example:
+   > If your InfluxDB 3 instance is running in Docker (not the same container as Explorer)
+   > or locally, use `host.docker.internal` as your server host to allow the Explorer container
+   > to connect to the InfluxDB container on the host--for example:
    >
    > ```txt
    > "DEFAULT_INFLUX_SERVER": "http://host.docker.internal:8181"
    > ```
    >
    > - If both Explorer and InfluxDB are in the same Docker network, use the container name instead.
-   > - If InfluxDB is running natively on your machine (not in Docker), use `localhost`.
    >
    > For more information, see the [Docker networking documentation](https://docs.docker.com/desktop/features/networking/).
 

--- a/content/influxdb3/explorer/install.md
+++ b/content/influxdb3/explorer/install.md
@@ -329,15 +329,19 @@ Instead of configuring connections through the UI, you can pre-define connection
    > [!Note]
    > #### When to use `host.docker.internal`
    >
-   > If your InfluxDB 3 instance is running in Docker (not the same container as Explorer)
-   > or locally, use `host.docker.internal` as your server host to allow the Explorer container
-   > to connect to the InfluxDB container on the host--for example:
+   > If your InfluxDB 3 instance is running on the Docker host, either natively
+   > or in a separate container with port `8181` published, use
+   > `host.docker.internal` as the server host--for example:
    >
    > ```txt
    > "DEFAULT_INFLUX_SERVER": "http://host.docker.internal:8181"
    > ```
    >
    > - If both Explorer and InfluxDB are in the same Docker network, use the container name instead.
+   > - Docker Desktop provides `host.docker.internal` automatically.
+   >   On Linux Docker Engine, map the hostname when you start Explorer:
+   >   `--add-host=host.docker.internal:host-gateway` with `docker run`, or
+   >   `extra_hosts: ["host.docker.internal:host-gateway"]` with Docker Compose.
    >
    > For more information, see the [Docker networking documentation](https://docs.docker.com/desktop/features/networking/).
 
@@ -353,6 +357,7 @@ Instead of configuring connections through the UI, you can pre-define connection
    ```bash
    docker run --detach \
      --name influxdb3-explorer \
+     --add-host=host.docker.internal:host-gateway \
      --publish 127.0.0.1:8888:8080 \
      --volume $(pwd)/config:/app-root/config:ro \
      influxdata/influxdb3-ui:{{% latest-patch %}}
@@ -367,6 +372,8 @@ Instead of configuring connections through the UI, you can pre-define connection
      explorer:
        image: influxdata/influxdb3-ui:{{% latest-patch %}}
        container_name: influxdb3-explorer
+       extra_hosts:
+         - "host.docker.internal:host-gateway"
        ports:
          - "127.0.0.1:8888:8080"
        volumes:
@@ -653,6 +660,7 @@ EOF
 # Run Explorer with all features
 docker run --detach \
   --name influxdb3-explorer \
+  --add-host=host.docker.internal:host-gateway \
   --pull always \
   --publish 127.0.0.1:8888:8443 \
   --volume $(pwd)/db:/db:rw \
@@ -676,6 +684,8 @@ services:
     container_name: influxdb3-explorer
     pull_policy: always
     command: ["--mode=admin"]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "127.0.0.1:8888:8443"
     volumes:


### PR DESCRIPTION
## What changed:

 - Updated the host.docker.internal callouts to clarify that “locally” means InfluxDB runs on the Docker
    host, natively or in a separately port-published container.

  - Added Linux Docker Engine instructions for --add-host=host.docker.internal:host-gateway and Compose
    extra_hosts.

  - Added those mappings to both preconfigured-connection Docker/Compose examples in content/influxdb3/
    explorer/install.md:330, plus the setup guidance in content/influxdb3/explorer/get-started.md:44.

## Why:

- Provide instructions for Linux Docker and Docker Compose users.
- Clarify native-on-the-host vs in a separate container.

No other InfluxDB 3 changes needed. Core and Enterprise share content/shared/influxdb3/install.md:1, which does not use host.docker.internal; no parallel install-doc correction was needed. The shared MCP-server Docker example already uses the same host-gateway mapping.

## Verification:

Vale passed; diff whitespace check passed.
The mapping pattern follows Docker’s Compose networking (https://docs.docker.com/compose/how-tos/networking/) and Docker daemon (https://docs.docker.com/reference/cli/dockerd/) guidance.