### PR TITLE
docs(influxdb3): editorial copyedits for #7549 (param/env cleanup)

### DIFF
--- a/content/influxdb3/enterprise/admin/clustering.md
+++ b/content/influxdb3/enterprise/admin/clustering.md
@@ -19,9 +19,10 @@ prepend: |
   > [!Note]
   > #### Using the performance upgrade preview?
   >
-  > Thread allocation on this page applies to the default (Parquet-backed)
-  > storage engine. If your nodes run with `--use-pacha-tree`, use the
-  > [performance upgrade preview configuration reference](/influxdb3/enterprise/performance-preview/configure/)
+  > Thread allocation on this page applies to the Parquet storage engine.
+  > If your cluster runs the upgraded storage engine (the default for new
+  > clusters in InfluxDB 3 Enterprise 3.11+), use the
+  > [configuration reference](/influxdb3/enterprise/performance-preview/configure/)
   > instead.
 ---
 

--- a/content/influxdb3/enterprise/admin/delete-data.md
+++ b/content/influxdb3/enterprise/admin/delete-data.md
@@ -17,7 +17,7 @@ related:
 
 Row-level deletion is an {{% product-name %}} feature that requires the
 [upgraded storage engine](/influxdb3/enterprise/performance-preview/)—the
-default for new clusters.
+default for new clusters on {{% product-name %}} 3.11+.
 On clusters that started on 3.10 or earlier, first run the
 [storage engine upgrade](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree)
 (`--upgrade-pacha-tree`).

--- a/content/influxdb3/enterprise/admin/delete-data.md
+++ b/content/influxdb3/enterprise/admin/delete-data.md
@@ -16,7 +16,7 @@ related:
 ---
 
 Row-level deletion is an {{% product-name %}} feature that requires the
-[upgraded storage engine](/influxdb3/enterprise/performance-preview/)--the
+[upgraded storage engine](/influxdb3/enterprise/performance-preview/)—the
 default for new clusters.
 On clusters that started on 3.10 or earlier, first run the
 [storage engine upgrade](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree)

--- a/content/influxdb3/enterprise/admin/import-data.md
+++ b/content/influxdb3/enterprise/admin/import-data.md
@@ -16,7 +16,7 @@ related:
 
 Bulk import is an {{% product-name %}} feature that requires the
 [upgraded storage engine](/influxdb3/enterprise/performance-preview/)—the
-default for new clusters.
+default for new clusters on {{% product-name %}} 3.11+.
 On clusters that started on 3.10 or earlier, first run the
 [storage engine upgrade](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree)
 (`--upgrade-pacha-tree`).

--- a/content/influxdb3/enterprise/admin/import-data.md
+++ b/content/influxdb3/enterprise/admin/import-data.md
@@ -15,7 +15,7 @@ related:
 ---
 
 Bulk import is an {{% product-name %}} feature that requires the
-[upgraded storage engine](/influxdb3/enterprise/performance-preview/)--the
+[upgraded storage engine](/influxdb3/enterprise/performance-preview/)—the
 default for new clusters.
 On clusters that started on 3.10 or earlier, first run the
 [storage engine upgrade](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree)

--- a/content/influxdb3/enterprise/admin/license.md
+++ b/content/influxdb3/enterprise/admin/license.md
@@ -137,10 +137,12 @@ address using one of the following methods:
 - **TOML config (DEB/RPM-only):** Set the [`license-email`](/influxdb3/enterprise/reference/config-options/#license-email) option in the [`/etc/influxdb3/influxdb3-enterprise.conf` file](/influxdb3/enterprise/install/#toml-configuration-linux) for a DEB or RPM install
 
 > [!Note]
-> The legacy `INFLUXDB3_ENTERPRISE_LICENSE_EMAIL`,
-> `INFLUXDB3_ENTERPRISE_LICENSE_FILE`, and `INFLUXDB3_ENTERPRISE_LICENSE_TYPE`
-> environment variable names are deprecated aliases; the server accepts them
-> but logs a deprecation warning at startup.
+> #### Deprecated Enterprise license environment variables
+>
+> In {{< product-name >}} 3.11+, use `INFLUXDB3_LICENSE_EMAIL`,
+> `INFLUXDB3_LICENSE_FILE`, and `INFLUXDB3_LICENSE_TYPE`.
+> The legacy `INFLUXDB3_ENTERPRISE_*` names remain supported as deprecated
+> aliases, but the server logs a deprecation warning at startup.
 
 If the server finds a valid license file in your object store, it ignores the
 license email option.

--- a/content/influxdb3/enterprise/admin/load-capture.md
+++ b/content/influxdb3/enterprise/admin/load-capture.md
@@ -22,7 +22,7 @@ The profile preserves workload characteristics that can help you analyze or repr
 > Anonymization does not remove all operational characteristics from a profile.
 
 > [!Note]
-> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)--the default for new clusters.
+> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)—the default for new clusters.
 > On clusters that started on 3.10 or earlier, first run the [storage engine upgrade](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree) (`--upgrade-pacha-tree`).
 > Send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
 > Load capture isn't available on a node that uses the default `--mode all` configuration.

