### PR TITLE
fix(api): render generated API sidebar tags

### DIFF
--- a/layouts/partials/api/section-children.html
+++ b/layouts/partials/api/section-children.html
@@ -43,33 +43,7 @@
   {{ end }}
 {{ end }}
 
-{{/* Separate conceptual (traitTag) and non-conceptual articles */}}
-{{ $conceptualArticles := slice }}
-{{ $operationArticles := slice }}
-
-{{ range $articles }}
-  {{ if and (reflect.IsMap .) (isset . "fields") }}
-    {{ $fields := index . "fields" }}
-    {{ if reflect.IsMap $fields }}
-      {{ $isConceptual := false }}
-      {{ if isset $fields "isConceptual" }}
-        {{ $isConceptual = index $fields "isConceptual" }}
-      {{ end }}
-      {{ if $isConceptual }}
-        {{ $conceptualArticles = $conceptualArticles | append . }}
-      {{ else }}
-        {{ $operationArticles = $operationArticles | append . }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
-{{ end }}
-
-{{/* Sort each group by weight (default 100), then alphabetically by tag name */}}
-{{ $conceptualArticles = sort $conceptualArticles "fields.weight" }}
-{{ $operationArticles = sort $operationArticles "fields.weight" }}
-
-{{/* Combine: conceptual first, then operations */}}
-{{ $sortedArticles := $conceptualArticles | append $operationArticles }}
+{{ $sortedArticles := partial "api/sorted-tag-articles.html" $articles }}
 
 {{/* Also include static API pages (HTML files) not in article data */}}
 {{/* These are compatibility API pages like v1-compatibility, v2, management */}}

--- a/layouts/partials/api/sorted-tag-articles.html
+++ b/layouts/partials/api/sorted-tag-articles.html
@@ -1,0 +1,39 @@
+{{/*
+  Sorted API Tag Articles
+
+  Sorts generated API tag articles (from data/article_data) for display:
+  partitions into conceptual (traitTag) and operation articles, sorts each
+  group by fields.weight, and returns conceptual articles first.
+
+  Skips malformed entries that are not maps with a "fields" map.
+
+  Parameter: slice of article maps, each with a "fields" map containing
+  optional "isConceptual" and "weight".
+  Returns: sorted slice.
+
+  Used by sidebar/api-menu-items.html and api/section-children.html.
+*/}}
+{{ $conceptualArticles := slice }}
+{{ $operationArticles := slice }}
+
+{{ range . }}
+  {{ if and (reflect.IsMap .) (isset . "fields") }}
+    {{ $fields := index . "fields" }}
+    {{ if reflect.IsMap $fields }}
+      {{ $isConceptual := false }}
+      {{ if isset $fields "isConceptual" }}
+        {{ $isConceptual = index $fields "isConceptual" }}
+      {{ end }}
+      {{ if $isConceptual }}
+        {{ $conceptualArticles = $conceptualArticles | append . }}
+      {{ else }}
+        {{ $operationArticles = $operationArticles | append . }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ $conceptualArticles = sort $conceptualArticles "fields.weight" }}
+{{ $operationArticles = sort $operationArticles "fields.weight" }}
+
+{{ return ($conceptualArticles | append $operationArticles) }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -78,12 +78,12 @@
   {{ $platformMenu := .Site.Menus.platform }}
 
   <!-- Product Main Navigation -->
-  {{ partialCached "sidebar/nested-menu" (dict "menu" $mainMenu "siteData" .Site.Data) $menuKey }}
+  {{ partial "sidebar/nested-menu" (dict "menu" $mainMenu "siteData" .Site.Data) }}
 
   <!-- Product Reference Navigation -->
   {{ if gt (len $refMenu) 0 }}
     <h4 class="reference">Reference</h4>
-    {{ partialCached "sidebar/nested-menu" (dict "menu" $refMenu "siteData" .Site.Data) (print $menuKey "_ref") }}
+    {{ partial "sidebar/nested-menu" (dict "menu" $refMenu "siteData" .Site.Data) }}
   {{ end }}
 
   <!-- Flux links for InfluxDB docs -->

--- a/layouts/partials/sidebar/api-menu-items.html
+++ b/layouts/partials/sidebar/api-menu-items.html
@@ -90,19 +90,12 @@
         {{ $conceptualArticles := slice }}
         {{ $operationArticles := slice }}
         {{ range $specArticles }}
-          {{ if and (reflect.IsMap .) (isset . "fields") }}
-            {{ $fields := index . "fields" }}
-            {{ if reflect.IsMap $fields }}
-              {{ $isConceptual := false }}
-              {{ if isset $fields "isConceptual" }}
-                {{ $isConceptual = index $fields "isConceptual" }}
-              {{ end }}
-              {{ if $isConceptual }}
-                {{ $conceptualArticles = $conceptualArticles | append . }}
-              {{ else }}
-                {{ $operationArticles = $operationArticles | append . }}
-              {{ end }}
-            {{ end }}
+          {{ $fields := index . "fields" }}
+          {{ $isConceptual := index $fields "isConceptual" }}
+          {{ if $isConceptual }}
+            {{ $conceptualArticles = $conceptualArticles | append . }}
+          {{ else }}
+            {{ $operationArticles = $operationArticles | append . }}
           {{ end }}
         {{ end }}
 
@@ -145,19 +138,12 @@
     {{ $operationArticles := slice }}
 
     {{ range $articles }}
-      {{ if and (reflect.IsMap .) (isset . "fields") }}
-        {{ $fields := index . "fields" }}
-        {{ if reflect.IsMap $fields }}
-          {{ $isConceptual := false }}
-          {{ if isset $fields "isConceptual" }}
-            {{ $isConceptual = index $fields "isConceptual" }}
-          {{ end }}
-          {{ if $isConceptual }}
-            {{ $conceptualArticles = $conceptualArticles | append . }}
-          {{ else }}
-            {{ $operationArticles = $operationArticles | append . }}
-          {{ end }}
-        {{ end }}
+      {{ $fields := index . "fields" }}
+      {{ $isConceptual := index $fields "isConceptual" }}
+      {{ if $isConceptual }}
+        {{ $conceptualArticles = $conceptualArticles | append . }}
+      {{ else }}
+        {{ $operationArticles = $operationArticles | append . }}
       {{ end }}
     {{ end }}
 

--- a/layouts/partials/sidebar/api-menu-items.html
+++ b/layouts/partials/sidebar/api-menu-items.html
@@ -93,22 +93,7 @@
       <a href="#" class="children-toggle" role="button" aria-label="Toggle {{ $specLabel }} nested items"></a>
       <a href="{{ $specUrl | relURL }}">{{ $specLabel }}</a>
       <ul class="children">
-        {{/* Separate conceptual and non-conceptual articles */}}
-        {{ $conceptualArticles := slice }}
-        {{ $operationArticles := slice }}
-        {{ range $specArticles }}
-          {{ $fields := index . "fields" }}
-          {{ $isConceptual := index $fields "isConceptual" }}
-          {{ if $isConceptual }}
-            {{ $conceptualArticles = $conceptualArticles | append . }}
-          {{ else }}
-            {{ $operationArticles = $operationArticles | append . }}
-          {{ end }}
-        {{ end }}
-
-        {{ $conceptualArticles = sort $conceptualArticles "fields.weight" }}
-        {{ $operationArticles = sort $operationArticles "fields.weight" }}
-        {{ $sortedArticles := $conceptualArticles | append $operationArticles }}
+        {{ $sortedArticles := partial "api/sorted-tag-articles.html" $specArticles }}
 
         {{ range $sortedArticles }}
           {{ $articlePath := index . "path" }}
@@ -140,26 +125,7 @@
   {{ end }}
 
   {{ if gt (len $articles) 0 }}
-    {{/* Separate conceptual (traitTag) and non-conceptual articles */}}
-    {{ $conceptualArticles := slice }}
-    {{ $operationArticles := slice }}
-
-    {{ range $articles }}
-      {{ $fields := index . "fields" }}
-      {{ $isConceptual := index $fields "isConceptual" }}
-      {{ if $isConceptual }}
-        {{ $conceptualArticles = $conceptualArticles | append . }}
-      {{ else }}
-        {{ $operationArticles = $operationArticles | append . }}
-      {{ end }}
-    {{ end }}
-
-    {{/* Sort each group by weight (default 100), then alphabetically by tag name */}}
-    {{ $conceptualArticles = sort $conceptualArticles "fields.weight" }}
-    {{ $operationArticles = sort $operationArticles "fields.weight" }}
-
-    {{/* Combine: conceptual first, then operations */}}
-    {{ $sortedArticles := $conceptualArticles | append $operationArticles }}
+    {{ $sortedArticles := partial "api/sorted-tag-articles.html" $articles }}
 
     {{/* Render each tag as a nav item */}}
     {{ range $sortedArticles }}

--- a/layouts/partials/sidebar/api-menu-items.html
+++ b/layouts/partials/sidebar/api-menu-items.html
@@ -20,15 +20,22 @@
 {{/* Derive data lookup path from the API section URL.
      Split "/influxdb3/core/api/" into segments and index into site.Data.
      Single-spec: /influxdb3/core/api/ → article_data.influxdb3.core.api
-     Multi-spec:  /influxdb3/cloud-dedicated/api/ → article_data.influxdb3.cloud-dedicated */}}
+     Multi-spec:  /influxdb3/cloud-dedicated/api/ → article_data.influxdb3.cloud-dedicated
+
+     When deployed under a subdirectory baseURL (e.g., PR previews at
+     /pr-preview/pr-N/…), .URL is site-root-relative and so includes that
+     prefix. Skip the extra leading segments computed from the baseURL path
+     depth, matching api/section-children.html. */}}
 {{ $urlPath := strings.TrimPrefix "/" (strings.TrimSuffix "/" $apiUrl) }}
 {{ $segments := split $urlPath "/" }}
