### PR TITLE
ci(pr-preview): use released Rust converter

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -153,12 +153,16 @@ jobs:
       id-token: write # required for AWS OIDC
     env:
       PREVIEW_BASE_URL: https://test2.docs.influxdata.com/pr-preview/pr-${{ github.event.number }}/
-      RUST_MARKDOWN_CONVERTER_VERSION: v0.1.0
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+
+      - name: Set Rust markdown converter version
+        run: |
+          VERSION=$(node -p "require('./scripts/rust-markdown-converter/package.json').version")
+          echo "RUST_MARKDOWN_CONVERTER_VERSION=v$VERSION" >> "$GITHUB_ENV"
 
       - name: Download pinned Rust markdown converter
         id: rust-converter

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -172,6 +172,7 @@ jobs:
           ASSET_DIR=scripts/rust-markdown-converter
           RELEASE=rust-markdown-converter-${RUST_MARKDOWN_CONVERTER_VERSION}
           BINARY=rust-markdown-converter-linux-x86_64-gnu.node
+          LOADER=rust-markdown-converter-loader.js
 
           if ! gh release view "$RELEASE" --repo "$GITHUB_REPOSITORY" >/dev/null; then
             echo "Pinned converter release $RELEASE is unavailable; using the build cache."
@@ -182,13 +183,16 @@ jobs:
           gh release download "$RELEASE" \
             --repo "$GITHUB_REPOSITORY" \
             --pattern "$BINARY" \
+            --pattern "$LOADER" \
             --pattern checksums.txt \
             --dir "$ASSET_DIR" \
             --clobber
           (
             cd "$ASSET_DIR"
             grep "  $BINARY$" checksums.txt | sha256sum --check --status
+            grep "  $LOADER$" checksums.txt | sha256sum --check --status
             mv "$BINARY" index.linux-x64-gnu.node
+            mv "$LOADER" index.js
             rm checksums.txt
           )
           echo 'RUST_MARKDOWN_CONVERTER_PREBUILT=true' >> "$GITHUB_ENV"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -153,11 +153,58 @@ jobs:
       id-token: write # required for AWS OIDC
     env:
       PREVIEW_BASE_URL: https://test2.docs.influxdata.com/pr-preview/pr-${{ github.event.number }}/
+      RUST_MARKDOWN_CONVERTER_VERSION: v0.1.0
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+
+      - name: Download pinned Rust markdown converter
+        id: rust-converter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ASSET_DIR=scripts/rust-markdown-converter
+          RELEASE=rust-markdown-converter-${RUST_MARKDOWN_CONVERTER_VERSION}
+          BINARY=rust-markdown-converter-linux-x86_64-gnu.node
+
+          if ! gh release view "$RELEASE" --repo "$GITHUB_REPOSITORY" >/dev/null; then
+            echo "Pinned converter release $RELEASE is unavailable; using the build cache."
+            echo 'prebuilt=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          gh release download "$RELEASE" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "$BINARY" \
+            --pattern checksums.txt \
+            --dir "$ASSET_DIR" \
+            --clobber
+          (
+            cd "$ASSET_DIR"
+            grep "  $BINARY$" checksums.txt | sha256sum --check --status
+            mv "$BINARY" index.linux-x64-gnu.node
+            rm checksums.txt
+          )
+          echo 'RUST_MARKDOWN_CONVERTER_PREBUILT=true' >> "$GITHUB_ENV"
+          echo 'prebuilt=true' >> "$GITHUB_OUTPUT"
+
+      - name: Cache Rust markdown converter build
+        if: steps.rust-converter.outputs.prebuilt != 'true'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            scripts/rust-markdown-converter/target
+          key: >-
+            rust-markdown-converter-${{ runner.os }}-${{ runner.arch }}-
+            ${{ hashFiles('scripts/rust-markdown-converter/rust-toolchain.toml') }}-
+            ${{ hashFiles('scripts/rust-markdown-converter/Cargo.lock') }}
+          restore-keys: |
+            rust-markdown-converter-${{ runner.os }}-${{ runner.arch }}-
+            ${{ hashFiles('scripts/rust-markdown-converter/rust-toolchain.toml') }}-
 
       - name: Setup docs environment
         uses: ./.github/actions/setup-docs-env

