### PR TITLE
feat(influxdb_v3-telegraf): make Telegraf influxdb_v3 output plugin the default for Core and Enterprise

### DIFF
--- a/content/influxdb3/core/write-data/use-telegraf/configure.md
+++ b/content/influxdb3/core/write-data/use-telegraf/configure.md
@@ -2,7 +2,7 @@
 title: Configure Telegraf to write to {{< product-name >}}
 seotitle: Configure Telegraf to write data to {{< product-name >}}
 description: >
-  Update existing or create new Telegraf configurations to use the `influxdb_v2`
+  Update existing or create new Telegraf configurations to use the `influxdb_v3`
   output plugin to write to {{< product-name >}}.
   Start Telegraf using the custom configuration.
 menu:
@@ -13,6 +13,7 @@ weight: 101
 influxdb3/core/tags: [telegraf]
 related:
   - /telegraf/v1/plugins/, Telegraf plugins
+  - /telegraf/v1/output-plugins/influxdb_v3/, Telegraf InfluxDB v3 output plugin
 alt_links:
   cloud: /influxdb/cloud/write-data/no-code/use-telegraf/manual-config/
 source: /shared/influxdb3-write-guides/use-telegraf/configure.md

--- a/content/influxdb3/enterprise/write-data/use-telegraf/configure.md
+++ b/content/influxdb3/enterprise/write-data/use-telegraf/configure.md
@@ -2,7 +2,7 @@
 title: Configure Telegraf to write to {{< product-name >}}
 seotitle: Configure Telegraf to write data to {{< product-name >}}
 description: >
-  Update existing or create new Telegraf configurations to use the `influxdb_v2`
+  Update existing or create new Telegraf configurations to use the `influxdb_v3`
   output plugin to write to {{< product-name >}}.
   Start Telegraf using the custom configuration.
 menu:
@@ -13,6 +13,7 @@ weight: 101
 influxdb3/enterprise/tags: [telegraf]
 related:
   - /telegraf/v1/plugins/, Telegraf plugins
+  - /telegraf/v1/output-plugins/influxdb_v3/, Telegraf InfluxDB v3 output plugin
 alt_links:
   cloud: /influxdb/cloud/write-data/no-code/use-telegraf/manual-config/
 source: /shared/influxdb3-write-guides/use-telegraf/configure.md

--- a/content/shared/influxdb3-write-guides/_index.md
+++ b/content/shared/influxdb3-write-guides/_index.md
@@ -32,7 +32,8 @@ is the text-based format used to write data to InfluxDB.
 > When bringing existing *v2* write workloads, use the {{% product-name %}}
 > HTTP API [`/api/v2/write` endpoint](/influxdb3/version/api/write-data/).
 >
-> **For Telegraf**, use the InfluxDB v1.x [`outputs.influxdb`](/telegraf/v1/output-plugins/influxdb/) or v2.x [`outputs.influxdb_v2`](/telegraf/v1/output-plugins/influxdb_v2/) output plugins.
+> **For Telegraf**, use the [`outputs.influxdb_v3`](/telegraf/v1/output-plugins/influxdb_v3/) output plugin.
+> For existing v1 or v2 write workloads, use the v1.x [`outputs.influxdb`](/telegraf/v1/output-plugins/influxdb/) or v2.x [`outputs.influxdb_v2`](/telegraf/v1/output-plugins/influxdb_v2/) output plugins.
 > See how to [use Telegraf to write data](/influxdb3/version/write-data/use-telegraf/).
 
 ## Timestamp precision across write APIs

--- a/content/shared/influxdb3-write-guides/best-practices/optimize-writes.md
+++ b/content/shared/influxdb3-write-guides/best-practices/optimize-writes.md
@@ -111,8 +111,11 @@ Benchmarks have shown up to a 5x speed improvement when data is compressed.
 
 ### Enable gzip compression in Telegraf
 
