### PR TITLE
docs(telegraf): restructure v1 nav and add section skeletons

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -38,7 +38,7 @@ Remove this file before merging `docs/telegraf-revamp` into `master`.
 5. **Level-based page weights** per `DOCS-FRONTMATTER.md` and newer doc sets (Telegraf Controller, InfluxDB 3 Explorer):
    top level 1–99 (sequential from 1), second level 101–199, third level 201–299.
    `_index.md` files are weighted one level up from other `.md` files in the same directory.
-   Sink items follow the Explorer precedent: Documentation MCP server 206, Release notes 250.
+   The Documentation MCP server sinks to 206 following the Explorer precedent; Release notes leads the reference nav at weight 1.
 
 ## Content sources
 
@@ -90,24 +90,24 @@ Plugin-level source of truth is `plugins/*/README.md` in the Telegraf repo and i
 ### Reference nav (`telegraf_v1_ref`)
 
 ```
-1   Plugin directory (plugins.md) — frozen structure below it
+1   Release notes (release-notes.md)
+2   Plugin directory (plugins.md) — frozen structure below it
       input-plugins/, output-plugins/, processor-plugins/,
       aggregator-plugins/, secretstore-plugins/ (auto-generated; do not touch)
-2   Telegraf commands (commands/_index.md)
+3   Telegraf commands (commands/_index.md)
       101+ config, plugins, secrets, service, version subcommand pages
-3   Data formats (data_formats/_index.md)
+4   Data formats (data_formats/_index.md)
       101 Input data formats (data_formats/input/_index.md) + per-format pages (201+)
       102 Output data formats (data_formats/output/_index.md) + per-format pages (201+)
       103 Template patterns (data_formats/template-patterns.md, moved with alias)
-4   Agent status evaluation (agent-status-eval/_index.md, shared)
+5   Agent status evaluation (agent-status-eval/_index.md, shared)
       101 CEL variables (agent-status-eval/variables.md, shared)
       102 CEL functions and operators (agent-status-eval/functions.md, shared)
       103 CEL expression examples (agent-status-eval/examples.md, shared)
-5   Supported platforms (supported-platforms.md)
-6   Glossary (glossary.md)
-7   Contribute to Telegraf (contribute.md)
+6   Supported platforms (supported-platforms.md)
+7   Glossary (glossary.md)
+8   Contribute to Telegraf (contribute.md)
 206 Documentation MCP server (mcp-server.md)
-250 Release notes (release-notes.md)
 ```
 
 Weights inside the frozen plugin directories are generated; leave them untouched.

--- a/content/telegraf/v1/_index.md
+++ b/content/telegraf/v1/_index.md
@@ -1,8 +1,10 @@
 ---
 title: Telegraf documentation
 description: >
-  Documentation for Telegraf, the plugin-driven server agent of the InfluxData
-  time series platform, used to collect and report metrics. Telegraf supports four categories of plugins -- input, output, aggregator, and processor.
+  Documentation for Telegraf, the plugin-driven server agent for collecting,
+  processing, and writing metrics and events.
+  Telegraf supports four categories of plugins: input, output, aggregator,
+  and processor.
 menu:
   telegraf_v1:
     name: Telegraf
@@ -13,16 +15,57 @@ weight: 1
 related:
   - /resources/videos/intro-to-telegraf/
   - /telegraf/v1/install/
-  - /telegraf/v1/get_started/
+  - /telegraf/v1/get-started/
+  - /telegraf/v1/concepts/
 cascade:
   product: telegraf
   version: v1
 ---
 
-Telegraf, a server-based agent, collects and sends metrics and events from databases, systems, and IoT sensors.
-Written in Go, Telegraf compiles into a single binary with no external dependencies--requiring very minimal memory.
+Telegraf is a plugin-driven server agent for collecting, processing, and
+writing metrics and events.
+Written in Go, Telegraf compiles into a single binary with no external
+dependencies and requires minimal memory.
 