--- a/.github/workflows/release-rust-markdown-converter.yml
+++ b/.github/workflows/release-rust-markdown-converter.yml
@@ -1,0 +1,103 @@
+name: Release Rust Markdown Converter
+
+on:
+  push:
+    tags:
+      - 'rust-markdown-converter-v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (for example, v0.1.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.asset }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset: rust-markdown-converter-linux-x86_64-gnu.node
+            output: index.linux-x64-gnu.node
+          - os: macos-14
+            asset: rust-markdown-converter-darwin-arm64.node
+            output: index.darwin-arm64.node
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          if [ ! -x "$HOME/.cargo/bin/rustup" ]; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+              | sh -s -- -y --profile minimal --default-toolchain none
+          fi
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          RUST_CHANNEL=$(grep '^channel' scripts/rust-markdown-converter/rust-toolchain.toml \
+            | sed 's/.*= *"\([^"]*\)".*/\1/')
+          "$HOME/.cargo/bin/rustup" toolchain install \
+            --profile minimal --no-self-update "$RUST_CHANNEL"
+          "$HOME/.cargo/bin/rustup" default "$RUST_CHANNEL"
+
+      - name: Build and test converter
+        run: |
+          node scripts/build-rust-converter.js
+          node -e "require('./scripts/rust-markdown-converter')"
+
+      - name: Prepare release assets
+        run: |
+          mkdir release-assets
+          cp scripts/rust-markdown-converter/${{ matrix.output }} \
+            release-assets/${{ matrix.asset }}
+
+      - name: Upload release asset
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.asset }}
+          path: release-assets/${{ matrix.asset }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          (
+            cd release-assets
+            sha256sum rust-markdown-converter-*.node > checksums.txt
+          )
+
+      - name: Determine release version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = workflow_dispatch ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/rust-markdown-converter-}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release create "rust-markdown-converter-$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "Rust Markdown Converter $VERSION" \
+            --notes "Prebuilt Rust N-API modules for docs-v2 CI." \
+            release-assets/rust-markdown-converter-*.node \
+            release-assets/checksums.txt

--- a/.github/workflows/release-rust-markdown-converter.yml
+++ b/.github/workflows/release-rust-markdown-converter.yml
@@ -24,9 +24,11 @@ jobs:
           - os: ubuntu-latest
             asset: rust-markdown-converter-linux-x86_64-gnu.node
             output: index.linux-x64-gnu.node
+            include-loader: true
           - os: macos-14
             asset: rust-markdown-converter-darwin-arm64.node
             output: index.darwin-arm64.node
+            include-loader: false
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -68,12 +70,23 @@ jobs:
           mkdir release-assets
           cp scripts/rust-markdown-converter/${{ matrix.output }} \
             release-assets/${{ matrix.asset }}
+          if [ "${{ matrix.include-loader }}" = "true" ]; then
+            cp scripts/rust-markdown-converter/index.js \
+              release-assets/rust-markdown-converter-loader.js
+          fi
 
       - name: Upload release asset
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.asset }}
           path: release-assets/${{ matrix.asset }}
+
+      - name: Upload generated module loader
+        if: matrix.include-loader
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rust-markdown-converter-loader
+          path: release-assets/rust-markdown-converter-loader.js
 
   release:
     needs: build
@@ -89,7 +102,8 @@ jobs:
         run: |
           (
             cd release-assets
-            sha256sum rust-markdown-converter-*.node > checksums.txt
+            sha256sum rust-markdown-converter-*.node \
+              rust-markdown-converter-loader.js > checksums.txt
           )
 
       - name: Determine release version
@@ -113,4 +127,5 @@ jobs:
             --title "Rust Markdown Converter $VERSION" \
             --notes "Prebuilt Rust N-API modules for docs-v2 CI." \
             release-assets/rust-markdown-converter-*.node \
+            release-assets/rust-markdown-converter-loader.js \
             release-assets/checksums.txt

--- a/.github/workflows/release-rust-markdown-converter.yml
+++ b/.github/workflows/release-rust-markdown-converter.yml
@@ -45,6 +45,19 @@ jobs:
             --profile minimal --no-self-update "$RUST_CHANNEL"
           "$HOME/.cargo/bin/rustup" default "$RUST_CHANNEL"
 
