### PR TITLE
fix(telegraf): Fix broken links and linter issues

### DIFF
--- a/content/telegraf/v1/release-notes.md
+++ b/content/telegraf/v1/release-notes.md
@@ -4194,6 +4194,7 @@ Older versions can be manually reverted on a per-plugin basis using the `tls_min
 ### New plugins
 
 #### Inputs
+
 - [AWS CloudWatch Metric Streams](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/cloudwatch_metric_streams) (`cloudwatch_metric_streams`) - Contributed by [@mccabecillian](https://github.com/mccabecillian).
 - [Linux CPU](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/linux_cpu)(`linux_cpu`) - Contributed by [@fabianishere](http://github.com/fabianishere).
 - [NSDP](https://github.com/hdecarne-github/nsdp-telegraf-plugin) (`nsdp`) - Contributed by [@hdecarne](https://github.com/@hdecarne).
@@ -4201,13 +4202,14 @@ Older versions can be manually reverted on a per-plugin basis using the `tls_min
 - [UPSD](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/upsd) (`upsd`) - Contributed by [@Malinskiy](http://github.com/Malinskiy).
 
 #### Outputs
+
 - [PostgreSQL](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/postgresql) (`postgresql`) - Contributed by [@phemmer](https://github.com/phemmer).
 - [RedisTimeSeries](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/redistimeseries) (`redistimeseries`) - Contributed by [@gkorland](http://github.com/gkorland).
 - [Stomp (Active MQ)](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/stomp) - Contributed by [@amus-sal](http://github.com/amus-sal).
 
 #### Serializers
-- [CSV](https://github.com/influxdata/telegraf/tree/master/plugins/serializers/csv) (`csv`) - Contributed by [@influxdata](http://github.com/influxdata).
 
+- [CSV](https://github.com/influxdata/telegraf/tree/master/plugins/serializers/csv) (`csv`) - Contributed by [@influxdata](http://github.com/influxdata).
 
 ### Input plugin updates
 
@@ -4256,23 +4258,25 @@ Older versions can be manually reverted on a per-plugin basis using the `tls_min
   - Improve metric parsing to extend output.
   - Add default appType as configuration option.
 - Redis Time Series (`redistimeseries`): Add integration test
-- SQL (`sql`): Add settings for Go `sql.DB` settings.
+- SQL (`sql`): Add settings for Go SQL DB settings.
 - ExecD (`execd`): Fix error when partially unserializable metrics are written.
 - Wavefront (`wavefront`): Update Wavefront SDK and use non-deprecated APIs.
 
-
 ### Serializer updates
+
 - JSON (`json`): Add new `json_transformation` option transform outputted JSON. This new option can be used to transform the JSON output using the JSONata language to accommodate for requirements on the receiver side. The setting can also filter and process JSON data points.
 - Prometheus (`prometheus`):
   - Provide option to reduce payload size by removing HELP from payload
   - Sort labels in prometheusremotewrite serializer
 
 ### Parser updates
+
 - Migrate parsers to new style.
 - XPath (`xpath`): Add support for returning underlying data types.
 - CSV (`csv`): Add `reset-mode` flag.
 
 ### Processor updates
+
 - Starlark (`starlark`): Add  benchmark for tag concatenation.
 
 ### Dependency updates
@@ -4298,8 +4302,6 @@ Older versions can be manually reverted on a per-plugin basis using the `tls_min
 - Update `gonum.org/v1/gonum` from 0.11.0 to 0.12.0.
 - Update `github.com/Azure/azure-kusto-go` from 0.7.0 to 0.8.0.
 - Update `google.golang.org/grpc` from 1.48.0 to 1.49.0.
-
-
 
 ## v1.23.4 {date="2022-08-16"}
 
@@ -4439,7 +4441,7 @@ Older versions can be manually reverted on a per-plugin basis using the `tls_min
 - RabbitMQ input plugin (`rabbitmq`) Don't require listeners to be present in overview.
 - Sync back `sample.confs` for Couchbuse input plugin (`couchbase`) and Groundwork output plugin (`groundwork`).
 - Filter out views in MongoDB lookup.
-- Fix race condition in configuration and prevent concurrent map writes to `c.UnusedFields`.
+- Fix race condition in configuration and prevent concurrent map writes to `UnusedFields`.
 - Restore sample configurations broken during initial migration
 - Sync back sample.confs for inputs.couchbase and outputs.groundwork.
 
@@ -4480,7 +4482,7 @@ Telegraf without having to paste in sample configurations from each plugin's REA
 - Add missing build constraints for sqlite.
 - Always build README-embedder for host-architecture.
 - Avoid calling `sadc` with invalid 0 interval.
-- Check `net.Listen()` error in tests.
+- Check network `Listen()` error in tests.
 - Add DataDog count metrics.
 - Deprecate unused database configuration option.
 - Document interval setting for internet speed plugin.
@@ -4500,11 +4502,12 @@ Telegraf without having to paste in sample configurations from each plugin's REA
 
 ### New plugins
 
-- [Fritzbox](https://github.com/gridscale/linux-psi-telegraf-plugin/blob/main/README.md)(`fritzbox`) - Contributed by [@hdecarne](https://github.com/@hdecarne).
-- [Huebridge](https://github.com/hdecarne-github/huebridge-telegraf-plugin/blob/main/README.md)(`huebridge`) - Contributed by [@hdecarne](https://github.com/@hdecarne).
+- [Fritzbox](https://github.com/gridscale/linux-psi-telegraf-plugin/blob/main/README.md)(`fritzbox`) - Contributed by [@hdecarne](https://github.com/hdecarne).
+- [Huebridge](https://github.com/hdecarne-github/huebridge-telegraf-plugin/blob/main/README.md)(`huebridge`) - Contributed by [@hdecarne](https://github.com/hdecarne).
 - [Slab](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/slab/README.md) (`slab`) - Contributed by @bobuhiro11.
 
 ### Input plugin updates
+
 - Burrow (`burrow`): Move Dialer to variable and run `make fmt`.
 - CPU (`cpu`): Add core and physical ID tags that contain information about physical CPU or cores in cases of hyper-threading.
 - HTTP (`http`): Use readers over closers.
@@ -4514,11 +4517,13 @@ Telegraf without having to paste in sample configurations from each plugin's REA
 - Redis (`redis`): Fix to `goroutine` leak triggered by auto-reload configuration mechanism.
 
 ### Output plugin updates
+
 - HTTP (`http`): Enable authentication against a Google API protected by the OAuth 2.0 protocol.
 - HTTP (`elasticsearch`): Add healthcheck timeout.
 - SQL (`sql`): Add table existence cache.
 
 ### Dependency updates
+
 - Update `github.com/wavefronthq/wavefront-sdk-go` from 0.9.10 to 0.9.11.
 - Update `github.com/aws/aws-sdk-go-v2/config` from 1.15.3 to 1.15.7.
 - Update `github.com/sensu/sensu-go/api/core/v2` from 2.13.0 to 2.14.0.
@@ -4536,15 +4541,18 @@ Telegraf without having to paste in sample configurations from each plugin's REA
 - Wait for network up in `systemd` packaging.
 
 ### Input plugin updates
+
 - Couchbase (`couchbase`): Do not assume metrics will all be of the same length.
 - StatsD (`statsd`): Fix error when closing network connection.
 - Add mount option filtering to disk plugin.
 
 ### Output plugin updates
+
 - Azure Monitor (`azure_monitor`): Reinitialize `http` client on context deadline error.
 - Wavefront (`wavefront`): Do not add `telegraf.host` tag if no `host` tag is provided.
 
 ### Dependency updates
+
 - Update `github.com/showwin/speedtest-go` from 1.1.4 to 1.1.5.
 - Update OpenTelemetry plugins to v0.51.0.
 
@@ -4553,6 +4561,7 @@ Telegraf without having to paste in sample configurations from each plugin's REA
 - Update Go to 1.18.1.
 
 ### Input plugin updates
+
 - InfluxDB Listener (`influxdb_listener`): Remove duplicate writes with upstream parser.
 - GNMI (`gnmi`): Use external xpath parser.
 - System (`system`): Reduce log level back to original level.
@@ -4563,6 +4572,7 @@ Telegraf without having to paste in sample configurations from each plugin's REA
 - Allow zero outputs when using `test-wait` parameter.
 
 ### Input plugin updates
+
 - Aerospike (`aerospike`): Fix statistics query bug.
 - Aliyun CMS (`aliyuncms`): Ensure metrics accept array.
 - Cisco Telemetry MDT (`cisco_telemetry_mdt`):
@@ -4602,6 +4612,7 @@ Telegraf without having to paste in sample configurations from each plugin's REA
 - Fix default value for logfile rotation interval.
 
 ### Input plugin updates
+
 - Intel PMU (`intel_pmu`): Fix slow running intel-pmu test.
 - Cloud PubSub (`cloud_pubsub`): Skip longer integration tests on `-short` mode.
 - Cloud PubSub Push (`cloud_pubsub_push`): Reduce timeouts and sleeps.
@@ -4610,6 +4621,7 @@ Telegraf without having to paste in sample configurations from each plugin's REA
 - vSphere (`vsphere`): Update debug message information.
 
 ### Output plugin updates
+
 - Azure Monitor (`azure_monitor`): Include body in error message.
 - HTTP (`http`): Switch HTTP 100 test case values.
 
@@ -4617,6 +4629,7 @@ Telegraf without having to paste in sample configurations from each plugin's REA
 - TopK (`topk`) Clarify the `k` and `fields` parameters.
 
 ### New external plugins
+
 - [PSI External Plugin](https://github.com/gridscale/linux-psi-telegraf-plugin/blob/main/README.md)(`external.psi`) - Contributed by [@ajfriesen](https://github.com/ajfriesen).
 
 ## v1.22.0 {date="2022-03-22"}
@@ -4676,7 +4689,7 @@ Telegraf without having to paste in sample configurations from each plugin's REA
 
 #### Processors
 
-- [Noise Processor](https://github.com/influxdata/telegraf/tree/master/plugins/processors/noise) (`noise`) - Contributed by [@wizarq](https://github.com/wizarq).
+- [Noise Processor](https://github.com/influxdata/telegraf/tree/master/plugins/processors/noise) (`noise`) - Contributed by [@shypard](https://github.com/shypard).
 
 ### Input plugin updates
 
@@ -5783,13 +5796,13 @@ The signing for RPM digest has changed to use sha256 to improve security. Due to
 - [Intel RDT Input Plugin](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/intel_rdt/README.md)(`intel_rdt`) - Contributed by [@p-zak](https://github.com/p-zak)
 - [NSD Input Plugin](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nsd/README.md)(`nsd`) - Contributed by [@gearnode](https://github.com/gearnode)
 - [OPC UA Input Plugin](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/opcua/README.md)(`opcua`) - Contributed by [@influxdata](https://github.com/influxdata)
-- [Proxmox Input Plugin](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/proxmox/README.md)(`proxmox`) - Contributed by [@effitient](https://github.com/effitient)
+- [Proxmox Input Plugin](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/proxmox/README.md)(`proxmox`) - Contributed by `@effitient`
 - [RAS Input Plugin](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/ras/README.md)(`ras`)- Contributed by [@p-zak](https://github.com/p-zak)
 - [Windows Eventlog Input Plugin](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/win_eventlog/README.md)(`win_eventlog`) - Contributed by [@simnv](https://github.com/simnv)
 
 #### Outputs
 
-- [Dynatrace Output Plugin](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/dynatrace/README.md)(`dynatrace`) - Contributed by [@thschue](https://github.com/theschue)
+- [Dynatrace Output Plugin](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/dynatrace/README.md)(`dynatrace`) - Contributed by [@thschue](https://github.com/thschue)
 - [Sumo Logic Output Plugin](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/sumologic/README.md) (`sumologic`) - Contributed by [@pmalek-sumo](https://github.com/pmalek-sumo)
 - [Timestream Output Plugin](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/timestream) (`timestream`) - Contributed by [@piotrwest](https://github.com/piotrwest)
 


### PR DESCRIPTION
This PR fixes broken links to Github users as well as the Value linter issues

## Checklist

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
- [ ] Local build passes (`npx hugo --quiet`)
