### PR TITLE
fix(search): label /influxdb3/cloud hits as Cloud, not Cloud (TSM)

### DIFF
--- a/assets/js/__tests__/doc-search.test.mjs
+++ b/assets/js/__tests__/doc-search.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { formatProduct, formatVersion } from '../components/doc-search.js';
+
+describe('formatVersion', () => {
+  it('distinguishes v2 Cloud from InfluxDB 3 Cloud', () => {
+    assert.equal(formatVersion('cloud', 'influxdb'), 'Cloud (TSM)');
+    assert.equal(formatVersion('cloud', 'influxdb3'), 'Cloud');
+  });
+
+  it('maps InfluxDB 3 version segments to display names', () => {
+    assert.equal(formatVersion('core', 'influxdb3'), 'Core');
+    assert.equal(formatVersion('enterprise', 'influxdb3'), 'Enterprise');
+    assert.equal(
+      formatVersion('cloud-serverless', 'influxdb3'),
+      'Cloud Serverless'
+    );
+    assert.equal(
+      formatVersion('cloud-dedicated', 'influxdb3'),
+      'Cloud Dedicated'
+    );
+    assert.equal(formatVersion('clustered', 'influxdb3'), 'Clustered');
+    assert.equal(formatVersion('explorer', 'influxdb3'), 'Explorer');
+    assert.equal(formatVersion('controller', 'telegraf'), 'Controller');
+  });
+
+  it('passes through numbered versions for multi-version products', () => {
+    assert.equal(formatVersion('v2', 'influxdb'), 'v2');
+    assert.equal(formatVersion('v1', 'influxdb'), 'v1');
+  });
+
+  it('returns an empty string for single-version products', () => {
+    assert.equal(formatVersion('v1', 'telegraf'), '');
+    assert.equal(formatVersion('v1', 'enterprise_influxdb'), '');
+  });
+
+  it('returns an empty string when the version segment is absent', () => {
+    assert.equal(formatVersion(undefined, 'influxdb3'), '');
+    assert.equal(formatVersion(null, 'influxdb3'), '');
+  });
+});
+
+describe('formatProduct', () => {
+  it('maps product path segments to display names', () => {
+    assert.equal(formatProduct('influxdb3'), 'InfluxDB 3');
+    assert.equal(formatProduct('influxdb'), 'InfluxDB');
+    assert.equal(formatProduct('enterprise_influxdb'), 'InfluxDB Enterprise');
+  });
+
+  it('falls back to the raw path segment when unmapped', () => {
+    assert.equal(formatProduct('not-a-product'), 'not-a-product');
+  });
+});

--- a/assets/js/components/doc-search.js
+++ b/assets/js/components/doc-search.js
@@ -4,6 +4,76 @@
  */
 const debug = false; // Set to true for debugging output
 
