### PR TITLE
Remove beta labeling from the InfluxDB 3 Enterprise export endpoints

### DIFF
--- a/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
+++ b/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
@@ -141,13 +141,14 @@ tags:
     x-related:
       - title: Use compatibility APIs to write data
         href: /influxdb3/enterprise/write-data/http-api/compatibility-apis/
-  - name: Export data (beta)
+  - name: Export data
     description: |
       Export compacted data as Parquet files for use with external tools.
 
-      > **Beta**: Export endpoints require the [performance upgrade preview](/influxdb3/enterprise/performance-preview/)
-      > (`--use-pacha-tree` flag). The performance upgrade preview is a beta feature
-      > and **should not be used for production workloads**.
+      > **Requires the upgraded storage engine**: Export endpoints require the
+      > [upgraded storage engine](/influxdb3/enterprise/performance-preview/), which is the default for
+      > new clusters. On clusters created with 3.10 or earlier, run the storage engine upgrade with
+      > [`--upgrade-pacha-tree`](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree).
 
       Data must be compacted before it can be exported.
       Uncompacted data is not available for export at this time.
@@ -162,7 +163,7 @@ tags:
       You can also use the [`influxdb3 export`](/influxdb3/enterprise/performance-preview/#export-to-parquet) CLI
       commands, which call these endpoints.
     x-related:
-      - title: Performance upgrade preview
+      - title: Storage engine upgrade
         href: /influxdb3/enterprise/performance-preview/
       - title: Export to Parquet
         href: /influxdb3/enterprise/performance-preview/#export-to-parquet
@@ -2299,15 +2300,16 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
       x-enterprise-only: true
-      summary: List databases available for export (beta)
+      summary: List databases available for export
       description: |
         Returns a list of databases that have compacted data available for Parquet export.
 
-        > **Beta**: This endpoint requires the [performance upgrade preview](/influxdb3/enterprise/performance-preview/)
-        > (`--use-pacha-tree` flag). The performance upgrade preview is a beta feature
-        > and **should not be used for production workloads**.
+        > **Requires the upgraded storage engine**: This endpoint requires the
+        > [upgraded storage engine](/influxdb3/enterprise/performance-preview/), which is the default for
+        > new clusters. On clusters created with 3.10 or earlier, run the storage engine upgrade with
+        > [`--upgrade-pacha-tree`](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree).
       tags:
-        - Export data (beta)
+        - Export data
         - Enterprise
   /api/v3/export/tables:
     get:
@@ -2326,15 +2328,16 @@ paths:
         "404":
           description: Database not found.
       x-enterprise-only: true
-      summary: List tables available for export (beta)
+      summary: List tables available for export
       description: |
         Returns a list of tables in a database that have compacted data available for Parquet export.
 
-        > **Beta**: This endpoint requires the [performance upgrade preview](/influxdb3/enterprise/performance-preview/)
-        > (`--use-pacha-tree` flag). The performance upgrade preview is a beta feature
-        > and **should not be used for production workloads**.
+        > **Requires the upgraded storage engine**: This endpoint requires the
+        > [upgraded storage engine](/influxdb3/enterprise/performance-preview/), which is the default for
+        > new clusters. On clusters created with 3.10 or earlier, run the storage engine upgrade with
+        > [`--upgrade-pacha-tree`](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree).
       tags:
-        - Export data (beta)
+        - Export data
         - Enterprise
   /api/v3/export/window_data:
     get:
@@ -2368,15 +2371,16 @@ paths:
         "404":
           description: Database, table, or window not found.
       x-enterprise-only: true
-      summary: Export window data as Parquet (beta)
+      summary: Export window data as Parquet
       description: |
         Downloads compacted data for the specified windows as a tar archive containing Parquet files.
 
-        > **Beta**: This endpoint requires the [performance upgrade preview](/influxdb3/enterprise/performance-preview/)
-        > (`--use-pacha-tree` flag). The performance upgrade preview is a beta feature
-        > and **should not be used for production workloads**.
+        > **Requires the upgraded storage engine**: This endpoint requires the
+        > [upgraded storage engine](/influxdb3/enterprise/performance-preview/), which is the default for
+        > new clusters. On clusters created with 3.10 or earlier, run the storage engine upgrade with
+        > [`--upgrade-pacha-tree`](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree).
       tags:
-        - Export data (beta)
+        - Export data
         - Enterprise
   /api/v3/export/windows:
     get:
@@ -2401,16 +2405,17 @@ paths:
         "404":
           description: Database or table not found.
       x-enterprise-only: true
-      summary: List compacted windows for a table (beta)
+      summary: List compacted windows for a table
       description: |
         Returns a list of compacted 24-hour UTC windows for a table.
         Each window represents a time range of compacted data that can be exported as Parquet.
 
-        > **Beta**: This endpoint requires the [performance upgrade preview](/influxdb3/enterprise/performance-preview/)
-        > (`--use-pacha-tree` flag). The performance upgrade preview is a beta feature
-        > and **should not be used for production workloads**.
+        > **Requires the upgraded storage engine**: This endpoint requires the
+        > [upgraded storage engine](/influxdb3/enterprise/performance-preview/), which is the default for
+        > new clusters. On clusters created with 3.10 or earlier, run the storage engine upgrade with
+        > [`--upgrade-pacha-tree`](/influxdb3/enterprise/reference/config-options/#upgrade-pacha-tree).
       tags:
-        - Export data (beta)
+        - Export data
         - Enterprise
   /api/v3/loadcap/profiles:
     get:

--- a/api-docs/influxdb3/enterprise/tags.yml
+++ b/api-docs/influxdb3/enterprise/tags.yml
@@ -1,7 +1,7 @@
 tags:
   Compatibility endpoints:
     drop: true
-  Export data (beta):
+  Export data:
     description: >
       Export data from InfluxDB 3 Enterprise databases.
       List databases, tables, export windows, and retrieve


### PR DESCRIPTION
## What changed

Removed beta labeling from the InfluxDB 3 Enterprise export endpoints in the
API reference.

- Renamed the `Export data (beta)` tag to `Export data`, in both the OpenAPI
  spec and the matching key in `tags.yml`. The two must stay in sync —
  `post-process-specs` matches config keys against the spec's operation tag
  names, so renaming only one would silently drop the tag description.
- Dropped `(beta)` from the four export operation summaries: list databases,
  list tables, list compacted windows, and export window data.
- Replaced the "should not be used for production workloads" beta notes with a
  requirement note. Each note now says the endpoints need the upgraded storage
  engine, which is the default for new clusters, and points operators on
  clusters created with 3.10 or earlier at `--upgrade-pacha-tree`.
- Retitled the `x-related` link from "Performance upgrade preview" to "Storage
  engine upgrade" so it matches the title of the page it links to.

## Why

InfluxDB 3 Enterprise 3.11 ships the upgraded storage engine as the default for
new clusters. The export endpoints are gated on that engine, so they are no
longer a beta feature, and the API reference was the last place still calling
them one.

The old notes were also actively misleading: they told readers to enable the
feature with `--use-pacha-tree` and warned them off production use. Both
statements are wrong as of 3.11.

## Impact

<!-- to customers or repo consumers -->

**For customers:** The export endpoints no longer read as unsupported.
Operators on new clusters learn they can use them as-is; operators on clusters
created with 3.10 or earlier get a direct link to the upgrade flag they need.

**For the repo:** The "Export data" tag heading and its description continue to
render, because the spec and `tags.yml` were renamed together.

## Verification

- `npx hugo --quiet` passes.
- Both changed files parse as valid YAML.
- No references to the old `Export data (beta)` tag name remain anywhere in the
  repo.

## Checklist

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)

***

Rebased onto `master` after the v3.11 release branch merged. This PR previously
targeted `release-influxdbv3.11` and its diff included that branch's commits;
it now contains only the API spec change above.

https://claude.ai/code/session_01XhnmbtyMVKHCM7NUVUUZdb