### PR TITLE
docs(influxdb3): define "WAL tail" in durability reference and glossary

### DIFF
--- a/content/shared/influxdb3-internals-reference/durability.md
+++ b/content/shared/influxdb3-internals-reference/durability.md
@@ -43,6 +43,14 @@ As written data moves through {{% product-name %}}, it follows a structured path
 - **Memory usage**: The persistence process uses memory from the configured memory pool ([`exec-mem-pool-bytes`](/influxdb3/version/reference/config-options/#exec-mem-pool-bytes)) when converting data to Parquet format. For write-heavy workloads, ensure adequate memory is allocated.
 - **Details**: Every ten minutes (default), {{% product-name %}} persists the oldest data from the queryable buffer to the object store in Parquet format, and keeps the remaining data (the most recent 5 minutes) in memory.
 
+### WAL tail
+
+The _WAL tail_ is the most recent data in the WAL that {{% product-name %}} has
+not yet persisted to Parquet.
+Because {{% product-name %}} flushes the WAL to object storage every second, the
+WAL tail is durable, but it remains in the WAL until the next Parquet
+persistence captures it.
+
 ### In-memory cache
 
 - **Process**: Recently persisted Parquet files are cached in memory.

--- a/content/shared/influxdb3-reference/glossary.md
+++ b/content/shared/influxdb3-reference/glossary.md
@@ -1258,6 +1258,13 @@ Points in the WAL are queryable and persist through a system reboot.
 On process start, all points in the WAL must be flushed before the system
 accepts new writes.
 
+### WAL tail
+
+The most recent points in the [WAL](#wal-write-ahead-log) that have not yet been
+persisted to Parquet.
+For details, see
+[Data durability](/influxdb3/version/reference/internals/durability/#wal-tail).
+
 ### windowing
 
 Grouping data based on specified time intervals.


### PR DESCRIPTION
## What changed

Define "WAL tail" once in the reference docs so the node-lifecycle pages can
point to a single definition.

- Add a **WAL tail** definition to the "Data flow for writes" section of the
  data durability reference.
- Add a **WAL tail** glossary entry that links to the durability reference.

## Why

The recover-node, stop-node, and remove-node pages use the term "WAL tail" but
no page defines it centrally. This adds one definition readers can find and
link to.

## Impact

Shared InfluxDB 3 reference content. Adds one definition and one glossary entry.
No change to commands, options, or behavior.

## Verification

- `npx hugo --quiet` passes.

## Checklist

- [x] Local build passes (`npx hugo --quiet`)
