### PR TITLE
fix(ui): address Lighthouse accessibility and SEO audit failures

### DIFF
--- a/assets/js/components/api-toc.ts
+++ b/assets/js/components/api-toc.ts
@@ -70,6 +70,12 @@ function getVisibleHeadings(maxLevel: number = 2): TocEntry[] {
       return;
     }
 
+    // Skip headings in the support-and-feedback block appended after the
+    // article content
+    if (heading.closest('.feedback')) {
+      return;
+    }
+
     // Skip hidden headings
     const rect = heading.getBoundingClientRect();
     if (rect.width === 0 && rect.height === 0) {

--- a/assets/js/components/doc-search.js
+++ b/assets/js/components/doc-search.js
@@ -128,6 +128,13 @@ export default function DocSearch({ component }) {
       },
     });
 
+    // DocSearch clones the search input to create its autocomplete hint
+    // element, duplicating the accesskey attribute. Remove the attribute from
+    // the clone so the accesskey stays unique on the page.
+    document.querySelectorAll('.ds-hint[accesskey]').forEach((hint) => {
+      hint.removeAttribute('accesskey');
+    });
+
     // Mark DocSearch as initialized
     window.InfluxDocs.search.initialized = true;
 

--- a/assets/js/release-toc.js
+++ b/assets/js/release-toc.js
@@ -5,9 +5,10 @@
  * release notes pages.
  */
 export default function ReleaseToc({ component }) {
-  // Get all h2 elements that are not checkpoint-releases
+  // Get all h2 elements that are not checkpoint-releases and not part of
+  // the support-and-feedback block appended after the article content
   const releases = Array.from(document.querySelectorAll('h2')).filter(
-    (el) => !el.id.match(/checkpoint-releases/)
+    (el) => !el.id.match(/checkpoint-releases/) && !el.closest('.feedback')
   );
 
   // Extract data about each release from the array of releases

--- a/assets/styles/layouts/article/_feedback.scss
+++ b/assets/styles/layouts/article/_feedback.scss
@@ -8,7 +8,14 @@
   box-shadow: 1px 2px 6px $article-shadow;
   background: rgba($article-text, .03);
 
-  h4 {color: $article-heading;}
+  /* Support-and-feedback heading is an h2 for a valid heading outline,
+     but keeps the h4 visual style it always had */
+  h2 {
+    color: $article-heading;
+    font-size: 1.35rem;
+    font-style: italic;
+    margin: -1.25rem 0 .5rem;
+  }
 }
 
 .support {

--- a/assets/styles/tools/icon-fonts/_icon-v3.scss
+++ b/assets/styles/tools/icon-fonts/_icon-v3.scss
@@ -15,6 +15,7 @@
     url('fonts/icomoon-v3.svg') format('svg');
   font-weight: normal;
   font-style: normal;
+  font-display: block;
 }
 
 .cf-icon {

--- a/assets/styles/tools/icon-fonts/_icon-v4.scss
+++ b/assets/styles/tools/icon-fonts/_icon-v4.scss
@@ -15,6 +15,7 @@
     url('fonts/icomoon-v4.svg') format('svg');
   font-weight: normal;
   font-style: normal;
+  font-display: block;
 }
 
 .cf-icon {

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Page not found</title>
     <meta name="description" content="Whoops! Looks like this page doesn't exist.">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="/img/favicon.png" type="image/png" sizes="32x32">
 
     {{ partialCached "header/javascript.html" . hugo.IsProduction hugo.IsServer }}

--- a/layouts/_default/landing-influxdb.html
+++ b/layouts/_default/landing-influxdb.html
@@ -53,7 +53,7 @@
     </div>
 
     <div class="article">
-      <article class="article--content">
+      <article class="article--content" role="main">
         {{ partial "article/format-selector.html" . }}
       </article>
     </div>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -7,7 +7,7 @@
     {{ partial "sidebar/sidebar-toggle.html" }}
 
     <div class="article">
-      <article class="article--content">
+      <article class="article--content" role="main">
         <h1>Related to "{{ .Title }}"</h1>
         <div class="list-links">
 

--- a/layouts/_default/tags-landing.html
+++ b/layouts/_default/tags-landing.html
@@ -7,7 +7,7 @@
     {{ partial "sidebar/sidebar-toggle.html" }}
 
     <div class="article">
-      <article class="article--content">
+      <article class="article--content" role="main">
         <h1>{{ .Title }}</h1>
         <ul class="list-links">
 

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -1,5 +1,5 @@
 <div class="article">
-  <article class="article--content">
+  <article class="article--content" role="main">
     <div class="title">
       <h1>{{ .RenderString .Title }}</h1>
       {{ partial "article/supported-versions.html" . }}

--- a/layouts/partials/article/feedback.html
+++ b/layouts/partials/article/feedback.html
@@ -69,7 +69,7 @@
 <hr/>
 <div class="feedback block">
   <div class="support">
-    <h4 id="bug-reports-and-feedback">Support and feedback</h4>
+    <h2 id="bug-reports-and-feedback">Support and feedback</h2>
     <p>
       Thank you for being part of our community!
       We welcome and encourage your feedback and bug reports for {{ $productName }} and this documentation.

--- a/layouts/partials/footer/fullscreen-code.html
+++ b/layouts/partials/footer/fullscreen-code.html
@@ -1,4 +1,4 @@
 <div class="fullscreen-code highlight">
   <div id="fullscreen-code-placeholder"></div>
-  <a class="fullscreen-close"><span class="icon-x"></span></a>
+  <a class="fullscreen-close" role="button" aria-label="Exit fullscreen code view"><span class="icon-x"></span></a>
 </div>

--- a/layouts/partials/footer/widgets/ask-ai-trigger.html
+++ b/layouts/partials/footer/widgets/ask-ai-trigger.html
@@ -1,5 +1,5 @@
 <div class="ask-ai-trigger widget magenta" data-component="ask-ai-trigger" data-tooltip="Ask InfluxData AI for help" style="display: none;">
-  <a class="ask-ai-open" >
+  <a class="ask-ai-open" role="button" tabindex="0">
     <div class="icon-influx-logo"></div>
     Ask AI
   </a>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -12,7 +12,7 @@
     {{ partial "header/title" . }}
 
     <meta name="description" content="{{ if .Description }}{{ .Description | .RenderString | plainify }}{{else}}{{ .Summary | .RenderString | plainify }}{{ end }}">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="/img/favicon.png" type="image/png" sizes="32x32">
 
     {{ partialCached "header/javascript.html" . hugo.IsProduction hugo.IsServer }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -67,7 +67,7 @@
               dir="auto"
               placeholder='{{ $searchPlaceholder }}'>
     </div>
-    <a id="contents-toggle-btn" href="#">
+    <a id="contents-toggle-btn" href="#" role="button" aria-label="Toggle navigation menu">
       <span class="toggle-hamburger"></span>
     </a>
   </div>
@@ -100,7 +100,9 @@
   <!-- Feature Board link for supported products -->
   {{ $featureBoardWhitelist := slice "influxdb3_core" "influxdb3_enterprise" }}
   {{ if in $featureBoardWhitelist (print $product "_" $currentVersion) }}
-    {{ partial "sidebar/feature-board.html" (dict "product" $product "version" $currentVersion "productName" $productData.name) }}
+    <li class="feature-board-item">
+      {{ partial "sidebar/feature-board.html" (dict "product" $product "version" $currentVersion "productName" $productData.name) }}
+    </li>
   {{ end }}
 
   <!-- Platform menu for 1.x docs -->

--- a/layouts/partials/sidebar/api-menu-items.html
+++ b/layouts/partials/sidebar/api-menu-items.html
@@ -83,7 +83,7 @@
     {{ end }}
 
     <li class="nav-item" data-nav-url="{{ $specUrl | relURL }}">
-      <a href="#" class="children-toggle"></a>
+      <a href="#" class="children-toggle" role="button" aria-label="Toggle {{ $specLabel }} nested items"></a>
       <a href="{{ $specUrl | relURL }}">{{ $specLabel }}</a>
       <ul class="children">
         {{/* Separate conceptual and non-conceptual articles */}}

--- a/layouts/partials/sidebar/nested-menu.html
+++ b/layouts/partials/sidebar/nested-menu.html
@@ -13,14 +13,14 @@
     <li class="nav-{{ $navClass }}" data-nav-url="{{ .URL }}"{{ if .Params.state }} state="{{ .Params.state }}"{{ end }}>
       {{ if $isApiParent }}
         {{/* API Reference: render custom API nav children instead of standard menu children */}}
-        <a href="#" class="children-toggle"></a>
+        <a href="#" class="children-toggle" role="button" aria-label="Toggle {{ .Name }} nested items"></a>
         <a href='{{ default .URL .Params.url }}'>{{ .Name }}</a>
         <ul class="children">
           {{ partial "sidebar/api-menu-items" (dict "url" .URL "siteData" $siteData) }}
         </ul>
       {{ else }}
         {{/* Standard menu rendering */}}
-        {{ if .HasChildren }}<a href="#" class="children-toggle"></a>{{ end }}
+        {{ if .HasChildren }}<a href="#" class="children-toggle" role="button" aria-label="Toggle {{ .Name }} nested items"></a>{{ end }}
         <a href='{{ default .URL .Params.url }}'>{{ .Name }}</a>
         {{ if .HasChildren }}
           <ul class="children">

--- a/layouts/partials/topnav.html
+++ b/layouts/partials/topnav.html
@@ -21,13 +21,13 @@
       </div>
       <div class="buttons">
         <div class="search-btn" data-component="search-button">
-          <button id="search-btn" data-action="toggle"><span class="cf-icon Search_New"></span></button>
+          <button id="search-btn" data-action="toggle" aria-label="Search the docs"><span class="cf-icon Search_New"></span></button>
         </div>
-        <button class="url-trigger" href="#"><span class="cf-icon CogSolid_New"></span></button>
+        <button class="url-trigger" aria-label="Customize InfluxDB URLs in code samples"><span class="cf-icon CogSolid_New"></span></button>
         <span data-component="theme-switch">
-          <button class="theme-switch theme-switch-light">
+          <button class="theme-switch theme-switch-light" aria-label="Switch to light theme">
             <span class="cf-icon Lightmode_New"></span></button>
-          <button class="theme-switch theme-switch-dark">
+          <button class="theme-switch theme-switch-dark" aria-label="Switch to dark theme">
             <span class="cf-icon Darkmode_New"></span></button>
         </span>
       </div>


### PR DESCRIPTION
Fixes issues reported by a Lighthouse 13 audit of docs.influxdata.com:

- Allow pinch-zoom on mobile by removing maximum-scale=1 from the
  viewport meta tag (a11y: meta-viewport)
- Add aria-labels to icon-only top nav buttons: search, URL preferences,
  and theme switchers (a11y: button-name)
- Add role and aria-labels to icon-only sidebar links: the nav toggle
  and every children-toggle expander (a11y: link-name)
- Wrap the Feature Board badge in an li so #nav-tree only has valid
  list children (a11y: list)
- Add role=main to non-API article templates to provide a main
  landmark (a11y: landmark-one-main)
- Change the Support and feedback heading from h4 to h2 to fix the
  heading outline, preserving its previous visual style (a11y:
  heading-order)
- Mark href-less trigger anchors (Ask AI widget, fullscreen code close)
  with role=button and accessible names (SEO: crawlable-anchors)
  
  
<img width="1812" height="908" alt="image" src="https://github.com/user-attachments/assets/dc0cdb9e-f844-4766-bd53-5402cdac45cf" />