+{{ $pathOffset := partialCached "base-path-offset.html" . }}
+{{ $productSegments := sub (len $segments) $pathOffset }}
 
 {{ $dataNode := dict }}
-{{ if ge (len $segments) 3 }}
-  {{ $seg0 := index $segments 0 }}
-  {{ $seg1 := index $segments 1 }}
-  {{ $seg2 := index $segments 2 }}
+{{ if ge $productSegments 3 }}
+  {{ $seg0 := index $segments (add $pathOffset 0) }}
+  {{ $seg1 := index $segments (add $pathOffset 1) }}
+  {{ $seg2 := index $segments (add $pathOffset 2) }}
   {{ with index $siteData.article_data $seg0 $seg1 $seg2 }}
     {{ $dataNode = . }}
   {{ end }}
@@ -50,9 +57,9 @@
 
 {{/* If no sub-sections found under the 3-segment node, try 2-segment lookup
      (product family + product, e.g. influxdb3/cloud-dedicated). */}}
-{{ if and (eq (len $subSections) 0) (ge (len $segments) 2) }}
-  {{ $seg0 := index $segments 0 }}
-  {{ $seg1 := index $segments 1 }}
+{{ if and (eq (len $subSections) 0) (ge $productSegments 2) }}
+  {{ $seg0 := index $segments (add $pathOffset 0) }}
+  {{ $seg1 := index $segments (add $pathOffset 1) }}
   {{ $dataNode2 := dict }}
   {{ with index $siteData.article_data $seg0 $seg1 }}
     {{ $dataNode2 = . }}

