### PR TITLE
docs(release-notes): add v3.10.5 and v3.9.11 release notes

### DIFF
--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -19,6 +19,35 @@
 > All updates to Core are automatically included in Enterprise.
 > The Enterprise sections below only list updates exclusive to Enterprise.
 
+## v3.10.5 {date="2026-07-20"}
+
+### Core
+
+#### Bug fixes
+
+- **Oversized buffer chunk persistence**: When a buffer chunk splits because a single string or tag column exceeds 2 GiB, each resulting chunk now persists to its own Parquet file. Previously, the split chunks all wrote to the same path, so all but one were silently overwritten—losing those rows and leaving snapshot metadata that fails reads with `Invalid Parquet file. Corrupt footer`.
+
+### Enterprise
+
+All Core updates are included in Enterprise.
+
+## v3.9.11 {date="2026-07-20"}
+
+### Core
+
+#### Bug fixes
+
+- **Oversized buffer chunk persistence**: When a buffer chunk splits because a single string or tag column exceeds 2 GiB, each resulting chunk now persists to its own Parquet file. Previously, the split chunks all wrote to the same path, so all but one were silently overwritten—losing those rows and leaving snapshot metadata that fails reads with `Invalid Parquet file. Corrupt footer`.
+
+### Enterprise
+
+All Core updates are included in Enterprise.
+Additional Enterprise-specific updates:
+
+#### Bug fixes
+
+- Other bug fixes and performance improvements
+
 ## v3.10.4 {date="2026-07-14"}
 
 <!-- Uncomment once Core v3.10.4 is released

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -25,7 +25,7 @@
 
 #### Bug fixes
 
-- **Oversized buffer chunk persistence**: When a buffer chunk splits because a single string or tag column exceeds 2 GiB, each resulting chunk now persists to its own Parquet file. Previously, the split chunks all wrote to the same path, so all but one were silently overwritten—losing those rows and leaving snapshot metadata that fails reads with `Invalid Parquet file. Corrupt footer`.
+- **Oversized buffer chunk persistence**: When a buffer chunk splits because a single string or tag column exceeds 2 GiB, each resulting chunk now persists to its own Parquet file. Previously, the split chunks all wrote to the same path.
 
 ### Enterprise
 
@@ -37,7 +37,7 @@ All Core updates are included in Enterprise.
 
 #### Bug fixes
 
-- **Oversized buffer chunk persistence**: When a buffer chunk splits because a single string or tag column exceeds 2 GiB, each resulting chunk now persists to its own Parquet file. Previously, the split chunks all wrote to the same path, so all but one were silently overwritten—losing those rows and leaving snapshot metadata that fails reads with `Invalid Parquet file. Corrupt footer`.
+- **Oversized buffer chunk persistence**: When a buffer chunk splits because a single string or tag column exceeds 2 GiB, each resulting chunk now persists to its own Parquet file. Previously, the split chunks all wrote to the same path.
 
 ### Enterprise
 

--- a/data/products.yml
+++ b/data/products.yml
@@ -12,7 +12,7 @@ influxdb3_core:
   versions: [core]
   list_order: 2
   latest: core
-  latest_patch: 3.10.3
+  latest_patch: 3.10.5
   placeholder_host: localhost:8181
   scheme: http
   limits:
@@ -57,7 +57,7 @@ influxdb3_enterprise:
   versions: [enterprise]
   list_order: 2
   latest: enterprise
-  latest_patch: 3.10.4
+  latest_patch: 3.10.5
   placeholder_host: localhost:8181
   scheme: http
   limits:


### PR DESCRIPTION
Adds release notes for InfluxDB 3 Core and Enterprise **v3.10.5** and **v3.9.11** (both tagged 2026-07-20, artifacts published 2026-07-21).

## What shipped

Both releases carry the same single Core fix, backported to each line:

- **Oversized buffer chunk persistence** ([influxdb_pro #4643](https://github.com/influxdata/influxdb_pro/pull/4643) / [#4642](https://github.com/influxdata/influxdb_pro/pull/4642), EAR6985) — split gen1 chunks now persist to distinct Parquet paths instead of racing on one path.

No Enterprise-exclusive user-facing changes. v3.9.11 also contains a source-tarball packaging fix ([#4671](https://github.com/influxdata/influxdb_pro/pull/4671)) that is build-only, so it rolls up under "Other bug fixes and performance improvements".

## Version bumps

| Product | Before | After |
| --- | --- | --- |
| `influxdb3_core` | 3.10.3 | 3.10.5 |
| `influxdb3_enterprise` | 3.10.4 | 3.10.5 |

Core jumps 3.10.3 → 3.10.5 because Core 3.10.4 and 3.9.10 were never published — only Enterprise artifacts exist for those. That is also why the Core section for v3.10.4 stays commented out in this PR.

## Note for reviewers

The v3.9.10 entry currently has an uncommented Core section ("Maintenance release…"), but Core 3.9.10 was never released either. Left as-is to keep this PR scoped; happy to fix in a follow-up or here if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqmR6PBuZAyVn5bgVk2F5U