### PR TITLE
fix(analytics): fire url_selector_preset on click, not change

### DIFF
--- a/assets/js/influxdb-url.js
+++ b/assets/js/influxdb-url.js
@@ -492,12 +492,16 @@ export function InfluxDBUrl() {
     updateUrls(getPrevUrls(), getUrls());
   });
 
-  // Track selecting a built-in (preset) URL for analytics. Scoped to radio
-  // options and excludes the custom radio, which is tracked separately when
-  // the custom value is applied.
+  // Track selecting a built-in (preset) URL for analytics. Bound to `click`
+  // rather than `change`: setRadioButtons() checks the stored (or default)
+  // preset on page load, so `change` never fires when the user selects the
+  // preset that is already checked. Products that offer a single preset
+  // (Core, Enterprise, OSS) are always in that state, which would leave preset
+  // usage unrecorded. Excludes the custom radio, which is tracked separately
+  // when the custom value is applied.
   $('input[type="radio"][name^="influxdb-"][name$="-url"]')
     .not('#custom')
-    .on('change', function () {
+    .on('click', function () {
       trackPresetUrlSelection(PRODUCT_CONTEXT, $(this).val());
     });
 

--- a/cypress/e2e/influxdb-url.cy.js
+++ b/cypress/e2e/influxdb-url.cy.js
@@ -15,6 +15,8 @@ const STORAGE_KEY = 'influxdata_docs_urls';
 const TEST_PAGE = '/influxdb3/core/plugins/';
 // A product with a protocol-less, product-specific URL field (applyProductUrl).
 const DEDICATED_PAGE = '/influxdb3/cloud-dedicated/get-started/setup/';
+// A product whose selector renders multiple presets grouped into regions.
+const CLOUD_TEST_PAGE = '/influxdb/cloud/get-started/';
 const EXPECTED_PRODUCT_KEYS = [
   'oss',
   'cloud',
@@ -154,13 +156,51 @@ describe('InfluxDB URL - selector analytics', function () {
     );
 
     // Preset URLs are public documented endpoints, so the selected value is
-    // reported to help compare preset vs. custom usage.
+    // reported to help compare preset vs. custom usage. One click reports
+    // exactly one event — `click` must not be counted alongside `change`.
     cy.get('@gtag').then((stub) => {
       const calls = stub
         .getCalls()
         .filter((c) => c.args[1] === 'url_selector_preset');
-      expect(calls.length).to.be.greaterThan(0);
+      expect(calls.length).to.equal(1);
       expect(calls[0].args[2].selected_url).to.be.a('string').and.not.be.empty;
+    });
+  });
+
+  it('reports one url_selector_preset when the selection changes', function () {
+    // Cloud renders several presets, so selecting a different one changes the
+    // checked state and fires both `click` and `change`. Verify that reports a
+    // single event — the click binding must not be counted twice.
+    cy.visit(CLOUD_TEST_PAGE, {
+      onBeforeLoad(win) {
+        // Suppress the v3 wayfinding modal, which otherwise covers the page
+        // and blocks the URL selector trigger.
+        win.localStorage.setItem(
+          'influxdata_docs_preferences',
+          JSON.stringify({ influxdb_url: 'cloud', v3_wayfinding_show: false })
+        );
+      },
+    });
+    stubGtag();
+    openCustomUrlModal();
+
+    cy.get('#cloud-urls input[type="radio"][name="influxdb-cloud-url"]')
+      .not('#custom')
+      .not(':checked')
+      .first()
+      .click({ force: true });
+
+    cy.get('@gtag').should(
+      'have.been.calledWith',
+      'event',
+      'url_selector_preset',
+      Cypress.sinon.match({ product: 'cloud' })
+    );
+    cy.get('@gtag').then((stub) => {
+      const calls = stub
+        .getCalls()
+        .filter((c) => c.args[1] === 'url_selector_preset');
+      expect(calls.length).to.equal(1);
     });
   });
 

--- a/cypress/e2e/influxdb-url.cy.js
+++ b/cypress/e2e/influxdb-url.cy.js
@@ -129,11 +129,22 @@ describe('InfluxDB URL - selector analytics', function () {
     stubGtag();
     openCustomUrlModal();
 
-    // Select a built-in (preset) radio option — not the custom radio.
+    // Regression for https://github.com/influxdata/docs-v2/issues/7577.
+    // The stored (or default) preset is already checked when the modal opens,
+    // so selecting it fires `click` but not `change`. Assert the precondition
+    // explicitly — a `change`-bound handler records nothing here.
     cy.get('input[type="radio"][name="influxdb-core-url"]')
       .not('#custom')
       .first()
-      .check({ force: true });
+      .should('be.checked');
+
+    // Select a built-in (preset) radio option — not the custom radio.
+    // Use click(), not check(): Cypress skips check() on an already-checked
+    // input and fires no events at all.
+    cy.get('input[type="radio"][name="influxdb-core-url"]')
+      .not('#custom')
+      .first()
+      .click({ force: true });
 
     cy.get('@gtag').should(
       'have.been.calledWith',


### PR DESCRIPTION
Closes #7577

## What changed

Bind the `url_selector_preset` GA4 event to the radio `click` event instead of `change` (`assets/js/influxdb-url.js`).

Update `cypress/e2e/influxdb-url.cy.js`:

- Use `.click()` instead of `.check()` to select the preset, and assert up front that the preset is already checked so the regression stays pinned.
- Add a Cloud case that selects a preset other than the checked one, asserting exactly one event.

## Why

`change` fires only when the checked state actually changes. `setRadioButtons()` checks the stored (or default) preset on page load, so the preset is already selected before the modal opens. Selecting it fires `click` but never `change`, and the event was dropped.

Core, Enterprise, and OSS render one preset plus Custom, so their preset is always preselected. For those products the event could only fire after the user first switched to Custom. That biased the preset vs. custom comparison added in #7504 toward zero preset usage.

The spec missed this because Cypress skips `.check()` on an already-checked input and fires no events at all.

## Impact

Preset URL selections are recorded again in GA4. Preset counts for Core, Enterprise, and OSS will rise from near zero, so historical preset vs. custom ratios are not comparable across this change.

No user-visible behavior changes. The event payload is unchanged: `product`, `host_type`, `selected_url`, `page_path`.

## Verification

Reproduced on clean `master` before the fix. A diagnostic run on `/influxdb3/core/plugins/` recorded the preset radio as `value="http://localhost:8181"`, `checked: true`, with `.check()` firing no events and `.click()` firing `click` but not `change`. That rules out both leads in the issue: the value is not falsy, and the radios are present when the handler binds.

```
node cypress/support/run-e2e-specs.js --spec "cypress/e2e/influxdb-url.cy.js" --no-mapping
```

- Before: 10 tests, 1 failing.
- After: 11 tests, 11 passing.
- `cypress/e2e/page-context.cy.js`: 14/14 passing.
- `cypress/e2e/topnav.cy.js`: "switches light to dark" fails. Pre-existing and unrelated — it fails identically with `assets/js/influxdb-url.js` restored to `origin/master`.
- `yarn` pre-commit and pre-push hooks pass (prettier, eslint, packages-audit, validate-agent-instructions).

## Checklist

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
- [x] Rebased/mergeable
- [x] Local build passes (Hugo server built and served the test pages during the e2e runs)