--- a/layouts/partials/sidebar/nested-menu.html
+++ b/layouts/partials/sidebar/nested-menu.html
@@ -1,14 +1,30 @@
 {{ $menu := .menu }}
 {{ $siteData := .siteData }}
+{{/* Number of leading path segments contributed by a subdirectory baseURL
+     (e.g. PR previews at https://.../pr-preview/pr-N/). Hugo menu entries'
+     .URL is site-root-relative, so it includes this prefix. Strip it before
+     doing product-family prefix matching or deriving API data lookup paths,
+     matching the same pattern used in api/section-children.html. */}}
+{{ $pathOffset := partialCached "base-path-offset.html" . }}
 
 {{ define "recursiveMenu" }}
   {{ $menuContext := .menu }}
   {{ $siteData := .siteData }}
+  {{ $pathOffset := .pathOffset }}
   {{ $depth := add .depth 1 }}
   {{ $navClass := cond (gt $depth 1) "item" "category" }}
   {{ range $menuContext }}
+    {{/* Strip the baseURL subpath from the menu URL before checking
+         product-family prefixes, so PR previews (and any other
+         subdirectory-baseURL deploy) match the same as production. */}}
+    {{ $relURL := .URL }}
+    {{ if gt $pathOffset 0 }}
+      {{ $urlSegments := split (strings.TrimPrefix "/" .URL) "/" }}
+      {{ $relURL = print "/" (delimit (after $pathOffset $urlSegments) "/") }}
+    {{ end }}
+
     {{/* Check if this is the InfluxDB HTTP API menu item for InfluxDB 3 products */}}
