### PR TITLE
docs(influxdb3): correct Python API reference to match validated server behavior

### DIFF
--- a/content/shared/influxdb3-plugins/python-api-reference.md
+++ b/content/shared/influxdb3-plugins/python-api-reference.md
@@ -86,7 +86,7 @@ Entry point for HTTP request triggers.
   The object must define a `__flask_response__()` method that returns `True`, a `status_code` attribute, a `headers` mapping, and a `get_data()` method that returns `str`.
   A genuine `flask.Response` is rejected: it does not define `__flask_response__`, and its `get_data()` returns bytes.
 - **A tuple** of `(body, status, headers)` following Flask conventions.
-  `status` and `headers` are optional; when `status` is present, `headers` may be the second or third element.
+  `status` and `headers` are optional; `headers` may be the second element only when `status` is omitted.
 - **A bare string, dictionary, list, or iterator**, rendered with defaults:
   dictionaries and lists are JSON-encoded with `Content-Type: application/json`; strings and other iterables are concatenated with a `text/html` default content type.
 
@@ -102,13 +102,9 @@ influxdb3_local.warn(*args: object) -> None
 influxdb3_local.error(*args: object) -> None
 ```
 
-Each method converts its arguments to strings, joins them with spaces, and logs the result at the named level:
+Each method converts its arguments to strings, joins them with spaces, and logs the result at the named level (`INFO`, `WARN`, or `ERROR`).
 
-- `info`: records the message in the system logs.
-- `warn`: forwards the message to the processing engine logs and test output.
-- `error`: records the message in the system logs and the plugin return payload.
-
-Log messages are stored in the `system.processing_engine_logs` table, where you can [query them using SQL](/influxdb3/version/admin/query-system-data/#query-trigger-logs).
+All three levels are stored in the `system.processing_engine_logs` table, where you can [query them using SQL](/influxdb3/version/admin/query-system-data/#query-trigger-logs), and appear in `influxdb3 test` output.
 
 ## Query data
 
@@ -261,7 +257,7 @@ Returns `True` when the key existed in the selected cache.
 Once the current plugin run has been cancelled—the server is shutting down, or the trigger was disabled or deleted—the logging, write, and query methods raise `KeyboardInterrupt`.
 
 `KeyboardInterrupt` subclasses `BaseException` rather than `Exception`, so a plugin's `except Exception` handler does not swallow it, and a long-running loop unwinds instead of hanging the shutdown or the disable.
-The message reads `influxdb3 is shutting down` for every cancellation cause, including a plain trigger disable.
+The message reads `influxdb3 is shutting down; aborting plugin execution` for every cancellation cause, including a plain trigger disable.
 
 The `cache` property and the cache methods do not check for cancellation and keep working.
 


### PR DESCRIPTION
## Summary

Follow-up to #7600. Manually validated the entire documented Python API surface against a live InfluxDB 3 Enterprise 3.12.0-nightly server (every entry point, return shape, method, exception, and behavioral claim). ~50 claims tested; three needed correction:

- **`process_request` tuple returns**: the doc said headers "may be the second or third element" when `status` is present. On the live server, `(body, headers, status)` fails with 500 `expected a dictionary in header item`—`headers` may be the second element only when `status` is omitted.
- **Cancellation message**: the full message is `influxdb3 is shutting down; aborting plugin execution`, not just `influxdb3 is shutting down`.
- **Log methods**: the per-level routing descriptions (info → system logs, warn → test output, error → return payload) don't match observed behavior. All three levels land identically in `system.processing_engine_logs` and in `influxdb3 test` output; `error()` never appeared in a distinct return payload. Replaced with a single accurate sentence.

Everything else in the reference validated exactly, including the duck-typed Flask response contract, `Unsupported return type` 500s, `TableBatch` dict shape, naive local-timezone `schedule_time`, cache scoping/TTL/restart behavior, `KeyboardInterrupt` cancellation semantics, and the full `LineBuilder` surface.

## Test evidence

- Fresh `quay.io/influxdb/influxdb3-enterprise:nightly` container (3.12.0-nightly, git `13535c4`), driven entirely over the HTTP API
- Assertion-battery plugins covering request/WAL/scheduled triggers, return shapes probed with `curl -i`, cancellation captured via mid-run trigger disable, cache scoping proven with same-named triggers on two databases, restart cache-clear verified
- Vale: 0 errors, 0 warnings on the edited file

🤖 Generated with [Claude Code](https://claude.com/claude-code)