### PR TITLE
fix(explorer): clarify cloud support and point to the Admin UI

### DIFF
--- a/content/influxdb3/cloud-dedicated/admin/_index.md
+++ b/content/influxdb3/cloud-dedicated/admin/_index.md
@@ -9,6 +9,18 @@ menu:
 weight: 6
 ---
 
+> [!Important]
+> #### Use the Admin UI, not InfluxDB 3 Explorer
+>
+> Administer your cluster with the {{% product-name %}}
+> [Admin UI](https://console.influxdata.com) at `console.influxdata.com` or with
+> the [`influxctl` CLI](/influxdb3/cloud-dedicated/reference/cli/influxctl/).
+>
+> [InfluxDB 3 Explorer](/influxdb3/explorer/) is the standalone UI for
+> [InfluxDB 3 Core](/influxdb3/core/) and
+> [InfluxDB 3 Enterprise](/influxdb3/enterprise/).
+> Don't use Explorer to administer {{% product-name %}}.
+
 The following articles provide information about managing your InfluxDB Cloud
 Dedicated resources:
 

--- a/content/influxdb3/cloud-dedicated/admin/_index.md
+++ b/content/influxdb3/cloud-dedicated/admin/_index.md
@@ -12,14 +12,11 @@ weight: 6
 > [!Important]
 > #### Use the Admin UI, not InfluxDB 3 Explorer
 >
-> Administer your cluster with the {{% product-name %}}
-> [Admin UI](https://console.influxdata.com) at `console.influxdata.com` or with
-> the [`influxctl` CLI](/influxdb3/cloud-dedicated/reference/cli/influxctl/).
->
-> [InfluxDB 3 Explorer](/influxdb3/explorer/) is the standalone UI for
+> Use the {{% product-name %}} [Admin UI](https://console.influxdata.com) at
+> `console.influxdata.com` rather than
+> [InfluxDB 3 Explorer](/influxdb3/explorer/), the standalone UI for
 > [InfluxDB 3 Core](/influxdb3/core/) and
 > [InfluxDB 3 Enterprise](/influxdb3/enterprise/).
-> Don't use Explorer to administer {{% product-name %}}.
 
 The following articles provide information about managing your InfluxDB Cloud
 Dedicated resources:

--- a/content/influxdb3/cloud-dedicated/get-started/_index.md
+++ b/content/influxdb3/cloud-dedicated/get-started/_index.md
@@ -128,6 +128,18 @@ The following table compares tools that you can use to interact with
 > Avoid using the `influx` CLI with {{% product-name %}}. While it
 > may coincidentally work, it isn't supported.
 
+> [!Important]
+> #### Administer your cluster with the Admin UI
+>
+> To manage databases, tables, tokens, and users, use the {{% product-name %}}
+> [Admin UI](https://console.influxdata.com) at `console.influxdata.com` or the
+> [`influxctl` CLI](/influxdb3/cloud-dedicated/reference/cli/influxctl/).
+>
+> [InfluxDB 3 Explorer](/influxdb3/explorer/) is the standalone UI for
+> [InfluxDB 3 Core](/influxdb3/core/) and
+> [InfluxDB 3 Enterprise](/influxdb3/enterprise/).
+> Don't use Explorer to administer {{% product-name %}}.
+
 ### `influxctl` CLI
 
 The

--- a/content/influxdb3/cloud-dedicated/get-started/_index.md
+++ b/content/influxdb3/cloud-dedicated/get-started/_index.md
@@ -110,7 +110,7 @@ The following table compares tools that you can use to interact with
 | [`influx3` data CLI](#influx3-data-cli){{< req text="\* " color="magenta" >}}                       |            -             | **{{< icon "check" >}}** | **{{< icon "check" >}}** |
 | [InfluxDB HTTP API](#influxdb-http-api){{< req text="\* " color="magenta" >}}                       |            -             | **{{< icon "check" >}}** | **{{< icon "check" >}}** |
 | <span style="opacity:.5;">InfluxDB user interface</span>                                            |            -             |            -             |            -             |
-| [InfluxDB 3 client libraries](#influxdb-3-client-libraries){{< req text="\* " color="magenta" >}} |            -             | **{{< icon "check" >}}** | **{{< icon "check" >}}** |
+| [InfluxDB 3 client libraries](#influxdb-client-libraries){{< req text="\* " color="magenta" >}}   |            -             | **{{< icon "check" >}}** | **{{< icon "check" >}}** |
 | [InfluxDB v2 client libraries](/influxdb3/cloud-dedicated/reference/client-libraries/v2/)            |            -             | **{{< icon "check" >}}** |            -             |
 | [InfluxDB v1 client libraries](/influxdb3/cloud-dedicated/reference/client-libraries/v1/)            |            -             | **{{< icon "check" >}}** | **{{< icon "check" >}}** |
 | [Telegraf](/telegraf/v1/){{< req text="\* " color="magenta" >}}                                     |            -             | **{{< icon "check" >}}** |            -             |

--- a/content/influxdb3/cloud-dedicated/get-started/_index.md
+++ b/content/influxdb3/cloud-dedicated/get-started/_index.md
@@ -131,14 +131,13 @@ The following table compares tools that you can use to interact with
 > [!Important]
 > #### Administer your cluster with the Admin UI
 >
-> To manage databases, tables, tokens, and users, use the {{% product-name %}}
-> [Admin UI](https://console.influxdata.com) at `console.influxdata.com` or the
-> [`influxctl` CLI](/influxdb3/cloud-dedicated/reference/cli/influxctl/).
->
-> [InfluxDB 3 Explorer](/influxdb3/explorer/) is the standalone UI for
+> Use the {{% product-name %}} [Admin UI](https://console.influxdata.com) at
+> `console.influxdata.com` rather than
+> [InfluxDB 3 Explorer](/influxdb3/explorer/), the standalone UI for
 > [InfluxDB 3 Core](/influxdb3/core/) and
 > [InfluxDB 3 Enterprise](/influxdb3/enterprise/).
-> Don't use Explorer to administer {{% product-name %}}.
+> For administrative tasks, see
+> [Administer InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/admin/).
 
 ### `influxctl` CLI
 

--- a/content/influxdb3/explorer/about/_index.md
+++ b/content/influxdb3/explorer/about/_index.md
@@ -29,9 +29,9 @@ Explorer to administer them.
 >
 > If you use [InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/) or
 > [InfluxDB 3 Cloud](/influxdb3/cloud/), use the
-> [Admin UI](https://console.influxdata.com) at `console.influxdata.com`--not
-> Explorer--to manage databases, tables, tokens, and users.
-> For more information, see
+> [Admin UI](https://console.influxdata.com) at `console.influxdata.com`
+> instead of Explorer to administer your cluster or instance.
+> For administrative tasks and the tools to use, see
 > [Administer InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/admin/) or
 > [Administer InfluxDB 3 Cloud](/influxdb3/cloud/admin/).
 

--- a/content/influxdb3/explorer/about/_index.md
+++ b/content/influxdb3/explorer/about/_index.md
@@ -9,12 +9,31 @@ weight: 10
 ---
 
 InfluxDB 3 Explorer is the user interface component of the InfluxDB 3 platform.
-It provides visual management of databases and tokens and an easy way to querying
-your time series data. Explorer is fully-featured for [InfluxDB 3 Core](/influxdb3/core/)
-and [Enterprise](/influxdb3/enterprise/).  In a future release it will also be able to 
-be used to query [InfluxDB Cloud Serverless](/influxdb3/cloud-serverless/),
-[InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/)
-and [InfluxDB Clustered](/influxdb3/clustered/).
+It provides visual management of databases and tokens and an easy way to query
+your time series data.
+
+## Product support
+
+Explorer is fully featured for [InfluxDB 3 Core](/influxdb3/core/) and
+[InfluxDB 3 Enterprise](/influxdb3/enterprise/).
+You can use Explorer to query data in and administer these products.
+
+Explorer provides only _partial_ support for
+[InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/) and
+[InfluxDB Cloud Serverless](/influxdb3/cloud-serverless/).
+You can connect Explorer to these products to query data, but you can't use
+Explorer to administer them.
+
+> [!Important]
+> #### Administer cloud products with the Admin UI
+>
+> If you use [InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/) or
+> [InfluxDB 3 Cloud](/influxdb3/cloud/), use the
+> [Admin UI](https://console.influxdata.com) at `console.influxdata.com`--not
+> Explorer--to manage databases, tables, tokens, and users.
+> For more information, see
+> [Administer InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/admin/) or
+> [Administer InfluxDB 3 Cloud](/influxdb3/cloud/admin/).
 
 ## Third Party Software
 

--- a/content/influxdb3/explorer/about/_index.md
+++ b/content/influxdb3/explorer/about/_index.md
@@ -31,7 +31,7 @@ Explorer to administer them.
 > [InfluxDB 3 Cloud](/influxdb3/cloud/), use the
 > [Admin UI](https://console.influxdata.com) at `console.influxdata.com`
 > instead of Explorer to administer your cluster or instance.
-> For administrative tasks and the tools to use, see
+> For administrative tasks, see
 > [Administer InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/admin/) or
 > [Administer InfluxDB 3 Cloud](/influxdb3/cloud/admin/).
 

--- a/content/influxdb3/explorer/get-started.md
+++ b/content/influxdb3/explorer/get-started.md
@@ -24,11 +24,28 @@ through each of those steps.
 
 InfluxDB 3 Explorer supports the following InfluxDB 3 products:
 
-- [InfluxDB 3 Core](/influxdb3/core/)
-- [InfluxDB 3 Enterprise](/influxdb3/enterprise/)
-- [InfluxDB Cloud Serverless](/influxdb3/cloud-serverless/)  (Query Mode Only)
-- [InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/)  (Query Mode Only)
-  
+| Product | Support |
+| :------ | :------ |
+| [InfluxDB 3 Core](/influxdb3/core/) | Query and administer |
+| [InfluxDB 3 Enterprise](/influxdb3/enterprise/) | Query and administer |
+| [InfluxDB Cloud Serverless](/influxdb3/cloud-serverless/) | Query only _(partial support)_ |
+| [InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/) | Query only _(partial support)_ |
+
+> [!Important]
+> #### Cloud products: use the Admin UI
+>
+> {{% product-name %}} provides only partial support for
+> [InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/)--you can query data,
+> but you can't administer your cluster.
+> To manage databases, tables, tokens, and users, use the
+> [Admin UI](https://console.influxdata.com) at `console.influxdata.com`.
+> For more information, see
+> [Administer InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/admin/).
+>
+> If you use [InfluxDB 3 Cloud](/influxdb3/cloud/), use the Admin UI at
+> `console.influxdata.com` instead of Explorer.
+> For more information, see
+> [Administer InfluxDB 3 Cloud](/influxdb3/cloud/admin/).
 
 1.  Navigate to **Configure** > **Servers**.
 2.  Click **+ Connect Your First Server**.

--- a/content/influxdb3/explorer/get-started.md
+++ b/content/influxdb3/explorer/get-started.md
@@ -34,17 +34,12 @@ InfluxDB 3 Explorer supports the following InfluxDB 3 products:
 > [!Important]
 > #### Cloud products: use the Admin UI
 >
-> {{% product-name %}} provides only partial support for
-> [InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/)--you can query data,
-> but you can't administer your cluster.
-> To manage databases, tables, tokens, and users, use the
-> [Admin UI](https://console.influxdata.com) at `console.influxdata.com`.
-> For more information, see
-> [Administer InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/admin/).
->
-> If you use [InfluxDB 3 Cloud](/influxdb3/cloud/), use the Admin UI at
-> `console.influxdata.com` instead of Explorer.
-> For more information, see
+> To administer [InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/) or
+> [InfluxDB 3 Cloud](/influxdb3/cloud/), use the
+> [Admin UI](https://console.influxdata.com) at `console.influxdata.com`
+> instead of {{% product-name %}}.
+> For administrative tasks and the tools to use, see
+> [Administer InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/admin/) or
 > [Administer InfluxDB 3 Cloud](/influxdb3/cloud/admin/).
 
 1.  Navigate to **Configure** > **Servers**.

--- a/content/influxdb3/explorer/get-started.md
+++ b/content/influxdb3/explorer/get-started.md
@@ -38,7 +38,7 @@ InfluxDB 3 Explorer supports the following InfluxDB 3 products:
 > [InfluxDB 3 Cloud](/influxdb3/cloud/), use the
 > [Admin UI](https://console.influxdata.com) at `console.influxdata.com`
 > instead of {{% product-name %}}.
-> For administrative tasks and the tools to use, see
+> For administrative tasks, see
 > [Administer InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/admin/) or
 > [Administer InfluxDB 3 Cloud](/influxdb3/cloud/admin/).
 

--- a/content/influxdb3/explorer/manage-databases.md
+++ b/content/influxdb3/explorer/manage-databases.md
@@ -17,7 +17,7 @@ or InfluxDB 3 Enterprise cluster.
 
 > [!Important]
 > Using {{% product-name %}} to manage a database in InfluxDB 3 requires that
-> Explorer is running in [admin mode](/influxdb3/explorer/install/#run-in-query-or-admin-mode)
+> Explorer is running in [admin mode](/influxdb3/explorer/install/#choose-operational-mode)
 > and that the token used in the InfluxDB 3 server configuration is an
 > [admin token](/influxdb3/enterprise/admin/tokens/admin/).
 

--- a/content/influxdb3/explorer/manage-tokens.md
+++ b/content/influxdb3/explorer/manage-tokens.md
@@ -17,7 +17,7 @@ Core instance or InfluxDB 3 Enterprise cluster.
 
 > [!Important]
 > Using {{% product-name %}} to manage authorization tokens in InfluxDB 3 requires that
-> Explorer is running in [admin mode](/influxdb3/explorer/install/#run-in-query-or-admin-mode)
+> Explorer is running in [admin mode](/influxdb3/explorer/install/#choose-operational-mode)
 > and that the token used in the InfluxDB 3 server configuration is an
 > [admin token](/influxdb3/enterprise/admin/tokens/admin/).
 

--- a/content/shared/influxdb3-admin/_index.md
+++ b/content/shared/influxdb3-admin/_index.md
@@ -2,4 +2,17 @@
 The following articles provide information about managing your
 {{< product-name >}} resources:
 
+{{% show-in "cloud" %}}
+> [!Important]
+> #### Use the Admin UI, not InfluxDB 3 Explorer
+>
+> Administer your instance with the {{% product-name %}}
+> [Admin UI](https://console.influxdata.com) at `console.influxdata.com`.
+>
+> [InfluxDB 3 Explorer](/influxdb3/explorer/) is the standalone UI for
+> [InfluxDB 3 Core](/influxdb3/core/) and
+> [InfluxDB 3 Enterprise](/influxdb3/enterprise/).
+> Use the Admin UI instead to manage databases, tables, tokens, and users.
+{{% /show-in %}}
+
 {{< children >}}

--- a/content/shared/influxdb3-admin/_index.md
+++ b/content/shared/influxdb3-admin/_index.md
@@ -7,12 +7,13 @@ The following articles provide information about managing your
 > #### Use the Admin UI, not InfluxDB 3 Explorer
 >
 > Administer your instance with the {{% product-name %}}
-> [Admin UI](https://console.influxdata.com) at `console.influxdata.com`.
+> [Admin UI](https://console.influxdata.com) at `console.influxdata.com` and
+> the tools described in the following articles.
 >
 > [InfluxDB 3 Explorer](/influxdb3/explorer/) is the standalone UI for
 > [InfluxDB 3 Core](/influxdb3/core/) and
 > [InfluxDB 3 Enterprise](/influxdb3/enterprise/).
-> Use the Admin UI instead to manage databases, tables, tokens, and users.
+> Don't use Explorer to administer {{% product-name %}}.
 {{% /show-in %}}
 
 {{< children >}}

--- a/content/shared/influxdb3-admin/_index.md
+++ b/content/shared/influxdb3-admin/_index.md
@@ -6,14 +6,11 @@ The following articles provide information about managing your
 > [!Important]
 > #### Use the Admin UI, not InfluxDB 3 Explorer
 >
-> Administer your instance with the {{% product-name %}}
-> [Admin UI](https://console.influxdata.com) at `console.influxdata.com` and
-> the tools described in the following articles.
->
-> [InfluxDB 3 Explorer](/influxdb3/explorer/) is the standalone UI for
+> Use the {{% product-name %}} [Admin UI](https://console.influxdata.com) at
+> `console.influxdata.com` rather than
+> [InfluxDB 3 Explorer](/influxdb3/explorer/), the standalone UI for
 > [InfluxDB 3 Core](/influxdb3/core/) and
 > [InfluxDB 3 Enterprise](/influxdb3/enterprise/).
-> Don't use Explorer to administer {{% product-name %}}.
 {{% /show-in %}}
 
 {{< children >}}


### PR DESCRIPTION
Related: #7626, #7627, #7628 (follow-ups, not closed by this PR)

## What changed

Explorer docs no longer imply that InfluxDB 3 Explorer is a supported way to work with InfluxDB Cloud Dedicated, and the Cloud Dedicated and InfluxDB 3 Cloud docs now point administrators to the Admin UI at console.influxdata.com.

- **About Explorer** — replaced the "in a future release" statement with a Product support section describing current support.
- **Explorer get started** — turned the supported-products list into a table separating "query and administer" from "query only", and added a callout sending Cloud Dedicated and InfluxDB 3 Cloud users to the Admin UI.
- **Cloud Dedicated admin and get started** — added callouts preferring the Admin UI over the standalone Explorer UI.
- **Shared InfluxDB 3 admin index** — added the same callout for InfluxDB 3 Cloud, scoped with `show-in` so it renders only for that product.
- **Explorer manage databases / manage tokens** — fixed two links pointing at `#run-in-query-or-admin-mode`, an anchor that does not exist. The heading on the install page is "Choose operational mode".
- **Cloud Dedicated get started** — fixed a pre-existing broken anchor in the tools table. It linked to `#influxdb-3-client-libraries`, but the heading is "InfluxDB client libraries" and covers both v3 and v2 client libraries, so the link was wrong rather than the heading. Unchanged on master; the link checker only began scanning the file because this branch modifies it.

## Why

A customer was told they could "technically use" Explorer with Cloud Dedicated. Explorer has only partial support for Dedicated, and Dedicated customers should be using the Admin UI.

The docs invited that mistake by contradicting themselves. About Explorer said support for Serverless, Dedicated, and Clustered was coming "in a future release", while the get started guide already listed Serverless and Dedicated as supported in query mode. Neither page mentioned the Admin UI.

## Impact

Cloud Dedicated and InfluxDB 3 Cloud readers are now directed to the console for administrative tasks. Core and Enterprise guidance is unchanged — Explorer is still the recommended UI for those products, and the new shared-content callout is scoped so it never appears on their pages.

**The callouts state a preference and nothing more.** They don't enumerate which resources the Admin UI manages, and they make no claim about what Explorer can do against a cluster. Two reasons:

1. Console feature support is unverified — see #7628.
2. Admin functionality is documented in the admin sections, and duplicating it in a callout means maintaining it twice. Enumerating resources also misleads by omission: an admin section whose children are CLI and API pages reads as though the Admin UI doesn't support those tasks.

Which interface to use for each task belongs on the specific admin pages, where it can be stated with the detail it needs.

For the same reason, no Admin UI row was added to the Cloud Dedicated tools comparison table.

## Verification

- `npx hugo --quiet` passes.
- **Shared-content scoping.** `content/shared/influxdb3-admin/_index.md` is sourced by Core, Enterprise, and InfluxDB 3 Cloud. An unscoped callout would tell Core and Enterprise users to avoid Explorer, which is the opposite of the guidance for those products. Confirmed in the built output that the callout appears on `/influxdb3/cloud/admin/` and on neither `/influxdb3/core/admin/` nor `/influxdb3/enterprise/admin/`. A site-wide search finds it on exactly two pages: Cloud and Cloud Dedicated.
- `version: cloud` is not globally unique — `influxdb_cloud` (Cloud TSM) cascades the same value. It is unambiguous here only because Cloud TSM doesn't source this file, which is why the scoping is verified by build output rather than assumed. Tracked in #7627.
- All internal and external links in the change resolve in the build, including the corrected `#choose-operational-mode` and `#influxdb-client-libraries` anchors.
- Vale reports 0 errors and 0 warnings across all changed files, under both the default and `cloud-dedicated` configs.
- No layout changes, so no e2e tests required.

## Checklist

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)

***

<details>
<summary><b>Suggested reviewers</b> (click to expand)</summary>

Based on files changed:

| Content | Product |
| --- | --- |
| Explorer | mavarius, peterbarnett03 |
| Cloud Dedicated | ritwika314, sanderson |
| `/content/shared/` | influxdata/product-managers |

Product review is worth having here: the support levels this PR documents came from a support thread, and the open questions in #7628 are what kept further capability claims out of the diff.

</details>