--- a/content/influxdb3/enterprise/admin/recover-node.md
+++ b/content/influxdb3/enterprise/admin/recover-node.md
@@ -59,8 +59,7 @@ protection against losing the tail.
 
 1. **Restart a server process with the same `--node-id`** (environment
    variable: `INFLUXDB3_NODE_ID`) and the same object store configuration.
-   This is functionally the same as restarting the original node.
-   On startup, WAL recovery replays the WAL files that were not drained, so the
+   This is functionally the same as restarting the original node: on startup, WAL recovery replays the WAL files that were not drained, so the
    acknowledged writes are safe again.
 
    <!--pytest.mark.skip-->

--- a/content/influxdb3/enterprise/admin/recover-node.md
+++ b/content/influxdb3/enterprise/admin/recover-node.md
@@ -17,21 +17,26 @@ related:
 influxdb3/enterprise/tags: [clustering, nodes, recovery, wal]
 ---
 
-Use this procedure to recover a node that stopped **ungracefully**--for
+Use this procedure to recover a node that stopped **ungracefully** — for
 example, the process crashed, was killed (`kill -9`), or its container was
-force-stopped--or that is wedged in the `stopping` state.
+force-stopped.
+It also applies to a node wedged in the `stopping` state.
 
-This procedure applies to both the Parquet engine and the upgraded storage
-engine (the default for new clusters).
+> [!Note]
+> This procedure applies to both the Parquet engine and the upgraded storage
+> engine (the default for new clusters in {{< product-name >}} 3.11+).
 
 ## Why ungraceful stops put writes at risk
 
-A node buffers recently acknowledged writes in its write-ahead log (WAL) and
-only periodically captures them in a snapshot.
-A graceful [`influxdb3 stop node`](/influxdb3/enterprise/reference/cli/influxdb3/stop/node/)
-against the **live** node drains this WAL tail before the node reads as
-`stopped`--the Parquet engine flushes the WAL and the upgraded storage
-engine snapshots it.
+A node stores recently acknowledged writes in its write-ahead log (WAL) until it
+captures them in a snapshot.
+These buffered writes—the ones a snapshot has not yet captured—are the node's
+_WAL tail_.
+Run the [`influxdb3 stop node`](/influxdb3/enterprise/reference/cli/influxdb3/stop/node/)
+command against a running node to save the WAL tail before the node reports a
+`stopped` state.
+The Parquet engine flushes the WAL, and the upgraded storage engine captures a
+snapshot.
 
 A node that dies without a graceful stop skips that drain:
 
@@ -40,24 +45,22 @@ A node that dies without a graceful stop skips that drain:
   purges its object-store file paths, permanently deleting any acknowledged
   writes not covered by its last snapshot.
 - Sending the process a bare `SIGTERM` (without calling `stop node`) does not
-  force a WAL snapshot on the upgraded storage engine, so a plain process
-  shutdown can also leave
-  a WAL tail behind.
+  force a WAL snapshot on the upgraded storage engine.
+  A plain process shutdown can also leave a WAL tail behind.
 
 On clusters that have fully adopted the upgraded storage engine,
 `remove node` refuses (HTTP 409) to remove a `stopped`
-node that still has an un-snapshotted WAL tail unless you pass
-`--force-finalize`.
-Parquet clusters and clusters still mid-upgrade do
-**not** have this safeguard--on those clusters, completing this recovery
-procedure before removal is the only protection against losing the tail.
+node that still has a WAL tail unless you pass `--force-finalize`.
+Parquet clusters and clusters still mid-upgrade do **not** have this safeguard.
+On those clusters, completing this recovery procedure before removal is the only
+protection against losing the tail.
 
 ## Recover the node
 
 1. **Restart a server process with the same `--node-id`** (environment
    variable: `INFLUXDB3_NODE_ID`) and the same object store configuration.
-   This is functionally the same as restarting the original node: on startup,
-   WAL recovery finds and replays the un-drained WAL files, so the
+   This is functionally the same as restarting the original node.
+   On startup, WAL recovery replays the WAL files that were not drained, so the
    acknowledged writes are safe again.
 
    <!--pytest.mark.skip-->
