### PR TITLE
docs(controller): document high availability

### DIFF
--- a/content/telegraf/controller/audit-logs/_index.md
+++ b/content/telegraf/controller/audit-logs/_index.md
@@ -7,7 +7,7 @@ description: >
 menu:
   telegraf_controller:
     name: Audit logs
-weight: 11
+weight: 12
 cascade:
   metadata: [Telegraf Enterprise]
   related:
@@ -58,10 +58,18 @@ platform-specific data directory:
 | macOS    | `~/Library/Logs/telegraf-controller/`                                                    |
 | Windows  | `%LOCALAPPDATA%\telegraf-controller\Log`                                                 |
 
-Files are named `audit-YYYY-MM.log`--one per calendar month.
+Files are named `audit-YYYY-MM.log`, one per calendar month.
 Each file is a SQLite database that enforces immutability through a database
 trigger: attempts to delete rows are rolled back.
 {{% product-name %}} keeps up to 48 months of audit files available for query.
+
+In a [high-availability (HA) cluster](/telegraf/controller/high-availability/),
+audit logging is **per node**, not shared.
+Each node writes its own audit files and, when queried, returns only its own
+events.
+To review activity across the cluster, forward each node's events to a shared
+destination and aggregate them there.
+See [Audit logs in a cluster](/telegraf/controller/high-availability/#audit-logs-in-a-cluster).
 
 ## Tamper detection
 
@@ -69,6 +77,13 @@ Each entry includes a SHA-256 hash that incorporates the entry's contents
 and the hash of the previous entry, forming a chain.
 Sequence numbers are contiguous within and across monthly files.
 Any modification, deletion, or out-of-order insertion breaks the chain.
+
+In a high-availability cluster, each node maintains its own hash chain and
+sequence numbers, so events from different nodes merged into a single stream do
+not form one valid chain.
+Verify integrity per node: separate aggregated events by their originating node,
+then check each node's chain on its own.
+See [Audit logs in a cluster](/telegraf/controller/high-availability/#audit-logs-in-a-cluster).
 
 ## License and permissions
 

--- a/content/telegraf/controller/high-availability/_index.md
+++ b/content/telegraf/controller/high-availability/_index.md
@@ -1,0 +1,175 @@
+---
+title: High availability
+description: >
+  Run multiple Telegraf Controller nodes against a shared PostgreSQL database
+  for continuous availability. One node is elected leader to run cluster-wide
+  background work while every node serves traffic, and a standby takes over if
+  the leader fails.
+menu:
+  telegraf_controller:
+    name: High availability
+weight: 11
+cascade:
+  metadata: [Telegraf Enterprise]
+related:
+  - /telegraf/controller/high-availability/deploy/
+  - /telegraf/controller/reference/architecture/
+  - /telegraf/controller/reference/config-options/
+  - /telegraf/enterprise/
+---
+
+High availability lets you run more than one {{% product-name %}} node against a
+shared PostgreSQL database so that management operations continue if a node
+fails. One node is elected **leader** and performs cluster-wide work; the
+remaining nodes stand by, ready to take over. Every node keeps accepting agent
+heartbeats, so agent monitoring continues without interruption during a
+failover.
+
+{{< telegraf/enterprise-feature "High availability" >}}
+
+- [How high availability works](#how-high-availability-works)
+- [What runs on the leader](#what-runs-on-the-leader)
+- [Requirements and constraints](#requirements-and-constraints)
+- [How configuration changes propagate](#how-configuration-changes-propagate)
+- [How licensing affects high availability](#how-licensing-affects-high-availability)
+- [Audit logs in a cluster](#audit-logs-in-a-cluster)
+
+## How high availability works
+
+When you set `HA_ENABLED=true`, each {{% product-name %}} node connects to the
+same PostgreSQL database and competes for a single PostgreSQL advisory lock. The
+node that holds the lock is the **leader**. The other nodes are **standbys**
+that continuously try to acquire the lock and take over the moment it becomes
+available.
+
+- **Leader**: holds the advisory lock, serves the web interface and API,
+  accepts agent heartbeats, and runs all cluster-wide background work.
+- **Standby**: connects to the same database, accepts agent heartbeats, and
+  serves the web interface and API to whichever node the load balancer routes
+  to, but does not run cluster-wide background work.
+
+Each node re-evaluates leadership every few seconds. If the leader releases the
+lock during a graceful shutdown, or its database connection drops after a crash,
+a standby acquires the lock and becomes the new leader.
+
+Coordination happens entirely through the shared database. Nodes do not
+communicate with each other directly, so no quorum, voting, or separate
+coordination service is required.
+
+## What runs on the leader
+
+Some work must happen exactly once for the whole cluster. {{% product-name %}}
+runs the following only on the leader:
+
+- **Agent status evaluation**: the background scheduler that marks agents as
+  `not_reporting` when they miss heartbeats, restores them to `ok` when
+  heartbeats resume, and applies reporting-rule retention.
+- **Usage telemetry**: the cluster reports anonymous usage once, from the leader
+  only, so the cluster counts as a single instance.
+
+Every node, leader or standby, continues to:
+
+- Accept agent heartbeats on the heartbeat port.
+- Serve the web interface and API to authenticated users when the instance is
+  licensed.
+
+Because every node ingests heartbeats, agents keep reporting throughout a
+leadership change.
+
+## Requirements and constraints
+
+Running {{% product-name %}} in a highly available configuration requires the
+following:
+
+- **A Telegraf Enterprise license.** The license is stored in the shared
+  database, so you apply it once and every node reads it. Leadership election
+  runs only while the license is valid, expiring, or within its grace period.
+  See [How licensing affects high availability](#how-licensing-affects-high-availability).
+- **PostgreSQL.** High availability depends on a PostgreSQL advisory lock and
+  shared state. SQLite is single-writer and cannot coordinate multiple nodes. If
+  you set `HA_ENABLED=true` with a SQLite database, {{% product-name %}} exits at
+  startup with an error.
+- **A direct PostgreSQL connection.** A leader holds its advisory lock on a
+  single database session for as long as it leads. A connection pooler in
+  transaction-pooling mode, such as PgBouncer, breaks this because it does not
+  keep one session bound to the node. Connect directly to PostgreSQL, or use a
+  pooler in session-pooling mode.
+- **An identical `SESSION_SECRET` and `DATABASE_URL` on every node.** A shared
+  `SESSION_SECRET` keeps a user's session valid on whichever node the load
+  balancer routes them to, so sticky sessions are not required. A shared
+  `DATABASE_URL` points every node at the same database.
+- **At least two nodes** for redundancy. There is no upper limit, but each node
+  holds a PostgreSQL connection, so size the database's `max_connections`
+  accordingly.
+
+> [!Note]
+> #### Ports can differ between nodes
+>
+> `SESSION_SECRET` and `DATABASE_URL` must match on every node, but the API, web
+> interface, and heartbeat ports can differ. Set them per node with
+> [`--port`](/telegraf/controller/reference/config-options/#port),
+> [`--ui-port`](/telegraf/controller/reference/config-options/#ui-port), and
+> [`--heartbeat-port`](/telegraf/controller/reference/config-options/#heartbeat-port).
+
+## How configuration changes propagate
+
+Each node caches settings, API tokens, and license state in memory. When a
+change is written on any node, {{% product-name %}} records a new cache version
+in the shared database, and every node reloads the affected data on its next
+poll.
+
+The poll interval is set by
+[`HA_POLL_INTERVAL_MS`](/telegraf/controller/reference/config-options/#ha-poll-interval-ms)
+and defaults to `5000` (5 seconds). This interval is the upper bound on how long
+a settings, token, or license change takes to apply across the cluster. Lower it
+for faster convergence, or raise it to reduce database polling.
+
+## How licensing affects high availability
+
+Because the license lives in the shared database, every node evaluates the same
+license state. A node attempts to become leader only while the license is valid.
+The license state determines whether a node can lead and whether it serves web
+interface and API traffic:
+
+| License state                    | Elects a leader? | Leader serves UI/API | Standby serves UI/API |
+| :------------------------------- | :--------------: | :------------------: | :-------------------: |
+| Valid, expiring, or grace period |       Yes        |         Yes          |          Yes          |
+| Expired (past grace period)      |  No new leader   |         Yes          |    No (returns 503)   |
+| Unlicensed                       |        No        |   No leader elected  |    No (returns 503)   |
+
+Agent heartbeats are always accepted on every node, regardless of license state.
+
+Licensing is checked when a node tries to acquire the lock, not continuously. A
+node that is already the leader when its license expires keeps the lock, but no
+standby can be promoted until you apply a valid license again. After you restore
+a license, a leader is elected within one election interval (a few seconds). For
+the full license lifecycle, see
+[License enforcement](/telegraf/controller/telegraf-enterprise/license-enforcement/).
+
+## Audit logs in a cluster
+
+[Audit logging](/telegraf/controller/audit-logs/) is **per node**, not shared.
+Each node writes its own tamper-evident audit files, maintains its own hash
+chain, and forwards events to whatever destination that node is configured to
+use. Querying a node's [audit log API](/telegraf/controller/audit-logs/view/)
+returns only that node's events.
+
+To review activity across the whole cluster, forward each node's audit events to
+a shared destination, such as syslog or a webhook, and aggregate them there. See
+[Forward audit events](/telegraf/controller/audit-logs/enable-configure/#forward-audit-events).
+
+> [!Important]
+> #### Tamper detection is per node
+>
+> Each node maintains its own
+> [hash chain](/telegraf/controller/audit-logs/#tamper-detection) and sequence
+> numbers, so events from different nodes merged into one time-ordered stream do
+> not form a single valid chain. Verify integrity per node: separate aggregated
+> events by their originating node, then check each node's chain on its own.
+>
+> Keep forwarded events separable by node. File forwarding writes a separate file
+> per node, and syslog forwarding tags each event with the originating host.
+> Webhook payloads do not include a node identifier, so send each node's events
+> to a distinct webhook endpoint when you need to tell nodes apart.
+
+{{< children hlevel="h2" >}}

--- a/content/telegraf/controller/high-availability/_index.md
+++ b/content/telegraf/controller/high-availability/_index.md
@@ -86,9 +86,11 @@ following:
   runs only while the license is valid, expiring, or within its grace period.
   See [How licensing affects high availability](#how-licensing-affects-high-availability).
 - **PostgreSQL.** High availability depends on a PostgreSQL advisory lock and
-  shared state. SQLite is single-writer and cannot coordinate multiple nodes. If
-  you set `HA_ENABLED=true` with a SQLite database, {{% product-name %}} exits at
-  startup with an error.
+  shared state. You can use self-managed PostgreSQL or a PostgreSQL-compatible
+  database, such as a managed PostgreSQL service, as long as it supports
+  session-level advisory locks. SQLite is single-writer and cannot coordinate
+  multiple nodes; if you set `HA_ENABLED=true` with a SQLite database,
+  {{% product-name %}} exits at startup with an error.
 - **A direct PostgreSQL connection.** A leader holds its advisory lock on a
   single database session for as long as it leads. A connection pooler in
   transaction-pooling mode, such as PgBouncer, breaks this because it does not

--- a/content/telegraf/controller/high-availability/deploy.md
+++ b/content/telegraf/controller/high-availability/deploy.md
@@ -36,7 +36,8 @@ endpoints, and tuning PostgreSQL for quick failover.
 - A valid [Telegraf Enterprise license](/telegraf/enterprise/). You apply the
   license once; every node reads it from the shared database. See
   [Apply a license](/telegraf/controller/telegraf-enterprise/apply-license/).
-- A PostgreSQL database that every node can reach over the network. High
+- A PostgreSQL database that every node can reach over the network. You can use
+  self-managed PostgreSQL or a PostgreSQL-compatible managed service. High
   availability does not support SQLite. See
   [Requirements and constraints](/telegraf/controller/high-availability/#requirements-and-constraints).
 - Two or more hosts to run the {{% product-name %}} binary.

--- a/content/telegraf/controller/high-availability/deploy.md
+++ b/content/telegraf/controller/high-availability/deploy.md
@@ -1,0 +1,248 @@
+---
+title: Deploy a highly available Telegraf Controller cluster
+list_title: Deploy a cluster
+description: >
+  Deploy multiple Telegraf Controller nodes against a shared PostgreSQL
+  database, route traffic with a load balancer using the health endpoints, and
+  tune PostgreSQL for fast failover.
+menu:
+  telegraf_controller:
+    name: Deploy a cluster
+    parent: High availability
+weight: 101
+related:
+  - /telegraf/controller/reference/config-options/
+  - /telegraf/controller/telegraf-enterprise/apply-license/
+  - /telegraf/controller/reference/architecture/
+---
+
+Deploy multiple {{% product-name %}} nodes against a shared PostgreSQL database,
+put them behind a load balancer, and let one node lead while the others stand
+by. This guide covers configuring the nodes, routing traffic with the health
+endpoints, and tuning PostgreSQL for quick failover.
+
+{{< telegraf/enterprise-feature "High availability" >}}
+
+- [Prerequisites](#prerequisites)
+- [Provision shared PostgreSQL and secrets](#provision-shared-postgresql-and-secrets)
+- [Enable high availability on each node](#enable-high-availability-on-each-node)
+- [Apply the license](#apply-the-license)
+- [Put the cluster behind a load balancer](#put-the-cluster-behind-a-load-balancer)
+- [Tune PostgreSQL for fast failover](#tune-postgresql-for-fast-failover)
+- [Verify leadership and failover](#verify-leadership-and-failover)
+
+## Prerequisites
+
+- A valid [Telegraf Enterprise license](/telegraf/enterprise/). You apply the
+  license once; every node reads it from the shared database. See
+  [Apply a license](/telegraf/controller/telegraf-enterprise/apply-license/).
+- A PostgreSQL database that every node can reach over the network. High
+  availability does not support SQLite. See
+  [Requirements and constraints](/telegraf/controller/high-availability/#requirements-and-constraints).
+- Two or more hosts to run the {{% product-name %}} binary.
+- A load balancer that can route traffic based on an HTTP health check.
+
+## Provision shared PostgreSQL and secrets
+
+Every node connects to the same PostgreSQL database and signs sessions with the
+same secret.
+
+1. Provision a PostgreSQL database and note its connection string. Connect nodes
+   directly to PostgreSQL, or use a connection pooler in **session-pooling**
+   mode. Transaction-pooling mode breaks leader election.
+
+2. Generate a single `SESSION_SECRET` to share across all nodes. Reuse the same
+   value on every node so a session stays valid regardless of which node serves
+   the request.
+
+   ```bash
+   openssl rand -hex 32
+   ```
+
+> [!Important]
+> #### Keep DATABASE_URL and SESSION_SECRET identical on every node
+>
+> A mismatched `DATABASE_URL` points a node at the wrong database, and a
+> mismatched `SESSION_SECRET` invalidates sessions when the load balancer routes
+> a user to a different node. The API, web interface, and heartbeat ports can
+> differ between nodes.
+
+## Enable high availability on each node
+
+On every node, set `HA_ENABLED=true`, point `DATABASE_URL` at the shared
+PostgreSQL database, and set the shared `SESSION_SECRET`. Start the binary the
+same way you would a single node. You apply the license separately, once, in the
+next step.
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[systemd](#)
+[Shell](#)
+[Windows (PowerShell)](#)
+<!-- [Docker](#) -->
+{{% /tabs %}}
+{{% tab-content %}}
+
+Add the high-availability variables to each node's systemd unit file (typically
+`/etc/systemd/system/telegraf-controller.service`):
+
+```ini { placeholders="POSTGRES_USER|POSTGRES_PASSWORD|POSTGRES_HOST|SHARED_SECRET" }
+[Service]
+Environment=HA_ENABLED=true
+Environment=DATABASE_URL=postgresql://POSTGRES_USER:POSTGRES_PASSWORD@POSTGRES_HOST:5432/telegraf_controller
+Environment=SESSION_SECRET=SHARED_SECRET
+```
+
+Reload systemd and restart the service on each node:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart telegraf-controller
+```
+
+{{% /tab-content %}}
+{{% tab-content %}}
+
+Export the high-availability variables, then start the binary on each node:
+
+```bash { placeholders="POSTGRES_USER|POSTGRES_PASSWORD|POSTGRES_HOST|SHARED_SECRET" }
+export HA_ENABLED=true
+export DATABASE_URL="postgresql://POSTGRES_USER:POSTGRES_PASSWORD@POSTGRES_HOST:5432/telegraf_controller"
+export SESSION_SECRET="SHARED_SECRET"
+
+telegraf_controller --no-interactive
+```
+
+{{% /tab-content %}}
+{{% tab-content %}}
+
+Set the high-availability variables, then start the binary on each node:
+
+```powershell { placeholders="POSTGRES_USER|POSTGRES_PASSWORD|POSTGRES_HOST|SHARED_SECRET" }
+$env:HA_ENABLED="true"
+$env:DATABASE_URL="postgresql://POSTGRES_USER:POSTGRES_PASSWORD@POSTGRES_HOST:5432/telegraf_controller"
+$env:SESSION_SECRET="SHARED_SECRET"
+
+./telegraf_controller.exe --no-interactive
+```
+
+{{% /tab-content %}}
+<!-- {{% tab-content %}} -->
+<!-- BEGIN Docker example — hidden until an official
+     influxdata/telegraf-controller Docker image is published, which is on the
+     roadmap. Restore this tab (and its button above) when the image ships.
+
+Pass the high-availability variables to each container:
+
+```bash
+docker run \
+  -e HA_ENABLED=true \
+  -e DATABASE_URL=postgresql://user:password@postgres.example.com:5432/telegraf_controller \
+  -e SESSION_SECRET=SHARED_SECRET \
+  influxdata/telegraf-controller
+```
+
+END Docker example -->
+<!-- {{% /tab-content %}} -->
+{{< /tabs-wrapper >}}
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`POSTGRES_USER`{{% /code-placeholder-key %}} and
+  {{% code-placeholder-key %}}`POSTGRES_PASSWORD`{{% /code-placeholder-key %}}:
+  the credentials for the shared PostgreSQL database.
+- {{% code-placeholder-key %}}`POSTGRES_HOST`{{% /code-placeholder-key %}}: the
+  hostname or address of the shared PostgreSQL database, reachable from every
+  node.
+- {{% code-placeholder-key %}}`SHARED_SECRET`{{% /code-placeholder-key %}}: the
+  shared session secret generated with `openssl rand -hex 32`, identical on
+  every node.
+
+Optionally, set
+[`HA_POLL_INTERVAL_MS`](/telegraf/controller/reference/config-options/#ha-poll-interval-ms)
+to change how quickly settings, token, and license changes propagate between
+nodes. It defaults to `5000` (5 seconds).
+
+## Apply the license
+
+Apply your Telegraf Enterprise license to one of your {{% product-name %}}
+nodes. Use either method:
+
+- Set [`LICENSE_FILE_PATH`](/telegraf/controller/reference/config-options/#license-file-path)
+  on one node at first startup to seed the license into the shared database.
+- Apply the license through the user interface or API after the cluster is
+  running.
+
+Every node reads the license from the shared database and becomes licensed
+within one poll interval, without a restart. For details, see
+[Apply a license](/telegraf/controller/telegraf-enterprise/apply-license/).
+
+After a license is present, one node acquires the leader lock and the rest stand
+by. Confirm the cluster's state with the
+[health endpoints](/telegraf/controller/high-availability/load-balancing/#health-endpoints).
+
+## Put the cluster behind a load balancer
+
+Run the cluster behind a load balancer that health-checks each node and routes
+around any node that fails. Route each class of traffic using the node's
+unauthenticated health endpoints:
+
+- **Web interface and API** traffic: route to nodes that return `200` from
+  `GET /health/ready` on the API port (default `8888`). If you serve the web
+  interface on a separate
+  [`ui-port`](/telegraf/controller/reference/config-options/#ui-port), route that
+  port as its own pool, health-checked with `GET /`.
+- **Agent heartbeat** traffic: route to nodes that return `200` from
+  `GET /health` on the heartbeat port (default `8000`).
+
+Because sessions are validated with the shared `SESSION_SECRET`, sticky sessions
+are not required.
+
+For the full list of health endpoints and example configurations for HAProxy,
+NGINX, and cloud load balancers such as AWS Elastic Load Balancing, see
+[Configure a load balancer](/telegraf/controller/high-availability/load-balancing/).
+
+## Tune PostgreSQL for fast failover
+
+When a leader shuts down gracefully, it releases the advisory lock and a standby
+takes over almost immediately, typically within a second or two. When a leader
+fails abruptly (a crash, a killed process, or a lost host), PostgreSQL must first
+notice that the leader's connection is gone before another node can acquire the
+lock. With default operating-system keepalive settings, that can take much
+longer than a graceful handoff.
+
+To bound failover time, shorten PostgreSQL's TCP keepalive settings so the server
+detects dropped connections sooner:
+
+```sql
+ALTER SYSTEM SET tcp_keepalives_idle = 10;
+ALTER SYSTEM SET tcp_keepalives_interval = 5;
+ALTER SYSTEM SET tcp_keepalives_count = 3;
+SELECT pg_reload_conf();
+```
+
+With settings in this range, failover after an abrupt failure completes in well
+under a minute. Adjust the values to match your availability requirements and
+network conditions. Throughout either kind of failover, the surviving nodes keep
+ingesting agent heartbeats.
+
+## Verify leadership and failover
+
+1. Identify the current leader by querying each node's leader endpoint. Exactly
+   one node returns `200`:
+
+   ```bash
+   curl -s http://node-1.example.com:8888/health/leader
+   curl -s http://node-2.example.com:8888/health/leader
+   ```
+
+2. Confirm that each licensed node reports ready:
+
+   ```bash
+   curl -s http://node-1.example.com:8888/health/ready
+   ```
+
+3. Test failover by stopping the leader (for example, `sudo systemctl stop
+   telegraf-controller` on the leader host). Within a few seconds, another
+   node's `GET /health/leader` returns `200`, and the load balancer continues to
+   serve web interface, API, and heartbeat traffic from the surviving nodes.

--- a/content/telegraf/controller/high-availability/load-balancing.md
+++ b/content/telegraf/controller/high-availability/load-balancing.md
@@ -1,0 +1,292 @@
+---
+title: Configure a load balancer for high availability
+list_title: Configure a load balancer
+description: >
+  Put a Telegraf Controller high-availability cluster behind a load balancer.
+  Health-check each node with the unauthenticated health endpoints and route web
+  interface, API, and agent heartbeat traffic to healthy nodes.
+menu:
+  telegraf_controller:
+    name: Configure a load balancer
+    parent: High availability
+weight: 102
+related:
+  - /telegraf/controller/high-availability/deploy/
+  - /telegraf/controller/reference/config-options/
+---
+
+A [high-availability](/telegraf/controller/high-availability/) cluster runs
+behind a load balancer that health-checks each node and routes around any node
+that fails. {{% product-name %}} exposes unauthenticated health endpoints for
+this purpose. This page describes those endpoints and shows worked
+configurations for common load balancers.
+
+{{< telegraf/enterprise-feature "High availability" >}}
+
+- [Health endpoints](#health-endpoints)
+- [Route traffic to healthy nodes](#route-traffic-to-healthy-nodes)
+- [Example configurations](#example-configurations)
+
+## Health endpoints
+
+Each node exposes health endpoints designed as load-balancer probes. They are
+unauthenticated, so a load balancer can probe them without credentials. The
+`/health/*` endpoints listen on the API port
+([`--port`](/telegraf/controller/reference/config-options/#port), default
+`8888`). The Rust heartbeat server exposes a separate `/health` endpoint on the
+heartbeat port
+([`--heartbeat-port`](/telegraf/controller/reference/config-options/#heartbeat-port),
+default `8000`).
+
+| Endpoint             | Port           | Status codes | Body                     | Purpose                                                                                     |
+| :------------------- | :------------- | :----------- | :----------------------- | :------------------------------------------------------------------------------------------ |
+| `GET /health/live`   | API port       | `200`        | `{"status":"ok"}`        | Process liveness. Does not check the database. Use as a liveness probe.                      |
+| `GET /health/ready`  | API port       | `200`, `503` | `{"ready":true\|false}`  | Node can serve web interface and API traffic. Use as the readiness probe for UI/API nodes.  |
+| `GET /health/leader` | API port       | `200`, `503` | `{"leader":true\|false}` | Returns `200` only on the current leader. Use to locate the leader.                         |
+| `GET /health`        | Heartbeat port | `200`, `503` | Status text              | Routing hint for heartbeat traffic. Heartbeat ingestion is always accepted, even on `503`.  |
+
+When you serve the web interface on a separate port with
+[`ui-port`](/telegraf/controller/reference/config-options/#ui-port), the
+`/health/*` endpoints stay on the API port. The web interface port serves only
+static files and has no health endpoint; health-check it with an HTTP `GET /`,
+which returns the web interface with `200`.
+
+## Route traffic to healthy nodes
+
+By default, a {{% product-name %}} node serves the web interface and API together
+on the API port and accepts agent heartbeats on the heartbeat port. You can also
+serve the web interface on its own port with
+[`ui-port`](/telegraf/controller/reference/config-options/#ui-port). Route each
+class of traffic to nodes that pass the matching health check:
+
+| Traffic                          | Port                                                | Health check                      |
+| :------------------------------- | :-------------------------------------------------- | :-------------------------------- |
+| Web interface and API (combined) | API port (`--port`, default `8888`)                 | `GET /health/ready` returns `200` |
+| Web interface (separate port)    | UI port (`--ui-port`)                               | `GET /` returns `200`             |
+| API (with a separate UI port)    | API port (`--port`, default `8888`)                 | `GET /health/ready` returns `200` |
+| Agent heartbeat                  | Heartbeat port (`--heartbeat-port`, default `8000`) | `GET /health` returns `200`       |
+
+Every licensed node serves web interface and API traffic, so distribute requests
+across all healthy nodes. Sessions are validated with the shared `SESSION_SECRET`,
+so sticky sessions are not required. Every node ingests heartbeats even when the
+heartbeat `GET /health` returns `503`, so that check is a routing hint rather than
+a gate.
+
+> [!Note]
+> Use `GET /health/leader` for diagnostics and for tools that need to reach the
+> leader directly. Do not use it as the readiness probe for web interface and API
+> traffic, because standby nodes serve that traffic too.
+
+> [!Note]
+> #### Serving the web interface on a separate port
+>
+> When you serve the web interface on its own port, route it as a separate pool.
+> Because browsers reach the API through the load balancer's external address,
+> also set
+> [`public-api-url`](/telegraf/controller/reference/config-options/#public-api-url)
+> and [`public-ui-url`](/telegraf/controller/reference/config-options/#public-ui-url)
+> so the web interface calls the correct external API URL and the API's CORS
+> checks allow the web interface origin. See
+> [Public URLs and CORS](/telegraf/controller/reference/config-options/#public-urls-and-cors).
+
+## Example configurations
+
+The following examples serve the web interface and API together on the API port
+and route agent heartbeat traffic separately, for a three-node cluster. Replace
+the node addresses, ports, and health-check thresholds with values that match
+your deployment. If you serve the web interface on its own port, add a third pool
+for the UI port, health-checked with `GET /`.
+
+{{< tabs-wrapper >}}
+{{% tabs %}}
+[HAProxy](#)
+[NGINX](#)
+[AWS Elastic Load Balancing](#)
+[Other cloud load balancers](#)
+{{% /tabs %}}
+{{% tab-content %}}
+
+Open-source HAProxy performs active HTTP health checks and stops routing to a
+node that fails them. Configure one backend per traffic class:
+
+```haproxy { placeholders="NODE_1_IP|NODE_2_IP|NODE_3_IP" }
+frontend fe_web
+    bind *:8888
+    default_backend be_api
+
+frontend fe_heartbeat
+    bind *:8000
+    default_backend be_heartbeat
+
+backend be_api
+    balance roundrobin
+    option httpchk
+    http-check send meth GET uri /health/ready
+    http-check expect status 200
+    server node1 NODE_1_IP:8888 check inter 3s fall 3 rise 2
+    server node2 NODE_2_IP:8888 check inter 3s fall 3 rise 2
+    server node3 NODE_3_IP:8888 check inter 3s fall 3 rise 2
+
+backend be_heartbeat
+    balance roundrobin
+    option httpchk
+    http-check send meth GET uri /health
+    http-check expect status 200
+    server node1 NODE_1_IP:8000 check inter 3s fall 3 rise 2
+    server node2 NODE_2_IP:8000 check inter 3s fall 3 rise 2
+    server node3 NODE_3_IP:8000 check inter 3s fall 3 rise 2
+```
+
+Replace
+{{% code-placeholder-key %}}`NODE_1_IP`{{% /code-placeholder-key %}},
+{{% code-placeholder-key %}}`NODE_2_IP`{{% /code-placeholder-key %}}, and
+{{% code-placeholder-key %}}`NODE_3_IP`{{% /code-placeholder-key %}} with the
+addresses of your {{% product-name %}} nodes.
+
+{{% /tab-content %}}
+{{% tab-content %}}
+
+Open-source NGINX proxies traffic and passively removes a node after failed
+responses, but it does not actively probe the health endpoints. For active
+health checks against `/health/ready`, use NGINX Plus.
+
+Open-source NGINX (passive checks):
+
+```nginx { placeholders="NODE_1_IP|NODE_2_IP|NODE_3_IP" }
+upstream tc_api {
+    server NODE_1_IP:8888 max_fails=3 fail_timeout=10s;
+    server NODE_2_IP:8888 max_fails=3 fail_timeout=10s;
+    server NODE_3_IP:8888 max_fails=3 fail_timeout=10s;
+}
+
+upstream tc_heartbeat {
+    server NODE_1_IP:8000 max_fails=3 fail_timeout=10s;
+    server NODE_2_IP:8000 max_fails=3 fail_timeout=10s;
+    server NODE_3_IP:8000 max_fails=3 fail_timeout=10s;
+}
+
+server {
+    listen 8888;
+    location / {
+        proxy_pass http://tc_api;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}
+
+server {
+    listen 8000;
+    location / {
+        proxy_pass http://tc_heartbeat;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}
+```
+
+NGINX Plus (active checks):
+
+```nginx { placeholders="NODE_1_IP|NODE_2_IP|NODE_3_IP" }
+upstream tc_api {
+    zone tc_api 64k;
+    server NODE_1_IP:8888;
+    server NODE_2_IP:8888;
+    server NODE_3_IP:8888;
+}
+
+upstream tc_heartbeat {
+    zone tc_heartbeat 64k;
+    server NODE_1_IP:8000;
+    server NODE_2_IP:8000;
+    server NODE_3_IP:8000;
+}
+
+match tc_ready {
+    status 200;
+}
+
+match tc_health {
+    status 200;
+}
+
+server {
+    listen 8888;
+    location / {
+        proxy_pass http://tc_api;
+        health_check uri=/health/ready match=tc_ready interval=3s fails=3 passes=2;
+    }
+}
+
+server {
+    listen 8000;
+    location / {
+        proxy_pass http://tc_heartbeat;
+        health_check uri=/health match=tc_health interval=3s fails=3 passes=2;
+    }
+}
+```
+
+Replace
+{{% code-placeholder-key %}}`NODE_1_IP`{{% /code-placeholder-key %}},
+{{% code-placeholder-key %}}`NODE_2_IP`{{% /code-placeholder-key %}}, and
+{{% code-placeholder-key %}}`NODE_3_IP`{{% /code-placeholder-key %}} with the
+addresses of your {{% product-name %}} nodes.
+
+{{% /tab-content %}}
+{{% tab-content %}}
+
+On AWS, create a target group per traffic class and configure each target
+group's health check to probe the node's health endpoint. This applies to both
+Application Load Balancers (ALB) and Network Load Balancers (NLB).
+
+| Target group          | Targets (port)  | Health check protocol | Health check path | Success codes |
+| :-------------------- | :-------------- | :-------------------- | :---------------- | :------------ |
+| Web interface and API | Nodes on `8888` | HTTP                  | `/health/ready`   | `200`         |
+| Agent heartbeat       | Nodes on `8000` | HTTP                  | `/health`         | `200`         |
+
+Create a target group for each traffic class with the AWS CLI:
+
+```bash { placeholders="VPC_ID" }
+# Web interface and API target group
+aws elbv2 create-target-group \
+  --name telegraf-controller-api \
+  --protocol HTTP \
+  --port 8888 \
+  --vpc-id VPC_ID \
+  --health-check-protocol HTTP \
+  --health-check-path /health/ready \
+  --matcher HttpCode=200
+
+# Agent heartbeat target group
+aws elbv2 create-target-group \
+  --name telegraf-controller-heartbeat \
+  --protocol HTTP \
+  --port 8000 \
+  --vpc-id VPC_ID \
+  --health-check-protocol HTTP \
+  --health-check-path /health \
+  --matcher HttpCode=200
+```
+
+Replace {{% code-placeholder-key %}}`VPC_ID`{{% /code-placeholder-key %}} with
+the ID of the VPC that contains your nodes, then register each node with both
+target groups.
+
+{{% /tab-content %}}
+{{% tab-content %}}
+
+Other cloud load balancers follow the same pattern. Configure the backend
+service or health probe to send an HTTP `GET` to each node's health endpoint and
+treat only `200` as healthy:
+
+- **Web interface and API**: HTTP health check on the API port (`8888`) at path
+  `/health/ready`, expecting `200`.
+- **Agent heartbeat**: HTTP health check on the heartbeat port (`8000`) at path
+  `/health`, expecting `200`.
+
+For example, use a Google Cloud health check or an Azure Load Balancer health
+probe with these settings. Consult your provider's documentation for the exact
+field names.
+
+{{% /tab-content %}}
+{{< /tabs-wrapper >}}

--- a/content/telegraf/controller/reference/architecture.md
+++ b/content/telegraf/controller/reference/architecture.md
@@ -47,6 +47,19 @@ The dual-server architecture separates high-frequency heartbeat traffic from
 regular management operations, ensuring that the web interface remains
 responsive even under heavy agent load.
 
+### High availability
+
+The process model above describes a single node. With
+[Telegraf Enterprise](/telegraf/enterprise/), you can run multiple
+{{% product-name %}} nodes against a shared PostgreSQL database for continuous
+availability. The nodes coordinate through a PostgreSQL advisory lock: one node
+is elected **leader** and runs the background scheduler, while the others stand
+by and take over if the leader fails. Every node accepts agent heartbeats, so
+monitoring continues during a leadership change.
+
+For requirements, license behavior, and deployment steps, see
+[High availability](/telegraf/controller/high-availability/).
+
 ## Configuration
 
 {{% product-name %}} configuration is controlled through command options and

--- a/content/telegraf/controller/reference/config-options.md
+++ b/content/telegraf/controller/reference/config-options.md
@@ -135,6 +135,9 @@ telegraf_controller --no-interactive
 - [Logging](#logging)
   - [rust-log](#rust-log)
   - [logs-dir](#logs-dir)
+- [High availability](#high-availability)
+  - [ha-enabled](#ha-enabled)
+  - [ha-poll-interval-ms](#ha-poll-interval-ms)
 - [Audit logging](#audit-logging)
   - [audit-enabled](#audit-enabled)
   - [audit-log-retention](#audit-log-retention)
@@ -1077,6 +1080,49 @@ Absolute path for heartbeat agent logs.
 | Command flag | Environment variable |
 | :----------- | :------------------- |
 | `--logs-dir` | `LOGS_DIR`           |
+
+---
+
+### High availability
+
+High availability is a [Telegraf Enterprise](/telegraf/enterprise/) feature that
+lets you run multiple {{% product-name %}} nodes against a shared PostgreSQL
+database, with one node elected leader. These options are read at startup only.
+High availability requires PostgreSQL; setting `HA_ENABLED=true` with a SQLite
+[`database`](#database) stops startup with an error. For a full walkthrough, see
+[Deploy a highly available cluster](/telegraf/controller/high-availability/deploy/).
+
+- [ha-enabled](#ha-enabled)
+- [ha-poll-interval-ms](#ha-poll-interval-ms)
+
+#### ha-enabled
+
+Enable high-availability mode. When `true`, the node coordinates with other
+nodes through a PostgreSQL advisory lock so that one node leads and the others
+stand by. Requires a PostgreSQL [`database`](#database) and a Telegraf
+Enterprise license. When unset, the node runs standalone and marks itself leader
+at startup.
+
+**Default:** `false`
+
+| Command flag | Environment variable |
+| :----------- | :------------------- |
+| _(none)_     | `HA_ENABLED`         |
+
+---
+
+#### ha-poll-interval-ms
+
+Interval, in milliseconds, at which each node reloads shared settings, API
+tokens, and license state from the database. This value is the upper bound on
+how long a change made on one node takes to apply across the cluster. Applies
+only when [`ha-enabled`](#ha-enabled) is `true`.
+
+**Default:** `5000`
+
+| Command flag | Environment variable  |
+| :----------- | :-------------------- |
+| _(none)_     | `HA_POLL_INTERVAL_MS` |
 
 ---
 

--- a/content/telegraf/enterprise/_index.md
+++ b/content/telegraf/enterprise/_index.md
@@ -2,8 +2,8 @@
 title: Telegraf Enterprise
 description: >
   Telegraf Enterprise combines Telegraf and Telegraf Controller with higher
-  scale limits, enterprise authentication and audit logging, and an
-  enterprise support contract from InfluxData for organizations running
+  scale limits, high availability, enterprise authentication and audit logging,
+  and an enterprise support contract from InfluxData for organizations running
   Telegraf at scale.
 menu:
   telegraf_enterprise:
@@ -15,9 +15,9 @@ cascade:
 
 **Telegraf Enterprise** is the commercial package for organizations running
 [Telegraf](/telegraf/v1/) and [Telegraf Controller](/telegraf/controller/) at
-scale. It combines higher Telegraf Controller limits, enterprise authentication
-and audit logging, and an enterprise support contract from InfluxData covering
-both the Telegraf agent and Telegraf Controller.
+scale. It combines higher Telegraf Controller limits, high availability,
+enterprise authentication and audit logging, and an enterprise support contract
+from InfluxData covering both the Telegraf agent and Telegraf Controller.
 
 <a href="{{% cta-link %}}" class="btn magenta large">Purchase Telegraf Enterprise</a>
 
@@ -52,6 +52,8 @@ Telegraf Controller:
 
 - **Audit logging**: Tamper-evident log of administrative actions
   performed in Telegraf Controller.
+- **High availability**: Run multiple Telegraf Controller nodes against a
+  shared PostgreSQL database so management operations continue if a node fails.
 - **LDAP authentication**: Authenticate Telegraf Controller users
   against an LDAP directory.
 - **OIDC authentication**: Single sign-on through OpenID Connect
@@ -67,6 +69,7 @@ deployments when no license is applied.
 | Configurations | 20 | Defined per contract |
 | Reporting agents | 100 | Defined per contract |
 | Audit logging | --- | Included |
+| High availability | --- | Included |
 | LDAP authentication | --- | Included |
 | OIDC authentication | --- | Included |
 | Local authentication and API tokens | Included | Included |

--- a/layouts/shortcodes/telegraf/enterprise-upgrade.html
+++ b/layouts/shortcodes/telegraf/enterprise-upgrade.html
@@ -3,7 +3,7 @@
     <div class="telegraf-enterprise-text">
       <h4 id="telegraf-enterprise-feature">Telegraf Enterprise</h4>
       <p>
-        Unlock higher configuration and agent limits, enhanced security features, and official support for Telegraf and Telegraf Controller.
+        Unlock higher configuration and agent limits, high availability, enhanced security features, and official support for Telegraf and Telegraf Controller.
       </p>
     </div>
     <div class="telegraf-enterprise-cta">


### PR DESCRIPTION
Document the enterprise high-availability feature for a compiled Telegraf Controller binary: an overview of leader election and shared state, a deployment guide, and load-balancer configuration (HAProxy, NGINX, AWS). Add HA configuration options to the config reference, note the multi-node model in the architecture reference, and list high availability as a Telegraf Enterprise feature.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)