### PR TITLE
Update install.md

### DIFF
--- a/content/telegraf/v1/install.md
+++ b/content/telegraf/v1/install.md
@@ -456,7 +456,7 @@ In PowerShell _as an administrator_, do the following:
    and extract its contents to `C:\Program Files\InfluxData\telegraf\`:
 
    ```powershell
-   wget `
+   iwr `
    https://dl.influxdata.com/telegraf/releases/telegraf-{{% latest-patch %}}_windows_amd64.zip `
    -UseBasicParsing `
    -OutFile telegraf-{{% latest-patch %}}_windows_amd64.zip


### PR DESCRIPTION
## What changed

Replaced `wget` with `iwr` alias in Powershell example.

## Why

wget was removed as an alias for Invoke-WebRequest after PowerShell v5.1

While `Windows PowerShell 5.1` retains `wget` as an alias for `Invoke-WebRequest`, the alias was removed in `PowerShell Core 6.0` (and subsequent versions like 7.0+).

*   **Windows PowerShell 5.1**: `wget` is an alias for `Invoke-WebRequest`.
*   **PowerShell 6.0+**: The `wget` alias was removed to avoid conflicts with the native Unix `wget` command.
*   **Recommendation**: Use the full cmdlet `Invoke-WebRequest` or its primary alias `iwr` for cross-platform compatibility.

## Impact

Fixes example for users running PowerShell 6.0+

## Verification

<!-- layout changes must include e2e tests: yarn test:e2e -->

## Checklist

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
- [ ] Local build passes (`npx hugo --quiet`)

***

