### PR TITLE
docs(influxdb3-enterprise): clarify license portability for operators

### DIFF
--- a/content/influxdb3/enterprise/admin/license.md
+++ b/content/influxdb3/enterprise/admin/license.md
@@ -24,6 +24,8 @@ the license type.
 > #### License storage portability in v3.10 and later
 >
 > Starting in **v3.10**, {{% product-name %}} licenses are no longer tied to a specific cluster's storage location.
+> You can copy a valid license file to another object store when moving a
+> deployment.
 > Licenses are still required, with per-cluster CPU core limits and license expiration continuing to apply.
 > This change applies to Commercial, Trial, and At-Home licenses and isn't
 > backwards compatible with versions earlier than v3.10.
@@ -35,6 +37,7 @@ the license type.
 - [Activate a license](#activate-a-license)
   - [Activate a trial or at-home license](#activate-a-trial-or-at-home-license)
   - [Activate a commercial license](#activate-a-commercial-license)
+- [Move a valid license to another object store](#move-a-valid-license-to-another-object-store)
 - [Change your license type](#change-your-license-type)
 - [Renew a license](#renew-a-license)
 - [Expiration behavior](#expiration-behavior)
@@ -117,7 +120,7 @@ The license file is a JWT file that contains the license information.
 >
 > If you're starting a new {{% product-name %}} server in a Docker container or
 > installed via DEB or RPM, you must use one of the methods to
-> [skip the email prompt](#skip-the-email-prompt).
+> [skip the email prompt](#skip-the-email-prompt) and specify a license type.
 > This ensures that the server can generate the license file after you
 > verify your email address. See the following examples:
 >
@@ -137,6 +140,18 @@ If the server finds a valid license file in your object store, it ignores the
 license email option.
 
 See examples to [start the server with your license email](#start-the-server-with-your-license-email).
+
+#### Select a license type without a prompt
+
+For a noninteractive startup, specify either `trial` or `home` in addition to
+the license email:
+
+- **CLI option:** Use `--license-type trial` or `--license-type home` with the
+  `influxdb3 serve` command.
+- **Environment variable:** Set the `INFLUXDB3_ENTERPRISE_LICENSE_TYPE`
+  environment variable.
+- **TOML config (DEB/RPM-only):** Set `license-type` in
+  `/etc/influxdb3/influxdb3-enterprise.conf`.
 
 #### Use an existing trial or at-home license
 
@@ -203,6 +218,26 @@ looks for the license file in your [object store directory](/influxdb3/enterpris
 <OBJECT_STORE>/<CLUSTER_ID>/trial_or_home_license
 ```
 
+### Move a valid license to another object store
+
+In v3.10 and later, you can copy a valid license file to the object store for
+another {{% product-name %}} deployment.
+Copy the file to the default license path that the new server checks:
+
+```text
+<NEW_OBJECT_STORE>/<NEW_CLUSTER_ID>/commercial_license
+<NEW_OBJECT_STORE>/<NEW_CLUSTER_ID>/trial_or_home_license
+```
+
+When the new server finds a valid license file in this location, it uses the
+file before checking license email options.
+Copying a license file doesn't renew an expired license or change its CPU
+limit.
+
+Treat license files as secrets.
+Don't commit a license file or include its contents in logs, support requests,
+or other shared artifacts.
+
 ### Start the server with your license email
 
 The following examples show how to provide your license email for different
@@ -222,6 +257,7 @@ The following examples show how to provide your license email for different
 influxdb3 serve \
 --cluster-id CLUSTER_ID \
 --node-id NODE_ID \
+--license-type LICENSE_TYPE \
 --license-email EMAIL_ADDRESS \
 # ...
 ```
@@ -230,8 +266,9 @@ influxdb3 serve \
 {{% code-tab-content %}}
 <!------------------------ BEGIN ENVIRONMENT VARIABLES ------------------------>
 <!-- pytest.mark.skip -->
-```bash { placeholders="EMAIL_ADDRESS" }
+```bash { placeholders="EMAIL_ADDRESS|LICENSE_TYPE" }
 INFLUXDB3_ENTERPRISE_LICENSE_EMAIL=EMAIL_ADDRESS
+INFLUXDB3_ENTERPRISE_LICENSE_TYPE=LICENSE_TYPE
 
 influxdb3 serve \
 --cluster-id CLUSTER_ID \
@@ -242,7 +279,7 @@ influxdb3 serve \
 {{% /code-tab-content %}}
 {{% code-tab-content %}}
 <!------------------------ BEGIN DOCKER COMPOSE ------------------------>
-```yaml { placeholders="EMAIL_ADDRESS|NODE_ID|CLUSTER_ID" }
+```yaml { placeholders="EMAIL_ADDRESS|LICENSE_TYPE|NODE_ID|CLUSTER_ID" }
 # compose.yaml
 name: data-crunching-stack
 services:
@@ -256,11 +293,13 @@ services:
       - serve
       - --node-id=NODE_ID
       - --cluster-id=CLUSTER_ID
+      - --license-type=LICENSE_TYPE
       - --object-store=file
       - --data-dir=/var/lib/influxdb3/data
       - --plugin-dir=/var/lib/influxdb3/plugins
     environment:
       - INFLUXDB3_ENTERPRISE_LICENSE_EMAIL=EMAIL_ADDRESS
+      - INFLUXDB3_ENTERPRISE_LICENSE_TYPE=LICENSE_TYPE
     volumes:
       - type: bind
         # Path to store data on your host system
@@ -277,6 +316,7 @@ services:
 Replace the following:
 
 - {{% code-placeholder-key %}}`EMAIL_ADDRESS`{{% /code-placeholder-key %}}: Your email address for license activation
+- {{% code-placeholder-key %}}`LICENSE_TYPE`{{% /code-placeholder-key %}}: `trial` or `home`
 - {{% code-placeholder-key %}}`NODE_ID`{{% /code-placeholder-key %}}: Your existing node identifier from Core
 - {{% code-placeholder-key %}}`CLUSTER_ID`{{% /code-placeholder-key %}}: A new cluster identifier for Enterprise
 - {{% code-placeholder-key %}}`~/.influxdb3/data`{{% /code-placeholder-key %}}: The same data directory you used with Core
@@ -287,8 +327,9 @@ Replace the following:
 <!------------------------ BEGIN DEB AND RPM TOML ------------------------>
 1. Edit `/etc/influxdb3/influxdb3-enterprise.conf` to add your license email:
 
-    ```toml { placeholders="EMAIL_ADDRESS" }
+    ```toml { placeholders="EMAIL_ADDRESS|LICENSE_TYPE" }
     license-email="EMAIL_ADDRESS"
+    license-type="LICENSE_TYPE"
     ```
 
 2. To start the server, run the following command:


### PR DESCRIPTION
  ## What changed

  - Clarified that v3.10+ license files are portable between object stores.
  - Documented the default destination paths for copied commercial and trial/home license files.
  - Explained that copied license files take precedence over license-email activation.
  - Added explicit noninteractive `trial` or `home` license-type configuration to CLI, environment-variable, Docker Compose, and TOML examples.
  - Added guidance to treat license files as secrets.

  ## Why

  The previous guidance did not clearly distinguish license-file portability from email-based activation and renewal. This could lead operators to request a
  new license when a valid existing file should be copied to replacement storage.

  ## Impact

  Operators can move a valid Enterprise license to new storage with less ambiguity. Noninteractive deployments have complete examples for selecting a trial
  or At-Home license type. The page also makes clear that copying a file does not renew an expired license or change its CPU limit.

  ## Verification

  - Ran `git diff --check`.
  - Ran Vale on `content/influxdb3/enterprise/admin/license.md`: 0 errors, warnings, or suggestions.
  - Attempted focused code-block linting. It could not run because the clean worktree lacks Node dependencies (`p-limit` is missing).