+      - name: Verify release version
+        run: |
+          EXPECTED_VERSION="v$(node -p 'require("./scripts/rust-markdown-converter/package.json").version')"
+          if [ "${{ github.event_name }}" = workflow_dispatch ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/rust-markdown-converter-}"
+          fi
+          if [ "$VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "Release version $VERSION does not match package version $EXPECTED_VERSION"
+            exit 1
+          fi
+
       - name: Build and test converter
         run: |
           node scripts/build-rust-converter.js

--- a/content/influxdb3/core/visualize-data/chronograf.md
+++ b/content/influxdb3/core/visualize-data/chronograf.md
@@ -77,7 +77,7 @@ chronograf
       http://{{< influxdb/host >}}
       ```
 
-    - **Connection Name:** Name to uniquely identify this connection configuration
+    - **Connection Name:** A name that uniquely identifies this connection configuration
     - **Database Token:** InfluxDB {{% token-link "database" %}}
       with read permissions on the database you want to query
     - **Telegraf Database Name:** InfluxDB [database](/influxdb3/core/admin/databases/)

--- a/content/influxdb3/enterprise/visualize-data/chronograf.md
+++ b/content/influxdb3/enterprise/visualize-data/chronograf.md
@@ -77,7 +77,7 @@ chronograf
       http://{{< influxdb/host >}}
       ```
 
-    - **Connection Name:** Name to uniquely identify this connection configuration
+    - **Connection Name:** A name that uniquely identifies this connection configuration
     - **Database Token:** InfluxDB {{% token-link "database" %}}
       with read permissions on the database you want to query
     - **Telegraf Database Name:** InfluxDB [database](/influxdb3/enterprise/admin/databases/)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,8 +28,12 @@ The build splits into two phases:
   html2md + scraper) converts each page's `article.article--content` to Markdown
   and emits the base frontmatter. The build hard-fails if the Rust module isn't
   built (no silent JS fallback). Build it with
-  `node scripts/build-rust-converter.js` (runs automatically on `postinstall`
-  when `cargo` is present; CI builds it explicitly).
+  `node scripts/build-rust-converter.js`, which runs automatically during
+  `yarn install`. On supported platforms, setup downloads the native module
+  pinned to `scripts/rust-markdown-converter/package.json`, verifies its
+  checksum, and caches it locally. If the release is unavailable, the platform
+  is unsupported, or you're offline, setup falls back to a local Rust build
+  when `cargo` is available.
 - **Phase 2 — section bundles (JS).** `combineMarkdown` concatenates the
   already-generated per-page `.md` into `index.section.md` (parent + children),
   emitting section frontmatter (`type: section`, `pages`, `child_pages`).

--- a/scripts/build-rust-converter.js
+++ b/scripts/build-rust-converter.js
@@ -7,7 +7,13 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { createRequire } from 'node:module';
-import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 
 const pkgDir = path.resolve('scripts/rust-markdown-converter');