@@ -91,14 +94,14 @@ procedure before removal is the only protection against losing the tail.
    influxdb3 remove node --node-id NODE_ID
    ```
 
-   If you are recovering the node to keep using it, skip this step--after a
-   graceful stop, you can start it again at any time.
+   If you are recovering the node to keep using it, skip this step.
+   After a graceful stop, you can start it again at any time.
 
 ## If the node cannot be brought back
 
-If the node genuinely cannot be restarted (for example, its data is
+If the node cannot be restarted (for example, its data is
 unrecoverable or the hardware is gone) and you accept the possible loss of
-un-snapshotted writes, use the
+writes not yet captured in a snapshot, use the
 [`--force-finalize` option](/influxdb3/enterprise/reference/cli/influxdb3/remove/node/#force-removal-of-a-node-that-did-not-shut-down-cleanly)
 to force the removal:
 

--- a/content/influxdb3/enterprise/admin/recover-node.md
+++ b/content/influxdb3/enterprise/admin/recover-node.md
@@ -45,8 +45,8 @@ A node that dies without a graceful stop skips that drain:
   purges its object-store file paths, permanently deleting any acknowledged
   writes not covered by its last snapshot.
 - Sending the process a bare `SIGTERM` (without calling `stop node`) does not
-  force a WAL snapshot on the upgraded storage engine.
-  A plain process shutdown can also leave a WAL tail behind.
+  force a WAL snapshot on the upgraded storage engine, so a plain process
+  shutdown can also leave a WAL tail behind.
 
 On clusters that have fully adopted the upgraded storage engine,
 `remove node` refuses (HTTP 409) to remove a `stopped`
@@ -85,16 +85,15 @@ protection against losing the tail.
    confirm the stop.
 
 3. **Remove the node** if you intend to permanently remove it from the
-   cluster:
+   cluster.
+   If you are recovering the node to keep using it, skip this step—after a
+   graceful stop, you can start it again at any time.
 
    <!--pytest.mark.skip-->
 
    ```bash { placeholders="NODE_ID" }
    influxdb3 remove node --node-id NODE_ID
    ```
-
-   If you are recovering the node to keep using it, skip this step.
-   After a graceful stop, you can start it again at any time.
 
 ## If the node cannot be brought back
 

--- a/content/influxdb3/enterprise/performance-preview/_index.md
+++ b/content/influxdb3/enterprise/performance-preview/_index.md
@@ -90,6 +90,8 @@ influxdb3 serve ...
 ```
 
 > [!Note]
+> #### Upgrading the storage engine
+>
 > The `--use-pacha-tree` flag and the `INFLUXDB3_USE_PACHA_TREE` and
 > `INFLUXDB3_ENTERPRISE_USE_PACHA_TREE` environment variables are deprecated.
 > They are still accepted and start the same migration, but the server logs a

--- a/content/influxdb3/enterprise/performance-preview/_index.md
+++ b/content/influxdb3/enterprise/performance-preview/_index.md
@@ -2,8 +2,8 @@
 title: Storage engine upgrade
 seotitle: Storage engine upgrade for InfluxDB 3 Enterprise
 description: >
-  Learn about the upgraded InfluxDB 3 Enterprise storage engine--the default
-  for new clusters--with improved single-series query performance, consistent
+  Learn about the upgraded InfluxDB 3 Enterprise storage engine—the default
+  for new clusters—with improved single-series query performance, consistent
   resource usage, wide-and-sparse table support, column families, and bulk
   data export.
 menu:
@@ -21,7 +21,7 @@ related:
 > [!Important]
 > #### The upgraded storage engine is the default for new clusters
 > The upgraded storage engine described on these pages is the default for
-> new {{% product-name %}} clusters--no flag is required.
+> new {{% product-name %}} clusters—no flag is required.
 > Clusters that started on 3.10 or earlier keep the Parquet engine until you
 > run the storage engine upgrade by restarting the cluster with
 > [`--upgrade-pacha-tree`](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree).