-    {{ $isApiParent := and (or (eq .Name "InfluxDB HTTP API") (eq .Name "InfluxDB Management API")) (or (hasPrefix .URL "/influxdb3/") (hasPrefix .URL "/influxdb/") (hasPrefix .URL "/enterprise_influxdb/")) }}
+    {{ $isApiParent := and (or (eq .Name "InfluxDB HTTP API") (eq .Name "InfluxDB Management API")) (or (hasPrefix $relURL "/influxdb3/") (hasPrefix $relURL "/influxdb/") (hasPrefix $relURL "/enterprise_influxdb/")) }}
 
     <li class="nav-{{ $navClass }}" data-nav-url="{{ .URL }}"{{ if .Params.state }} state="{{ .Params.state }}"{{ end }}>
       {{ if $isApiParent }}
@@ -16,6 +32,9 @@
         <a href="#" class="children-toggle" role="button" aria-label="Toggle {{ .Name }} nested items"></a>
         <a href='{{ default .URL .Params.url }}'>{{ .Name }}</a>
         <ul class="children">
+          {{/* Pass the original (baseURL-prefixed) URL: api-menu-items.html
+               builds hrefs by concatenating onto it directly, and separately
+               strips the baseURL offset itself for its data lookup. */}}
           {{ partial "sidebar/api-menu-items" (dict "url" .URL "siteData" $siteData) }}
         </ul>
       {{ else }}
@@ -24,7 +43,7 @@
         <a href='{{ default .URL .Params.url }}'>{{ .Name }}</a>
         {{ if .HasChildren }}
           <ul class="children">
-          {{ template "recursiveMenu" (dict "menu" .Children "siteData" $siteData "depth" $depth) }}
+          {{ template "recursiveMenu" (dict "menu" .Children "siteData" $siteData "pathOffset" $pathOffset "depth" $depth) }}
           </ul>
         {{ end }}
       {{ end }}
@@ -32,4 +51,4 @@
   {{ end }}
 {{ end }}
 
-{{ template "recursiveMenu" (dict "menu" .menu "siteData" $siteData "depth" 0) }}
+{{ template "recursiveMenu" (dict "menu" .menu "siteData" $siteData "pathOffset" $pathOffset "depth" 0) }}


### PR DESCRIPTION
## What changed

- Fixed the API-reference sidebar so generated tag pages, such as **Table**, render under **InfluxDB HTTP API**.

## Why

Hugo decodes the generated API article entries as maps, but the sidebar's defensive `isset`/map-shape checks incorrectly rejected every entry.
The generated pages remained routable, but their links were absent from navigation; only the separately appended **All endpoints** link appeared.

This defect predates the S3 preview migration.
The old path-selective preview did not expose the complete generated API tree for review.
The new full-site preview does, so this PR made the existing sidebar failure visible.
The S3 deployment itself correctly published the generated API pages.

## Impact

Readers can navigate to generated API tag pages from the sidebar in PR previews and production builds.

## Verification

- [x] `yarn build:api-docs`
- [x] `npx hugo --environment production --renderToMemory --ignoreCache --cacheDir /tmp/pr-7561-hugo-cache --logLevel warn`
- [ ] The focused Cypress API-reference suite started Hugo successfully, but Chrome did not connect in the local environment.

## Checklist

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