-In the `influxdb_v2` output plugin configuration in your `telegraf.conf`, set the
-`content_encoding` option to `gzip`:
+The [`influxdb_v3` output plugin](/telegraf/v1/output-plugins/influxdb_v3/)
+compresses write request bodies with gzip by default.
+
+If you use the `influxdb_v2` output plugin, set the `content_encoding` option
+to `gzip` in your `telegraf.conf`:
 
 ```toml
 [[outputs.influxdb_v2]]
@@ -198,7 +201,7 @@ your own code and external applications.
 The following examples show how to [configure the Telegraf agent](/telegraf/v1/configuration)
 and [plugins](/telegraf/v1/plugins/) to optimize writes.
 The examples use the [File input plugin](/telegraf/v1/plugins/#input-file) to
-read data from a file and use the [InfluxDB v2 output plugin](/telegraf/v1/plugins/#input-influxdb)
+read data from a file and use the [InfluxDB v3 output plugin](/telegraf/v1/plugins/#output-influxdb_v3)
 to write data to a database, but you can use any input and output plugin.
 
 ### Prerequisites
@@ -225,11 +228,10 @@ remove data elements (before processor and aggregator plugins run).
         fieldpass = ["usage_system", "usage_idle"]
         # Remove the specified tags from points.
         tagexclude = ["host"]
-      [[outputs.influxdb_v2]]
+      [[outputs.influxdb_v3]]
         urls = ["{{< influxdb/host-url >}}"]
         token = "AUTH_TOKEN"
-        organization = ""
-        bucket = "DATABASE_NAME"
+        database = "DATABASE_NAME"
     EOF
     ```
 
@@ -329,12 +331,11 @@ curl -s "{{< influxdb/host-url >}}/api/v2/write?bucket=DATABASE_NAME&precision=s
         ## A data type and a list of fields to convert to the data type.
         float = ["temp", "hum"]
         integer = ["co"]
-    [[outputs.influxdb_v2]]
-      ## InfluxDB v2 API credentials and the database to write to.
+    [[outputs.influxdb_v3]]
+      ## InfluxDB credentials and the database to write to.
       urls = ["{{< influxdb/host-url >}}"]
       token = "AUTH_TOKEN"
-      organization = ""
-      bucket = "DATABASE_NAME"
+      database = "DATABASE_NAME"
     EOF
     ```
 
@@ -424,13 +425,12 @@ table, tag set, and timestamp), and then merges points in each series:
       grace = "$grace_duration"
       ## If true, drops the original metric.
       drop_original = true
-    # Writes metrics as line protocol to the InfluxDB v2 API
-    [[outputs.influxdb_v2]]
-      ## InfluxDB v2 API credentials and the database to write data to.
+    # Writes metrics as line protocol to InfluxDB
+    [[outputs.influxdb_v3]]
+      ## InfluxDB credentials and the database to write data to.
       urls = ["{{< influxdb/host-url >}}"]
       token = "AUTH_TOKEN"
-      organization = ""
-      bucket = "DATABASE_NAME"
+      database = "DATABASE_NAME"
     EOF
     ```
 
@@ -521,13 +521,12 @@ field values, and then write the data to InfluxDB:
     [[processors.dedup]]
       ## Drops duplicates within the specified duration
       dedup_interval = "$dedup_duration"
-    # Writes metrics as line protocol to the InfluxDB v2 API
-    [[outputs.influxdb_v2]]
-      ## InfluxDB v2 API credentials and the database to write data to.
+    # Writes metrics as line protocol to InfluxDB
+    [[outputs.influxdb_v3]]
+      ## InfluxDB credentials and the database to write data to.
       urls = ["{{< influxdb/host-url >}}"]
       token = "AUTH_TOKEN"
