### PR TITLE
fix(analytics): track preset URL selection on click and change

### DIFF
--- a/assets/js/influxdb-url.js
+++ b/assets/js/influxdb-url.js
@@ -492,16 +492,34 @@ export function InfluxDBUrl() {
     updateUrls(getPrevUrls(), getUrls());
   });
 
-  // Track selecting a built-in (preset) URL for analytics. Bound to `click`
-  // rather than `change`: setRadioButtons() checks the stored (or default)
-  // preset on page load, so `change` never fires when the user selects the
-  // preset that is already checked. Products that offer a single preset
-  // (Core, Enterprise, OSS) are always in that state, which would leave preset
-  // usage unrecorded. Excludes the custom radio, which is tracked separately
-  // when the custom value is applied.
+  // Track selecting a built-in (preset) URL for analytics. Selecting a preset
+  // reliably delivers only one of `click` or `change`, and which one depends
+  // on how the selection was made:
+  //
+  // - `change` alone is unreliable. setRadioButtons() checks the stored (or
+  //   default) preset on page load, so selecting the preset that is already
+  //   checked never changes the state. Products with a single preset (Core,
+  //   Enterprise, OSS) are always in that state.
+  // - `click` alone is unreliable. Clicking a region heading forwards a click
+  //   to its first cluster with jQuery .trigger(), which suppresses jQuery's
+  //   own click handlers for the activation it performs, so only `change`
+  //   reaches this handler.
+  //
+  // Bind both and drop the duplicate when one selection fires both. Excludes
+  // the custom radio, which is tracked when the custom value is applied.
+  let presetSelectionReported = false;
   $('input[type="radio"][name^="influxdb-"][name$="-url"]')
     .not('#custom')
-    .on('click', function () {
+    .on('click change', function () {
+      if (presetSelectionReported) {
+        return;
+      }
+      // A single selection fires its events within one task, so clearing the
+      // flag asynchronously keeps later selections reportable.
+      presetSelectionReported = true;
+      setTimeout(function () {
+        presetSelectionReported = false;
+      }, 0);
       trackPresetUrlSelection(PRODUCT_CONTEXT, $(this).val());
     });
 

--- a/cypress/e2e/influxdb-url.cy.js
+++ b/cypress/e2e/influxdb-url.cy.js
@@ -167,10 +167,22 @@ describe('InfluxDB URL - selector analytics', function () {
     });
   });
 
-  it('reports one url_selector_preset when the selection changes', function () {
-    // Cloud renders several presets, so selecting a different one changes the
-    // checked state and fires both `click` and `change`. Verify that reports a
-    // single event — the click binding must not be counted twice.
+  function expectOnePresetEvent(product) {
+    cy.get('@gtag').should(
+      'have.been.calledWith',
+      'event',
+      'url_selector_preset',
+      Cypress.sinon.match({ product })
+    );
+    cy.get('@gtag').then((stub) => {
+      const calls = stub
+        .getCalls()
+        .filter((c) => c.args[1] === 'url_selector_preset');
+      expect(calls.length).to.equal(1);
+    });
+  }
+
+  function visitCloudPage() {
     cy.visit(CLOUD_TEST_PAGE, {
       onBeforeLoad(win) {
         // Suppress the v3 wayfinding modal, which otherwise covers the page
@@ -181,6 +193,13 @@ describe('InfluxDB URL - selector analytics', function () {
         );
       },
     });
+  }
+
+  it('reports one url_selector_preset when the selection changes', function () {
+    // Cloud renders several presets, so selecting a different one changes the
+    // checked state and fires both `click` and `change`. Verify that reports a
+    // single event and is not counted twice.
+    visitCloudPage();
     stubGtag();
     openCustomUrlModal();
 
@@ -190,18 +209,27 @@ describe('InfluxDB URL - selector analytics', function () {
       .first()
       .click({ force: true });
 
-    cy.get('@gtag').should(
-      'have.been.calledWith',
-      'event',
-      'url_selector_preset',
-      Cypress.sinon.match({ product: 'cloud' })
-    );
-    cy.get('@gtag').then((stub) => {
-      const calls = stub
-        .getCalls()
-        .filter((c) => c.args[1] === 'url_selector_preset');
-      expect(calls.length).to.equal(1);
-    });
+    expectOnePresetEvent('cloud');
+  });
+
+  it('reports url_selector_preset when a region heading is selected', function () {
+    // Clicking a region heading forwards the click to its first cluster with
+    // jQuery .trigger(), which suppresses jQuery's own click handlers. Only
+    // `change` reaches the tracker on this path, so a click-only binding
+    // records nothing.
+    visitCloudPage();
+    stubGtag();
+    openCustomUrlModal();
+
+    // The cascade only runs when the region is not already selected.
+    cy.get('#cloud-urls .fake-radio')
+      .first()
+      .should('not.have.class', 'checked');
+
+    cy.get('#cloud-urls p.region').first().click({ force: true });
+
+    cy.get('#cloud-urls .fake-radio').first().should('have.class', 'checked');
+    expectOnePresetEvent('cloud');
   });
 
   it('does not fire url_selector_preset when a custom URL is applied', function () {


### PR DESCRIPTION
Follow-up to #7578, which merged before this correction landed.

## What changed

Bind `url_selector_preset` to both `click` and `change`, and drop the duplicate when one selection fires both (`assets/js/influxdb-url.js`).

Add a Cypress case that selects a Cloud region heading.

## Why

#7578 moved the event from `change` to `click`. That fixed the reported case but broke a different one: the region heading.

The region handler forwards the click to the region's first cluster with jQuery `.trigger('click')`. jQuery suppresses its own click handlers for the native activation it performs, so only `change` reaches the tracker on that path.

Each path delivers exactly one of the two events:

| Selection | `click` | `change` |
| --- | --- | --- |
| Preset already checked (Core, Enterprise, OSS) | fires | — |
| Cloud region heading | suppressed | fires |
| A different preset, selected directly | fires | fires |

Binding both covers all three. The duplicate guard keeps the third case at one event.

## Impact

Cloud region selections are recorded again. Core, Enterprise, and OSS keep the behavior from #7578.

No user-visible change. The event payload is unchanged: `product`, `host_type`, `selected_url`, `page_path`.

## Verification

Measured the region cascade five times per binding on `/influxdb/cloud/get-started/`, confirming the selection changed each time:

| Binding | Region cascade fires `url_selector_preset` |
| --- | --- |
| `change` (before #7578) | 5/5 |
| `click` (after #7578) | 0/5 |
| `click change` (this PR) | 5/5 |

```
node cypress/support/run-e2e-specs.js --spec "cypress/e2e/influxdb-url.cy.js" --no-mapping
```

12 tests, 12 passing.

The two Cypress cases pin both directions. The region case fails with a click-only binding, and the Core case fails with a change-only binding. Both were confirmed by temporarily reverting each binding.

## Checklist

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
- [x] Rebased/mergeable
- [x] Local build passes (Hugo built and served the test pages during the e2e runs)
