### PR TITLE
feat: Enterprise 1.x mTLS

### DIFF
--- a/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
@@ -196,6 +196,72 @@ Set to `true` to allow the data node to accept self-signed certificates if [`htt
 
 Environment variable: `INFLUXDB_META_META_INSECURE_TLS`
 
+#### meta-client-certificate {metadata="v1.13.0+"}
+
+Default is `""`.
+
+The client certificate this data node presents to meta nodes when dialing them,
+enabling mutual TLS (mTLS).
+The certificate should be a PEM-encoded bundle of the certificate and key.
+If it is just the certificate, specify a key in
+[`meta-client-private-key`](#meta-client-private-key).
+
+Environment variable: `INFLUXDB_META_META_CLIENT_CERTIFICATE`
+
+#### meta-client-private-key {metadata="v1.13.0+"}
+
+Default is `""`.
+
+Use a separate private key location for the meta client certificate.
+
+Environment variable: `INFLUXDB_META_META_CLIENT_PRIVATE_KEY`
+
+#### meta-insecure-certificate {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Relaxes the local file-permission checks on
+[`meta-client-certificate`](#meta-client-certificate) and
+[`meta-client-private-key`](#meta-client-private-key) when `true`.
+
+Environment variable: `INFLUXDB_META_META_INSECURE_CERTIFICATE`
+
+#### meta-ignore-cert-sanity-checks {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Loads [`meta-client-certificate`](#meta-client-certificate) even when it fails
+the checks for whether a client can use it, such as the certificate not
+permitting client authentication.
+The failed checks are logged instead.
+A missing or unparseable certificate is still an error.
+
+Environment variable: `INFLUXDB_META_META_IGNORE_CERT_SANITY_CHECKS`
+
+#### meta-root-ca {metadata="v1.13.0+"}
+
+Default is unset.
+
+The CA pool used to verify the server certificates of the meta nodes this data
+node dials (mTLS).
+Leaving it unset uses the host's system roots.
+Changes to this pool take effect on configuration reload (`SIGHUP`) and don't
+require a restart.
+
+Specify the CA pool as an inline table with the following keys:
+
+- `paths`: list of PEM files to trust
+- `include-system`: if `true`, also trust the host's system CA pool
+
+```toml
+meta-root-ca = { paths = ["/etc/ssl/cluster-ca.pem"], include-system = false }
+```
+
+Environment variables:
+
+- `INFLUXDB_META_META_ROOT_CA_PATHS`
+- `INFLUXDB_META_META_ROOT_CA_INCLUDE_SYSTEM`
+
 #### meta-auth-enabled
 
 Default is `false`.
@@ -660,6 +726,103 @@ Default is `false`.
 Skips file permission checking for `https-certificate` and `https-private-key` when `true`.
 
 Environment variable: `INFLUXDB_CLUSTER_HTTPS_INSECURE_CERTIFICATE`
+
+#### https-ignore-sanity-checks {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Loads a certificate even when it fails the checks for whether it can be used at
+all, such as a server certificate not permitting server authentication.
+The failed checks are logged instead.
+A missing or unparseable server certificate is still an error.
+
+Environment variable: `INFLUXDB_CLUSTER_HTTPS_IGNORE_SANITY_CHECKS`
+
+#### https-client-certificate {metadata="v1.13.0+"}
+
+Default is `""`.
+
+The certificate this data node presents when it dials a peer data node (mutual
+TLS).
+Leaving it unset presents `https-certificate` and `https-private-key` to peers
+instead.
+This is the opposite direction from `https-client-ca`, which verifies the peers
+that dial this node.
+
+Environment variable: `INFLUXDB_CLUSTER_HTTPS_CLIENT_CERTIFICATE`
+
+#### https-client-private-key {metadata="v1.13.0+"}
+
+Default is `""`.
+
+Use a separate private key location for the `https-client-certificate`.
+
+Environment variable: `INFLUXDB_CLUSTER_HTTPS_CLIENT_PRIVATE_KEY`
+
+#### https-client-auth-type {metadata="v1.13.0+"}
+
+Default is unset (`NoClientCert`).
+
+Enables mutual TLS (mTLS) by requiring and/or verifying a certificate from peer
+data nodes that connect to this node's cluster listener.
+Set to one of the following:
+
+- `NoClientCert`
+- `RequestClientCert`
+- `RequireAnyClientCert`
+- `VerifyClientCertIfGiven`
+- `RequireAndVerifyClientCert`
+
+Leaving it unset disables client-certificate authentication (`NoClientCert`).
+
+Environment variable: `INFLUXDB_CLUSTER_HTTPS_CLIENT_AUTH_TYPE`
+
+#### https-client-ca {metadata="v1.13.0+"}
+
+Default is unset.
+
+The CA pool used to verify certificates presented by peers connecting to this
+node's cluster listener (mTLS).
+Changes to this pool take effect on configuration reload (`SIGHUP`) and don't
+require a restart.
+
+Specify the CA pool as an inline table with the following keys:
+
+- `paths`: list of PEM files to trust
+- `include-system`: if `true`, also trust the host's system CA pool
+
+```toml
+https-client-ca = { paths = ["/etc/ssl/cluster-ca.pem"], include-system = false }
+```
+
+Environment variables:
+
+- `INFLUXDB_CLUSTER_HTTPS_CLIENT_CA_PATHS`
+- `INFLUXDB_CLUSTER_HTTPS_CLIENT_CA_INCLUDE_SYSTEM`
+
+#### https-root-ca {metadata="v1.13.0+"}
+
+Default is unset.
+
+The CA pool used to verify the server certificates of peer data nodes that this
+node dials (mTLS).
+Leaving it unset uses the host's system roots.
+Changes to this pool take effect on configuration reload (`SIGHUP`) and don't
+require a restart.
+
+Specify the CA pool as an inline table with the following keys:
+
+- `paths`: list of PEM files to trust
+- `include-system`: if `true`, also trust the host's system CA pool
+
+```toml
+https-root-ca = { paths = ["/etc/ssl/cluster-ca.pem"], include-system = false }
+```
+
+Environment variables:
+
+- `INFLUXDB_CLUSTER_HTTPS_ROOT_CA_PATHS`
+- `INFLUXDB_CLUSTER_HTTPS_ROOT_CA_INCLUDE_SYSTEM`
 
 #### cluster-tracing
 
@@ -1218,6 +1381,56 @@ Skips file permission checking for `https-certificate` and `https-private-key` w
 
 Environment variable: `INFLUXDB_HTTP_HTTPS_INSECURE_CERTIFICATE`
 
+#### https-ignore-sanity-checks {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Loads `https-certificate` even when it fails the checks for whether a server can
+use it, such as the certificate not permitting server authentication.
+The failed checks are logged instead.
+A missing or unparseable certificate is still an error.
+
+Environment variable: `INFLUXDB_HTTP_HTTPS_IGNORE_SANITY_CHECKS`
+
+#### https-client-auth-type {metadata="v1.13.0+"}
+
+Default is unset (`NoClientCert`).
+
+The type of client certificate authentication (mutual TLS) to require for
+connections to the HTTP API.
+Set to one of the following:
+
+- `NoClientCert`
+- `RequestClientCert`
+- `RequireAnyClientCert`
+- `VerifyClientCertIfGiven`
+- `RequireAndVerifyClientCert`
+
+Leaving it unset disables client authentication (`NoClientCert`).
+
+Environment variable: `INFLUXDB_HTTP_HTTPS_CLIENT_AUTH_TYPE`
+
+#### https-client-ca {metadata="v1.13.0+"}
+
+Default is unset.
+
+CA certificates used to verify client certificates during client authentication
+(mTLS).
+
+Specify the CA pool as an inline table with the following keys:
+
+- `paths`: list of PEM files to trust
+- `include-system`: if `true`, also trust the host's system CA pool
+
+```toml
+https-client-ca = { paths = ["/etc/ssl/client-ca.pem"], include-system = false }
+```
+
+Environment variables:
+
+- `INFLUXDB_HTTP_HTTPS_CLIENT_CA_PATHS`
+- `INFLUXDB_HTTP_HTTPS_CLIENT_CA_INCLUDE_SYSTEM`
+
 #### shared-secret
 
 Default is `""`.
@@ -1381,6 +1594,65 @@ The path to the PEM-encoded CA certs file.
 If the set to the empty string (`""`), the default system certs will used.
 
 Environment variable: `INFLUXDB_SUBSCRIBER_CA_CERTS`
+
+#### root-ca {metadata="v1.13.0+"}
+
+Default is unset.
+
+Additional CA certificates used to verify subscription endpoint server
+certificates, combined with [`ca-certs`](#ca-certs).
+
+Specify the CA pool as an inline table with the following keys:
+
+- `paths`: list of PEM files to trust
+- `include-system`: if `true`, also trust the host's system CA pool
+
+```toml
+root-ca = { paths = ["/etc/ssl/subscriber-ca.pem"], include-system = false }
+```
+
+Environment variables:
+
+- `INFLUXDB_SUBSCRIBER_ROOT_CA_PATHS`
+- `INFLUXDB_SUBSCRIBER_ROOT_CA_INCLUDE_SYSTEM`
+
+#### certificate {metadata="v1.13.0+"}
+
+Default is `""`.
+
+The client certificate the subscriber presents to HTTPS endpoints for mutual TLS
+(mTLS).
+Empty means no client certificate is presented.
+
+Environment variable: `INFLUXDB_SUBSCRIBER_CERTIFICATE`
+
+#### private-key {metadata="v1.13.0+"}
+
+Default is `""`.
+
+The private key for the subscriber client [`certificate`](#certificate).
+
+Environment variable: `INFLUXDB_SUBSCRIBER_PRIVATE_KEY`
+
+#### insecure-certificate {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Allows insecure file permissions on [`certificate`](#certificate) and
+[`private-key`](#private-key) when `true`.
+
+Environment variable: `INFLUXDB_SUBSCRIBER_INSECURE_CERTIFICATE`
+
+#### ignore-cert-sanity-checks {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Loads [`certificate`](#certificate) even when it fails the checks for whether a
+server can use it, such as the certificate not permitting server authentication.
+The failed checks are logged instead.
+A missing or unparseable certificate is still an error.
+
+Environment variable: `INFLUXDB_SUBSCRIBER_IGNORE_CERT_SANITY_CHECKS`
 
 #### write-concurrency
 
@@ -1564,8 +1836,38 @@ For more information, see [OpenTSDB protocol support in InfluxDB](/enterprise_in
 # retention-policy = ""
 # consistency-level = "one"
 # tls-enabled = false
-# certificate= "/etc/ssl/influxdb.pem"
+# certificate = "/etc/ssl/influxdb.pem"
+
+# TLS private key when TLS is enabled.
+# If blank, defaults to assuming the key is in the certificate.
+# private-key = ""                                                 # v1.13.0+
+
+# Allow insecure file permissions on certificate and private-key.
+# insecure-certificate = false                                     # v1.13.0+
+
+# Load the certificate even when it fails the checks for whether a server can
+# use it, such as the certificate not permitting server authentication.
+# The failed checks are logged instead.
+# A missing or unparseable certificate is still an error.
+# ignore-cert-sanity-checks = false                                # v1.13.0+
+
+# The type of client certificate authentication (mutual TLS) to require. One of
+# NoClientCert, RequestClientCert, RequireAnyClientCert,
+# VerifyClientCertIfGiven, or RequireAndVerifyClientCert. Unset disables client
+# authentication.
+# client-auth-type = "RequireAndVerifyClientCert"                  # v1.13.0+
+
+# CA certificates used to verify client certificates during client
+# authentication. "paths" lists PEM files to trust; "include-system" also
+# trusts the host's system CA pool.
+# client-ca = { paths = ["/etc/ssl/client-ca.pem"], include-system = false } # v1.13.0+
 ```
+
+{{% note %}}
+The OpenTSDB TLS mutual-authentication options (`private-key`,
+`insecure-certificate`, `ignore-cert-sanity-checks`, `client-auth-type`, and
+`client-ca`) were added in **v1.13.0**.
+{{% /note %}}
 
 #### log-point-errors
 

--- a/content/enterprise_influxdb/v1/administration/configure/config-meta-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/configure/config-meta-nodes.md
@@ -204,6 +204,105 @@ This is useful when testing with self-signed certificates.
 
 Environment variable: `INFLUXDB_META_DATA_INSECURE_TLS`
 
+#### https-ignore-sanity-checks {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Loads a certificate even when it fails the checks for whether it can be used at
+all, such as a server certificate not permitting server authentication.
+The failed checks are logged instead.
+A missing or unparseable server certificate is still an error.
+Applies to both the HTTP API and data/raft listeners.
+
+Environment variable: `INFLUXDB_META_HTTPS_IGNORE_SANITY_CHECKS`
+
+#### https-client-certificate {metadata="v1.13.0+"}
+
+Default is `""`.
+
+The certificate this meta node presents when it dials a peer, such as another
+meta node or a data node (mutual TLS).
+Leaving it unset presents [`https-certificate`](#https-certificate) and
+[`https-private-key`](#https-private-key) to peers instead.
+This is the opposite direction from [`https-client-ca`](#https-client-ca), which
+verifies the peers that dial this node.
+
+Environment variable: `INFLUXDB_META_HTTPS_CLIENT_CERTIFICATE`
+
+#### https-client-private-key {metadata="v1.13.0+"}
+
+Default is `""`.
+
+Use a separate private key location for the
+[`https-client-certificate`](#https-client-certificate).
+
+Environment variable: `INFLUXDB_META_HTTPS_CLIENT_PRIVATE_KEY`
+
+#### https-client-auth-type {metadata="v1.13.0+"}
+
+Default is unset (`NoClientCert`).
+
+Enables mutual TLS (mTLS) by requiring and/or verifying a certificate from peers
+that connect to this meta node's HTTP API and data/raft listeners.
+Set to one of the following:
+
+- `NoClientCert`
+- `RequestClientCert`
+- `RequireAnyClientCert`
+- `VerifyClientCertIfGiven`
+- `RequireAndVerifyClientCert`
+
+Leaving it unset disables client-certificate authentication (`NoClientCert`).
+
+Environment variable: `INFLUXDB_META_HTTPS_CLIENT_AUTH_TYPE`
+
+#### https-client-ca {metadata="v1.13.0+"}
+
+Default is unset.
+
+The CA pool used to verify certificates presented by peers connecting to this
+meta node's listeners (mTLS).
+Changes to this pool take effect on configuration reload (`SIGHUP`) and don't
+require a restart.
+
+Specify the CA pool as an inline table with the following keys:
+
+- `paths`: list of PEM files to trust
+- `include-system`: if `true`, also trust the host's system CA pool
+
+```toml
+https-client-ca = { paths = ["/etc/ssl/cluster-ca.pem"], include-system = false }
+```
+
+Environment variables:
+
+- `INFLUXDB_META_HTTPS_CLIENT_CA_PATHS`
+- `INFLUXDB_META_HTTPS_CLIENT_CA_INCLUDE_SYSTEM`
+
+#### https-root-ca {metadata="v1.13.0+"}
+
+Default is unset.
+
+The CA pool used to verify the server certificates of the peers this meta node
+dials, such as other meta nodes and data nodes (mTLS).
+Leaving it unset uses the host's system roots.
+Changes to this pool take effect on configuration reload (`SIGHUP`) and don't
+require a restart.
+
+Specify the CA pool as an inline table with the following keys:
+
+- `paths`: list of PEM files to trust
+- `include-system`: if `true`, also trust the host's system CA pool
+
+```toml
+https-root-ca = { paths = ["/etc/ssl/cluster-ca.pem"], include-system = false }
+```
+
+Environment variables:
+
+- `INFLUXDB_META_HTTPS_ROOT_CA_PATHS`
+- `INFLUXDB_META_HTTPS_ROOT_CA_INCLUDE_SYSTEM`
+
 #### gossip-frequency
 
 Default is `"5s"`.

--- a/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
+++ b/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
@@ -17,6 +17,7 @@ Enabling HTTPS over TLS encrypts the communication between clients and the Influ
 When configured with a signed certificate, HTTPS over TLS can also verify the authenticity of the InfluxDB Enterprise server to connecting clients.
 
 This pages outlines how to set up HTTPS with InfluxDB Enterprise using either a signed or self-signed certificate.
+It also describes how to enable [mutual TLS (mTLS)](#enable-mutual-tls-mtls) so that both ends of each connection authenticate each other.
 
 {{% warn %}}
 InfluxData **strongly recommends** enabling HTTPS, especially if you plan on sending requests to InfluxDB Enterprise over a network.
@@ -55,7 +56,7 @@ Regardless of your certificate's type, InfluxDB Enterprise supports certificates
 a private key file (`.key`) and a signed certificate file (`.crt`) file pair, as well as certificates
 that combine the private key file and the signed certificate file into a single bundled file (`.pem`).
 
-In general, each node node should have its own certificate, whether signed or unsigned.
+In general, each node should have its own certificate, whether signed or unsigned.
 
 ## Set up HTTPS in an InfluxDB Enterprise cluster
 
@@ -251,6 +252,219 @@ With a self-signed certificate, you must also use the `-k` option to skip certif
     ```
 
     That's it! You've successfully set up HTTPS with InfluxDB Enterprise.
+
+## Enable mutual TLS (mTLS) {metadata="v1.13.0+"}
+
+With standard HTTPS, only the server presents a certificate and the client verifies it.
+**Mutual TLS (mTLS)** additionally requires the _client_ to present a certificate that the _server_ verifies, so both ends of every connection authenticate each other.
+
+In an InfluxDB Enterprise cluster, you can require mTLS on:
+
+- **Inter-node connections**: meta-to-meta, meta-to-data, and data-to-data traffic.
+- **HTTP API connections**: clients such as the [`influx` CLI](/enterprise_influxdb/v1/tools/influx-cli/use-influx/), `influxd-ctl`, and Telegraf connecting to the data node or meta node API.
+
+{{% note %}}
+mTLS options require **InfluxDB Enterprise v1.13.0+** and build on the HTTPS
+configuration described above.
+Complete [Set up HTTPS](#set-up-https-in-an-influxdb-enterprise-cluster) before
+enabling mTLS.
+
+Creating the certificates, private keys, and CA files needed for mTLS is outside
+the scope of this guide.
+The following steps assume you already have a CA certificate (for example,
+`/etc/ssl/cluster-ca.crt`) that signed each node's certificate, plus the server
+certificate and key installed on each node.
+{{% /note %}}
+
+### How mTLS settings map to connections
+
+Each node acts as both a **server** (accepting connections) and a **client**
+(dialing other nodes), so configure mTLS from both perspectives.
+
+| Role              | Purpose                                                        | Settings                                          |
+| :---------------- | :------------------------------------------------------------ | :------------------------------------------------ |
+| Server (listener) | Require and verify certificates from connecting clients       | `*-client-auth-type`, `*-client-ca`               |
+| Client (dialer)   | Present a certificate to the servers this node dials          | `*-client-certificate`, `*-client-private-key`    |
+| Client (dialer)   | Verify the server certificates of the servers this node dials | `*-root-ca` (`meta-root-ca` for meta connections) |
+
+{{% note %}}
+If you don't set a separate client certificate (`*-client-certificate`), the node
+presents its server certificate (`https-certificate`) when dialing peers.
+Set a separate client certificate only if you use distinct certificates for the
+client and server roles.
+{{% /note %}}
+
+Set `*-client-auth-type` to one of the following:
+
+| Value                        | Behavior                                                             |
+| :--------------------------- | :------------------------------------------------------------------ |
+| `NoClientCert`               | Don't request a client certificate (mTLS disabled).                 |
+| `RequestClientCert`          | Request a certificate, but don't require or verify it.              |
+| `RequireAnyClientCert`       | Require a certificate, but don't verify it against a CA.            |
+| `VerifyClientCertIfGiven`    | Verify the certificate against the CA only if one is presented.     |
+| `RequireAndVerifyClientCert` | Require and verify a certificate against the CA (enforced mTLS).    |
+
+The CA settings (`*-client-ca` and `*-root-ca`) are inline tables:
+
+- `paths`: list of PEM files whose certificates are trusted
+- `include-system` _(optional)_: if `true`, also trust the host's system CA pool (default is `false`)
+
+### Configure mTLS on meta nodes
+
+In the `[meta]` section of each meta node configuration file (`influxdb-meta.conf`),
+add the following to the [HTTPS settings you already configured](#set-up-https-in-an-influxdb-enterprise-cluster):
+
+```toml
+[meta]
+
+  [...]
+
+  # Require and verify a certificate from peers that connect to this meta node
+  # (applies to both the HTTP API and raft/data listeners).
+  https-client-auth-type = "RequireAndVerifyClientCert"
+
+  # CA used to verify certificates presented by connecting peers.
+  https-client-ca = { paths = ["/etc/ssl/cluster-ca.crt"] }
+
+  # CA used to verify the server certificates of the peers this meta node dials
+  # (other meta nodes and data nodes).
+  https-root-ca = { paths = ["/etc/ssl/cluster-ca.crt"] }
+
+  # Optional: present a separate client certificate when dialing peers.
+  # If unset, the meta node presents `https-certificate` and `https-private-key`.
+  # https-client-certificate = "/etc/ssl/influxdb-meta-client.crt"
+  # https-client-private-key = "/etc/ssl/influxdb-meta-client.key"
+```
+
+{{% note %}}
+When you verify peer server certificates with `https-root-ca`, you no longer need
+`https-insecure-tls` or `data-insecure-tls` to skip verification.
+Remove those settings (or leave them `false`) to keep server verification enabled.
+{{% /note %}}
+
+### Configure mTLS on data nodes
+
+In the data node configuration file (`influxdb.conf`), configure mTLS for each
+type of connection.
+
+#### Inter-data-node connections `[cluster]`
+
+```toml
+[cluster]
+
+  [...]
+
+  # Require and verify a certificate from peer data nodes that connect to this
+  # node's cluster listener.
+  https-client-auth-type = "RequireAndVerifyClientCert"
+
+  # CA used to verify certificates presented by connecting peer data nodes.
+  https-client-ca = { paths = ["/etc/ssl/cluster-ca.crt"] }
+
+  # CA used to verify the server certificates of peer data nodes this node dials.
+  https-root-ca = { paths = ["/etc/ssl/cluster-ca.crt"] }
+
+  # Optional: present a separate client certificate when dialing peers.
+  # If unset, the data node presents `https-certificate` and `https-private-key`.
+  # https-client-certificate = "/etc/ssl/influxdb-data-client.crt"
+  # https-client-private-key = "/etc/ssl/influxdb-data-client.key"
+```
+
+#### Data-node-to-meta-node connections `[meta]`
+
+```toml
+[meta]
+
+  [...]
+
+  meta-tls-enabled = true
+
+  # Client certificate this data node presents to meta nodes (mTLS).
+  # If unset, no client certificate is presented.
+  meta-client-certificate = "/etc/ssl/influxdb-data.crt"
+  meta-client-private-key  = "/etc/ssl/influxdb-data.key"
+
+  # CA used to verify the server certificates of the meta nodes this data node dials.
+  meta-root-ca = { paths = ["/etc/ssl/cluster-ca.crt"] }
+```
+
+#### HTTP API connections `[http]`
+
+To require client certificates from clients that connect to the data node HTTP API
+(for example, the `influx` CLI and Telegraf), configure the `[http]` section:
+
+```toml
+[http]
+
+  [...]
+
+  # Require and verify a client certificate for HTTP API connections.
+  https-client-auth-type = "RequireAndVerifyClientCert"
+
+  # CA used to verify client certificates.
+  https-client-ca = { paths = ["/etc/ssl/client-ca.crt"] }
+```
+
+{{% warn %}}
+Requiring client certificates on the HTTP API (`[http] https-client-auth-type`)
+means **every** HTTP API client must present a valid certificate.
+Before enabling this setting, ensure all clients&mdash;including the `influx` CLI,
+Telegraf, and your applications&mdash;are configured to present a client certificate.
+{{% /warn %}}
+
+### Apply the configuration
+
+If you're enabling HTTPS and mTLS at the same time, restart each node as described
+in [Set up HTTPS](#set-up-https-in-an-influxdb-enterprise-cluster):
+
+```sh
+sudo systemctl restart influxdb-meta
+sudo systemctl restart influxdb
+```
+
+If HTTPS is already enabled and you're only adding or changing mTLS settings
+(client authentication type, CA pools, or certificates), you can apply the
+changes without a restart by reloading each process with `SIGHUP`:
+
+```sh
+sudo systemctl reload influxdb-meta
+sudo systemctl reload influxdb
+```
+
+{{% note %}}
+Enabling or disabling HTTPS (`https-enabled`) always requires a restart.
+Only certificate, CA pool, and client-authentication changes can be applied with
+`SIGHUP`.
+{{% /note %}}
+
+### Verify mTLS
+
+After you require client certificates on the meta node listeners, `influxd-ctl`
+must present a client certificate to connect:
+
+```sh
+influxd-ctl -bind-tls \
+  -cert /etc/ssl/influxd-ctl-client.crt \
+  -key /etc/ssl/influxd-ctl-client.key \
+  -ca-cert /etc/ssl/cluster-ca.crt \
+  show
+```
+
+- `-cert` and `-key`: the client certificate and private key `influxd-ctl` presents
+  (use `-client-cert` and `-client-key` to present a separate client identity).
+- `-ca-cert`: the CA used to verify the meta node's server certificate.
+
+If you require client certificates on the data node HTTP API, connect with the
+`influx` CLI by passing the client certificate and key:
+
+```sh
+influx -ssl -host <domain_name>.com \
+  -cert /etc/ssl/influx-client.crt \
+  -key /etc/ssl/influx-client.key
+```
+
+You can also set the `INFLUX_CERT` and `INFLUX_KEY` environment variables instead
+of the `-cert` and `-key` flags.
 
 ## Connect Telegraf to a secured InfluxDB Enterprise instance
 

--- a/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
+++ b/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
@@ -403,12 +403,11 @@ To require client certificates from clients that connect to the data node HTTP A
   https-client-ca = { paths = ["/etc/ssl/client-ca.crt"] }
 ```
 
-{{% warn %}}
-Requiring client certificates on the HTTP API (`[http] https-client-auth-type`)
-means **every** HTTP API client must present a valid certificate.
-Before enabling this setting, ensure all clients&mdash;including the `influx` CLI,
-Telegraf, and your applications&mdash;are configured to present a client certificate.
-{{% /warn %}}
+> [!Important]
+> Requiring client certificates on the HTTP API (`[http] https-client-auth-type`)
+> means **every** HTTP API client must present a valid certificate.
+> Before enabling this setting, ensure all clients&mdash;including the `influx` CLI,
+> Telegraf, and your applications&mdash;are configured to present a client certificate.
 
 ### Apply the configuration
 

--- a/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
+++ b/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
@@ -286,12 +286,11 @@ Each node acts as both a **server** (accepting connections) and a **client**
 | Client (dialer)   | Present a certificate to the servers this node dials          | `*-client-certificate`, `*-client-private-key`    |
 | Client (dialer)   | Verify the server certificates of the servers this node dials | `*-root-ca` (`meta-root-ca` for meta connections) |
 
-{{% note %}}
-If you don't set a separate client certificate (`*-client-certificate`), the node
-presents its server certificate (`https-certificate`) when dialing peers.
-Set a separate client certificate only if you use distinct certificates for the
-client and server roles.
-{{% /note %}}
+> [!Note]
+> If you don't set a separate client certificate (`*-client-certificate`), the node
+> presents its server certificate (`https-certificate`) when dialing peers.
+> Set a separate client certificate only if you use distinct certificates for the
+> client and server roles.
 
 Set `*-client-auth-type` to one of the following:
 

--- a/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
+++ b/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
@@ -427,11 +427,10 @@ sudo systemctl reload influxdb-meta
 sudo systemctl reload influxdb
 ```
 
-{{% note %}}
-Enabling or disabling HTTPS (`https-enabled`) always requires a restart.
-Only certificate, CA pool, and client-authentication changes can be applied with
-`SIGHUP`.
-{{% /note %}}
+> [!Note]
+> Enabling or disabling HTTPS (`https-enabled`) always requires a restart.
+> Only certificate, CA pool, and client-authentication changes can be applied with
+> `SIGHUP`.
 
 ### Verify mTLS
 

--- a/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
+++ b/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
@@ -263,18 +263,17 @@ In an InfluxDB Enterprise cluster, you can require mTLS on:
 - **Inter-node connections**: meta-to-meta, meta-to-data, and data-to-data traffic.
 - **HTTP API connections**: clients such as the [`influx` CLI](/enterprise_influxdb/v1/tools/influx-cli/use-influx/), `influxd-ctl`, and Telegraf connecting to the data node or meta node API.
 
-{{% note %}}
-mTLS options require **InfluxDB Enterprise v1.13.0+** and build on the HTTPS
-configuration described above.
-Complete [Set up HTTPS](#set-up-https-in-an-influxdb-enterprise-cluster) before
-enabling mTLS.
-
-Creating the certificates, private keys, and CA files needed for mTLS is outside
-the scope of this guide.
-The following steps assume you already have a CA certificate (for example,
-`/etc/ssl/cluster-ca.crt`) that signed each node's certificate, plus the server
-certificate and key installed on each node.
-{{% /note %}}
+> [!Note]
+> mTLS options require **InfluxDB Enterprise v1.13.0+** and build on the HTTPS
+> configuration described above.
+> Complete [Set up HTTPS](#set-up-https-in-an-influxdb-enterprise-cluster) before
+> enabling mTLS.
+> 
+> Creating the certificates, private keys, and CA files needed for mTLS is outside
+> the scope of this guide.
+> The following steps assume you already have a CA certificate (for example,
+> `/etc/ssl/cluster-ca.crt`) that signed each node's certificate, plus the server
+> certificate and key installed on each node.
 
 ### How mTLS settings map to connections
 

--- a/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
+++ b/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
@@ -335,11 +335,10 @@ add the following to the [HTTPS settings you already configured](#set-up-https-i
   # https-client-private-key = "/etc/ssl/influxdb-meta-client.key"
 ```
 
-{{% note %}}
-When you verify peer server certificates with `https-root-ca`, you no longer need
-`https-insecure-tls` or `data-insecure-tls` to skip verification.
-Remove those settings (or leave them `false`) to keep server verification enabled.
-{{% /note %}}
+> [!Note]
+> When you verify peer server certificates with `https-root-ca`, you no longer need
+> `https-insecure-tls` or `data-insecure-tls` to skip verification.
+> Remove those settings (or leave them `false`) to keep server verification enabled.
 
 ### Configure mTLS on data nodes
 

--- a/content/enterprise_influxdb/v1/administration/manage/clusters/replacing-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/manage/clusters/replacing-nodes.md
@@ -61,6 +61,14 @@ influxd-ctl -bind-tls [-k] <command>
 influxd-ctl -bind-tls remove-meta enterprise-meta-02:8091
 ```
 
+{{% note %}}
+If the cluster requires mutual TLS (mTLS), also pass a client certificate and key
+with `-cert` and `-key` (and `-ca-cert` to verify the meta node's certificate).
+For more information, see the
+[`influxd-ctl` global flags](/enterprise_influxdb/v1/tools/influxd-ctl/#influxd-ctl-global-flags)
+and [Enable mutual TLS (mTLS)](/enterprise_influxdb/v1/administration/configure/security/enable_tls/#enable-mutual-tls-mtls). _v1.13.0+_
+{{% /note %}}
+
 #### `curl -k`
 
 `curl` natively supports TLS/SSL connections, but if using a self-signed certificate,

--- a/content/enterprise_influxdb/v1/administration/manage/clusters/replacing-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/manage/clusters/replacing-nodes.md
@@ -61,13 +61,12 @@ influxd-ctl -bind-tls [-k] <command>
 influxd-ctl -bind-tls remove-meta enterprise-meta-02:8091
 ```
 
-{{% note %}}
-If the cluster requires mutual TLS (mTLS), also pass a client certificate and key
-with `-cert` and `-key` (and `-ca-cert` to verify the meta node's certificate).
-For more information, see the
-[`influxd-ctl` global flags](/enterprise_influxdb/v1/tools/influxd-ctl/#influxd-ctl-global-flags)
-and [Enable mutual TLS (mTLS)](/enterprise_influxdb/v1/administration/configure/security/enable_tls/#enable-mutual-tls-mtls). _v1.13.0+_
-{{% /note %}}
+> [!Note]
+> If the cluster requires mutual TLS (mTLS), also pass a client certificate and key
+> with `-cert` and `-key` (and `-ca-cert` to verify the meta node's certificate).
+> For more information, see the
+> [`influxd-ctl` global flags](/enterprise_influxdb/v1/tools/influxd-ctl/#influxd-ctl-global-flags)
+> and [Enable mutual TLS (mTLS)](/enterprise_influxdb/v1/administration/configure/security/enable_tls/#enable-mutual-tls-mtls). _v1.13.0+_
 
 #### `curl -k`
 

--- a/content/enterprise_influxdb/v1/tools/influx-cli/_index.md
+++ b/content/enterprise_influxdb/v1/tools/influx-cli/_index.md
@@ -30,6 +30,11 @@ influx [flags]
 | `-username`       | Username to connect to the server                                                                     |
 | `-ssl`            | Use https for requests                                                                                |
 | `-unsafessl`      | Set this when connecting to the cluster using https                                                   |
+| `-cert`           | Path to the client certificate file (PEM) presented for mutual TLS (mTLS). Also settable via `INFLUX_CERT`. _v1.13.0+_ |
+| `-key`            | Path to the client private key file (PEM) for mutual TLS (mTLS). Also settable via `INFLUX_KEY`. _v1.13.0+_ |
+| `-root-ca`        | Path to the CA bundle (PEM) used to verify the server certificate. Also settable via `INFLUX_ROOT_CA`. _v1.13.0+_ |
+| `-insecure-certificate` | Ignore file permission checks when loading the client certificate and key. Also settable via `INFLUX_INSECURE_CERTIFICATE`. _v1.13.0+_ |
+| `-ignore-cert-sanity-checks` | Load the client certificate even if it fails client-authentication sanity checks. Also settable via `INFLUX_IGNORE_CERT_SANITY_CHECKS`. _v1.13.0+_ |
 | `-execute`        | Execute command and quit                                                                              |
 | `-format`         | Specify the format of the server responses: json, csv, or column                                      |
 | `-precision`      | Specify the format of the timestamp: rfc3339, h, m, s, ms, u or ns                                    |

--- a/content/enterprise_influxdb/v1/tools/influx-cli/use-influx-cli.md
+++ b/content/enterprise_influxdb/v1/tools/influx-cli/use-influx-cli.md
@@ -87,6 +87,10 @@ Arguments specify connection, write, import, and output options for the CLI sess
 `-h`, `-help`
 List `influx` arguments
 
+`-cert 'path'` _(v1.13.0+)_
+Path to the client certificate file (PEM) presented for mutual TLS (mTLS).
+Alternatively, set the certificate with the `INFLUX_CERT` environment variable.
+
 `-compressed`
 Set to true if the import file is compressed.
 Use with `-import`.
@@ -109,9 +113,21 @@ See [-format](#specify-the-format-of-the-server-responses-with--format).
 The host to which `influx` connects.
 By default, InfluxDB runs on localhost.
 
+`-ignore-cert-sanity-checks` _(v1.13.0+)_
+Load the client certificate even if it fails client-authentication sanity checks.
+Alternatively, set this with the `INFLUX_IGNORE_CERT_SANITY_CHECKS` environment variable.
+
 `-import`
 Import new data or [exported data](/enterprise_influxdb/v1/administration/backup-and-restore/#exporting-data) from a file.
 See [-import](#import-data-from-a-file).
+
+`-insecure-certificate` _(v1.13.0+)_
+Ignore file permission checks when loading the client certificate and key.
+Alternatively, set this with the `INFLUX_INSECURE_CERTIFICATE` environment variable.
+
+`-key 'path'` _(v1.13.0+)_
+Path to the client private key file (PEM) for mutual TLS (mTLS).
+Alternatively, set the key with the `INFLUX_KEY` environment variable.
 
 `-password 'password'`
 The password `influx` uses to connect to the server.
@@ -140,6 +156,10 @@ Precision defaults to nanoseconds.
 
 `-pretty`
 Turns on pretty print for the `json` format.
+
+`-root-ca 'path'` _(v1.13.0+)_
+Path to the CA bundle (PEM) used to verify the server certificate.
+Alternatively, set the CA bundle with the `INFLUX_ROOT_CA` environment variable.
 
 `-ssl`
 Use HTTPS for requests.

--- a/content/enterprise_influxdb/v1/tools/influxd-ctl/_index.md
+++ b/content/enterprise_influxdb/v1/tools/influxd-ctl/_index.md
@@ -49,17 +49,24 @@ influxd-ctl [global-flags] <command> [command-flags] [arguments]
 
 ## Global flags {#influxd-ctl-global-flags}
 
-| Flag         | Description                                                              |
-| :----------- | :----------------------------------------------------------------------- |
-| `-auth-type` | Authentication type to use (`none` _default_, `basic`, `jwt`)            |
-| `-bind`      | Meta node HTTP bind address _(default is `localhost:8091`)_              |
-| `-bind-tls`  | Use TLS                                                                  |
-| `-config`    | Configuration file path                                                  |
-| `-k`         | Skip certificate verification _(ignored without `-bind-tls`)_            |
-| `-pwd`       | Password for basic authentication _(ignored without `-auth-type basic`)_ |
-| `-secret`    | JWT shared secret _(ignored without `-auth-type jwt`)_                   |
-| `-timeout`   | Override the default timeout of 10s for operations _(for example, `30s`, `1m`)_. _v1.12.3+_ |
-| `-user`      | Username _(ignored without `-auth-type basic` or `jwt`)_                 |
+| Flag                         | Description                                                                                                           |
+| :--------------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| `-auth-type`                 | Authentication type to use (`none` _default_, `basic`, `jwt`)                                                        |
+| `-bind`                      | Meta node HTTP bind address _(default is `localhost:8091`)_                                                          |
+| `-bind-tls`                  | Use TLS                                                                                                              |
+| `-ca-cert`                   | CA certificate used to verify the meta node's server certificate _(ignored without `-bind-tls`)_. _v1.13.0+_        |
+| `-cert`                      | Client certificate for mutual TLS (mTLS), used unless `-client-cert` is given _(ignored without `-bind-tls`)_. _v1.13.0+_ |
+| `-client-cert`               | Client certificate for mutual TLS (mTLS), overriding `-cert` _(ignored without `-bind-tls`)_. _v1.13.0+_           |
+| `-client-key`                | Client private key for `-client-cert` _(ignored without `-bind-tls`)_. _v1.13.0+_                                   |
+| `-config`                    | Configuration file path                                                                                             |
+| `-ignore-cert-sanity-checks` | Present the client certificate even if it fails the checks for whether a client can use it. _v1.13.0+_             |
+| `-insecure-certificate`      | Skip file-permission checks on the certificate and private key. _v1.13.0+_                                          |
+| `-k`                         | Skip certificate verification _(ignored without `-bind-tls`)_                                                       |
+| `-key`                       | Client private key for `-cert` _(ignored without `-bind-tls`)_. _v1.13.0+_                                          |
+| `-pwd`                       | Password for basic authentication _(ignored without `-auth-type basic`)_                                            |
+| `-secret`                    | JWT shared secret _(ignored without `-auth-type jwt`)_                                                              |
+| `-timeout`                   | Override the default timeout of 10s for operations _(for example, `30s`, `1m`)_. _v1.12.3+_                         |
+| `-user`                      | Username _(ignored without `-auth-type basic` or `jwt`)_                                                            |
 
 ## Examples
 
@@ -67,6 +74,7 @@ influxd-ctl [global-flags] <command> [command-flags] [arguments]
 - [Authenticate with JWT](#authenticate-with-jwt)
 - [Authenticate with basic authentication](#authenticate-with-basic-authentication)
 - [Override the default timeout](#override-the-default-timeout)
+- [Connect with mutual TLS (mTLS)](#connect-with-mutual-tls-mtls)
 
 ### Bind to a remote meta node
 
@@ -91,6 +99,35 @@ influxd-ctl -auth-type basic -user admin -pwd passw0rd
 ```sh
 influxd-ctl -timeout 30s show-shards
 ```
+
+### Connect with mutual TLS (mTLS) {metadata="v1.13.0+"}
+
+When the cluster's meta nodes require a client certificate
+([`https-client-auth-type`](/enterprise_influxdb/v1/administration/configure/config-meta-nodes/#https-client-auth-type)),
+use `-cert` and `-key` to present a client certificate and private key, and use
+`-ca-cert` to verify the meta node's server certificate:
+
+```sh
+influxd-ctl -bind-tls \
+  -cert /etc/ssl/influxd-ctl-client.crt \
+  -key /etc/ssl/influxd-ctl-client.key \
+  -ca-cert /etc/ssl/cluster-ca.crt \
+  show
+```
+
+To present a dedicated client certificate that overrides `-cert`, use
+`-client-cert` and `-client-key`:
+
+```sh
+influxd-ctl -bind-tls \
+  -client-cert /etc/ssl/influxd-ctl-client.crt \
+  -client-key /etc/ssl/influxd-ctl-client.key \
+  -ca-cert /etc/ssl/cluster-ca.crt \
+  show
+```
+
+For more information about configuring mTLS in a cluster, see
+[Enable mutual TLS (mTLS)](/enterprise_influxdb/v1/administration/configure/security/enable_tls/#enable-mutual-tls-mtls).
 
 {{< expand-wrapper >}}
 {{% expand "Troubleshoot `influxd-ctl` authentication" %}}


### PR DESCRIPTION
Document new configuration settings and command line options to support mTLS. Add instructions on enabled mTLS in an Enterprise 1.x cluster. These features will be available in 1.13.0.

Part of https://github.com/influxdata/DAR/issues/727