-      organization = ""
-      bucket = "DATABASE_NAME"
+      database = "DATABASE_NAME"
     EOF
     ```
 
@@ -753,13 +752,12 @@ The Go `multiplier.go` sample code does the following:
     [[processors.execd]]
       ## A list that contains the executable command and arguments to run as a daemon.
       command = ["go", "run", "multiplier.go"]
-    # Writes metrics as line protocol to the InfluxDB v2 API
-    [[outputs.influxdb_v2]]
-      ## InfluxDB v2 API credentials and the database to write data to.
+    # Writes metrics as line protocol to InfluxDB
+    [[outputs.influxdb_v3]]
+      ## InfluxDB credentials and the database to write data to.
       urls = ["{{< influxdb/host-url >}}"]
       token = "AUTH_TOKEN"
-      organization = ""
-      bucket = "DATABASE_NAME"
+      database = "DATABASE_NAME"
     EOF
     ```
 

--- a/content/shared/influxdb3-write-guides/http-api/_index.md
+++ b/content/shared/influxdb3-write-guides/http-api/_index.md
@@ -15,7 +15,8 @@ Different APIs are available depending on your integration method.
 > When bringing existing _v2_ write workloads, use the {{% product-name %}}
 > HTTP API [`/api/v2/write` endpoint](/influxdb3/version/api/write-data/).
 >
-> **For Telegraf**, use the InfluxDB v1.x [`outputs.influxdb`](/telegraf/v1/output-plugins/influxdb/) or v2.x [`outputs.influxdb_v2`](/telegraf/v1/output-plugins/influxdb_v2/) output plugins.
+> **For Telegraf**, use the [`outputs.influxdb_v3`](/telegraf/v1/output-plugins/influxdb_v3/) output plugin.
+> For existing v1 or v2 write workloads, use the v1.x [`outputs.influxdb`](/telegraf/v1/output-plugins/influxdb/) or v2.x [`outputs.influxdb_v2`](/telegraf/v1/output-plugins/influxdb_v2/) output plugins.
 > See how to [use Telegraf to write data](/influxdb3/version/write-data/use-telegraf/).
 {{% /show-in %}}
 

