### PR TITLE
chore(github): update default PR templates with plain-writing guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,11 +12,11 @@ Closes #
 
 ## Impact
 
-(to customers or repo consumers)
+<!-- to customers or repo consumers -->
 
 ## Verification
 
-(layout changes must include e2e tests: `yarn test:e2e`)
+<!-- layout changes must include e2e tests: yarn test:e2e -->
 
 ## Checklist
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,22 @@
-## Summary
+<!--
+Write plainly and clearly.
+Use short sentences and active voice, and avoid jargon.
+A reviewer should understand the change without opening the diff.
+-->
 
 Closes #
 
-<!-- Brief description: What changed and why? -->
+## What changed
+
+## Why
+
+## Impact
+
+<!-- Impact to customers or repo consumers -->
+
+## Verification
+
+<!-- How you verified the change, for example: local build passes (npx hugo --quiet), tested links, previewed pages -->
 
 ## Checklist
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,11 +12,11 @@ Closes #
 
 ## Impact
 
-<!-- Impact to customers or repo consumers -->
+(to customers or repo consumers)
 
 ## Verification
 
-<!-- How you verified the change, for example: local build passes (npx hugo --quiet), tested links, previewed pages -->
+(layout changes must include e2e tests: `yarn test:e2e`)
 
 ## Checklist
 

--- a/.github/pull_request_template/general.md
+++ b/.github/pull_request_template/general.md
@@ -12,11 +12,11 @@ Closes #
 
 ## Impact
 
-(to customers or repo consumers)
+<!-- to customers or repo consumers -->
 
 ## Verification
 
-(layout changes must include e2e tests: `yarn test:e2e`)
+<!-- layout changes must include e2e tests: yarn test:e2e -->
 
 ## Preview pages
 

--- a/.github/pull_request_template/general.md
+++ b/.github/pull_request_template/general.md
@@ -12,11 +12,11 @@ Closes #
 
 ## Impact
 
-<!-- Impact to customers or repo consumers -->
+(to customers or repo consumers)
 
 ## Verification
 
-<!-- How you verified the change, for example: local build passes (npx hugo --quiet), tested links, previewed pages -->
+(layout changes must include e2e tests: `yarn test:e2e`)
 
 ## Preview pages
 

--- a/.github/pull_request_template/general.md
+++ b/.github/pull_request_template/general.md
@@ -1,18 +1,22 @@
-## What changed
+<!--
+Write plainly and clearly.
+Use short sentences and active voice, and avoid jargon.
+A reviewer should understand the change without opening the diff.
+-->
 
--
+Closes #
+
+## What changed
 
 ## Why
 
--
-
 ## Impact
 
--
+<!-- Impact to customers or repo consumers -->
 
-## Validation
+## Verification
 
--
+<!-- How you verified the change, for example: local build passes (npx hugo --quiet), tested links, previewed pages -->
 
 ## Preview pages
 


### PR DESCRIPTION
## What changed

- Replaced the `## Summary` section in the default PR template (`.github/PULL_REQUEST_TEMPLATE.md`) and the selectable general template (`.github/pull_request_template/general.md`) with four sections: **What changed**, **Why**, **Impact**, and **Verification**.
- Added hidden HTML comments that encourage plain, clear writing and hint at what each section needs: Impact covers customers or repo consumers, and Verification reminds authors that layout changes must include e2e tests (`yarn test:e2e`).
- Kept `Closes #`, the CLA/build checklist, and the collapsed suggested-reviewers tables.
- Left the specialized `influxdb_v1_release.md` template unchanged.

## Why

The old Summary format asked only what changed and why. The new sections also prompt authors to state who is affected and how they verified the change, and the hints nudge toward plain writing without rendering as boilerplate if left in place.

## Impact

Contributors see the new form on every new PR. Existing PRs and the published site are unaffected.

## Verification

Template-only change — previewed the Markdown rendering, including that the hint comments stay hidden. No layouts changed, so no e2e tests apply; the Hugo build doesn't consume `.github/` files.

## Checklist

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
- [ ] Local build passes (`npx hugo --quiet`) — not run; `.github/` templates aren't part of the site build