### PR TITLE
docs(influxdb3): define cache --node-spec semantics and warm-up trade-off

### DIFF
--- a/content/shared/influxdb3-admin/distinct-value-cache/_index.md
+++ b/content/shared/influxdb3-admin/distinct-value-cache/_index.md
@@ -79,6 +79,17 @@ node requires to maintain it. Consider the following:
 On cache creation, {{% product-name %}} loads historical data into the cache.
 On restart, the server automatically reloads cache data.
 
+{{% show-in "enterprise" %}}
+In a multi-node cluster, only nodes included in the cache's
+[node specification](/influxdb3/version/admin/distinct-value-cache/create/)
+load historical data--at creation and on restart.
+Excluded nodes still serve the cache and add newly written data to it,
+but until new data arrives, queries served by those nodes return only values
+written after the cache was created (or after the node restarted).
+Only specify a node list to reduce the initial cache warm-up load, and only
+if you accept temporarily incomplete query results from excluded nodes.
+{{% /show-in %}}
+
 ### High cardinality limits
 
 “Cardinality” refers to the number of unique key column combinations in your 

--- a/content/shared/influxdb3-admin/distinct-value-cache/create.md
+++ b/content/shared/influxdb3-admin/distinct-value-cache/create.md
@@ -12,8 +12,14 @@ to create a Distinct Value Cache (DVC). Provide the following:
 - **Table** (`-t`, `--table`): _({{< req >}})_ The name of the table to
   associate the DVC with.
 {{% show-in "enterprise" %}}
-- **Node specification** (`-n`, `--node-spec`): Specify which nodes the DVC
-  should be configured on.
+- **Node specification** (`-n`, `--node-spec`): Specify which nodes load
+  historical data into the DVC. The default (`all`) loads historical data on
+  all query- and processing-capable nodes. To reduce the initial cache warm-up
+  load, use `nodes:<node-id>[,<node-id>...]` to limit the historical data load
+  to specific nodes. All query-capable nodes serve the DVC and add newly
+  written data to it, but excluded nodes return incomplete query results until
+  new data arrives. Only specify a node list if you accept temporarily
+  incomplete query results from excluded nodes.
 {{% /show-in %}}
 - **Columns** (`--columns`): _({{< req >}})_ Specify which columns to cache
   distinct values for. These are typically tag columns but can also be

--- a/content/shared/influxdb3-admin/last-value-cache/_index.md
+++ b/content/shared/influxdb3-admin/last-value-cache/_index.md
@@ -93,6 +93,17 @@ maintain it. Consider the following:
 On cache creation, {{% product-name %}} loads historical data into the cache.
 On restart, the server automatically reloads cache data.
 
+{{% show-in "enterprise" %}}
+In a multi-node cluster, only nodes included in the cache's
+[node specification](/influxdb3/version/admin/last-value-cache/create/)
+load historical data--at creation and on restart.
+Excluded nodes still serve the cache and add newly written data to it,
+but until new data arrives, queries served by those nodes return only values
+written after the cache was created (or after the node restarted).
+Only specify a node list to reduce the initial cache warm-up load, and only
+if you accept temporarily incomplete query results from excluded nodes.
+{{% /show-in %}}
+
 ### High cardinality key columns
 
 “Cardinality” refers to the number of unique key column combinations in your 

--- a/content/shared/influxdb3-admin/last-value-cache/create.md
+++ b/content/shared/influxdb3-admin/last-value-cache/create.md
@@ -12,8 +12,14 @@ to create a Last Value Cache (LVC). Provide the following:
 - **Table** (`-t`, `--table`): _({{< req >}})_ The name of the table to
   associate the LVC with.
 {{% show-in "enterprise" %}}
-- **Node specification** (`-n`, `--node-spec`): Specify which nodes the LVC
-  should be configured on.
+- **Node specification** (`-n`, `--node-spec`): Specify which nodes load
+  historical data into the LVC. The default (`all`) loads historical data on
+  all query- and processing-capable nodes. To reduce the initial cache warm-up
+  load, use `nodes:<node-id>[,<node-id>...]` to limit the historical data load
+  to specific nodes. All query-capable nodes serve the LVC and add newly
+  written data to it, but excluded nodes return incomplete query results until
+  new data arrives. Only specify a node list if you accept temporarily
+  incomplete query results from excluded nodes.
 {{% /show-in %}}
 - **Key columns** (`--key-columns`): Specify which columns to include in the
   primary key of the cache. Rows in the LVC are uniquely identified by their

