### PR TITLE
docs(controller): troubleshoot heartbeat 401 Invalid token from database TLS failures

### DIFF
--- a/content/telegraf/controller/install/secure-tls.md
+++ b/content/telegraf/controller/install/secure-tls.md
@@ -264,5 +264,9 @@ unknown authority`, the agent does not trust the CA that signed the
 - The certificate is valid for the hostname the agent uses to connect.
 - In Docker, the mounted certificate file is readable by the container.
 
+If agents receive a `401` response with an `Invalid token` error instead of a
+certificate error, the problem is not the agent connection. See
+[Agent heartbeats return 401 Invalid token](/telegraf/controller/install/troubleshoot/#agent-heartbeats-return-401-invalid-token).
+
 For more installation and startup issues, see
 [Troubleshoot {{% product-name %}} installation](/telegraf/controller/install/troubleshoot/).

--- a/content/telegraf/controller/install/troubleshoot.md
+++ b/content/telegraf/controller/install/troubleshoot.md
@@ -18,6 +18,7 @@ configuration.
 - [Port Already in Use](#port-already-in-use)
 - [Permission Denied (Linux/macOS)](#permission-denied-linuxmacos)
 - [Database Connection Issues](#database-connection-issues)
+- [Agent heartbeats return 401 Invalid token](#agent-heartbeats-return-401-invalid-token)
 - [Firewall Configuration](#firewall-configuration)
 - [Security Considerations](#security-considerations)
 
@@ -150,6 +151,112 @@ database you're using:
 - Ensure PostgreSQL is running
 - Check the format of and credentials in your data source name (DSN or database URL)
 - Verify network connectivity
+- If the service logs `error performing TLS handshake`, the PostgreSQL server's
+  certificate is not trusted. See
+  [Agent heartbeats return 401 Invalid token](#agent-heartbeats-return-401-invalid-token).
+
+## Agent heartbeats return 401 Invalid token
+
+If every agent heartbeat fails with a `401` response and an `Invalid token`
+error, but the same token authenticates successfully with the web interface
+and the REST API, the heartbeat service usually cannot read tokens from the
+database.
+
+{{% product-name %}} validates heartbeat tokens separately from API requests.
+The embedded heartbeat service maintains its own database connection and
+checks each token against an in-memory cache loaded from the database. If that
+connection fails (for example, the PostgreSQL TLS handshake fails because the
+server certificate is signed by a private CA), the cache stays empty and the
+heartbeat service rejects every token with `Invalid token`. The web interface
+and API keep working because they use a separate database connection.
+The cache refreshes automatically when tokens change and reloads when the
+service starts.
+
+### Check the token cache logs
+
+Search the service logs for token cache and TLS errors. For example, with
+systemd:
+
+```sh
+journalctl -u telegraf-controller | grep -iE "token cache|tls handshake"
+```
+
+A failing service logs errors like the following:
+
+```text
+Failed to refresh token cache: ...
+Pool error: Error occurred while creating a new object: error performing TLS handshake
+```
+
+A healthy service logs the number of tokens loaded:
+
+```text
+Token cache refreshed: 5 tokens loaded
+```
+
+If the cache refresh fails, continue to the next step.
+If the refresh succeeds but reports `0 tokens loaded`, no active tokens exist
+in the database; [create a new token](/telegraf/controller/tokens/create/) or
+check that existing tokens are not revoked.
+
+### Provide the database CA certificate
+
+`error performing TLS handshake` means {{% product-name %}} does not trust the
+certificate presented by the PostgreSQL server. Certificate verification uses
+a bundled set of public root certificates (the Mozilla root store), so
+certificates issued by a private CA, including Amazon RDS, fail verification
+until you provide the CA certificate:
+
+1. Download the CA certificate for your PostgreSQL server. For example, for
+   Amazon RDS:
+
+   ```sh
+   wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
+     -O /opt/telegraf-controller/rds-global-bundle.pem
+   ```
+
+2. Point {{% product-name %}} at the CA certificate using the
+   [`DATABASE_CA_CERT` or `PGSSLROOTCERT`](/telegraf/controller/reference/config-options/#database-ca-cert)
+   environment variable, or the
+   [`sslrootcert`](/telegraf/controller/reference/config-options/#sslrootcert)
+   parameter in the database URL:
+
+   ```sh
+   DATABASE_CA_CERT=/opt/telegraf-controller/rds-global-bundle.pem
+   ```
+
+3. Restart the service and confirm the logs show
+   `Token cache refreshed: N tokens loaded` with a nonzero count.
+
+> [!Note]
+> #### Temporarily connect without verification
+>
+> To confirm the diagnosis, or to restore service while you obtain the CA
+> certificate, you can encrypt the connection without verifying the server
+> certificate: set
+> [`sslmode=require`](/telegraf/controller/reference/config-options/#sslmode)
+> in the database URL, or set
+> [`DATABASE_SSL_NO_VERIFY=1`](/telegraf/controller/reference/config-options/#database-ssl-no-verify).
+> Use these options for troubleshooting only; provide a CA certificate for
+> production deployments.
+
+### Other causes of heartbeat 401 responses
+
+The heartbeat endpoint returns a distinct error message for each failure mode:
+
+- **`Missing or invalid Authorization header`**: the request has no
+  `Authorization` header, or the header does not use the `Bearer <token>` or
+  `Token <token>` scheme.
+- **`Invalid token format`**: the token does not start with the `tc-apiv1_`
+  prefix. Check for truncation or quoting issues in the agent configuration.
+- **`Invalid token`**: the token is not in the token cache. Either the token
+  was [revoked](/telegraf/controller/tokens/revoke/) or deleted, or the cache
+  failed to load (see above).
+- **`Token expired`**: the token is past its expiration date. Create a new
+  token and update the agent configuration.
+
+For how agents send tokens with heartbeat requests, see
+[Use API tokens](/telegraf/controller/tokens/use/#for-heartbeat-requests).
 
 ## Firewall configuration
 

--- a/content/telegraf/controller/reference/config-options.md
+++ b/content/telegraf/controller/reference/config-options.md
@@ -384,7 +384,12 @@ telegraf_controller \
 To verify the server certificate, provide a CA certificate with
 [`sslrootcert`](#sslrootcert), [`database-ca-cert`](#database-ca-cert), or
 `PGSSLROOTCERT`. If you request verification but do not provide a CA
-certificate, {{% product-name %}} falls back to the system trust store.
+certificate, {{% product-name %}} verifies against a bundled set of public
+root certificates (the Mozilla root store). Certificates issued by a private
+CA, including Amazon RDS, fail verification unless you provide the CA
+certificate. If database certificate verification fails, agent heartbeats are
+rejected; see
+[Agent heartbeats return 401 Invalid token](/telegraf/controller/install/troubleshoot/#agent-heartbeats-return-401-invalid-token).
 
 > [!Note]
 > #### Client certificate authentication is not supported

--- a/content/telegraf/controller/tokens/use.md
+++ b/content/telegraf/controller/tokens/use.md
@@ -81,6 +81,9 @@ When authentication is required for the heartbeat endpoint, agents must include
 a valid token with each heartbeat request.
 If a heartbeat request is missing a token or includes an invalid token,
 {{% product-name %}} rejects the request and the agent's status is not updated.
+If heartbeats are rejected with `Invalid token` even though the same token
+works in the web interface and the API, see
+[Agent heartbeats return 401 Invalid token](/telegraf/controller/install/troubleshoot/#agent-heartbeats-return-401-invalid-token).
 
 ## With external API clients
 


### PR DESCRIPTION
Add a symptom-first troubleshooting section for agent heartbeats failing with 401 Invalid token while the web UI and API work: diagnose via token cache log lines, fix PostgreSQL TLS handshake failures with a CA certificate (Amazon RDS example), and list the other heartbeat 401 error messages. Correct the Database TLS trust-store wording in config options and cross-link from secure-tls and token usage pages.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
