### PR TITLE
fix(notifications): exclude InfluxDB 3 Cloud from Enterprise 3.10 banner

### DIFF
--- a/data/notifications.yaml
+++ b/data/notifications.yaml
@@ -118,6 +118,7 @@
   exclude:
     - /influxdb3/core/
     - /influxdb3/explorer/
+    - /influxdb3/cloud/
     - /influxdb3/cloud-dedicated/
     - /influxdb3/cloud-serverless/
     - /influxdb3/clustered/


### PR DESCRIPTION
## What changed 

The `influxdb3-10-enterprise-release` notification in `data/notifications.yaml` is scoped to `/influxdb3/` and excludes core, explorer, cloud-dedicated, cloud-serverless, and clustered — but not `/influxdb3/cloud/`. Because notification matching is a substring test (`path.includes(...)` in `assets/js/notifications.js`), the `/influxdb3/` scope matched `/influxdb3/cloud/` with nothing excluding it, so the "InfluxDB 3.10 is now available" (Enterprise) banner rendered on the InfluxDB 3 Cloud docs.

This adds `/influxdb3/cloud/` to the notification's `exclude` list, suppressing the Enterprise banner across the entire Cloud product section (`/influxdb3/cloud/**`). The sibling `cloud-dedicated`/`cloud-serverless` paths are unaffected, since their strings don't contain the substring `/influxdb3/cloud/`.

## Why

The Core/Enterprise release announcement might confuse Cloud customers.

## Checklist

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
- [ ] Local build passes (`npx hugo --quiet`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG87tn9ixPcQKQmXuqPskQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RG87tn9ixPcQKQmXuqPskQ)_