--- a/scripts/build-rust-converter.js
+++ b/scripts/build-rust-converter.js
@@ -73,8 +73,11 @@ function downloadPrebuilt() {
   const release = `rust-markdown-converter-${prebuiltVersion}`;
   const releaseUrl = `https://github.com/influxdata/docs-v2/releases/download/${release}`;
   const assetPath = path.join(pkgDir, target.asset);
+  const loaderAsset = 'rust-markdown-converter-loader.js';
+  const loaderAssetPath = path.join(pkgDir, loaderAsset);
   const checksumPath = path.join(pkgDir, 'checksums.txt');
   const outputPath = path.join(pkgDir, target.output);
+  const loaderOutputPath = path.join(pkgDir, 'index.js');
 
   try {
     execFileSync('curl', [
@@ -100,25 +103,52 @@ function downloadPrebuilt() {
       '--max-time',
       '30',
       '--output',
+      loaderAssetPath,
+      `${releaseUrl}/${loaderAsset}`,
+    ]);
+    execFileSync('curl', [
+      '--fail',
+      '--location',
+      '--silent',
+      '--show-error',
+      '--connect-timeout',
+      '5',
+      '--max-time',
+      '30',
+      '--output',
       checksumPath,
       `${releaseUrl}/checksums.txt`,
     ]);
 
-    const expectedChecksum = readFileSync(checksumPath, 'utf8')
-      .split('\n')
-      .find((line) => line.endsWith(`  ${target.asset}`))
-      ?.split(/\s+/)[0];
-    const actualChecksum = createHash('sha256')
-      .update(readFileSync(assetPath))
-      .digest('hex');
-    if (!expectedChecksum || actualChecksum !== expectedChecksum) {
-      throw new Error(`checksum verification failed for ${target.asset}`);
+    const checksums = new Map(
+      readFileSync(checksumPath, 'utf8')
+        .trim()
+        .split('\n')
+        .map((line) => {
+          const [checksum, asset] = line.split(/\s{2,}/);
+          return [asset, checksum];
+        })
+    );
+    for (const [asset, assetFile] of [
+      [target.asset, assetPath],
+      [loaderAsset, loaderAssetPath],
+    ]) {
+      const actualChecksum = createHash('sha256')
+        .update(readFileSync(assetFile))
+        .digest('hex');
+      if (checksums.get(asset) !== actualChecksum) {
+        throw new Error(`checksum verification failed for ${asset}`);
+      }
     }
 
     renameSync(assetPath, outputPath);
-    writeFileSync(prebuiltVersionPath, `${prebuiltVersion}\n`);
-    console.log(`✓ Downloaded Rust markdown converter ${prebuiltVersion}`);
-    return usePrebuilt();
+    renameSync(loaderAssetPath, loaderOutputPath);
+    if (usePrebuilt()) {
+      writeFileSync(prebuiltVersionPath, `${prebuiltVersion}\n`);
+      console.log(`✓ Downloaded Rust markdown converter ${prebuiltVersion}`);
+      return true;
+    }
+    return false;
   } catch (error) {
     console.warn(
       `⚠ Could not download Rust markdown converter ${prebuiltVersion}; rebuilding it: ${error.message}`
@@ -126,6 +156,7 @@ function downloadPrebuilt() {
     return false;
   } finally {
     rmSync(assetPath, { force: true });
+    rmSync(loaderAssetPath, { force: true });
     rmSync(checksumPath, { force: true });
   }
 }

--- a/scripts/build-rust-converter.js
+++ b/scripts/build-rust-converter.js
@@ -5,23 +5,133 @@
  * on machines without Rust. CI builds it explicitly (see .circleci/config.yml).
  */
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { createRequire } from 'node:module';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 const pkgDir = path.resolve('scripts/rust-markdown-converter');
 const require = createRequire(import.meta.url);
+const packageVersion = JSON.parse(
+  readFileSync(path.join(pkgDir, 'package.json'), 'utf8')
+).version;
+const prebuiltVersion = `v${packageVersion}`;
+const prebuiltVersionPath = path.join(pkgDir, '.prebuilt-version');
 
-if (process.env.RUST_MARKDOWN_CONVERTER_PREBUILT === 'true') {
+function nativeAsset() {
+  if (process.platform === 'darwin' && process.arch === 'arm64') {
+    return {
+      asset: 'rust-markdown-converter-darwin-arm64.node',
+      output: 'index.darwin-arm64.node',
+    };
+  }
+
+  if (process.platform === 'linux' && process.arch === 'x64') {
+    const report = process.report?.getReport();
+    if (report?.header?.glibcVersionRuntime) {
+      return {
+        asset: 'rust-markdown-converter-linux-x86_64-gnu.node',
+        output: 'index.linux-x64-gnu.node',
+      };
+    }
+  }
+}
+
+function usePrebuilt() {
   try {
     require(pkgDir);
     console.log('✓ Using prebuilt Rust markdown converter');
-    process.exit(0);
+    return true;
   } catch (error) {
     console.warn(
       `⚠ Prebuilt Rust markdown converter could not load; rebuilding it: ${error.message}`
     );
+    return false;
   }
+}
+
+function downloadPrebuilt() {
+  const target = nativeAsset();
+  if (!target) {
+    return false;
+  }
+
+  if (
+    existsSync(prebuiltVersionPath) &&
+    readFileSync(prebuiltVersionPath, 'utf8').trim() === prebuiltVersion &&
+    usePrebuilt()
+  ) {
+    return true;
+  }
+
+  const release = `rust-markdown-converter-${prebuiltVersion}`;
+  const releaseUrl = `https://github.com/influxdata/docs-v2/releases/download/${release}`;
+  const assetPath = path.join(pkgDir, target.asset);
+  const checksumPath = path.join(pkgDir, 'checksums.txt');
+  const outputPath = path.join(pkgDir, target.output);
+
+  try {
+    execFileSync('curl', [
+      '--fail',
+      '--location',
+      '--silent',
+      '--show-error',
+      '--connect-timeout',
+      '5',
+      '--max-time',
+      '30',
+      '--output',
+      assetPath,
+      `${releaseUrl}/${target.asset}`,
+    ]);
+    execFileSync('curl', [
+      '--fail',
+      '--location',
+      '--silent',
+      '--show-error',
+      '--connect-timeout',
+      '5',
+      '--max-time',
+      '30',
+      '--output',
+      checksumPath,
+      `${releaseUrl}/checksums.txt`,
+    ]);
+
+    const expectedChecksum = readFileSync(checksumPath, 'utf8')
+      .split('\n')
+      .find((line) => line.endsWith(`  ${target.asset}`))
+      ?.split(/\s+/)[0];
+    const actualChecksum = createHash('sha256')
+      .update(readFileSync(assetPath))
+      .digest('hex');
+    if (!expectedChecksum || actualChecksum !== expectedChecksum) {
+      throw new Error(`checksum verification failed for ${target.asset}`);
+    }
+
+    renameSync(assetPath, outputPath);
+    writeFileSync(prebuiltVersionPath, `${prebuiltVersion}\n`);
+    console.log(`✓ Downloaded Rust markdown converter ${prebuiltVersion}`);
+    return usePrebuilt();
+  } catch (error) {
+    console.warn(
+      `⚠ Could not download Rust markdown converter ${prebuiltVersion}; rebuilding it: ${error.message}`
+    );
+    return false;
+  } finally {
+    rmSync(assetPath, { force: true });
+    rmSync(checksumPath, { force: true });
+  }
+}
+
+if (process.env.RUST_MARKDOWN_CONVERTER_PREBUILT === 'true') {
+  if (usePrebuilt()) {
+    process.exit(0);
+  }
+}
+
+if (downloadPrebuilt()) {
+  process.exit(0);
 }
 
 function has(cmd) {

--- a/scripts/build-rust-converter.js
+++ b/scripts/build-rust-converter.js
@@ -5,10 +5,24 @@
  * on machines without Rust. CI builds it explicitly (see .circleci/config.yml).
  */
 import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 const pkgDir = path.resolve('scripts/rust-markdown-converter');
+const require = createRequire(import.meta.url);
+
+if (process.env.RUST_MARKDOWN_CONVERTER_PREBUILT === 'true') {
+  try {
+    require(pkgDir);
+    console.log('✓ Using prebuilt Rust markdown converter');
+    process.exit(0);
+  } catch (error) {
+    console.warn(
+      `⚠ Prebuilt Rust markdown converter could not load; rebuilding it: ${error.message}`
+    );
+  }
+}
 
 function has(cmd) {
   try {

--- a/scripts/rust-markdown-converter/.gitignore
+++ b/scripts/rust-markdown-converter/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .cargo/
 *.d.ts
 index.js
+.prebuilt-version


### PR DESCRIPTION
## Summary

- build and publish native Rust markdown converter modules for Linux x86_64 GNU and macOS ARM64
- prefer the checksum-verified, pinned Linux release in PR Preview
- retain the Cargo build cache as a fallback until the pinned release is available

## Why

PR Preview currently compiles the Rust markdown converter during `yarn install`, increasing preview turnaround time.

## Validation

- `actionlint .github/workflows/pr-preview.yml .github/workflows/release-rust-markdown-converter.yml`
- `git diff --check`
- `yarn test:markdown-parity`

## PR Preview

- /influxdb3/cloud/
- /influxdb3/enterprise/api/