### PR TITLE
docs(influxdb3-cloud): add CLI install page and Cloud glossary

### DIFF
--- a/content/influxdb3/cloud/install.md
+++ b/content/influxdb3/cloud/install.md
@@ -61,9 +61,6 @@ The archive includes the `influxdb3` CLI.
   •
   [sha256](https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-{{< latest-patch product="influxdb3_enterprise" >}}_darwin_arm64.tar.gz.sha256)
 
-> [!Note]
-> macOS Intel builds are coming soon.
-
 {{% /expand %}}
 {{% expand "Windows binaries" %}}
 

--- a/content/influxdb3/cloud/install.md
+++ b/content/influxdb3/cloud/install.md
@@ -1,8 +1,8 @@
 ---
 title: Install the influxdb3 CLI for InfluxDB 3 Cloud
 description: >
-  Install the InfluxDB 3 Enterprise CLI to write data to and query InfluxDB 3
-  Cloud.
+  Install the `influxdb3` CLI to administer, write data to, and query
+  InfluxDB 3 Cloud.
 menu:
   influxdb3_cloud:
     name: Install the influxdb3 CLI
@@ -10,14 +10,15 @@ weight: 2
 influxdb3/cloud/tags: [install]
 related:
   - /influxdb3/cloud/get-started/setup/
+  - /influxdb3/cloud/reference/cli/influxdb3/
 canonical: self
 ---
 
 InfluxDB 3 Cloud is fully managed, so you don't install or run an InfluxDB server.
-To write data to and query your Cloud instance, install the `influxdb3` CLI.
+To administer your {{% product-name %}} instance and write and query data, install the `influxdb3` CLI.
 
