### PR TITLE
test(topnav): stop depending on the notification count

### DIFF
--- a/cypress/e2e/topnav.cy.js
+++ b/cypress/e2e/topnav.cy.js
@@ -2,26 +2,49 @@ describe('global top navigation', function () {
   beforeEach(function () {
     // Visit the Docs home page
     cy.visit('/');
-    cy.get('.notification').filter(':visible').find('.close-notification').click({ force: true });
-});
+    // Dismiss any notification banners covering the nav. The count depends on
+    // which entries in data/notifications.yaml target this page, so handle
+    // none, one, or several without asserting a count.
+    cy.get('body').then(($body) => {
+      const $close = $body.find('.notification:visible .close-notification');
+      if ($close.length) {
+        cy.wrap($close).click({ force: true, multiple: true });
+      }
+    });
+  });
 
   describe('theme switcher', function () {
     it('switches light to dark', function () {
-        // Default is light theme
-        cy.get('body.home').should('have.css', 'background-color', 'rgb(243, 244, 251)');
-        cy.get('#theme-switch-dark').click();
-        cy.get('body.home').should('have.css', 'background-color', 'rgb(7, 7, 14)');
-        cy.get('#theme-switch-light').click();
-        cy.get('body.home').should('have.css', 'background-color', 'rgb(243, 244, 251)');
+      // Default is light theme. The switcher renders both buttons and shows
+      // only the one for the theme you can switch to, so target it by class.
+      cy.get('body.home').should(
+        'have.css',
+        'background-color',
+        'rgb(243, 244, 251)'
+      );
+      cy.get('.theme-switch-dark').click();
+      cy.get('body.home').should(
+        'have.css',
+        'background-color',
+        'rgb(7, 7, 14)'
+      );
+      cy.get('.theme-switch-light').click();
+      cy.get('body.home').should(
+        'have.css',
+        'background-color',
+        'rgb(243, 244, 251)'
+      );
     });
   });
 
   describe('product dropdown', function () {
     it('has links to all products', function () {
-        cy.get('#product-dropdown .selected').contains('Select product').click({ force: true });
+      cy.get('#product-dropdown .selected')
+        .contains('Select product')
+        .click({ force: true });
       cy.task('getData', 'products').then((productData) => {
         Object.values(productData).forEach((p) => {
-        cy.get('#dropdown-items a').should('be.visible');
+          cy.get('#dropdown-items a').should('be.visible');
           let name = p.altname?.length > p.name.length ? p.altname : p.name;
           name = name.replace(/\((.*)\)/, '$1');
           cy.get('#dropdown-items a')
@@ -32,7 +55,9 @@ describe('global top navigation', function () {
           cy.url().should('include', urlFrag);
           // Test that the selected option is for the current product.
           // Reopen the dropdown.
-        cy.get('#product-dropdown .selected').contains(name).click({ force: true });
+          cy.get('#product-dropdown .selected')
+            .contains(name)
+            .click({ force: true });
         });
       });
     });


### PR DESCRIPTION
Closes #7576

## What changed

`cypress/e2e/topnav.cy.js`:

- Dismiss whatever notification banners are present instead of assuming exactly one.
- Target the theme switcher by class (`.theme-switch-dark`) instead of by ID (`#theme-switch-dark`).

## Why

The `beforeEach` hook dismissed the banner with a single `cy.click()`, which rejects a multi-element subject. The home page renders three notifications, so the hook threw and every test in the suite was skipped.

The fix suggested in #7576 adds `multiple: true`. That covers more than one banner but still throws when none are visible, and entries in `data/notifications.yaml` are page-scoped, so zero is reachable. Guarding on presence handles none, one, or several.

Fixing the hook let the theme test run for the first time in a while, and it failed. The switcher moved from `#theme-switch-dark` to a `.theme-switch-dark` button, so the selector no longer matched anything.

## Impact

Test-only. No site or content changes.

The suite goes from 1 failing and 1 skipped to 1 passing and 1 failing. The remaining failure is the product dropdown test, which is broken for unrelated reasons and tracked separately.

Worth noting: this spec does not run in CI. `pr-render-check.yml` runs only `render-regression.cy.js` and `canonical.cy.js`, which is why the rot went unnoticed.

## Verification

```
node cypress/support/run-e2e-specs.js --spec "cypress/e2e/topnav.cy.js" --no-mapping
```

- Before: 2 tests, 0 passing, 1 failing, 1 skipped.
- After: 2 tests, 1 passing, 1 failing, 0 skipped.

The hook now dismisses all three banners, confirmed in the Cypress command log as a single `wrap` of 3 elements followed by 3 clicks.

## Checklist

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
- [x] Rebased/mergeable
- [x] Local build passes (Hugo built and served the home page during the e2e runs)