--- a/content/shared/influxdb3-write-guides/http-api/compatibility-apis.md
+++ b/content/shared/influxdb3-write-guides/http-api/compatibility-apis.md
@@ -19,6 +19,7 @@ to write points as line protocol data to {{% product-name %}}.
 > [v2-compatible `/api/v2/write` endpoint](#influxdb-v2-compatibility).
 >
 > **For Telegraf**, use the InfluxDB v1.x [`outputs.influxdb`](/telegraf/v1/output-plugins/influxdb/) or v2.x [`outputs.influxdb_v2`](/telegraf/v1/output-plugins/influxdb_v2/) output plugins.
+> {{% show-in "core,enterprise" %}}For new write workloads, use the [`outputs.influxdb_v3`](/telegraf/v1/output-plugins/influxdb_v3/) output plugin, which writes to the native [`/api/v3/write_lp` endpoint](/influxdb3/version/write-data/http-api/v3-write-lp/).{{% /show-in %}}
 > See how to [use Telegraf to write data](/influxdb3/version/write-data/use-telegraf/).
 
 > [!Note]

--- a/content/shared/influxdb3-write-guides/use-telegraf/_index.md
+++ b/content/shared/influxdb3-write-guides/use-telegraf/_index.md
@@ -8,7 +8,12 @@ For a list of available plugins, see [Telegraf plugins](/telegraf/v1/plugins/).
 
 #### Requirements
 
-- **Telegraf 1.9.2 or greater**.
+- **Telegraf 1.38 or greater** to use the `influxdb_v3` output plugin.
+  Earlier versions of Telegraf (1.9.2 or greater) can use the
+  [`influxdb_v2`](/telegraf/v1/output-plugins/influxdb_v2/) or
+  [`influxdb`](/telegraf/v1/output-plugins/influxdb/) (v1) output plugins to
+  write to {{% product-name %}}
+  [compatibility APIs](/influxdb3/version/write-data/http-api/compatibility-apis/).
   _For information about installing Telegraf, see the
   [Telegraf Installation instructions](/telegraf/v1/install/)._
 
@@ -21,29 +26,28 @@ Each Telegraf configuration must **have at least one input plugin and one output
 Telegraf input plugins retrieve metrics from different sources.
 Telegraf output plugins write those metrics to a destination.
 
-Use the [`outputs.influxdb_v2`](/telegraf/v1/plugins/#output-influxdb_v2) plugin
-to connect to the InfluxDB v2 write API included in {{% product-name %}} and
-write metrics collected by Telegraf to {{< product-name >}}.
+Use the [`outputs.influxdb_v3`](/telegraf/v1/plugins/#output-influxdb_v3) plugin
+to connect to the {{% product-name %}} native write API and write metrics
+collected by Telegraf to {{< product-name >}}.
 
 ```toml { placeholders="AUTH_TOKEN|DATABASE_NAME" }
 # ...
 
-[[outputs.influxdb_v2]]
+[[outputs.influxdb_v3]]
   urls = ["{{< influxdb/host-url >}}"]
   token = "AUTH_TOKEN"
-  organization = ""
-  bucket = "DATABASE_NAME"
+  database = "DATABASE_NAME"
 
 # ...
 ```
 
 Replace the following:
 
-- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
-  the name of the database to write data to
 - {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}}:
   your {{< product-name >}} {{% token-link %}}.
   _Store this in a secret store or environment variable to avoid exposing the raw token string._
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
+  the name of the database to write data to
 
 _See how to [Configure Telegraf to write to {{% product-name %}}](/influxdb3/version/write-data/use-telegraf/configure/)._
 

--- a/content/shared/influxdb3-write-guides/use-telegraf/configure.md
+++ b/content/shared/influxdb3-write-guides/use-telegraf/configure.md
@@ -1,10 +1,18 @@
 
-Use the Telegraf [`influxdb_v2` output plugin](/telegraf/v1/output-plugins/influxdb_v2/)
+Use the Telegraf [`influxdb_v3` output plugin](/telegraf/v1/output-plugins/influxdb_v3/)
 to collect and write metrics to {{< product-name >}}.
-This plugin uses the InfluxDB v2 HTTP API write endpoint available with 
-{{% product-name %}}.
-Learn how to enable and configure the `influxdb_v2` output plugin to write data
+This plugin uses the {{% product-name %}} native HTTP API
+[`/api/v3/write_lp` endpoint](/influxdb3/version/write-data/http-api/v3-write-lp/)
+and requires **Telegraf 1.38 or greater**.
+Learn how to enable and configure the `influxdb_v3` output plugin to write data
 to {{% product-name %}}.
+
+If you use an earlier version of Telegraf or bring an existing Telegraf
+configuration from InfluxDB v1 or v2, you can use the
+[`influxdb_v2`](#use-the-influxdb-v2-output-plugin) or
+[`influxdb`](#use-the-influxdb-v1-output-plugin) (v1) output plugins to write
+to {{% product-name %}}
+[compatibility APIs](/influxdb3/version/write-data/http-api/compatibility-apis/).
 
 > [!Note]
 > _View the [requirements](/influxdb3/version/write-data/use-telegraf#requirements)
@@ -14,11 +22,13 @@ to {{% product-name %}}.
 
 - [Configure Telegraf input and output plugins](#configure-telegraf-input-and-output-plugins)
   - [Add Telegraf plugins](#add-telegraf-plugins)
-  - [Enable and configure the InfluxDB v2 output plugin](#enable-and-configure-the-influxdb-v2-output-plugin)
+  - [Enable and configure the InfluxDB v3 output plugin](#enable-and-configure-the-influxdb-v3-output-plugin)
     - [urls](#urls)
     - [token](#token)
-    - [organization](#organization)
-    - [bucket](#bucket)
+    - [database](#database)
+    - [Additional plugin options](#additional-plugin-options)
+  - [Use the InfluxDB v2 output plugin](#use-the-influxdb-v2-output-plugin)
+  - [Use the InfluxDB v1 output plugin](#use-the-influxdb-v1-output-plugin)
   - [Other Telegraf configuration options](#other-telegraf-configuration-options)
 - [Start Telegraf](#start-telegraf)
 
@@ -44,18 +54,17 @@ the steps below.
 3.  Copy and paste the example configuration into your Telegraf configuration file
     (typically named `telegraf.conf`).
 
-### Enable and configure the InfluxDB v2 output plugin
+### Enable and configure the InfluxDB v3 output plugin
 
 To send data to {{< product-name >}}, enable the
-[`influxdb_v2` output plugin](/telegraf/v1/output-plugins/influxdb_v2/)
+[`influxdb_v3` output plugin](/telegraf/v1/output-plugins/influxdb_v3/)
 in the `telegraf.conf`.
 
 ```toml { placeholders="AUTH_TOKEN|DATABASE_NAME" }
-[[outputs.influxdb_v2]]
+[[outputs.influxdb_v3]]
   urls = ["{{< influxdb/host-url >}}"]
   token = "AUTH_TOKEN"
-  organization = ""
-  bucket = "DATABASE_NAME"
+  database = "DATABASE_NAME"
 ```
 
 Replace the following:
@@ -66,7 +75,7 @@ Replace the following:
   your {{< product-name >}} {{% token-link %}}.
   _Store this in a secret store or environment variable to avoid exposing the raw token string._
 
-The InfluxDB output plugin configuration contains the following options:
+The InfluxDB v3 output plugin configuration contains the following options:
 
 #### urls
 
@@ -76,6 +85,9 @@ To write to {{% product-name %}}, include your {{% product-name %}} URL:
 ```toml
 ["{{< influxdb/host-url >}}"]
 ```
+
+If you specify multiple URLs, Telegraf randomly selects one of them for each
+write interval and fails over to another if the write doesn't succeed.
 
 #### token
 
@@ -91,28 +103,102 @@ Your {{% product-name %}} authorization token.
 > interpolation. For example:
 > 
 > ```toml
-> [[outputs.influxdb_v2]]
+> [[outputs.influxdb_v3]]
 >   urls = ["{{< influxdb/host-url >}}"]
 >   token = "${INFLUX_TOKEN}"
 >   # ...
 > ```
 
-#### organization
-
-For {{% product-name %}}, set this to an empty string (`""`).
-
-#### bucket
+#### database
 
 The name of the {{% product-name %}} database to write data to.
+
+#### Additional plugin options
+
+The plugin provides additional options for controlling write behavior,
+including:
+
+- **`database_tag`**: the metric tag to use to determine the destination
+  database, overriding `database`.
+- **`sync`**: set to `false` to acknowledge writes before WAL persistence
+  completes, which reduces write latency but increases the risk of data loss.
+  Default is `true`.
+  _See [Use no_sync for immediate write responses](/influxdb3/version/write-data/http-api/v3-write-lp/#use-no_sync-for-immediate-write-responses)._
+- **`content_encoding`**: the plugin compresses write request bodies with gzip
+  by default.
+
+For all plugin options, see the
+[`influxdb_v3` output plugin](/telegraf/v1/output-plugins/influxdb_v3/) reference.
+
+### Use the InfluxDB v2 output plugin
+
+If you bring an existing InfluxDB v2 write workload or use a Telegraf version
+earlier than 1.38, use the
+[`influxdb_v2` output plugin](/telegraf/v1/output-plugins/influxdb_v2/)
+to write to {{< product-name >}} through the InfluxDB
+[v2 compatibility API](/influxdb3/version/write-data/http-api/compatibility-apis/#influxdb-v2-compatibility).
+
+```toml { placeholders="AUTH_TOKEN|DATABASE_NAME" }
+[[outputs.influxdb_v2]]
+  urls = ["{{< influxdb/host-url >}}"]
+  token = "AUTH_TOKEN"
+  organization = ""
+  bucket = "DATABASE_NAME"
+```
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
+  the name of the database to write data to
+- {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}}:
+  your {{< product-name >}} {{% token-link %}}
+
+For {{% product-name %}}, set the following v2-specific options:
+
+- **`organization`**: set to an empty string (`""`).
+- **`bucket`**: the name of the database to write data to.
 
 > [!Note]
 > An InfluxDB v2 _**bucket**_ is synonymous with an {{% product-name %}} _**database**_.
 
+### Use the InfluxDB v1 output plugin
+
+If you bring an existing InfluxDB v1 write workload, use the
+[`influxdb` output plugin](/telegraf/v1/output-plugins/influxdb/)
+to write to {{< product-name >}} through the InfluxDB
+[v1 compatibility API](/influxdb3/version/write-data/http-api/compatibility-apis/#influxdb-v1-compatibility).
+
+```toml { placeholders="AUTH_TOKEN|DATABASE_NAME" }
+[[outputs.influxdb]]
+  urls = ["{{< influxdb/host-url >}}"]
+  database = "DATABASE_NAME"
+  skip_database_creation = true
+  username = "ignored"
+  password = "AUTH_TOKEN"
+```
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`DATABASE_NAME`{{% /code-placeholder-key %}}:
+  the name of the database to write data to
+- {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}}:
+  your {{< product-name >}} {{% token-link %}}
+
+For {{% product-name %}}, set the following v1-specific options:
+
+- **`skip_database_creation`**: set to `true`.
+  {{% product-name %}} doesn't support creating databases through the v1 API.
+- **`password`**: your authorization token.
+  The v1 compatibility API authenticates with the token passed as the password
+  credential and ignores `username`.
+
 ### Other Telegraf configuration options
 
 For more plugin configuration options, see the
-[`influxdb_v2` output plugin README](/telegraf/v1/output-plugins/influxdb_v2/)
-on GitHub.
+[`influxdb_v3`](/telegraf/v1/output-plugins/influxdb_v3/),
+[`influxdb_v2`](/telegraf/v1/output-plugins/influxdb_v2/), and
+[`influxdb` (v1)](/telegraf/v1/output-plugins/influxdb/) output plugin
+references.
 
 ## Start Telegraf
 

--- a/content/shared/influxdb3-write-guides/use-telegraf/csv.md
+++ b/content/shared/influxdb3-write-guides/use-telegraf/csv.md
@@ -53,7 +53,7 @@ metrics from different sources and writes them to specified destinations.
 ## Configure Telegraf to write to InfluxDB
 
 To send data to {{< product-name >}}, enable and configure the
-[`influxdb_v2` output plugin](/influxdb3/version/write-data/use-telegraf/configure/#enable-and-configure-the-influxdb-v2-output-plugin)
+[`influxdb_v3` output plugin](/influxdb3/version/write-data/use-telegraf/configure/#enable-and-configure-the-influxdb-v3-output-plugin)
 in your `telegraf.conf`.
 
 ```toml { placeholders="AUTH_TOKEN|DATABASE_NAME" }
@@ -80,12 +80,10 @@ in your `telegraf.conf`.
   csv_skip_errors = false
   csv_reset_mode = "none"
 
-[[outputs.influxdb_v2]]
+[[outputs.influxdb_v3]]
   urls = ["{{< influxdb/host-url >}}"]
   token = "AUTH_TOKEN"
-  organization = ""
-  bucket = "DATABASE_NAME"
-  content_encoding = "gzip"
+  database = "DATABASE_NAME"
 ```
 
 Replace the following:
@@ -106,7 +104,7 @@ Replace the following:
   > interpolation. For example:
   > 
   > ```toml
-  > [[outputs.influxdb_v2]]
+  > [[outputs.influxdb_v3]]
   >   urls = ["{{< influxdb/host-url >}}"]
   >   token = "${INFLUX_TOKEN}"
   >   # ...
@@ -119,7 +117,6 @@ CSV data to {{% product-name %}}.
 #### Other Telegraf configuration options
 
 The preceding examples describe Telegraf configurations necessary for writing to
-{{% product-name %}}. The `influxdb_v2` output plugin provides several other
+{{% product-name %}}. The `influxdb_v3` output plugin provides several other
 configuration options. For more information, see the
-[`influxdb_v2` plugin options](/telegraf/v1/output-plugins/influxdb_v2/)
-on GitHub.
+[`influxdb_v3` plugin options](/telegraf/v1/output-plugins/influxdb_v3/).

--- a/content/shared/influxdb3-write-guides/use-telegraf/dual-write.md
+++ b/content/shared/influxdb3-write-guides/use-telegraf/dual-write.md
@@ -7,10 +7,11 @@ to a separate instance or for migrating from other versions of InfluxDB to
 The following example configures Telegraf for dual writing to {{% product-name %}} and an InfluxDB v2 OSS instance.
 Specifically, it uses the following:
 
-  - The [InfluxDB v2 output plugin](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/influxdb_v2)
-    twice--the first pointing to {{< product-name >}} and the other to an
-    InfluxDB v2 OSS instance.
-  - Two different tokens--one for InfluxDB v2 OSS and one for {{< product-name >}}.
+  - The [InfluxDB v3 output plugin](/telegraf/v1/output-plugins/influxdb_v3/)
+    pointing to {{< product-name >}} and the
+    [InfluxDB v2 output plugin](/telegraf/v1/output-plugins/influxdb_v2/)
+    pointing to an InfluxDB v2 OSS instance.
+  - Two different tokens: one for InfluxDB v2 OSS and one for {{< product-name >}}.
     Configure both tokens as environment variables and use string interpolation
     in your Telegraf configuration file to reference each environment variable.
 
@@ -21,15 +22,13 @@ Specifically, it uses the following:
 # include in your configuration.
 
 # Send data to {{% product-name %}}
-[[outputs.influxdb_v2]]
+[[outputs.influxdb_v3]]
   ## The {{% product-name %}} URL
   urls = ["{{< influxdb/host-url >}}"]
   ## {{% product-name %}} authorization token
   token = "${INFLUX_TOKEN}"
-  ## For {{% product-name %}}, set organization to an empty string
-  organization = ""
   ## Destination database to write into
-  bucket = "DATABASE_NAME"
+  database = "DATABASE_NAME"
 
 # Send data to InfluxDB v2 OSS
 [[outputs.influxdb_v2]]
@@ -44,8 +43,9 @@ Specifically, it uses the following:
 ```
 
 Telegraf lets you dual write data to any version of InfluxDB using the
-[`influxdb` (InfluxDB v1)](/telegraf/v1/output-plugins/influxdb/
-and [`influxdb_v2` output plugins](/telegraf/v1/output-plugins/influxdb_v2/).
+[`influxdb` (v1)](/telegraf/v1/output-plugins/influxdb/),
+[`influxdb_v2`](/telegraf/v1/output-plugins/influxdb_v2/), and
+[`influxdb_v3`](/telegraf/v1/output-plugins/influxdb_v3/) output plugins.
 A single Telegraf agent sends identical data sets to all target outputs.
 You cannot filter data based on the output.
 


### PR DESCRIPTION
Restructure the Core and Enterprise Telegraf write guides around the `influxdb_v3` output plugin (Telegraf 1.38+), which writes to the native `/api/v3/write_lp` endpoint using urls, token, and database options. Keep `influxdb_v2` and `influxdb` (v1) output plugin instructions as compatibility sections, and update endpoint-guidance tips and optimize-writes examples to match.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