--- a/content/shared/influxdb3-cli/create/distinct_cache.md
+++ b/content/shared/influxdb3-cli/create/distinct_cache.md
@@ -35,6 +35,14 @@ influxdb3 create distinct_cache [OPTIONS] \
 | `-h`   | `--help`            | Print help information                                                                                                                                                  |
 |        | `--help-all`        | Print detailed help information                                                                                                                                         |
 
+{{% show-in "enterprise" %}}
+Additional {{% product-name %}} option:
+
+| Option |               | Description                                                                                                                                                                 |
+| :----- | :------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-n`   | `--node-spec` | Which node(s) load historical data into the cache. Two value formats are supported: `all` (default) - all query- and processing-capable nodes load historical data, or `nodes:<node-id>[,<node-id>..]` - only the listed nodes load historical data, reducing the initial cache warm-up load at the cost of temporarily incomplete query results from excluded nodes |
+{{% /show-in %}}
+
 > [!Important]
 >
 > #### Metadata cache hierarchy

--- a/content/shared/influxdb3-cli/create/last_cache.md
+++ b/content/shared/influxdb3-cli/create/last_cache.md
@@ -33,6 +33,14 @@ influxdb3 create last_cache [OPTIONS] \
 | `-h`   | `--help`          | Print help information                                                                                                                                                |
 |        | `--help-all`      | Print detailed help information                                                                                                                                       |
 
+{{% show-in "enterprise" %}}
+Additional {{% product-name %}} option:
+
+| Option |               | Description                                                                                                                                                                 |
+| :----- | :------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-n`   | `--node-spec` | Which node(s) load historical data into the cache. Two value formats are supported: `all` (default) - all query- and processing-capable nodes load historical data, or `nodes:<node-id>[,<node-id>..]` - only the listed nodes load historical data, reducing the initial cache warm-up load at the cost of temporarily incomplete query results from excluded nodes |
+{{% /show-in %}}
+
 ### Option environment variables
 
 You can use the following environment variables as substitutes for CLI options:


### PR DESCRIPTION
## Summary

The `--node-spec` flag on `influxdb3 create last_cache` / `create distinct_cache` (Enterprise) has never had defined semantics in the docs — the admin pages say only "Specify which nodes the [cache] should be configured on," the CLI reference pages omit the flag entirely, and the shared "Cache data loading" sections promise unconditional historical loading with no node-spec caveat.

This PR documents what the flag actually controls: **which Enterprise nodes load historical data into the cache** (at creation and on restart). All query-capable nodes serve the cache and add newly written data to it. The guidance is explicit about when to use it: only to reduce the initial cache warm-up load, and only if temporarily incomplete query results from excluded nodes are acceptable.

## Changes (all in `content/shared/`, Enterprise-gated with `{{% show-in "enterprise" %}}`)

- `influxdb3-cli/create/last_cache.md`, `influxdb3-cli/create/distinct_cache.md`: add an "Additional Enterprise option" table for `-n`/`--node-spec` (pattern borrowed from `create/trigger.md`), including the warm-up/incomplete-results trade-off. The flag was previously undocumented on these pages.
- `influxdb3-admin/last-value-cache/create.md`, `influxdb3-admin/distinct-value-cache/create.md`: replace the undefined "configured on" bullet with the historical-data-load semantics and the "only specify a node list if…" guidance.
- `influxdb3-admin/last-value-cache/_index.md`, `influxdb3-admin/distinct-value-cache/_index.md`: add an Enterprise paragraph to "Cache data loading" covering multi-node behavior: excluded nodes don't load historical data (at creation or restart), still serve and update the cache, and return only post-creation/post-restart values until new data arrives.

## Dependency / timing

The "excluded nodes still serve the cache and add newly written data to it" behavior is completed by influxdata/influxdb_pro#5155 (in review). Released versions have a defect where a cache created with an explicit node list errors on excluded query nodes until they restart (EAR-driven fix; see influxdata/EAR#7045). Suggest holding this PR as draft until #5155 merges and/or ships. Historical-load semantics (`--node-spec` gating warming) are accurate for released versions.

## Verification

- `npx hugo --quiet`: clean build.
- Rendered output checked: the new content appears on `influxdb3/enterprise/...` pages (admin LVC/DVC + CLI reference) and does not appear on the corresponding `influxdb3/core/...` pages; the internal links to the create pages render.
- `yarn lint` / lefthook pre-commit: pass (Vale skipped locally — no binary/Docker; runs in CI).