### PR TITLE
Telegraf Controller v1.0.2

### DIFF
--- a/content/telegraf/controller/get-started.md
+++ b/content/telegraf/controller/get-started.md
@@ -16,6 +16,8 @@ This guide walks you through the core workflow: creating a configuration,
 starting a Telegraf agent using the configuration, and verifying that the agent
 reports back to {{% product-name %}}.
 
+{{< youtube "g-d3QnG05aw" >}}
+
 1. [Create an API token](#create-an-api-token)
 2. [Create a Telegraf configuration](#create-a-telegraf-configuration)
 3. [Start a Telegraf agent](#start-a-telegraf-agent)

--- a/content/telegraf/controller/reference/release-notes.md
+++ b/content/telegraf/controller/reference/release-notes.md
@@ -9,10 +9,41 @@ menu:
 weight: 101
 ---
 
-## v1.0.1 {date="2026-07-01"}
+## v1.0.2 {date="2026-08-04"}
 
 <!-- Update and move the link to the latest version. -->
-[Download Telegraf Controller v1.0.1](/telegraf/controller/install/#download-and-install-telegraf-controller)
+[Download Telegraf Controller v1.0.2](/telegraf/controller/install/#download-and-install-telegraf-controller)
+
+### Features
+
+- Add plugin support to the Telegraf Builder UI:
+  - MQTT Consumer (`inputs.mqtt_consumer`)
+  - Multifile (`inputs.multifile`)
+  - MySQL (`inputs.mysql`)
+  - NATS Server Monitoring (`inputs.nats`)
+  - NATS Consumer (`inputs.nats_consumer`)
+  - Neoom Beaam (`inputs.neoom_beaam`)
+  - Neptune Apex (`inputs.neptune_apex`)
+  - Apache Zookeeper (`inputs.zookeeper`)
+
+### Bug fixes
+
+- Fix agent list filters, page reset when filters change, and a pagination
+  off-by-one error.
+- Fix filtering agents by the Undefined status and pagination when a filter
+  returns no results.
+- No longer require a reporting rule's auto-delete threshold to be longer than
+  its not-reporting threshold, and clarify the auto-delete field help text.
+- Store agent timestamps consistently between the heartbeat service and the
+  API, fixing unreliable not-reporting status checks, incorrect sorting and
+  filtering by last-reported time, and a time zone offset on PostgreSQL
+  servers not set to UTC.
+- Fix the elapsed time display when an agent's last report is momentarily in
+  the future.
+
+---
+
+## v1.0.1 {date="2026-07-01"}
 
 ### Features
 

--- a/data/products.yml
+++ b/data/products.yml
@@ -396,7 +396,7 @@ telegraf_controller:
   link: 'https://influxdata.com/contact-sales-telegraf-enterprise/?utm_source=website&utm_medium=direct&utm_campaign=Telegraf-Enterprise'
   versions: [v1]
   latest: 1.0
-  latest_patch: 1.0.1
+  latest_patch: 1.0.2
   schema:
     operating_system: "Docker"
     application_category: "DeveloperApplication"

--- a/data/tc_downloads.yml
+++ b/data/tc_downloads.yml
@@ -1,24 +1,24 @@
-version: "1.0.1"
+version: "1.0.2"
 platforms:
   - name: Linux
     builds:
       - arch: x64
         os: linux
-        sha256: "74566dabff9edd3cd2f3e12c751ced77a74d854f973b2d13eb964db87899fcb9"
+        sha256: "..."
       - arch: arm64
         os: linux
-        sha256: "cbca3b30449cd228314489e50b22823c692bdff2169c4d42eb6ff21b5225b041"
+        sha256: "..."
   - name: macOS
     builds:
       - arch: x64
         os: macos
-        sha256: "1fc0381e3b4016a55c88fdcaab4d42c96b9a5e8354e6f6f2f8de229966706b8a"
+        sha256: "..."
       - arch: arm64
         os: macos
-        sha256: "d6c879f1b5e27be7a8b98118efd8a689193f0858a05d27cedc8e3c689103cc05"
+        sha256: "..."
   - name: Windows
     builds:
       - arch: x64
         os: win
         ext: .exe
-        sha256: "8aa5cb79b2e168ae147e7834838bb838b6a508d47173af9d7600ccb12796e36f"
+        sha256: "..."

--- a/data/tc_downloads.yml
+++ b/data/tc_downloads.yml
@@ -4,21 +4,21 @@ platforms:
     builds:
       - arch: x64
         os: linux
-        sha256: "..."
+        sha256: "7dd9785718a395fefaf7d4457dc853135785664785d78a7694a1351fe2562f5c"
       - arch: arm64
         os: linux
-        sha256: "..."
+        sha256: "eaa95888041f92f763f25e09a8426c809179d1c9406d201186d01516eacbeee9"
   - name: macOS
     builds:
       - arch: x64
         os: macos
-        sha256: "..."
+        sha256: "bf91df01b877f3c06ac0dfa531d061166dfe654f28728283a50c845e225d7518"
       - arch: arm64
         os: macos
-        sha256: "..."
+        sha256: "5685fe0b5bb35626fd80c82400c17cea6088df5b0d9ecd7877c4e3ac7801c4e5"
   - name: Windows
     builds:
       - arch: x64
         os: win
         ext: .exe
-        sha256: "..."
+        sha256: "660106838e1452827c18ffe4c66726f61a12e2175b79b69095a12244f4cf51bf"


### PR DESCRIPTION
Release notes and download updates for Telegraf Controller 1.0.2.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