@@ -111,8 +111,8 @@ for system tables and telemetry.
 > Queries continue to work normally during this period.
 > See [Upgrade from Parquet](#upgrade-from-parquet) for details.
 >
-> Before upgrading a production cluster, we recommend testing the storage
-> engine upgrade in a staging or test environment first.
+> Before you upgrade a production cluster, test the storage engine upgrade in a
+> staging or test environment first.
 
 ## What's changed
 
@@ -335,8 +335,8 @@ the storage engine upgrade especially benefits workloads with:
 > Hybrid query mode (enabled by default) allows querying across both legacy
 > Parquet data and new `.pt` data seamlessly.
 >
-> Before upgrading a production cluster, we recommend testing the storage
-> engine upgrade in a staging or test environment first.
+> Before you upgrade a production cluster, test the storage engine upgrade in a
+> staging or test environment first.
 
 ## Bug reports and feedback
 

--- a/content/influxdb3/enterprise/performance-preview/configure.md
+++ b/content/influxdb3/enterprise/performance-preview/configure.md
@@ -20,6 +20,7 @@ related:
 
 > [!Important]
 > #### The upgraded storage engine is the default for new clusters
+>
 > New {{% product-name %}} clusters default to the upgraded storage
 > engine--no flag is required.
 > Clusters that started on 3.10 or earlier keep the Parquet engine until you
@@ -44,6 +45,7 @@ default `influxdb3 serve --help` output; use `--help-all` to list them.
 > There is no backward compatibility for preview option names:
 > old `--pt-*` flags cause a startup error, and legacy `INFLUXDB3_PT_*` and
 > `INFLUXDB3_ENTERPRISE_PT_*` environment variables are ignored.
+>
 > The server logs a warning at startup for each `INFLUXDB3_PT_*` or
 > `INFLUXDB3_ENTERPRISE_PT_*` environment variable that is still set.
 >
@@ -60,9 +62,10 @@ default `influxdb3 serve --help` output; use `--help-all` to list them.
 > [Migrate from pt- option names](#migrate-from-pt-option-names).
 
 > [!Note]
-> On clusters running the upgraded storage engine, the IO and DataFusion
-> runtimes each default to the
-> licensed core count.
+> #### Runtime defaults and thread counts
+>
+> On InfluxDB 3 Enterprise 3.11+ clusters running the upgraded storage engine, the IO and DataFusion
+> runtimes each default to the licensed core count.
 > Thread counts set above the licensed core count are capped with a startup
 > warning.
 

--- a/content/influxdb3/enterprise/performance-preview/configure.md
+++ b/content/influxdb3/enterprise/performance-preview/configure.md
@@ -22,7 +22,7 @@ related:
 > #### The upgraded storage engine is the default for new clusters
 >
 > New {{% product-name %}} clusters default to the upgraded storage
-> engine--no flag is required.
+> engine—no flag is required.
 > Clusters that started on 3.10 or earlier keep the Parquet engine until you
 > run the storage engine upgrade by restarting the cluster with
 > [`--upgrade-pacha-tree`](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree).
@@ -40,7 +40,7 @@ default `influxdb3 serve --help` output; use `--help-all` to list them.
 > [!Important]
 > #### The `pt-` option prefix was removed
 >
-> Preview options no longer use the `pt-` prefix--for example,
+> Preview options no longer use the `pt-` prefix—for example,
 > `--pt-snapshot-size` is now `--snapshot-size`.
 > There is no backward compatibility for preview option names:
 > old `--pt-*` flags cause a startup error, and legacy `INFLUXDB3_PT_*` and
@@ -502,7 +502,7 @@ There are no aliases: old `--pt-*` flags cause a startup error, and legacy
 `INFLUXDB3_PT_*` and `INFLUXDB3_ENTERPRISE_PT_*` environment variables are
 ignored (the server logs a warning at startup for each one that is still set).
 
-Environment variable names follow the option names--for example,
+Environment variable names follow the option names—for example,
 `INFLUXDB3_PT_SNAPSHOT_SIZE` becomes `INFLUXDB3_SNAPSHOT_SIZE`.
 Any `--pt-*` option not listed below drops the `pt-` prefix without any
 other change to its name.

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/import/_index.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/import/_index.md
@@ -16,7 +16,7 @@ The `influxdb3 import` command manages bulk imports of Parquet data into
 {{< product-name >}} databases and tables.
 
 > [!Important]
-> Bulk import requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)--the default for new clusters.
+> Bulk import requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)—the default for new clusters.
 > On clusters that started on 3.10 or earlier, first run the [storage engine upgrade](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree) (`--upgrade-pacha-tree`).
 > The target database and table must exist before importing.
 

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/_index.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/_index.md
@@ -16,7 +16,7 @@ related:
 Use `influxdb3 loadcap` to capture and manage anonymized workload profiles on a query-capable InfluxDB 3 Enterprise node.
 
 > [!Note]
-> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)--the default for new clusters.
+> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)—the default for new clusters.
 > On clusters that started on 3.10 or earlier, first run the [storage engine upgrade](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree) (`--upgrade-pacha-tree`).
 > Send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
 > Load capture isn't available on a node that uses the default `--mode all` configuration.

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/delete.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/delete.md
@@ -16,7 +16,7 @@ related:
 Use `influxdb3 loadcap delete` to delete a workload capture profile.
 
 > [!Note]
-> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)--the default for new clusters.
+> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)—the default for new clusters.
 > On clusters that started on 3.10 or earlier, first run the [storage engine upgrade](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree) (`--upgrade-pacha-tree`).
 > Send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
 > Load capture isn't available on a node that uses the default `--mode all` configuration.

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/download.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/download.md
@@ -17,7 +17,7 @@ Use `influxdb3 loadcap download` to download a workload capture profile.
 If you omit `--output`, the command writes `<PROFILE_ID>.tar.gz` to the current directory.
 
 > [!Note]
-> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)--the default for new clusters.
+> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)—the default for new clusters.
 > On clusters that started on 3.10 or earlier, first run the [storage engine upgrade](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree) (`--upgrade-pacha-tree`).
 > Send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
 > Load capture isn't available on a node that uses the default `--mode all` configuration.

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/files.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/files.md
@@ -16,7 +16,7 @@ related:
 Use `influxdb3 loadcap files` to list files in a workload capture profile.
 
 > [!Note]
-> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)--the default for new clusters.
+> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)—the default for new clusters.
 > On clusters that started on 3.10 or earlier, first run the [storage engine upgrade](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree) (`--upgrade-pacha-tree`).
 > Send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
 > Load capture isn't available on a node that uses the default `--mode all` configuration.

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/list.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/list.md
@@ -17,7 +17,7 @@ related:
 Use `influxdb3 loadcap list` to list capture profiles stored by a query-capable InfluxDB 3 Enterprise node.
 
 > [!Note]
-> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)--the default for new clusters.
+> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)—the default for new clusters.
 > On clusters that started on 3.10 or earlier, first run the [storage engine upgrade](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree) (`--upgrade-pacha-tree`).
 > Send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
 > Load capture isn't available on a node that uses the default `--mode all` configuration.

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/preview.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/preview.md
@@ -16,7 +16,7 @@ related:
 Use `influxdb3 loadcap preview` to inspect a workload capture profile without downloading it.
 
 > [!Note]
-> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)--the default for new clusters.
+> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)—the default for new clusters.
 > On clusters that started on 3.10 or earlier, first run the [storage engine upgrade](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree) (`--upgrade-pacha-tree`).
 > Send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
 > Load capture isn't available on a node that uses the default `--mode all` configuration.

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/start.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/start.md
@@ -17,7 +17,7 @@ Use `influxdb3 loadcap start` to capture write requests, query requests, or both
 Only one capture can run on a node at a time.
 
 > [!Note]
-> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)--the default for new clusters.
+> Load capture requires the [upgraded storage engine](/influxdb3/enterprise/performance-preview/)—the default for new clusters.
 > On clusters that started on 3.10 or earlier, first run the [storage engine upgrade](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree) (`--upgrade-pacha-tree`).
 > Send requests to a node with an explicit `--mode` setting that includes `query`, for example, `--mode query` or `--mode ingest --mode query --mode compact`.
 > Load capture isn't available on a node that uses the default `--mode all` configuration.

--- a/content/shared/influxdb3-cli/config-options.md
+++ b/content/shared/influxdb3-cli/config-options.md
@@ -88,15 +88,15 @@ influxdb3 serve
 Several environment variables were renamed so that each variable matches its
 command option.
 {{% show-in "enterprise" %}}In addition, Enterprise-specific variables dropped
-the `ENTERPRISE_` segment--for example, `INFLUXDB3_ENTERPRISE_LICENSE_EMAIL`
+the `ENTERPRISE_` segment—for example, `INFLUXDB3_ENTERPRISE_LICENSE_EMAIL`
 is now `INFLUXDB3_LICENSE_EMAIL`.{{% /show-in %}}
 Legacy names remain supported as deprecated aliases; the server logs a
 deprecation warning at startup when it detects one.
 If both the new and the legacy name are set, the new name takes precedence.
 Option tables on this page list deprecated aliases where they exist.
 
-Use the following tables to migrate a deployment configuration--for example,
-Helm values or a systemd environment file--in one pass.
+Use the following tables to migrate a deployment configuration—for example,
+Helm values or a systemd environment file—in one pass.
 
 #### Renamed options (legacy names aliased)
 
@@ -180,7 +180,7 @@ Legacy names remain supported as deprecated aliases.
 
 #### Removed pt- option names (no aliases)
 