-For an introduction to Telegraf and an overview of how it works, watch the following video:
+Telegraf moves data through a configurable pipeline:
+
+- **Input plugins** collect metrics from systems, services, databases, and
+  IoT sensors.
+- **Processor plugins** transform and filter metrics as they pass through the
+  pipeline.
+- **Aggregator plugins** create aggregate metrics, such as running means,
+  minimums, and maximums, over configurable periods.
+- **Output plugins** write metrics to InfluxDB and other destinations.
+
+To learn how metrics move through the pipeline, see
+[How Telegraf works](/telegraf/v1/concepts/).
+
+## Key capabilities
+
+- **300+ plugins**: collect from and write to databases, message queues, cloud
+  services, and IoT devices.
+  Browse the [Plugin directory](/telegraf/v1/plugins/).
+- **Parsers and serializers**: read and write many
+  [input](/telegraf/v1/data_formats/input/) and
+  [output](/telegraf/v1/data_formats/output/) data formats, including JSON,
+  CSV, Prometheus, and InfluxDB line protocol.
+- **Metric filtering**: select and modify metrics at each stage of the
+  pipeline with [metric filtering](/telegraf/v1/configuration/#metric-filtering).
+- **Buffering and delivery**: buffer metrics in memory or on disk and retry
+  failed writes.
+- **Secret stores**: keep credentials out of plain-text configuration files
+  with [secret store plugins](/telegraf/v1/secretstore-plugins/).
+- **Manage agents at scale**: use [Telegraf Controller](/telegraf/controller/)
+  to centrally manage configurations and monitor Telegraf agents across your
+  infrastructure.
+
+## Get started
+
+1. [Install Telegraf](/telegraf/v1/install/)
+2. [Get started with Telegraf](/telegraf/v1/get-started/)
+
+For an introduction to Telegraf and an overview of how it works, watch the
+following video:
 
 {{< youtube vGJeo3FaMds >}}
 

--- a/content/telegraf/v1/_index.md
+++ b/content/telegraf/v1/_index.md
@@ -42,7 +42,7 @@ To learn how metrics move through the pipeline, see
 
 ## Key capabilities
 
-- **300+ plugins**: collect from and write to databases, message queues, cloud
+- **400+ plugins**: collect from and write to databases, message queues, cloud
   services, and IoT devices.
   Browse the [Plugin directory](/telegraf/v1/plugins/).
 - **Parsers and serializers**: read and write many

--- a/content/telegraf/v1/administer/_index.md
+++ b/content/telegraf/v1/administer/_index.md
@@ -1,0 +1,14 @@
+---
+title: Administer Telegraf
+description: >
+  Run and manage Telegraf in production: run Telegraf as a service, monitor
+  agent health, and troubleshoot common issues.
+menu:
+  telegraf_v1:
+    name: Administer Telegraf
+    weight: 8
+---
+
+Run and manage Telegraf in production.
+
+{{< children >}}

--- a/content/telegraf/v1/administer/troubleshoot.md
+++ b/content/telegraf/v1/administer/troubleshoot.md
@@ -3,13 +3,12 @@ title: Troubleshoot Telegraf
 description: Resolve common issues with Telegraf.
 menu:
   telegraf_v1:
-
-    name: Troubleshoot
-    Parent: Configure plugins
-    weight: 79
+    name: Troubleshoot Telegraf
+    parent: Administer Telegraf
+    weight: 105
 aliases:
   - /telegraf/v1/administration/troubleshooting/
-  - /telegraf/v1/administration/troubleshooting/
+  - /telegraf/v1/configure_plugins/troubleshoot/
 ---
 
 ## Validate your Telegraf configuration with `--test`

--- a/content/telegraf/v1/commands/_index.md
+++ b/content/telegraf/v1/commands/_index.md
@@ -4,7 +4,7 @@ description: The `telegraf` command starts and runs all the processes necessary 
 menu:
   telegraf_v1_ref:
     name: Telegraf commands
-    weight: 25
+    weight: 3
 ---
 
 The `telegraf` command starts and runs all the processes necessary for Telegraf to function.

--- a/content/telegraf/v1/concepts/_index.md
+++ b/content/telegraf/v1/concepts/_index.md
@@ -1,0 +1,16 @@
+---
+title: How Telegraf works
+description: >
+  Learn Telegraf core concepts: the metric data model and the data pipeline
+  that moves metrics from inputs through processors and aggregators to outputs.
+menu:
+  telegraf_v1:
+    name: How Telegraf works
+    weight: 4
+---
+
+Telegraf is a plugin-driven agent that collects, transforms, and writes metrics.
+Learn the core concepts behind Telegraf: how metrics are structured and how they
+move through the Telegraf data pipeline.
+
+{{< children >}}

--- a/content/telegraf/v1/concepts/metrics.md
+++ b/content/telegraf/v1/concepts/metrics.md
@@ -2,10 +2,12 @@
 title: Telegraf metrics
 description: Telegraf metrics are internal representations used to model data during processing and are based on InfluxDB's data model. Each metric component includes the measurement name, tags, fields, and timestamp.
 menu:
-  telegraf_v1_ref:
-    name: Metrics
-    weight: 10
-    parent: Concepts
+  telegraf_v1:
+    name: Telegraf metrics
+    weight: 101
+    parent: How Telegraf works
+aliases:
+  - /telegraf/v1/metrics/
 ---
 
 Telegraf metrics are the internal representation used to model data during

--- a/content/telegraf/v1/configure_plugins/_index.md
+++ b/content/telegraf/v1/configure_plugins/_index.md
@@ -1,13 +1,21 @@
 ---
-title: Configure plugins
-description:
+title: Use Telegraf plugins
+description: >
+  Use Telegraf plugins to collect metrics from a variety of sources, transform
+  them, and write them to your destinations.
 menu:
   telegraf_v1:
-
-     name: Configure plugins
-     weight: 50
+    name: Use plugins
+    weight: 6
 ---
 
-Telegraf is a server-based agent for collecting and sending metrics and events from databases, systems, and IoT sensors.
+Telegraf plugins collect, transform, and write metrics.
+Input plugins collect metrics, processor and aggregator plugins transform them,
+and output plugins write them to your destinations.
 
 {{< children hlevel="h2" >}}
+
+For the complete list of available plugins, see the
+[Plugin directory](/telegraf/v1/plugins/).
+To learn how metrics move through the Telegraf data pipeline, see
+[How Telegraf works](/telegraf/v1/concepts/).

--- a/content/telegraf/v1/configure_plugins/aggregator_processor/_index.md
+++ b/content/telegraf/v1/configure_plugins/aggregator_processor/_index.md
@@ -5,8 +5,8 @@ description: |
 menu:
   telegraf_v1:
      name: Aggregator and processor plugins
-     weight: 50
-     parent: Configure plugins
+     weight: 103
+     parent: Use plugins
 related:
   - /telegraf/v1/aggregator-plugins/
   - /telegraf/v1/processor-plugins/

--- a/content/telegraf/v1/configure_plugins/external_plugins/_index.md
+++ b/content/telegraf/v1/configure_plugins/external_plugins/_index.md
@@ -5,8 +5,8 @@ description: |
 menu:
   telegraf_v1:
      name: External plugins
-     weight: 50
-     parent: Configure plugins
+     weight: 104
+     parent: Use plugins
 ---
 
 [External plugins](https://github.com/influxdata/telegraf/blob/master/EXTERNAL_PLUGINS.md) are external programs that are built outside

--- a/content/telegraf/v1/configure_plugins/external_plugins/shim.md
+++ b/content/telegraf/v1/configure_plugins/external_plugins/shim.md
@@ -5,7 +5,7 @@ menu:
   telegraf_v1:
   
      name: Use the `execd` shim
-     weight: 50
+     weight: 201
      parent: External plugins
 ---
 

--- a/content/telegraf/v1/configure_plugins/external_plugins/write_external_plugin.md
+++ b/content/telegraf/v1/configure_plugins/external_plugins/write_external_plugin.md
@@ -5,7 +5,7 @@ menu:
   telegraf_v1:
 
      name: Write an external plugin
-     weight: 50
+     weight: 202
      parent: External plugins
 ---
 Set up your plugin to use it with `execd`.

--- a/content/telegraf/v1/configure_plugins/input_plugins/_index.md
+++ b/content/telegraf/v1/configure_plugins/input_plugins/_index.md
@@ -6,8 +6,8 @@ menu:
   telegraf_v1:
 
      name: Input plugins
-     weight: 10
-     parent: Configure plugins
+     weight: 101
+     parent: Use plugins
 related:
   - /telegraf/v1/input-plugins/
 ---

--- a/content/telegraf/v1/configure_plugins/input_plugins/using_http.md
+++ b/content/telegraf/v1/configure_plugins/input_plugins/using_http.md
@@ -5,7 +5,7 @@ menu:
   telegraf_v1:
 
     name: Using the HTTP plugin
-    weight: 30
+    weight: 202
     parent: Input plugins
 ---
 

--- a/content/telegraf/v1/configure_plugins/output_plugins/_index.md
+++ b/content/telegraf/v1/configure_plugins/output_plugins/_index.md
@@ -5,8 +5,8 @@ description: |
 menu:
   telegraf_v1:
      name: Output plugins
-     weight: 20
-     parent: Configure plugins
+     weight: 102
+     parent: Use plugins
 related:
   - /telegraf/v1/output-plugins/
   - /telegraf/v1/data_formats/output/

--- a/content/telegraf/v1/contribute.md
+++ b/content/telegraf/v1/contribute.md
@@ -4,7 +4,7 @@ description:
 menu:
   telegraf_v1_ref:
     name: Contribute to Telegraf
-    weight: 80
+    weight: 8
 ---
 
 There are many ways to contribute to InfluxData open source products.

--- a/content/telegraf/v1/data_formats/_index.md
+++ b/content/telegraf/v1/data_formats/_index.md
@@ -4,10 +4,8 @@ list_title: Data formats
 description: Telegraf supports input data formats and output data formats for converting input and output data.
 menu:
   telegraf_v1_ref:
-
-     name: Data formats
-
-     weight: 50
+    name: Data formats
+    weight: 4
 ---
 
 This section covers the input data formats and output data formats used in the Telegraf plugin-driven server agent component of the InfluxData time series platform.

--- a/content/telegraf/v1/data_formats/input/_index.md
+++ b/content/telegraf/v1/data_formats/input/_index.md
@@ -5,7 +5,7 @@ description: Telegraf supports parsing input data formats into Telegraf metrics.
 menu:
   telegraf_v1_ref:
     name: Input data formats
-    weight: 1
+    weight: 101
     parent: Data formats
 ---
 

--- a/content/telegraf/v1/data_formats/output/_index.md
+++ b/content/telegraf/v1/data_formats/output/_index.md
@@ -5,7 +5,7 @@ description: Telegraf serializes metrics into output data formats.
 menu:
   telegraf_v1_ref:
     name: Output data formats
-    weight: 1
+    weight: 102
     parent: Data formats
 related:
   - /telegraf/v1/configure_plugins/output_plugins/

--- a/content/telegraf/v1/data_formats/template-patterns.md
+++ b/content/telegraf/v1/data_formats/template-patterns.md
@@ -5,8 +5,11 @@ description: |
     and from Telegraf metrics.
 menu:
   telegraf_v1_ref:
-    weight: 10
     name: Template patterns
+    parent: Data formats
+    weight: 103
+aliases:
+  - /telegraf/v1/configure_plugins/template-patterns/
 ---
 
 Template patterns describe how a dot-delimited string should be mapped to

--- a/content/telegraf/v1/enterprise.md
+++ b/content/telegraf/v1/enterprise.md
@@ -7,7 +7,7 @@ description: >
 menu:
   telegraf_v1:
     name: Telegraf Enterprise
-    weight: 90
+    weight: 10
     params:
       state: new
   telegraf_enterprise:
@@ -16,7 +16,7 @@ menu:
     parent: Telegraf
     params:
       state: new
-weight: 90
+weight: 10
 ---
 
 **Telegraf Enterprise** is the commercial package for organizations running

--- a/content/telegraf/v1/examples/_index.md
+++ b/content/telegraf/v1/examples/_index.md
@@ -1,0 +1,17 @@
+---
+title: Telegraf configuration examples
+list_title: Configuration examples
+description: >
+  Complete example Telegraf configurations for common collection, processing,
+  and writing scenarios.
+menu:
+  telegraf_v1:
+    name: Configuration examples
+    weight: 7
+---
+
+Use complete, working Telegraf configurations for common scenarios.
+Each example includes the full configuration file, a walkthrough of each
+section, and sample output.
+
+{{< children >}}

--- a/content/telegraf/v1/get-started.md
+++ b/content/telegraf/v1/get-started.md
@@ -4,7 +4,7 @@ description: Configure and start Telegraf
 menu:
   telegraf_v1:
     name: Get started
-    weight: 30
+    weight: 3
 aliases:
   - /telegraf/v1/introduction/getting-started/
   - /telegraf/v1/get_started/

--- a/content/telegraf/v1/glossary.md
+++ b/content/telegraf/v1/glossary.md
@@ -4,7 +4,7 @@ description: This section includes definitions of important terms for related to
 menu:
   telegraf_v1_ref:
     name: Glossary
-    weight: 79
+    weight: 7
 ---
 
 ## agent

--- a/content/telegraf/v1/install.md
+++ b/content/telegraf/v1/install.md
@@ -4,7 +4,7 @@ description: Learn how to install, configure, and start Telegraf on your system.
 menu:
   telegraf_v1:
     name: Install
-    weight: 20
+    weight: 2
 aliases:
 - /telegraf/v1/introduction/installation/
 - /telegraf/v1/install/

--- a/content/telegraf/v1/plugins.md
+++ b/content/telegraf/v1/plugins.md
@@ -7,7 +7,7 @@ description: >
 menu:
   telegraf_v1_ref:
     identifier: plugins_reference
-    weight: 10
+    weight: 2
 weight: 6
 aliases:
   - /telegraf/v1/plugins/aggregators/

--- a/content/telegraf/v1/release-notes.md
+++ b/content/telegraf/v1/release-notes.md
@@ -8,7 +8,7 @@ aliases:
 menu:
   telegraf_v1_ref:
     name: Release notes
-    weight: 60
+    weight: 1
 ---
 
 ## v1.39.2 {date="2026-07-20"}


### PR DESCRIPTION
- Restructures Telegraf docs navigation for documentation revamp.
- Adds base landing pages.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
