### PR TITLE
docs(controller): document focus mode

### DIFF
--- a/content/telegraf/controller/configs/ui/_index.md
+++ b/content/telegraf/controller/configs/ui/_index.md
@@ -20,4 +20,18 @@ create, edit, and update Telegraf TOML configuration files.
 - **Telegraf Builder**: Use a visual interface to manage and configure
   Telegraf plugins. _The Telegraf Builder is currently a beta feature._
 
+## Focus mode
+
+Use focus mode to expand the configuration editing area to fill your browser
+window while you work. Focus mode applies to both the Code Editor and the
+Telegraf Builder and is available when creating or editing a configuration.
+
+- To enter focus mode, click **{{% icon "fullscreen" %}} Focus** in the upper
+  right of the configuration editing area.
+- To exit focus mode, click **{{% icon "fullscreen" %}} Unfocus** or press
+  {{< keybind mac="Esc" other="Esc" >}}.
+
+Focus mode does not persist between page loads. Reloading the page returns the
+configuration editing area to the standard view.
+
 {{< children hlevel="h2" >}}

--- a/content/telegraf/controller/configs/ui/code-editor.md
+++ b/content/telegraf/controller/configs/ui/code-editor.md
@@ -20,6 +20,9 @@ Telegraf configuration TOML.
 The Code Editor is the default view when managing a configuration. If it is not
 displayed, click the **Code Editor** tab.
 
+To expand the editor to fill your browser window while you work, use
+[focus mode](/telegraf/controller/configs/ui/#focus-mode).
+
 > [!Important]
 > #### Switching from the Code Editor to the Telegraf Builder
 > 

--- a/content/telegraf/controller/configs/ui/telegraf-builder.md
+++ b/content/telegraf/controller/configs/ui/telegraf-builder.md
@@ -17,6 +17,9 @@ The **Telegraf Builder** is a visual interface for managing and configuring
 Telegraf plugins in a configuration. The builder is available when creating or
 updating a configuration.
 
+To expand the builder to fill your browser window while you work, use
+[focus mode](/telegraf/controller/configs/ui/#focus-mode).
+
 > [!Important]
 > #### The Telegraf Builder is a beta feature
 >


### PR DESCRIPTION
Add a Focus mode section to the Configuration UI tools page covering how to enter and exit the expanded editing view, and cross-link it from the Code Editor and Telegraf Builder pages.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