-The CLI is included with InfluxDB 3 Enterprise.
-Install the Enterprise build using one of the following methods.
+The `influxdb3` CLI is distributed in the InfluxDB 3 Enterprise binary.
+Install the Enterprise binary using one of the following methods.
 
 - [Quick install for Linux and macOS](#quick-install-for-linux-and-macos)
 - [Download the CLI binary](#download-the-cli-binary)
@@ -92,5 +93,5 @@ reload your shell configuration--for example:
 source ~/.zshrc
 ```
 
-To connect the CLI to your Cloud instance, continue to
+To connect the CLI to your {{% product-name %}} instance, continue to
 [set up InfluxDB 3 Cloud](/influxdb3/cloud/get-started/setup/).

--- a/content/influxdb3/cloud/install.md
+++ b/content/influxdb3/cloud/install.md
@@ -1,0 +1,96 @@
+---
+title: Install the influxdb3 CLI for InfluxDB 3 Cloud
+description: >
+  Install the InfluxDB 3 Enterprise CLI to write data to and query InfluxDB 3
+  Cloud.
+menu:
+  influxdb3_cloud:
+    name: Install the influxdb3 CLI
+weight: 2
+influxdb3/cloud/tags: [install]
+related:
+  - /influxdb3/cloud/get-started/setup/
+canonical: self
+---
+
+InfluxDB 3 Cloud is fully managed, so you don't install or run an InfluxDB server.
+To write data to and query your Cloud instance, install the `influxdb3` CLI.
+
+The CLI is included with InfluxDB 3 Enterprise.
+Install the Enterprise build using one of the following methods.
+
+- [Quick install for Linux and macOS](#quick-install-for-linux-and-macos)
+- [Download the CLI binary](#download-the-cli-binary)
+- [Verify the installation](#verify-the-installation)
+
+## Quick install for Linux and macOS
+
+To install the CLI on **Linux** or **macOS**, download and run the InfluxDB 3
+Enterprise quick installer:
+
+<!--pytest.mark.skip-->
+```bash
+curl -O https://www.influxdata.com/d/install_influxdb3.sh \
+&& sh install_influxdb3.sh enterprise
+```
+
+> [!Note]
+> The installer also sets up a local InfluxDB 3 server.
+> For InfluxDB 3 Cloud, you only need the CLI, so skip the prompts to start a server.
+
+## Download the CLI binary
+
+Download an InfluxDB 3 Enterprise archive for your operating system.
+The archive includes the `influxdb3` CLI.
+
+{{< expand-wrapper >}}
+{{% expand "Linux binaries" %}}
+
+- [Linux | AMD64 (x86_64) | GNU](https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-{{< latest-patch product="influxdb3_enterprise" >}}_linux_amd64.tar.gz)
+  •
+  [sha256](https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-{{< latest-patch product="influxdb3_enterprise" >}}_linux_amd64.tar.gz.sha256)
+- [Linux | ARM64 (AArch64) | GNU](https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-{{< latest-patch product="influxdb3_enterprise" >}}_linux_arm64.tar.gz)
+  •
+  [sha256](https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-{{< latest-patch product="influxdb3_enterprise" >}}_linux_arm64.tar.gz.sha256)
+
+{{% /expand %}}
+{{% expand "macOS binaries" %}}
+
+- [macOS | Silicon (ARM64)](https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-{{< latest-patch product="influxdb3_enterprise" >}}_darwin_arm64.tar.gz)
+  •
+  [sha256](https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-{{< latest-patch product="influxdb3_enterprise" >}}_darwin_arm64.tar.gz.sha256)
+
+> [!Note]
+> macOS Intel builds are coming soon.
+
+{{% /expand %}}
+{{% expand "Windows binaries" %}}
+
+- [Windows (AMD64, x86_64) binary](https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-{{< latest-patch product="influxdb3_enterprise" >}}-windows_amd64.zip)
+  •
+  [sha256](https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-{{< latest-patch product="influxdb3_enterprise" >}}-windows_amd64.zip.sha256)
+
+{{% /expand %}}
+{{< /expand-wrapper >}}
+
+Extract the archive and add the directory that contains the `influxdb3` binary
+to your `PATH`.
+
+## Verify the installation
+
+Run the following command to verify that the CLI is installed:
+
+```bash
+influxdb3 --version
+```
+
+If your shell can't locate `influxdb3` after a [quick install](#quick-install-for-linux-and-macos),
+reload your shell configuration--for example:
+
+<!--pytest.mark.skip-->
+```zsh
+source ~/.zshrc
+```
+
+To connect the CLI to your Cloud instance, continue to
+[set up InfluxDB 3 Cloud](/influxdb3/cloud/get-started/setup/).

--- a/content/influxdb3/cloud/reference/glossary.md
+++ b/content/influxdb3/cloud/reference/glossary.md
@@ -1,0 +1,15 @@
+---
+title: Glossary
+description: >
+  Terms related to InfluxData products and platforms.
+weight: 109
+menu:
+  influxdb3_cloud:
+    parent: Reference
+influxdb3/cloud/tags: [glossary]
+source: /shared/influxdb3-reference/glossary.md
+---
+
+<!-- The content for this page is at
+// SOURCE content/shared/influxdb3-reference/glossary.md
+-->

--- a/content/influxdb3/cloud/request-information.md
+++ b/content/influxdb3/cloud/request-information.md
@@ -26,7 +26,6 @@ aliases:
   - /influxdb3/cloud/reference/cli/influxdb3/update/database/
   - /influxdb3/cloud/reference/cli/influxdb3/write/
   - /influxdb3/cloud/reference/client-libraries/v3/
-  - /influxdb3/cloud/reference/glossary/
   - /influxdb3/cloud/reference/influxql/
   - /influxdb3/cloud/reference/influxql/feature-support/
   - /influxdb3/cloud/reference/influxql/functions/
@@ -73,13 +72,10 @@ anchors that belonged to it. Tracked in influxdata/docs-v2#7391.
   <span id="at-time-zone"></span>
   <span id="avoid-wide-schemas"></span>
   <span id="boolean"></span>
-  <span id="database"></span>
   <span id="date_bin"></span>
   <span id="date_bin_gapfill"></span>
   <span id="default-time-range"></span>
   <span id="design-for-performance"></span>
-  <span id="field"></span>
-  <span id="field-key"></span>
   <span id="float"></span>
   <span id="from-clause"></span>
   <span id="get-started-home-sensor-data"></span>
@@ -110,16 +106,12 @@ anchors that belonged to it. Tracked in influxdata/docs-v2#7391.
   <span id="show-measurements"></span>
   <span id="sort-tags-by-query-priority"></span>
   <span id="string"></span>
-  <span id="table"></span>
-  <span id="tag"></span>
-  <span id="tag-key"></span>
   <span id="tag/Database"></span>
   <span id="tag/Table"></span>
   <span id="tag/Token"></span>
   <span id="time"></span>
   <span id="time-ranges"></span>
   <span id="time-syntax"></span>
-  <span id="timestamp"></span>
   <span id="to_timestamp"></span>
   <span id="to_timestamp_micros"></span>
   <span id="to_timestamp_millis"></span>
@@ -127,7 +119,6 @@ anchors that belonged to it. Tracked in influxdata/docs-v2#7391.
   <span id="to_timestamp_seconds"></span>
   <span id="to_unixtime"></span>
   <span id="uinteger"></span>
-  <span id="unix-timestamp"></span>
   <span id="write-home-sensor-data-to-influxdb"></span>
   <span id="write-the-home-sensor-data-to-influxdb"></span>
 </div>

--- a/content/influxdb3/cloud/request-information.md
+++ b/content/influxdb3/cloud/request-information.md
@@ -15,7 +15,6 @@ aliases:
   - /influxdb3/cloud/api/v3/
   - /influxdb3/cloud/guides/api-compatibility/v1/
   - /influxdb3/cloud/guides/api-compatibility/v2/
-  - /influxdb3/cloud/install/
   - /influxdb3/cloud/write-data/use-telegraf/
   - /influxdb3/cloud/write-data/use-telegraf/csv/
   - /influxdb3/cloud/reference/cli/influxdb3/create/database/

--- a/content/shared/influxdb3-get-started/setup-cloud.md
+++ b/content/shared/influxdb3-get-started/setup-cloud.md
@@ -45,7 +45,7 @@ script:
 
 ```bash
 curl -O https://www.influxdata.com/d/install_influxdb3.sh \
-&& sh install_influxdb3.sh
+&& sh install_influxdb3.sh enterprise
 ```
 
 > [!Note]

--- a/content/shared/influxdb3-get-started/setup-cloud.md
+++ b/content/shared/influxdb3-get-started/setup-cloud.md
@@ -53,8 +53,8 @@ curl -O https://www.influxdata.com/d/install_influxdb3.sh \
 > For {{% product-name %}}, you only need the CLI, so you can skip the prompts
 > to start a server.
 
-For other installation methods, including Windows binaries and Docker images,
-see [Install InfluxDB 3](/influxdb3/core/install/).
+For Windows binaries and other CLI installation options,
+see [Install the influxdb3 CLI for InfluxDB 3 Cloud](/influxdb3/cloud/install/).
 
 ### Connect to your instance
 

--- a/content/shared/influxdb3-get-started/setup-cloud.md
+++ b/content/shared/influxdb3-get-started/setup-cloud.md
@@ -37,7 +37,8 @@ instance and log in with your InfluxData account.
 
 ### Install the influxdb3 CLI
 
-The `influxdb3` CLI is included in the InfluxDB 3 binary.
+The `influxdb3` CLI is distributed in the InfluxDB 3 Enterprise binary.
+For {{% product-name %}}, you install the Enterprise binary to get the CLI—you don't run the server.
 To install it on **Linux** or **macOS**, download and run the quick installer
 script:
 

--- a/content/shared/influxdb3-reference/glossary.md
+++ b/content/shared/influxdb3-reference/glossary.md
@@ -458,9 +458,32 @@ Related entries:
 [output plugin](#output-plugin),
 [processor plugin](#processor-plugin)
 
+{{% show-in "core,enterprise,cloud" %}}
+### influxdb3 CLI
+
+The command line interface for InfluxDB 3.
+Use the `influxdb3` CLI to administer your instance--for example, to create and
+manage databases, tables, and tokens--and to write and query data.
+{{% /show-in %}}
+{{% show-in "cloud" %}}
+The `influxdb3` CLI is distributed in the InfluxDB 3 Enterprise binary
+(the _Enterprise CLI_).
+To use it with {{% product-name %}},
+[install the CLI](/influxdb3/cloud/install/) and connect it to your
+[instance](#instance)--you don't run a server.
+{{% /show-in %}}
+
 ### instance
 
+{{% show-in "cloud" %}}
+Your provisioned, fully managed {{% product-name %}} service—the endpoint
+that your host URL points to and that the `influxdb3` CLI and client
+libraries connect to. InfluxData operates the underlying servers; you
+interact with your instance, not with individual nodes or servers.
+{{% /show-in %}}
+{{% hide-in "cloud" %}}
 An entity comprising data on a server (or virtual server in cloud computing).
+{{% /hide-in %}}
 
 ### integer
 


### PR DESCRIPTION
## What changed

- `content/shared/influxdb3-get-started/setup-cloud.md`: added CLI install steps to the Cloud setup guide, passing the `enterprise` argument to `install_influxdb3.sh`, and clarified that the `influxdb3` CLI is distributed in the InfluxDB 3 Enterprise binary.
- `content/influxdb3/cloud/install.md` (new): CLI install page for InfluxDB 3 Cloud — quick installer, Enterprise binary downloads (versions resolve through `{{< latest-patch product="influxdb3_enterprise" >}}`), and install verification. Links the setup guide and the Cloud CLI reference.
- `content/influxdb3/cloud/reference/glossary.md` (new): Cloud glossary stub sourcing `/shared/influxdb3-reference/glossary.md`, matching the other products.
- `content/shared/influxdb3-reference/glossary.md`: added an `influxdb3 CLI` entry (shown in Core, Enterprise, and Cloud) with a Cloud-only distribution note, and a Cloud-specific `instance` definition. Other editions keep the previous `instance` definition via `hide-in`.
- `content/influxdb3/cloud/request-information.md`: removed the `/install/` and `/reference/glossary/` aliases and the glossary-owned hidden anchors, because those pages now exist.

## Why

Fixes #7528. Cloud customers were sent to Enterprise docs to get the `influxdb3` CLI. This gives Cloud its own install path.

Two decisions worth stating:

- The install page duplicates the Enterprise download links instead of sharing `content/shared/influxdb3/install.md`. The shared page documents a server install (systemd, Docker, licenses); the Cloud page documents a client CLI install. Sharing would mean gating most of a server page for a client-only audience. Versions auto-resolve from `data/products.yml`, so the duplication needs manual edits only when artifact naming or platform coverage changes.
- The setup guide's installer command passes `enterprise` because the OAuth device-code login (`influxdb3 auth login --oauth`) requires the Enterprise CLI build; the Core build cannot complete Cloud setup.

## Impact

- Two new published pages for InfluxDB 3 Cloud: `/influxdb3/cloud/install/` and `/influxdb3/cloud/reference/glossary/`.
- The shared glossary changes are visibility-gated: Core and Enterprise gain the `influxdb3 CLI` entry; Cloud Dedicated, Cloud Serverless, and Clustered pages are unchanged.
- Links that previously redirected to the request-information page for `/install/` and `/reference/glossary/` now land on real pages.

## Verification

- `npx hugo --quiet` passes.
- Vale on the changed files: no new warnings (two pre-existing heading warnings in the shared glossary are untouched).
- lefthook pre-commit lints (product Vale checks, v3 CLI-version guard) pass.
- `yarn lint-codeblocks` passed for the edited setup-cloud code blocks.