+// Use object-based lookups instead of conditionals for version and product
+// names. These can be replaced with data from productData in the future.
+
+// Products that expose more than one numbered version in the URL path
+const multiVersion = ['influxdb'];
+
+// Version display name mappings, keyed by the version path segment
+const versionDisplayNames = {
+  cloud: 'Cloud',
+  core: 'Core',
+  enterprise: 'Enterprise',
+  'cloud-serverless': 'Cloud Serverless',
+  'cloud-dedicated': 'Cloud Dedicated',
+  clustered: 'Clustered',
+  explorer: 'Explorer',
+  controller: 'Controller',
+};
+
+// Version display names for a specific product, keyed by "product/version".
+// Use for version segments that appear under more than one product--for
+// example, /influxdb/cloud/ is the TSM-backed v2 Cloud, while
+// /influxdb3/cloud/ is InfluxDB 3 Cloud.
+const productVersionDisplayNames = {
+  'influxdb/cloud': 'Cloud (TSM)',
+};
+
+// Product display name mappings
+const productDisplayNames = {
+  influxdb: 'InfluxDB',
+  influxdb3: 'InfluxDB 3',
+  explorer: 'InfluxDB 3 Explorer',
+  enterprise_influxdb: 'InfluxDB Enterprise',
+  flux: 'Flux',
+  telegraf: 'Telegraf',
+  controller: 'Telegraf Controller',
+  chronograf: 'Chronograf',
+  kapacitor: 'Kapacitor',
+  platform: 'InfluxData Platform',
+  resources: 'Additional Resources',
+};
+
+/**
+ * Format the version segment of a docs URL for display in search results.
+ * Product-specific names win over version-only names.
+ *
+ * @param {string|null|undefined} version - version path segment
+ * @param {string|null|undefined} productKey - product path segment
+ * @returns {string} display name, or '' when the version isn't displayable
+ */
+export function formatVersion(version, productKey) {
+  if (version == null) {
+    return '';
+  }
+  return (
+    productVersionDisplayNames[`${productKey}/${version}`] ??
+    versionDisplayNames[version] ??
+    (multiVersion.includes(productKey) ? version : '')
+  );
+}
+
+/**
+ * Format the product segment of a docs URL for display in search results.
+ *
+ * @param {string|null|undefined} productKey - product path segment
+ * @returns {string} display name, or the raw segment when unmapped
+ */
+export function formatProduct(productKey) {
+  return productDisplayNames[productKey] || productKey;
+}
+
 export default function DocSearch({ component }) {
   // Store configuration from component data attributes
   const config = {
@@ -43,38 +113,6 @@ export default function DocSearch({ component }) {
     if (debug) {
       console.log('Initializing DocSearch...');
     }
-    const multiVersion = ['influxdb'];
-
-    // Use object-based lookups instead of conditionals for version and product
-    // names. These can be replaced with data from productData in the future.
-
-    // Version display name mappings
-    const versionDisplayNames = {
-      cloud: 'Cloud (TSM)',
-      core: 'Core',
-      enterprise: 'Enterprise',
-      'cloud-serverless': 'Cloud Serverless',
-      'cloud-dedicated': 'Cloud Dedicated',
-      clustered: 'Clustered',
-      explorer: 'Explorer',
-      controller: 'Controller',
-    };
-
-    // Product display name mappings
-    const productDisplayNames = {
-      influxdb: 'InfluxDB',
-      influxdb3: 'InfluxDB 3',
-      explorer: 'InfluxDB 3 Explorer',
-      enterprise_influxdb: 'InfluxDB Enterprise',
-      flux: 'Flux',
-      telegraf: 'Telegraf',
-      controller: 'Telegraf Controller',
-      chronograf: 'Chronograf',
-      kapacitor: 'Kapacitor',
-      platform: 'InfluxData Platform',
-      resources: 'Additional Resources',
-    };
-
     // Initialize DocSearch with configuration
     window.docsearch({
       apiKey: config.apiKey,
@@ -83,25 +121,12 @@ export default function DocSearch({ component }) {
       inputSelector: config.inputSelector,
       debug: config.debug,
       transformData: function (hits) {
-        // Format version using object lookup instead of if-else chain
-        function fmtVersion(version, productKey) {
-          if (version == null) {
-            return '';
-          } else if (versionDisplayNames[version]) {
-            return versionDisplayNames[version];
-          } else if (multiVersion.includes(productKey)) {
-            return version;
-          } else {
-            return '';
-          }
-        }
-
         hits.map((hit) => {
           const pathData = new URL(hit.url).pathname
             .split('/')
             .filter((n) => n);
-          const product = productDisplayNames[pathData[0]] || pathData[0];
-          const version = fmtVersion(pathData[1], pathData[0]);
+          const product = formatProduct(pathData[0]);
+          const version = formatVersion(pathData[1], pathData[0]);
 
           hit.product = product;
           hit.version = version;


### PR DESCRIPTION
## What changed

Search result labels now show **InfluxDB 3 Cloud** for `/influxdb3/cloud/`
hits instead of **InfluxDB 3 Cloud (TSM)**.

In `assets/js/components/doc-search.js`:

- Added a product-scoped display-name map keyed by `"product/version"`.
  It takes precedence over the version-only map. It holds one entry:
  `influxdb/cloud` -> `Cloud (TSM)`.
- The version-only map now maps `cloud` to the general name, `Cloud`.
- Moved the display-name maps to module scope and exported two pure
  helpers, `formatVersion()` and `formatProduct()`, so the mapping can be
  unit tested.
- Added `assets/js/__tests__/doc-search.test.mjs` with 7 `node --test`
  cases.

## Why

`fmtVersion()` resolved the version display name from the version path
segment alone. Every path with a `cloud` segment got the v2-specific
`Cloud (TSM)` name, including `/influxdb3/cloud/`.

Two products use a `cloud` version segment: `/influxdb/cloud/` (the
TSM-backed v2 Cloud) and `/influxdb3/cloud/` (InfluxDB 3 Cloud). The
lookup had no way to tell them apart.

## Impact

Readers searching from an InfluxDB 3 Cloud page see correctly labeled
results. Labels for all other products are unchanged.

InfluxDB 3 Cloud pages are already indexed and tagged. The Algolia index
holds 1872 records under the `influxdb3-cloud` searchTag, and pages emit
`<meta name="docsearch:searchTag" content="influxdb3-cloud">`. This PR
only corrects how those hits are labeled in the results list.

## Verification

```
node --test 'assets/js/__tests__/*.test.mjs'
# tests 7  # pass 7  # fail 0

yarn eslint assets/js/components/doc-search.js
# 0 errors, 2 warnings (max-len at :135 and :138, pre-existing lines)

npx prettier --check assets/js/components/doc-search.js assets/js/__tests__/doc-search.test.mjs
# clean

npx hugo --quiet
# passes
```

Test cases cover both cloud paths, the InfluxDB 3 version segments,
multi-version passthrough (`influxdb/v2`), single-version products that
render no version (`telegraf/v1`), a null or missing version segment, and
the unmapped-product fallback.

## Checklist

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
