### PR TITLE
feat(icons): add Lucide icons for Telegraf Controller and Explorer

### DIFF
--- a/DOCS-SHORTCODES.md
+++ b/DOCS-SHORTCODES.md
@@ -616,6 +616,37 @@ The following case insensitive values are supported:
 - settings
 - feedback
 
+### Lucide icons
+
+Use the `lucide` shortcode to inject an icon from the
+[Lucide](https://lucide.dev/icons) library into paragraph text---for example,
+to reference a control in a product UI that uses Lucide icons. Both the Telegraf
+Controller and InfluxDB 3 Explorer UIs use Lucide icons. Any icon name listed at
+[lucide.dev/icons](https://lucide.dev/icons) works; the shortcode inlines the
+SVG, so only the icons you reference are included in the build.
+
+Because Hugo doesn't allow mixing positional and named parameters in a single
+shortcode call, use the positional form for a bare icon and the named form
+when you add a size:
+
+```md
+Click {{< lucide "circle-plus" >}} to add a plugin.
+
+Status {{< lucide icon="circle-check" size="large" >}} indicates success.
+```
+
+Parameters:
+
+- **icon** (or the first positional argument): the Lucide icon name in
+  kebab-case, exactly as listed at lucide.dev/icons.
+- **size**: `small` or `large`. Defaults to the surrounding text size (1em).
+  Named form only.
+
+Icons are decorative (hidden from screen readers with `aria-hidden`), so pair
+each icon with the text that names the control. Icons inherit the surrounding
+text color (including dark mode). An unknown icon name renders nothing and logs
+a build warning.
+
 ## Content Formatting
 
 ### Truncated content blocks

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,79 @@
+# Plan: `lucide` shortcode — make the Lucide icon library available in docs
+
+## Goal
+
+Provide a reusable Hugo shortcode, `{{< lucide "name" >}}`, that inlines any
+icon from the [Lucide](https://lucide.dev/icons) library as SVG. Telegraf
+Controller docs are the first consumer (the TC UI uses Lucide icons), but the
+shortcode is product-neutral so any docs can use it.
+
+## Why inline SVG (not an icon font)
+
+- The repo's existing `icon`/`nav-icon` shortcodes use IcoMoon **icon fonts**
+  tied to the InfluxDB "Clockface" UI. Lucide is SVG-first.
+- Inlining ships only the icons actually referenced (no full-font payload, no
+  extra network request), inherits text color via `currentColor`, and gives
+  real accessibility hooks.
+- Lucide icon names are stable, documented, kebab-case — so the shortcode is a
+  thin name pass-through, with no per-icon mapping table to maintain (unlike
+  the \~270-line `icon.html`).
+
+## Design
+
+### Sourcing
+
+- Add `lucide-static` as a `devDependency`. It ships every icon as an
+  individual SVG under `node_modules/lucide-static/icons/<name>.svg`.
+- Reachable from Hugo via the existing `node_modules` → `assets/node_modules`
+  mount (`config/_default/hugo.yml`), so `resources.Get` can read them. No new
+  config.
+
+### Shortcode — `layouts/shortcodes/lucide.html`
+
+- Args: positional `0` = icon name; named `label` (accessible name),
+  `size` (`small` | `large`, default 1em).
+- `resources.Get "node_modules/lucide-static/icons/<name>.svg"`; on miss, log a
+  build warning (`warnf`) and render nothing — a typo doesn't fail the build.
+- Strip Lucide's hardcoded `width="24" height="24"` so CSS/font-size controls
+  size (the `viewBox` stays, so it scales).
+- Inject accessibility attrs: `aria-hidden="true" focusable="false"` by
+  default, or `role="img" aria-label="…"` when `label` is set.
+- Append the `size` modifier to the existing `class="lucide …"` when provided.
+
+### Styling — `assets/styles/layouts/_lucide-icons.scss`
+
+- Target `svg.lucide` (Lucide already emits `class="lucide lucide-<name>"`).
+- `width/height: 1em`, `vertical-align: -0.125em`, `stroke: currentColor`;
+  `.small` and `.large` modifiers.
+- Register with `+ "layouts/lucide-icons"` in `assets/styles/styles-default.scss`.
+
+### Docs / example / test
+
+- `DOCS-SHORTCODES.md`: new entry (syntax, `label`, `size`, note that any
+  lucide.dev name works).
+- `content/example.md`: usages (plain, `label`, `size`) — render target.
+- `cypress/e2e/content/lucide-shortcode.cy.js`: visit `/example/`; assert
+  `svg.lucide` renders, `aria-label` present when `label` set, unknown name
+  yields no `svg`.
+
+## Files touched
+
+| File                                         | Change                   |
+| -------------------------------------------- | ------------------------ |
+| `package.json`                               | + `lucide-static` devDep |
+| `layouts/shortcodes/lucide.html`             | new                      |
+| `assets/styles/layouts/_lucide-icons.scss`   | new                      |
+| `assets/styles/styles-default.scss`          | + 1 import line          |
+| `DOCS-SHORTCODES.md`                         | new entry                |
+| `content/example.md`                         | usage examples           |
+| `cypress/e2e/content/lucide-shortcode.cy.js` | new                      |
+
+## Verification
+
+- `npx hugo --quiet` builds with no template errors.
+- Cypress test passes against `/example/`.
+
+## Out of scope
+
+- Migrating existing `icon`/`nav-icon` usages to Lucide.
+- Adding Lucide icons to specific Telegraf Controller content pages (follow-up).

--- a/assets/styles/layouts/_lucide-icons.scss
+++ b/assets/styles/layouts/_lucide-icons.scss
@@ -1,0 +1,29 @@
+// Inline Lucide icons rendered by the {{< lucide >}} shortcode.
+//
+// Lucide's static SVGs ship with `class="lucide lucide-<name>"` and
+// `stroke="currentColor"`, so icons inherit the surrounding text color
+// (including dark mode) with no extra styling. The shortcode strips the
+// hardcoded 24x24 dimensions so size follows the text via `em` units.
+
+svg.lucide {
+  display: inline-block;
+  width: 1.1em;
+  height: 1.1em;
+  vertical-align: text-top;
+  stroke: currentColor;
+  flex: none;
+
+  &.small {
+    width: 0.85em;
+    height: 0.85em;
+  }
+
+  &.large {
+    width: 1.25em;
+    height: 1.25em;
+  }
+}
+
+strong svg.lucide {
+  stroke-width: 2.25;
+}

--- a/assets/styles/styles-default.scss
+++ b/assets/styles/styles-default.scss
@@ -20,6 +20,7 @@
         "layouts/content-wrapper",
         "layouts/article",
         "layouts/inline-icons",
+        "layouts/lucide-icons",
         "layouts/syntax-highlighting",
         "layouts/algolia-search-overrides",
         "layouts/landing",

--- a/content/example.md
+++ b/content/example.md
@@ -252,6 +252,32 @@ This is **bold** text. This is *italic* text. This is ***bold and italic***.
 {{< icon "view" >}} view\
 {{< icon "x" >}} x
 
+### Lucide icons
+
+Inline icons from the [Lucide](https://lucide.dev/icons) library, rendered with
+the `lucide` shortcode.
+
+<div id="lucide-examples">
+
+Default: {{< lucide "circle-plus" >}}
+Settings: {{< lucide "settings" >}}
+Large: {{< lucide icon="circle-check" size="large" >}}
+Small: {{< lucide icon="circle-check" size="small" >}}
+
+</div>
+
+An unknown icon name renders nothing and logs a build warning:
+<span id="lucide-unknown">{{< lucide "not-a-real-icon-xyz" >}}</span>
+
+Inline usage inside a list item and bold text:
+
+<div id="lucide-inline">
+
+- To enter focus mode, click **{{< lucide "fullscreen" >}} Focus** in the
+  upper right of the editing area.
+
+</div>
+
 ## h2 This is a header2
 
 This is a paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/content/telegraf/controller/configs/ui/_index.md
+++ b/content/telegraf/controller/configs/ui/_index.md
@@ -26,9 +26,9 @@ Use focus mode to expand the configuration editing area to fill your browser
 window while you work. Focus mode applies to both the Code Editor and the
 Telegraf Builder and is available when creating or editing a configuration.
 
-- To enter focus mode, click **{{% icon "fullscreen" %}} Focus** in the upper
+- To enter focus mode, click **{{% lucide "fullscreen" %}} Focus** in the upper
   right of the configuration editing area.
-- To exit focus mode, click **{{% icon "fullscreen" %}} Unfocus** or press
+- To exit focus mode, click **{{% lucide "minimize" %}} Unfocus** or press
   {{< keybind mac="Esc" other="Esc" >}}.
 
 Focus mode does not persist between page loads. Reloading the page returns the

--- a/cypress/e2e/content/lucide-shortcode.cy.js
+++ b/cypress/e2e/content/lucide-shortcode.cy.js
@@ -1,0 +1,65 @@
+/// <reference types="cypress" />
+
+/**
+ * Tests for the `lucide` shortcode.
+ *
+ * Verifies that the shortcode inlines icons from the lucide-static package as
+ * SVG, renders them as decorative (aria-hidden), supports `size` modifiers,
+ * inherits text color, preserves inner element geometry, renders as real markup
+ * inline (not escaped text), and degrades gracefully (renders nothing) for an
+ * unknown icon name.
+ *
+ * Assertions target the `#lucide-examples`, `#lucide-inline`, and
+ * `#lucide-unknown` fixtures in content/example.md.
+ */
+
+describe('lucide shortcode', function () {
+  beforeEach(() => cy.visit('/example/'));
+
+  it('inlines an SVG icon for each usage', function () {
+    cy.get('#lucide-examples svg.lucide').should('have.length', 4);
+  });
+
+  it('renders icons as decorative (hidden from screen readers)', function () {
+    cy.get('#lucide-examples svg.lucide').each(($svg) => {
+      cy.wrap($svg)
+        .should('have.attr', 'aria-hidden', 'true')
+        .and('not.have.attr', 'aria-label');
+    });
+  });
+
+  it('applies size modifier classes', function () {
+    cy.get('#lucide-examples svg.lucide.large').should('exist');
+    cy.get('#lucide-examples svg.lucide.small').should('exist');
+  });
+
+  it('inherits the surrounding text color', function () {
+    cy.get('#lucide-examples svg.lucide-circle-plus').should(
+      'have.attr',
+      'stroke',
+      'currentColor'
+    );
+  });
+
+  it('preserves inner element geometry (does not strip child dimensions)', function () {
+    // Regression: the width/height strip must not touch inner shapes like
+    // <rect>, or icons such as `fullscreen` render as empty boxes.
+    cy.get('#lucide-inline svg.lucide-fullscreen rect')
+      .should('have.attr', 'width')
+      .and('not.be.empty');
+    cy.get('#lucide-inline svg.lucide-fullscreen rect')
+      .should('have.attr', 'height')
+      .and('not.be.empty');
+  });
+
+  it('renders as an SVG element (not escaped text) inline in a list and bold', function () {
+    // Regression: multi-line raw HTML is escaped by Goldmark inline parsing.
+    // The shortcode must emit a single line so it renders as real markup.
+    cy.get('#lucide-inline li strong svg.lucide-fullscreen').should('exist');
+    cy.get('#lucide-inline').should('not.contain', '<svg');
+  });
+
+  it('renders nothing for an unknown icon name', function () {
+    cy.get('#lucide-unknown').should('exist').find('svg').should('not.exist');
+  });
+});

--- a/layouts/shortcodes/lucide.html
+++ b/layouts/shortcodes/lucide.html
@@ -1,0 +1,48 @@
+{{- /*
+  Renders a Lucide icon (https://lucide.dev/icons) as inline SVG.
+
+  Icons are decorative: they accompany the text that names the control, so they
+  are hidden from screen readers (aria-hidden) to avoid duplicate announcements.
+
+  Usage:
+    {{< lucide "circle-plus" >}}
+    {{< lucide icon="circle-check" size="large" >}}
+
+  Params (Hugo forbids mixing positional and named params in one call, so use
+  the positional form for a bare icon and the named form when adding a size):
+    0 / icon  Lucide icon name (kebab-case, exactly as listed at
+              lucide.dev/icons).
+    size      Optional size modifier: "small" or "large". Defaults to 1em,
+              sized to the surrounding text. Named form only.
+
+  Icons are read from the lucide-static package through the node_modules asset
+  mount. Lucide is ISC-licensed; see node_modules/lucide-static/LICENSE.
+*/ -}}
+{{- $name := "" -}}
+{{- $size := "" -}}
+{{- if .IsNamedParams -}}
+  {{- $name = .Get "icon" -}}
+  {{- $size = .Get "size" | default "" -}}
+{{- else -}}
+  {{- $name = .Get 0 -}}
+{{- end -}}
+
+{{- with resources.Get (printf "node_modules/lucide-static/icons/%s.svg" $name) -}}
+  {{- $svg := .Content -}}
+  {{- /* Strip the license comment. */ -}}
+  {{- $svg = $svg | replaceRE `(?s)<!--.*?-->` "" -}}
+  {{- /* Icons are decorative---the adjacent text names the control. */ -}}
+  {{- $svg = $svg | replaceRE `<svg` `<svg aria-hidden="true" focusable="false"` -}}
+  {{- /* Add the size modifier to the icon's existing class. */ -}}
+  {{- if ne $size "" -}}
+    {{- $svg = $svg | replaceRE `class="lucide ` (printf `class="lucide %s ` $size) -}}
+  {{- end -}}
+  {{- /* Collapse to a single line so the inline SVG renders as HTML in every
+         Markdown context (paragraphs, list items, bold text)---multi-line raw
+         HTML is escaped as text by Goldmark inline parsing. Size comes from CSS
+         (svg.lucide), which overrides the icon's width/height attributes. */ -}}
+  {{- $svg = $svg | replaceRE `\s*\n\s*` " " | strings.TrimSpace -}}
+  {{- $svg | safeHTML -}}
+{{- else -}}
+  {{- warnf "lucide shortcode: no icon named %q (see https://lucide.dev/icons)" $name -}}
+{{- end -}}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "globals": "^15.14.0",
     "hugo-extended": "0.156.0",
+    "lucide-static": "^1.28.0",
     "pixelmatch": "^6.0.0",
     "pngjs": "^7.0.0",
     "postcss": ">=8.5.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3340,6 +3340,11 @@ lru-cache@^7.14.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
+lucide-static@^1.28.0:
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/lucide-static/-/lucide-static-1.28.0.tgz#cf222b19159cdbfab424649bd255a6d794502cef"
+  integrity sha512-dC3VJwRFsjEVX7Iaq4rY88pm7Fi2OmOb8P0WRzXsUMgbt7sCmFX8bLhaDBeNW6JdRjuele+jKqqFaam4yr+Ygg==
+
 markdown-link@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/markdown-link/-/markdown-link-0.1.1.tgz#32c5c65199a6457316322d1e4229d13407c8c7cf"


### PR DESCRIPTION
Adds Lucide SVG icon support for use in Telegraf Controller and InfluxDB 3 Explorer docs.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
