### PR TITLE
chore(controller): updated and add lucide icons to controller docs

### DIFF
--- a/.ci/vale/styles/config/vocabularies/InfluxDataDocs/accept.txt
+++ b/.ci/vale/styles/config/vocabularies/InfluxDataDocs/accept.txt
@@ -84,6 +84,7 @@ keep-url
 lat
 (locf|LOCF)
 logicalplan
+[Ll]ucide
 noaa|NOAA
 npm|NPM
 oauth|OAuth

--- a/assets/styles/layouts/_lucide-icons.scss
+++ b/assets/styles/layouts/_lucide-icons.scss
@@ -9,7 +9,7 @@ svg.lucide {
   display: inline-block;
   width: 1.1em;
   height: 1.1em;
-  vertical-align: text-top;
+  vertical-align: -.2em;
   stroke: currentColor;
   flex: none;
 

--- a/content/telegraf/controller/agents/_index.md
+++ b/content/telegraf/controller/agents/_index.md
@@ -17,8 +17,8 @@ Controller can distinguish one agent from another.
 
 - {{% product-name %}} automatically creates agents the first time a heartbeat
   arrives from a unique agent.
-- Click the **More button ({{% icon "tc-more" %}})** in the agent list and select
-  **View Details** to see information and reporting history for an agent.
+- Click the **More button ({{% lucide "ellipsis-vertical" %}})** in the agent list and select
+  **{{% lucide "eye" %}} View Details** to see information and reporting history for an agent.
 - Reporting rules define how long an agent can go without sending a heartbeat
   before {{% product-name "short" %}} marks it as **Not Reporting**. They can
   also automatically delete agents that haven't reported in a specified amount

--- a/content/telegraf/controller/agents/create.md
+++ b/content/telegraf/controller/agents/create.md
@@ -90,5 +90,5 @@ to specify the `instance_id`.
 
 1. Open {{% product-name %}} and go to **Agents**.
 2. Confirm the agent appears in the list with the expected `instance_id`.
-3. Click the **More button ({{% icon "tc-more" %}})** and select
-  **View Details** to verify metadata, labels, and the reporting rule assignment.
+3. Click the **More button ({{% lucide "ellipsis-vertical" %}})** and select
+  **{{% lucide "eye" %}} View Details** to verify metadata, labels, and the reporting rule assignment.

--- a/content/telegraf/controller/agents/delete.md
+++ b/content/telegraf/controller/agents/delete.md
@@ -26,14 +26,14 @@ Remove individual or multiple Telegraf agents from {{% product-name %}}.
 ## Delete a single agent
 
 1.  In **Agents**, find the agent you want to remove.
-2.  Click the **More button ({{% icon "tc-more" %}})** and select
-    **{{% icon "trash" %}} Delete Agent**.
+2.  Click the **More button ({{% lucide "ellipsis-vertical" %}})** and select
+    **{{% lucide "trash-2" %}} Delete Agent**.
 3.  Confirm the deletion.
 
 ## Delete multiple agents
 
 1.  In **Agents**, select the checkboxes for the agents you want to remove.
-2.  Select **{{% icon "trash" %}} Delete Agents**.
+2.  Select **{{% lucide "trash-2" %}} Delete Agents**.
 3.  Confirm the deletion.
 
 ## Automatically delete agents

--- a/content/telegraf/controller/agents/reporting-rules.md
+++ b/content/telegraf/controller/agents/reporting-rules.md
@@ -38,7 +38,7 @@ list or an agent details page.
 ## Create a reporting rule
 
 1.  In Telegraf Controller, go to **Reporting Rules**.
-2.  Select **+ Add Rule**.
+2.  Select **{{% lucide "plus" %}} Add Rule**.
 3.  Enter the following:
     - **Description**: Reporting rule description
     - **Not Reporting Threshold**: The maximum time an agent can go without
@@ -51,18 +51,18 @@ list or an agent details page.
 
 ## Update a reporting rule
 
-1.  In **Reporting Rules**, click the **More button ({{% icon "tc-more" %}})**
+1.  In **Reporting Rules**, click the **More button ({{% lucide "ellipsis-vertical" %}})**
     of the rule you want to update.
-2.  Select **Edit**.
+2.  Select **{{% lucide "pencil" %}} Edit**.
 3.  Edit the description, not reporting threshold, auto-delete settings, or make
     the rule the default reporting rule.
 4.  Save your changes.
 
 ## Delete a reporting rule
 
-1.  In **Reporting Rules**, click the **More button ({{% icon "tc-more" %}})**
+1.  In **Reporting Rules**, click the **More button ({{% lucide "ellipsis-vertical" %}})**
     of the rule you want to delete.
-2.  Select **Delete** and confirm.
+2.  Select **{{% lucide "trash-2" %}} Delete** and confirm.
 
 > [!Important]
 >
@@ -80,15 +80,15 @@ list or an agent details page.
 
 ### From the reporting rules list
 
-1.  In **Reporting Rules**, click the **More button ({{% icon "tc-more" %}})**
+1.  In **Reporting Rules**, click the **More button ({{% lucide "ellipsis-vertical" %}})**
     of the rule you want to make the default.
-2.  Select **Make Default**.
+2.  Select **{{% lucide "check" %}} Make Default**.
 
 ### From reporting rule details
 
-1.  In **Reporting Rules**, click the **More button ({{% icon "tc-more" %}})**
+1.  In **Reporting Rules**, click the **More button ({{% lucide "ellipsis-vertical" %}})**
     of the rule you want to make the default.
-2.  Select **Edit**.
+2.  Select **{{% lucide "pencil" %}} Edit**.
 3.  Toggle **Default Rule** to true.
 4.  Save your changes.
 
@@ -97,12 +97,12 @@ list or an agent details page.
 ### From the agent list
 
 1. In **Agents**, select one or more agents.
-2. Select **Assign Rule**.
+2. Select **{{% lucide "file-check" %}} Assign Rule**.
 3. Choose a rule and assign it.
 
 ### From an agent details page
 
-1. In **Agents**, click the **More button ({{% icon "tc-more" %}})** for an
-   agent and select **View Details**.
+1. In **Agents**, click the **More button ({{% lucide "ellipsis-vertical" %}})** for an
+   agent and select **{{% lucide "eye" %}} View Details**.
 2. In the **Reporting Rule** section, select **Change**.
 3. Choose a rule and apply it.

--- a/content/telegraf/controller/agents/status.md
+++ b/content/telegraf/controller/agents/status.md
@@ -121,7 +121,7 @@ time-based expressions, see
 
 1.  In {{% product-name %}}, go to **Agents**.
 2.  Check the **Status** column for each agent.
-3.  To see more details, click the **More button ({{% icon "tc-more" %}})** and
-    select **View Details**.
+3.  To see more details, click the **More button ({{% lucide "ellipsis-vertical" %}})** and
+    select **{{% lucide "eye" %}} View Details**.
 4.  The details page shows the reported status, reporting rule assignment, and
     the time of the last heartbeat.

--- a/content/telegraf/controller/authentication/ldap.md
+++ b/content/telegraf/controller/authentication/ldap.md
@@ -212,7 +212,7 @@ Group-to-role mappings translate directory group membership into
 
 1. On the **Settings** page, scroll to **LDAP Authentication >
    Group role mappings**.
-2. Click **Add mapping** and provide:
+2. Click **{{% lucide "plus" %}} Add Mapping** and provide:
    - **Provider ID**: a label that identifies the LDAP instance. Use the
      default `default` unless you run multiple directories.
    - **Group name**: the value {{% product-name %}} receives in the

--- a/content/telegraf/controller/authentication/oidc.md
+++ b/content/telegraf/controller/authentication/oidc.md
@@ -237,7 +237,7 @@ Group-to-role mappings translate values from the OIDC groups claim into
 
 1. On the **Settings** page, scroll to **OIDC Authentication >
    Group role mappings**.
-2. Click **Add mapping** and provide:
+2. Click **{{% lucide "plus" %}} Add Mapping** and provide:
    - **Provider ID**: a label that identifies the OIDC provider
      instance. Use the default `default` unless you run multiple
      providers.

--- a/content/telegraf/controller/configs/create.md
+++ b/content/telegraf/controller/configs/create.md
@@ -24,7 +24,7 @@ plugins.
 
 1.  In the {{% product-name %}} web interface, select **Configurations** in the 
     navigation bar. 
-2.  Click **{{% icon "plus" %}} Add Config**.
+2.  Click **{{% lucide "plus" %}} Add Config**.
 3.  Enter a configuration name and optional description.
 4.  Use the {{% product-name %}} [Code Editor](#use-the-code-editor) or
     [Telegraf Builder](#use-the-telegraf-builder) to provide or build the

--- a/content/telegraf/controller/configs/delete.md
+++ b/content/telegraf/controller/configs/delete.md
@@ -34,8 +34,8 @@ configuration detail page.
 
 1.  In the {{% product-name %}} web interface, select **Configurations** in the 
     navigation bar.
-2.  Click the **More button ({{% icon "tc-more" %}})** next to the configuration
-    you want to delete and select **{{% icon "trash" %}} Delete**.
+2.  Click the **More button ({{% lucide "ellipsis-vertical" %}})** next to the configuration
+    you want to delete and select **{{% lucide "trash-2" %}} Delete**.
 3.  Confirm the deletion.
 
 ### From the configuration detail page
@@ -53,5 +53,5 @@ configuration detail page.
 1.  In the {{% product-name %}} web interface, select **Configurations** in the 
     navigation bar.
 2.  Use the select boxes to select all of the configurations you want to delete.
-3.  In the bulk options menu that appears, click **{{% icon "trash" %}} Delete**.
+3.  In the bulk options menu that appears, click **{{% lucide "trash-2" %}} Delete**.
 4.  Confirm the deletion.

--- a/content/telegraf/controller/configs/ui/telegraf-builder.md
+++ b/content/telegraf/controller/configs/ui/telegraf-builder.md
@@ -49,7 +49,7 @@ in the builder grouped by plugin type.
 
 - **Search plugins**: Use the search bar in the Plugin Library pane to search
   for Telegraf plugins. Search by plugin name, identifier, or description.
-- **Add plugins to your configuration**: Click **{{% icon "plus" %}}** next to the
+- **Add plugins to your configuration**: Click **{{% lucide "plus" %}}** next to the
   plugin to add it to your configuration.
 
 ## Configuration pane
@@ -83,7 +83,7 @@ required and only need to be included in a configuration when set.
 
 1.  On the **Global Tags** card, enable the
     **{{% icon "toggle" %}} Include in config** toggle.
-2.  Click **{{% icon "plus" %}} Add Global Tag**.
+2.  Click **{{% lucide "plus" %}} Add Global Tag**.
 3.  Provide a key and a value for the global tag.
 4.  Repeat steps 2-3 for additional global tags.
 
@@ -132,5 +132,5 @@ For more information about using Telegraf plugin filters, see
 
 #### Remove a plugin from the configuration
 
-To remove a plugin from the configuration, click the **{{% icon "trash" %}}**
+To remove a plugin from the configuration, click the **{{% lucide "trash-2" %}}**
 icon on the plugin card.

--- a/content/telegraf/controller/configs/update.md
+++ b/content/telegraf/controller/configs/update.md
@@ -18,8 +18,8 @@ options.
 1.  In the {{% product-name %}} web interface, select **Configurations** in the 
     navigation bar.
 2.  Click the name of the configuration you want to edit or click the
-    **More button ({{% icon "tc-more" %}})** and select
-    **{{% icon "eye" %}} View/Edit**.
+    **More button ({{% lucide "ellipsis-vertical" %}})** and select
+    **{{% lucide "eye" %}} View/Edit**.
 3.  Update global settings, labels, parameters, and plugin settings as needed.
 4.  Review the TOML preview and resolve any validation errors.
 5.  Click **Save**.
@@ -35,11 +35,11 @@ compare, roll back, or prune versions, see
 1.  In the {{% product-name %}} web interface, select **Configurations** in the 
     navigation bar.
 2.  Click the name of the configuration you want to edit or click the
-    **More button ({{% icon "tc-more" %}})** and select
-    **{{% icon "eye" %}} View/Edit**.
+    **More button ({{% lucide "ellipsis-vertical" %}})** and select
+    **{{% lucide "eye" %}} View/Edit**.
 3.  Under **Configuration Information**, click the text under **Name** or
     **Description**. The name or description will load into a form field.
-4.  Provide a new name or description and click **{{% icon "check" %}}**.
+4.  Provide a new name or description and click **{{% lucide "check" %}}**.
 
 Name and description changes do not create a new configuration version.
 

--- a/content/telegraf/controller/configs/versions.md
+++ b/content/telegraf/controller/configs/versions.md
@@ -57,19 +57,19 @@ The version history table includes the following for each version:
 - **Change Note**: the description provided when the version was saved.
 
 To view the full TOML content stored in a version, click the
-**More button ({{% icon "tc-more" %}})** in the version's row and select
-**{{% icon "eye" %}} View/Edit**.
+**More button ({{% lucide "ellipsis-vertical" %}})** in the version's row and select
+**{{% lucide "eye" %}} View/Edit**.
 
 ## Update a change note
 
-1.  In the version's row, click the **More button ({{% icon "tc-more" %}})**
-    and select **{{% icon "eye" %}} View/Edit**.
+1.  In the version's row, click the **More button ({{% lucide "ellipsis-vertical" %}})**
+    and select **{{% lucide "eye" %}} View/Edit**.
 2.  Update the change note and confirm your changes.
 
 ## Compare versions
 
 1.  In the version history table, select exactly two versions.
-2.  Click **Compare**.
+2.  Click **{{% lucide "git-compare" %}} Compare**.
 
 The **Compare Versions** dialog displays a diff of the TOML content of the two
 versions, using the lower-numbered version as the base.
@@ -83,8 +83,8 @@ A rollback does not rewrite history: {{% product-name %}} creates a new
 version containing the restored content, with a change note that records
 which version it was restored from.
 
-1.  In the version's row, click the **More button ({{% icon "tc-more" %}})**
-    and select **Rollback**.
+1.  In the version's row, click the **More button ({{% lucide "ellipsis-vertical" %}})**
+    and select **{{% lucide "rotate-ccw" %}} Rollback**.
 2.  Review the confirmation and click **Confirm & Rollback**.
 
 You can roll back to any version except the version marked **Current**.
@@ -107,14 +107,14 @@ up old versions you no longer need. Pruning is permanent.
 
 ### Prune a single version
 
-1.  In the version's row, click the **More button ({{% icon "tc-more" %}})**
-    and select **Prune**.
+1.  In the version's row, click the **More button ({{% lucide "ellipsis-vertical" %}})**
+    and select **{{% lucide "trash-2" %}} Prune**.
 2.  Review the confirmation and click **Confirm & Prune**.
 
 ### Prune selected versions
 
 1.  In the version history table, select the versions to prune.
-2.  Click **Prune**.
+2.  Click **{{% lucide "trash-2" %}} Prune**.
 3.  Review the confirmation and click **Confirm & Prune**.
 
 If your selection includes the current version, {{% product-name %}} keeps
@@ -124,7 +124,7 @@ the current version and prunes the other selected versions.
 
 With no versions selected:
 
-1.  Click **Prune**.
+1.  Click **{{% lucide "trash-2" %}} Prune**.
 2.  Select a pruning criterion:
     - **Before version**: prune all versions before the version you select.
     - **Before date & time**: prune all versions created before the date and

--- a/content/telegraf/controller/get-started.md
+++ b/content/telegraf/controller/get-started.md
@@ -31,7 +31,7 @@ API tokens authenticate Telegraf agents when they retrieve configurations and
 send heartbeats to {{% product-name %}}.
 
 1.  Navigate to the **API Tokens** page.
-2.  Click **+ Create API Token**.
+2.  Click **{{% lucide "plus" %}} Create API Token**.
 3.  Enter a description--for example, `Getting started agent token`.
 4.  Select a token **Expiration**.
 5.  Select the permissions to assign to the token. For convenience, you can
@@ -66,7 +66,7 @@ stdout and reports agent health back to {{% product-name %}}.
 
 1.  In the {{% product-name %}} user interface (UI), select **Configurations**
     in the navigation bar.
-2.  Click **{{% icon "plus" %}} Add Config**.
+2.  Click **{{% lucide "plus" %}} Add Config**.
 3.  Enter a name and description for the configuration--for example,
     "Getting Started."
 4.  In the **Code Editor**, enter the following TOML:
@@ -264,8 +264,8 @@ in {{% product-name %}}.
 
 1.  In {{% product-name %}}, select **Agents** in the navigation bar.
 2.  Confirm your agent appears in the list with an **Ok** status.
-3.  Click the **More button ({{% icon "tc-more" %}})** and select
-    **View Details** to see agent metadata, the loaded configuration, and
+3.  Click the **More button ({{% lucide "ellipsis-vertical" %}})** and select
+    **{{% lucide "eye" %}} View Details** to see agent metadata, the loaded configuration, and
     reporting history.
 
 ## Update the configuration

--- a/content/telegraf/controller/tokens/create.md
+++ b/content/telegraf/controller/tokens/create.md
@@ -21,7 +21,7 @@ Tokens let you grant scoped access to external tools, scripts, and services with
 ## Create a token
 
 1.  Navigate to the **API Tokens** page.
-2.  Click **Create Token**.
+2.  Click **{{% lucide "plus" %}} Create API Token**.
 3.  Enter a **Description** for the token that identifies where or how the token
     will be used.
 4.  _(Optional)_ Set an **Expiration** date.

--- a/content/telegraf/controller/tokens/delete.md
+++ b/content/telegraf/controller/tokens/delete.md
@@ -39,7 +39,7 @@ For more information about revoking a token, see
 ## Delete a token
 
 1.  Navigate to the **API Tokens** page or open the token's detail view.
-2.  Click **Delete** to initiate the deletion. If on the token detail
+2.  Click **{{% lucide "trash-2" %}} Delete** to initiate the deletion. If on the token detail
     page, select the **Manage** tab to reveal the **Delete** action.
 3.  In the confirmation dialog, confirm that you want to permanently delete the token.
 
@@ -52,7 +52,7 @@ that relies on the deleted token will no longer be able to authenticate with
 You can delete multiple tokens at once from the **API Tokens** page.
 
 1. On the **API Tokens** page, select the checkboxes next to each token you want to delete.
-2. Click the **Delete** option in the bulk actions bar.
+2. Click the **{{% lucide "trash-2" %}} Delete** option in the bulk actions bar.
 3. In the confirmation dialog, review the number of tokens to be deleted and confirm.
 
 All selected tokens are permanently removed and immediately invalidated.

--- a/content/telegraf/controller/tokens/reassign.md
+++ b/content/telegraf/controller/tokens/reassign.md
@@ -26,7 +26,7 @@ token's detail view or the tokens list.
 
 1.  In {{% product-name %}}, navigate to the **API Tokens** page or open the
     detail page for the token you want to reassign.
-2.  Click **Reassign** on the token you want to transfer. If on the token detail
+2.  Click **{{% lucide "user-plus" %}} Reassign** on the token you want to transfer. If on the token detail
     page, select the **Manage** tab to reveal the **Reassign** action.
 3.  In the dialog that appears, select the target user you want to assign the
     token to.
@@ -43,7 +43,7 @@ If you need to reassign multiple tokens at once, use the bulk reassign option.
 
 1.  On the **API Tokens** page, select the checkboxes next to the tokens you want
     to reassign.
-2.  Click the **Reassign** option in the bulk actions bar.
+2.  Click the **{{% lucide "user-plus" %}} Reassign** option in the bulk actions bar.
 3.  Select the target user you want to assign the selected tokens to.
 4.  Click **Confirm** to reassign all selected tokens.
 

--- a/content/telegraf/controller/tokens/revoke.md
+++ b/content/telegraf/controller/tokens/revoke.md
@@ -35,7 +35,7 @@ For more information about deleting a token, see
 ## Revoke a token
 
 1.  Navigate to the **API Tokens** page, or open the token's detail view.
-2.  Click **Revoke**. If on the token detail page, select the **Manage** tab to
+2.  Click **{{% lucide "ban" %}} Revoke**. If on the token detail page, select the **Manage** tab to
     reveal the **Revoke** action.
 3.  Confirm the revocation in the dialog.
 
@@ -54,7 +54,7 @@ immediately rejected.
 To revoke multiple tokens at once:
 
 1. On the **API Tokens** page, select the tokens you want to revoke.
-2. Click **Revoke** in the bulk actions bar.
+2. Click **{{% lucide "ban" %}} Revoke** in the bulk actions bar.
 3. Confirm the revocation in the dialog.
 
 All selected tokens are immediately revoked and can no longer be used for

--- a/content/telegraf/controller/users/delete.md
+++ b/content/telegraf/controller/users/delete.md
@@ -29,7 +29,7 @@ removed:
 
 1.  In the {{% product-name %}} UI, navigate to **Users** and click the user you
     want to delete to open their detail page.
-2.  Click **Delete User**.
+2.  Click **{{% lucide "trash-2" %}} Delete User**.
 3.  In the confirmation dialog, confirm the deletion.
 
 The user is immediately removed and can no longer authenticate with

--- a/content/telegraf/controller/users/invite.md
+++ b/content/telegraf/controller/users/invite.md
@@ -21,7 +21,7 @@ immediately active.
 ## Create an invite
 
 1. Navigate to the **Users** page.
-2. Click the {{% icon "plus" %}} **Invite User** button.
+2. Click the {{% lucide "plus" %}} **Invite User** button.
 3. Select an **Authentication provider** for the new user. The selector
    appears only when more than one provider is enabled. Default is
    **Local**. See
@@ -106,7 +106,7 @@ To revoke a pending invite before it is used:
 
 1. Navigate to the **Users** page.
 2. Locate the pending invite you want to remove.
-3. Click the **Delete** button next to the invite.
+3. Click the **{{% lucide "trash-2" %}} Delete** button next to the invite.
 4. Confirm the deletion when prompted.
 
 Deleting a pending invite invalidates the invite link. The invited user can no

--- a/content/telegraf/controller/users/transfer-ownership.md
+++ b/content/telegraf/controller/users/transfer-ownership.md
@@ -27,7 +27,7 @@ administrator.
 
 1.  Navigate to the **Users** page or the target user's detail page.
 2.  Choose the target **Administrator** from the list (if not already selected).
-3.  Select the **Make Owner** option. If on the user detail page, select the
+3.  Select the **{{% lucide "shield" %}} Make Owner** option. If on the user detail page, select the
     **Manage** tab to reveal the **Make Owner** option.
 4.  Confirm the username of the user you want to transfer ownership to and click
     **Transfer Ownership**.

--- a/layouts/shortcodes/icon.html
+++ b/layouts/shortcodes/icon.html
@@ -81,8 +81,6 @@
   <span class="inline ui-toggle blue"><span class="circle"></span></span>
   {{- else if eq $icon "toggle-green" -}}
   <span class="inline ui-toggle green"><span class="circle"></span></span>
-  {{- else if (eq $icon "tc-more") -}}
-  <span class="inline" style="margin: 0 .25rem; vertical-align: middle;">&#8942;</span>
   {{- end -}}
 {{- else if eq $version "v3" -}}
   {{- if or (eq $icon "nav-admin") (eq $icon "influx") (eq $icon "influx-icon") -}}


### PR DESCRIPTION
- Updates the Telegraf Controller documentation to use the new `lucide` icon shortcode.
- Removes the `tc-more` icon.
- Adds `[Ll]ucide` to the Vale accept list.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