-Options for the upgraded storage engine (PachaTree) dropped the `pt-`
+Options for the upgraded storage engine dropped the `pt-`
 prefix without backward compatibility: old `--pt-*` flags cause a startup
 error, and legacy `INFLUXDB3_PT_*` and `INFLUXDB3_ENTERPRISE_PT_*`
 environment variables are ignored (the server logs a warning at startup for
@@ -475,8 +475,8 @@ For the upgrade procedure, see
 > \[!Note]
 > `--use-pacha-tree` (environment variable `INFLUXDB3_USE_PACHA_TREE`; legacy
 > `INFLUXDB3_ENTERPRISE_USE_PACHA_TREE`) is deprecated.
-> It is still accepted and keeps its previous behavior--on an existing Parquet
-> cluster it starts the same migration as `--upgrade-pacha-tree`--but the
+> It is still accepted and keeps its previous behavior—on an existing Parquet
+> cluster it starts the same migration as `--upgrade-pacha-tree`—but the
 > server logs a deprecation warning at startup.
 
 | influxdb3 serve option | Environment variable |
@@ -1543,7 +1543,7 @@ Provides custom configuration to DataFusion as a comma-separated list of
 #### max-http-request-size
 
 Specifies the maximum size of HTTP requests.
-Prefer a [unit suffix](#size-option-values)--for example, `10mb`.
+Prefer a [unit suffix](#size-option-values)—for example, `10mb`.
 A bare number is accepted as bytes (its pre-3.11 meaning) with a startup
 warning.
 
@@ -1578,7 +1578,7 @@ Specifies the size of the memory pool used for query processing and data operati
 This memory pool is used when {{% product-name %}} processes queries and performs
 internal data management tasks.
 Provide a value with a [unit suffix](#size-option-values) or as a percentage
-of the total available memory--for example: `8gb` or `10%`.
+of the total available memory—for example: `8gb` or `10%`.
 
 **Default:** `20%`
 
@@ -1600,7 +1600,7 @@ of the total available memory--for example: `8gb` or `10%`.
 
 Specifies the threshold for the internal memory buffer. Supports either a
 percentage (portion of available memory) or a value with a
-[unit suffix](#size-option-values)--for example: `70%` or `1000mb`.
+[unit suffix](#size-option-values)—for example: `70%` or `1000mb`.
 
 **Default:** `50%`
 
@@ -1973,7 +1973,7 @@ Specifies the interval to prefetch into the Parquet cache during compaction.
 
 Specifies the size of the in-memory data file cache.
 Provide a value with a [unit suffix](#size-option-values) or as a percentage
-of total available memory--for example, `4gb` or `20%`.
+of total available memory—for example, `4gb` or `20%`.
 
 This is a total budget.
 {{% show-in "enterprise" %}}
@@ -2035,7 +2035,7 @@ the time window for caching recent data files in memory.
 {{% show-in "enterprise" %}}**Default:** `3d`{{% /show-in %}}
 
 Only files containing data with a timestamp between `now` and `now - duration`
-are cached when accessed during queries--for example, with a `5h` setting:
+are cached when accessed during queries—for example, with a `5h` setting:
 
 - Current time: `2024-06-10 15:00:00`
 - Cache window: Last 5 hours (`2024-06-10 10:00:00` to now)

--- a/content/shared/influxdb3-cli/config-options.md
+++ b/content/shared/influxdb3-cli/config-options.md
@@ -178,7 +178,7 @@ Legacy names remain supported as deprecated aliases.
 | `INFLUXDB3_ENTERPRISE_WAIT_FOR_RUNNING_INGESTER` | `INFLUXDB3_WAIT_FOR_RUNNING_INGESTER` |
 | `INFLUXDB3_ENTERPRISE_WAIT_FOR_RUNNING_INGESTOR` | `INFLUXDB3_WAIT_FOR_RUNNING_INGESTOR` |
 
-#### Removed pt- option names (no aliases)
+#### Removed pt- option names (no aliases) {#removed-pt-option-names-no-aliases metadata="v3.11+"}
 
 Options for the upgraded storage engine dropped the `pt-`
 prefix without backward compatibility: old `--pt-*` flags cause a startup

--- a/content/shared/influxdb3-cli/config-options.md
+++ b/content/shared/influxdb3-cli/config-options.md
@@ -180,7 +180,7 @@ Legacy names remain supported as deprecated aliases.
 
 #### Removed pt- option names (no aliases) {#removed-pt-option-names-no-aliases metadata="v3.11+"}
 
-Options for the upgraded storage engine dropped the `pt-`
+In {{< product-name >}} 3.11+, options for the upgraded storage engine dropped the `pt-`
 prefix without backward compatibility: old `--pt-*` flags cause a startup
 error, and legacy `INFLUXDB3_PT_*` and `INFLUXDB3_ENTERPRISE_PT_*`
 environment variables are ignored (the server logs a warning at startup for

--- a/content/shared/influxdb3-cli/remove/node.md
+++ b/content/shared/influxdb3-cli/remove/node.md
@@ -61,11 +61,11 @@ Any acknowledged writes that were **not** covered by the node's final
 snapshot are deleted with them.
 That is why the node must complete a graceful stop first.
 
-### Removal is refused if unsnapshotted WAL remains (upgraded engine)
+### Removal is refused if unsnapshotted WAL remains (upgraded engine) {#removal-is-refused-if-unsnapshotted-wal-remains-upgraded-engine metadata="v3.11+"}
 
 On clusters that have fully adopted the upgraded storage engine (the default
-for new clusters), removing a `stopped` node
-that still has an unsnapshotted WAL tail is **refused** (HTTP 409):
+for new clusters), {{% product-name %}} **refuses** (HTTP 409) to remove a
+`stopped` node that still has an unsnapshotted WAL tail:
 
 ```text
 node 'NODE_ID' has unsnapshotted WAL (wal file N, snapshotted through M);
@@ -88,7 +88,7 @@ and then remove it.
 > [`stop node`](/influxdb3/version/reference/cli/influxdb3/stop/node/) before
 > removal is the only protection against losing the WAL tail.
 
-## Force removal of a node that did not shut down cleanly
+## Force removal of a node that did not shut down cleanly {#force-removal-of-a-node-that-did-not-shut-down-cleanly metadata="v3.11+"}
 
 If `remove node` fails without `--force-finalize`, the node never finished
 stopping—its process is gone and never confirmed a clean stop.

--- a/content/shared/influxdb3-cli/remove/node.md
+++ b/content/shared/influxdb3-cli/remove/node.md
@@ -8,7 +8,7 @@ catalog entry and the node's object-store file paths are purged.
 >
 > A node must be `stopped` before it can be removed.
 > Use [`influxdb3 stop node`](/influxdb3/version/reference/cli/influxdb3/stop/node/)
-> against the live node and wait for it to reach `stopped`--the graceful stop
+> against the live node and wait for it to reach `stopped`—the graceful stop
 > is what drains the node's write-ahead log (WAL) tail.
 > A node stuck in `stopping` (for example, because the process was killed
 > mid-stop or was already dead) cannot be removed normally.
@@ -58,14 +58,14 @@ When you remove a node:
 Removal permanently deletes the node's object-store file paths, including its
 WAL files.
 Any acknowledged writes that were **not** covered by the node's final
-snapshot are deleted with them--that is why the node must complete a graceful
-stop first.
+snapshot are deleted with them.
+That is why the node must complete a graceful stop first.
 
-### Removal is refused if un-snapshotted WAL remains (upgraded engine)
+### Removal is refused if unsnapshotted WAL remains (upgraded engine)
 
 On clusters that have fully adopted the upgraded storage engine (the default
 for new clusters), removing a `stopped` node
-that still has an un-snapshotted WAL tail is **refused** (HTTP 409):
+that still has an unsnapshotted WAL tail is **refused** (HTTP 409):
 
 ```text
 node 'NODE_ID' has unsnapshotted WAL (wal file N, snapshotted through M);
@@ -83,15 +83,16 @@ and then remove it.
 > This safeguard applies only to clusters that have fully adopted the
 > upgraded storage engine (new clusters, or after the storage engine upgrade
 > completes).
-> Parquet clusters and clusters still mid-upgrade are **not**
-> guarded--on those clusters, a graceful
+> Parquet clusters and clusters still mid-upgrade are **not** guarded.
+> On those clusters, a graceful
 > [`stop node`](/influxdb3/version/reference/cli/influxdb3/stop/node/) before
-> removal is the only protection against losing an un-drained WAL tail.
+> removal is the only protection against losing the WAL tail.
 
 ## Force removal of a node that did not shut down cleanly
 
 If `remove node` fails without `--force-finalize`, the node never finished
-stopping--its process is gone and never confirmed a clean stop.
+stopping.
+Its process is gone and never confirmed a clean stop.
 `--force-finalize` removes it anyway.
 
 **This can lose data**: recently acknowledged writes the node had not yet
@@ -100,8 +101,8 @@ If the node had finished snapshotting and only failed to report a clean stop,
 nothing is lost.
 
 Prefer the safe path first: restart the node with the same `--node-id`, let
-it shut down cleanly, and remove it again--see
-[Recover a crashed node](/influxdb3/version/admin/recover-node/).
+it shut down cleanly, and remove it again.
+See [Recover a crashed node](/influxdb3/version/admin/recover-node/).
 Use `--force-finalize` only when the node cannot be brought back and you
 accept the possible loss.
 
@@ -146,7 +147,7 @@ influxdb3 remove node --node-id NODE_ID --no-confirm
 
 Only use `--force-finalize` after attempting
 [crash recovery](/influxdb3/version/admin/recover-node/), when the node
-cannot be brought back and you accept the possible loss of un-snapshotted
+cannot be brought back and you accept the possible loss of unsnapshotted
 writes:
 
 <!--pytest.mark.skip-->

--- a/content/shared/influxdb3-cli/remove/node.md
+++ b/content/shared/influxdb3-cli/remove/node.md
@@ -91,8 +91,7 @@ and then remove it.
 ## Force removal of a node that did not shut down cleanly
 
 If `remove node` fails without `--force-finalize`, the node never finished
-stopping.
-Its process is gone and never confirmed a clean stop.
+stopping—its process is gone and never confirmed a clean stop.
 `--force-finalize` removes it anyway.
 
 **This can lose data**: recently acknowledged writes the node had not yet

--- a/content/shared/influxdb3-cli/stop/node.md
+++ b/content/shared/influxdb3-cli/stop/node.md
@@ -8,7 +8,7 @@ When you run this command against a **live** node:
    The cascade drains the node's WAL tail—the writes buffered in the
    write-ahead log (WAL) since the last snapshot.
    The Parquet engine flushes the WAL, and the upgraded storage engine
-   (the default for new clusters) snapshots it.
+   (the default for new clusters in {{< product-name >}} 3.11+) snapshots it.
 3. The node reads as `stopped` in the catalog, and its licensed cores are
    freed for other nodes.
 

--- a/content/shared/influxdb3-cli/stop/node.md
+++ b/content/shared/influxdb3-cli/stop/node.md
@@ -4,10 +4,11 @@ node in your {{< product-name >}} cluster.
 When you run this command against a **live** node:
 
 1. The node is marked as `stopping` in the catalog.
-2. The node completes its stop cascade--including draining its
-   write-ahead log (WAL) tail (the Parquet engine flushes the WAL; the
-   upgraded storage engine, the default for new clusters, snapshots
-   it)--and then confirms the stop.
+2. The node completes its stop cascade, then confirms the stop.
+   The cascade drains the node's WAL tail—the writes buffered in the
+   write-ahead log (WAL) since the last snapshot.
+   The Parquet engine flushes the WAL, and the upgraded storage engine
+   (the default for new clusters) snapshots it.
 3. The node reads as `stopped` in the catalog, and its licensed cores are
    freed for other nodes.
 
@@ -17,7 +18,7 @@ status if the node does not reach `stopped` in time.
 Use `--no-wait` to return as soon as the stop request is accepted.
 
 > [!Important]
-> #### Run this command against the live node--do not kill it first
+> #### Run this command against the live node—do not kill it first
 >
 > `stop node` is how a node drains its WAL tail.
 > If you kill the process first (for example, with `kill -9` or by
@@ -48,7 +49,7 @@ influxdb3 stop node [OPTIONS] --node-id <NODE_ID>
 | :----- | :------------- | :--------------------------------------------------------------------------------------- |
 |        | `--node-id`    | *({{< req >}})* The node ID to stop                                                      |
 |        | `--no-confirm` | Skip the confirmation prompt (`--force` is a deprecated alias)                           |
-|        | `--timeout`    | How long to wait for the node to reach `stopped` before giving up--for example: `30s`, `5m`, `1h` (default is `5m`) |
+|        | `--timeout`    | How long to wait for the node to reach `stopped` before giving up—for example: `30s`, `5m`, `1h` (default is `5m`) |
 |        | `--no-wait`    | Return as soon as the stop request is accepted instead of waiting for `stopped`          |
 | `-H`   | `--host`       | Host URL of the running {{< product-name >}} server (default is `http://127.0.0.1:8181`) |
 |        | `--token`      | Authentication token                                                                     |
@@ -78,7 +79,7 @@ upgraded engine: WAL snapshot).
   reaches `stopped`, up to `--timeout` (default `5m`).
 - If the node does not reach `stopped` within the timeout, the command prints
   the last observed state and exits with a non-zero status.
-  The node may be wedged in `stopping`--for example, if the process died
+  The node may be wedged in `stopping`—for example, if the process died
   mid-cascade.
   To recover, follow
   [Recover a crashed node](/influxdb3/version/admin/recover-node/).
@@ -89,8 +90,8 @@ upgraded engine: WAL snapshot).
 - The command requires authentication if the server has auth enabled.
 
 Running `stop node` against a node whose process is **already dead** cannot
-drain anything: the catalog still moves the node toward `stopped`, but any
-un-drained WAL tail remains at risk until the node is restarted.
+drain anything: the catalog still moves the node toward `stopped`, but the
+WAL tail remains at risk until the node is restarted.
 See [Recover a crashed node](/influxdb3/version/admin/recover-node/).
 
 ## Examples


### PR DESCRIPTION
## What changed

Editorial copyedits over the pages in #7549. Prose only — no changes to
documented commands, options, defaults, or config-option behavior.

- Replace prose double hyphens (`--`) with em dashes. Command flags such as
  `--upgrade-pacha-tree` stay literal.
- Remove the internal "PachaTree" codename from reader-facing prose. Identifiers
  (`--upgrade-pacha-tree`, `INFLUXDB3_PT_*`) stay literal.
- Define "WAL tail" on first use in the recover-node and stop-node pages.
- Change "we recommend testing…" to the second-person imperative "test…".
- Replace the coined negations "un-snapshotted" and "un-drained" with plain
  wording, and remove the hedge word "genuinely".
- Split several run-on sentences into one sentence per line.
- Add "InfluxDB 3.11+" version qualifiers where a page states a new default or
  renamed behavior.

## Why

Align the prose with the Google Developer Documentation Style Guide and this
repo's conventions: active voice, second person, one sentence per line, and em
dashes. Remove jargon and shorthand a reader would otherwise need to decode.

## Impact

Documentation prose only. No change to documented commands, options, defaults,
or behavior. This branch is based on the current head of #7549, so the diff
shows only the copyedits.

## Verification

- `npx hugo --quiet` passes.
- Rendered the affected pages and confirmed the em dash, callout, WAL-tail
  definition, and version-qualifier changes.

## Checklist

- [x] Local build passes (`npx hugo --quiet`)
- [ ] Rebased/mergeable
