### PR TITLE
Correct backup status value in incremental backup guidance

### DIFF
--- a/content/shared/influxdb3-admin/backup-restore.md
+++ b/content/shared/influxdb3-admin/backup-restore.md
@@ -131,7 +131,8 @@ backup, which saves time and storage space compared to a full backup. Each
 incremental backup names the backup it chains from with `--parent`.
 
 `create backup` returns as soon as the backup starts, not when it finishes.
-Check that a backup's status is `complete` before creating a child
+`influxdb3 status backup` reports `in_progress`, `completed`, or `failed`.
+Check that a backup's status is `completed` before creating a child
 incremental backup that names it as `--parent`:
 
 ```bash


### PR DESCRIPTION
## What changed

The incremental backup section of the Enterprise backup and restore guide
told readers to wait for a backup status of `complete`. Corrected to
`completed`, and added the full set of values the command reports.

## Why

`influxdb3 status backup` reports `in_progress`, `completed`, or `failed`.
`complete` is not one of them, so a reader scripting the documented poll
would never see a match.

Naming all three values also tells readers waiting for success that
`failed` is the other terminal state, rather than leaving them to poll a
backup that has already stopped.

## Impact

One paragraph in `content/shared/influxdb3-admin/backup-restore.md`,
shared by InfluxDB 3 Enterprise. No behavior or command changes.

## Verification

Status values confirmed against InfluxDB 3 Enterprise 3.11.0, and against
a live instance during backup and restore verification, where polling
returned `completed`.