### PR TITLE
docs(telegraf): add concepts content for metrics and data pipeline

### DIFF
--- a/content/telegraf/v1/concepts/_index.md
+++ b/content/telegraf/v1/concepts/_index.md
@@ -1,16 +1,76 @@
 ---
 title: How Telegraf works
 description: >
-  Learn Telegraf core concepts: the metric data model and the data pipeline
-  that moves metrics from inputs through processors and aggregators to outputs.
+  Learn Telegraf core concepts: plugin types, the metric data model, and the
+  data pipeline that moves metrics from inputs through processors and
+  aggregators to outputs.
 menu:
   telegraf_v1:
     name: How Telegraf works
     weight: 4
+related:
+  - /telegraf/v1/plugins/
+  - /telegraf/v1/configure_plugins/
+  - /telegraf/v1/configuration/
 ---
 
-Telegraf is a plugin-driven agent that collects, transforms, and writes metrics.
-Learn the core concepts behind Telegraf: how metrics are structured and how they
-move through the Telegraf data pipeline.
+Telegraf is a plugin-driven agent.
+A single Telegraf binary contains hundreds of plugins, and the plugins you
+enable in your [configuration file](/telegraf/v1/configuration/) determine
+what Telegraf collects, how it transforms that data, and where it writes it.
+
+## Plugin types
+
+Four plugin types form the Telegraf
+[data pipeline](/telegraf/v1/concepts/data-pipeline/):
+
+- **Input plugins** collect [metrics](/telegraf/v1/concepts/metrics/) from
+  systems, services, databases, and sensors.
+- **Processor plugins** transform, decorate, and filter metrics as they pass
+  through the pipeline.
+- **Aggregator plugins** produce new aggregate metrics, such as running means,
+  minimums, and maximums, over configurable time windows.
+- **Output plugins** write metrics to destinations such as InfluxDB, files,
+  and message queues.
+
+Two more plugin types extend how Telegraf runs:
+
+- **Secret store plugins** keep credentials out of plain-text configuration
+  files and resolve them at runtime.
+  See [secret store plugins](/telegraf/v1/secretstore-plugins/).
+- **External plugins** run outside the Telegraf binary, in any language,
+  through the `execd` family of plugins.
+  See [external plugins](/telegraf/v1/configure_plugins/external_plugins/).
+
+Every plugin is configured in the same TOML configuration file, and you can
+enable multiple instances of the same plugin.
+For the complete list of available plugins, see the
+[Plugin directory](/telegraf/v1/plugins/).
+
+## Polling and service inputs
+
+Most input plugins poll: on each collection interval, Telegraf calls the
+plugin to gather current values, such as CPU usage or a database query result.
+
+**Service input plugins** listen instead of polling.
+They run continuously, receiving data pushed to them from sources such as
+message queues (Kafka, MQTT, AMQP), socket listeners, and webhooks, and they
+emit metrics into the pipeline as data arrives.
+
+## Parsers and serializers
+
+Many plugins move data in formats other than Telegraf metrics:
+
+- **Parsers** convert raw input data, such as JSON, CSV, or Prometheus
+  exposition format, into Telegraf metrics.
+  Input plugins that support parsing accept a `data_format` option that
+  selects one of the [input data formats](/telegraf/v1/data_formats/input/).
+- **Serializers** convert Telegraf metrics into an output representation,
+  such as InfluxDB line protocol, JSON, or Graphite.
+  Output plugins that support serialization accept a `data_format` option
+  that selects one of the
+  [output data formats](/telegraf/v1/data_formats/output/).
+
+## Learn more
 
 {{< children >}}

--- a/content/telegraf/v1/concepts/data-pipeline.md
+++ b/content/telegraf/v1/concepts/data-pipeline.md
@@ -1,0 +1,149 @@
+---
+title: The Telegraf data pipeline
+description: >
+  Learn how metrics flow through Telegraf: input plugins collect and parse
+  data, processor and aggregator plugins transform it, and output plugins
+  buffer, serialize, and write it to destinations.
+menu:
+  telegraf_v1:
+    name: Data pipeline
+    weight: 102
+    parent: How Telegraf works
+related:
+  - /telegraf/v1/concepts/metrics/
+  - /telegraf/v1/configure_plugins/aggregator_processor/
+  - /telegraf/v1/configuration/
+---
+
+Every metric that Telegraf handles follows the same path: input plugins
+collect it, processor and aggregator plugins transform it, and output plugins
+write it to one or more destinations.
+
+{{< diagram >}}
+graph TD
+  Inputs[<strong>Input plugins</strong> \n <em>Collect and parse</em>]
+  P1[<strong>Processor plugins</strong> \n <em>First pass</em>]
+  Agg[<strong>Aggregator plugins</strong> \n <em>Windowed aggregates</em>]
+  P2[<strong>Processor plugins</strong> \n <em>Second pass</em>]
+  Buffer[<strong>Output buffer</strong>]
+  Outputs[<strong>Output plugins</strong> \n <em>Serialize and write</em>]
+
+  Inputs --> P1
+  P1 --> Agg
+  Agg --> P2
+  P2 --> Buffer
+  Buffer --> Outputs
+{{< /diagram >}}
+
+Processor and aggregator plugins are optional.
+With none configured, metrics move directly from inputs to the output buffer.
+
+## Collect: input plugins
+
+On each collection interval, Telegraf calls every polling input plugin to
+gather metrics.
+[Service input plugins](/telegraf/v1/concepts/#polling-and-service-inputs)
+emit metrics as data arrives instead of waiting for the interval.
+
+Input plugins that read raw data, such as files, message queues, or HTTP
+responses, use a [parser](/telegraf/v1/data_formats/input/) selected by the
+plugin's `data_format` option to convert that data into
+[Telegraf metrics](/telegraf/v1/concepts/metrics/).
+
+Input plugins apply [metric filters](#where-filtering-happens) after
+gathering, so only metrics that pass the plugin's filters enter the pipeline.
+
+## Process: processor plugins
+
+Processor plugins act on metrics as they pass through and immediately emit
+the result.
+Typical uses include renaming metrics, converting units, enriching metrics
+with tags, and running calculations.
+
+Metrics that match a processor's filters are handed to the processor;
+metrics that do not match bypass the processor and continue downstream
+unchanged.
+
+## Aggregate: aggregator plugins
+
+Aggregator plugins produce new aggregate metrics, such as running means,
+minimums, maximums, and standard deviations.
+Each aggregator collects matching metrics into a time window defined by its
+`period` setting and emits the aggregate values at the end of each period.
+
+- Aggregators only aggregate metrics with timestamps inside the current
+  period. Metrics older than the period are not included.
+- Aggregates are created for each unique combination of measurement, field,
+  and tag set. Use `taginclude` to group aggregates by specific tags only.
+- By default, aggregators emit the aggregates *and* pass the original metrics
+  downstream. Set `drop_original = true` to emit only the aggregates.
+
+## Processor ordering
+
+By default, processors run twice: once before aggregators and again on the
+metrics that aggregators emit.
+Running processors again lets you transform aggregate metrics, but it can
+also produce unintended results. For example, a processor that scales values
+scales them a second time after aggregation
+(see [influxdata/telegraf#7993](https://github.com/influxdata/telegraf/issues/7993)).
+
+To control this behavior, use the following `[agent]` settings:
+
+- `skip_processors_before_aggregators = true`: processors run only *after*
+  aggregators.
+- `skip_processors_after_aggregators = true`: processors run only *before*
+  aggregators.
+
+Alternatively, use metric filtering on the processor so aggregate metrics
+bypass it, and make custom processor scripts idempotent so repeated
+processing has no side effects.
+
+## Write: output plugins
+
+Output plugins write metrics to their destinations.
+Telegraf writes in batches of up to `metric_batch_size` metrics, on every
+`flush_interval`, or sooner when a full batch is ready.
+Output plugins that support serialization use a
+[serializer](/telegraf/v1/data_formats/output/) selected by the plugin's
+`data_format` option to convert metrics into the destination's format.
+
+Output plugins apply metric filters before writing, so each output can
+receive a different subset of the pipeline's metrics.
+
+## Buffering and delivery
+
+Each output plugin has its own buffer that holds metrics awaiting a
+successful write.
+If a destination is unreachable, metrics accumulate in the buffer, up to
+`metric_buffer_limit` metrics, and Telegraf retries on the next flush.
+
+The `[agent]` `buffer_strategy` setting controls buffer durability:
+
+- `memory` (default): metrics buffer in memory only.
+  If the buffer fills, Telegraf drops the oldest metrics to make room for new
+  ones, and buffered metrics are lost if Telegraf stops.
+- `disk`: each output persists its buffer to a write-ahead log in
+  `buffer_directory`, and Telegraf removes entries as writes succeed.
+  After a restart, Telegraf flushes existing log entries before new metrics.
+  Telegraf does not limit the disk space these files use; monitor the buffer
+  directory to keep it from filling the disk.
+
+For end-to-end delivery guarantees with queue-based inputs, see
+[tracking metrics](/telegraf/v1/concepts/metrics/#tracking-metrics).
+
+## Where filtering happens
+
+You can attach [metric filters](/telegraf/v1/configuration/#metric-filtering)
+to any plugin, but the point at which they apply depends on the plugin type:
+
+- **Input plugins** filter *after* gathering: only passing metrics enter the
+  pipeline.
+- **Processor plugins** filter *before* processing: non-matching metrics
+  bypass the processor unchanged.
+- **Aggregator plugins** filter *before* aggregation: non-matching metrics
+  pass downstream without being aggregated.
+- **Output plugins** filter *before* writing: only passing metrics are sent
+  to the destination.
+
+For filter syntax and examples, see
+[Metric filtering](/telegraf/v1/configuration/#metric-filtering).

--- a/content/telegraf/v1/concepts/metrics.md
+++ b/content/telegraf/v1/concepts/metrics.md
@@ -1,6 +1,9 @@
 ---
 title: Telegraf metrics
-description: Telegraf metrics are internal representations used to model data during processing and are based on InfluxDB's data model. Each metric component includes the measurement name, tags, fields, and timestamp.
+description: >
+  Telegraf metrics are the internal representation used to model data during
+  processing. Each metric includes a measurement name, tags, fields, and a
+  timestamp.
 menu:
   telegraf_v1:
     name: Telegraf metrics
@@ -8,26 +11,87 @@ menu:
     parent: How Telegraf works
 aliases:
   - /telegraf/v1/metrics/
+related:
+  - /telegraf/v1/concepts/data-pipeline/
+  - /telegraf/v1/data_formats/output/
+  - /telegraf/v1/data_formats/output/influx/
 ---
 
 Telegraf metrics are the internal representation used to model data during
 processing.
-These metrics are closely based on InfluxDB's data model and contain
-four main components:
+Metrics are closely based on InfluxDB's data model and contain four main
+components:
 
-- **Measurement name**: Description and namespace for the metric.
-- **Tags**: Key/Value string pairs and usually used to identify the
-  metric.
-- **Fields**: Key/Value pairs that are typed and usually contain the
-  metric data.
-- **Timestamp**: Date and time associated with the fields.
+- **Measurement name**: the description and namespace for the metric, such as
+  `cpu` or `mem`.
+- **Tags**: key-value string pairs, usually used to identify the source of the
+  metric, such as the host name or region.
+- **Fields**: typed key-value pairs that contain the metric data, such as a
+  numeric usage value.
+- **Timestamp**: the date and time associated with the fields.
 
-Telegraf metrics exist only in memory and must be converted to a concrete
-representation to be transmitted or viewed.
-Telegraf provides [output data formats][output data formats] (also known as *serializers*) for these conversions.
-Telegraf's default serializer converts to [InfluxDB line
-protocol][line protocol], which provides a high performance and one-to-one
-direct mapping from Telegraf metrics.
+For example, the following metric, shown in InfluxDB line protocol, has the
+measurement name `cpu`, two tags, two fields, and a nanosecond timestamp:
 
-[output data formats]: /telegraf/v1/data_formats/output/
-[line protocol]: /telegraf/v1/data_formats/output/influx/
+```text
+cpu,host=web01,cpu=cpu0 usage_idle=92.5,usage_user=4.2 1717000000000000000
+```
+
+When deciding how to structure data, use tags for string values that identify
+and filter metrics, and use fields for the measured values themselves.
+Many destinations, including InfluxDB, index tags, so filtering by tag is
+more efficient than filtering by field.
+
+## Serializing metrics
+
+Telegraf holds metrics in memory as it moves them through the
+[data pipeline](/telegraf/v1/concepts/data-pipeline/).
+To write, transmit, or view metrics, Telegraf converts each one to a concrete
+representation using an [output data format](/telegraf/v1/data_formats/output/)
+(also known as a *serializer*).
+
+While InfluxDB is the primary output target for Telegraf, Telegraf is not
+tied to it: serializers convert metrics to formats such as Prometheus,
+Graphite, JSON, and CSV, and
+[output plugins](/telegraf/v1/plugins/#output-plugins) deliver them to many
+different destinations, including databases, message queues, and cloud
+services.
+The default serializer converts metrics to
+[InfluxDB line protocol](/telegraf/v1/data_formats/output/influx/), which
+provides a high-performance, one-to-one mapping from Telegraf metrics.
+
+> [!Note]
+> By default, metrics awaiting delivery are held only in memory and are lost
+> if Telegraf stops.
+> To persist pending metrics to disk, use the `disk`
+> [buffer strategy](/telegraf/v1/concepts/data-pipeline/#buffering-and-delivery).
+
+## Tracking metrics
+
+Tracking metrics ensure that data is passed from an input and handed to an
+output before Telegraf acknowledges the message back to the input.
+Use them with queue-based sources to make sure messages reach the destination
+before the source removes them.
+
+For example, if a configuration reads from MQTT, Kafka, or an AMQP source,
+Telegraf reads the message and waits until the metric is handed to the output
+before telling the source that the message was read.
+If Telegraf stops or the host crashes, messages that were not completely
+delivered to an output are re-read later.
+
+> [!Note]
+> Delivery acknowledgment applies only to internal plugins.
+> For [external plugins](/telegraf/v1/configure_plugins/external_plugins/),
+> Telegraf acknowledges metrics regardless of the actual output.
+
+### Undelivered messages
+
+When an input uses tracking metrics, the plugin provides an additional
+`max_undelivered_messages` setting that determines how many messages Telegraf
+reads before requiring acknowledgments.
+In practice, Telegraf might not read new messages from an input at every
+collection interval.
+
+Use caution with this setting.
+Setting the value too high can cause Telegraf to push constant batches to an
+output and ignore the flush interval.


### PR DESCRIPTION
- Expand How Telegraf works into an architecture overview: plugin types, polling vs. service inputs, and parsers and serializers.
- Rewrite Telegraf metrics: metric model with line protocol example, tags vs. fields guidance, serialization across many destinations, and tracking metrics with delivery acknowledgment.
- Add The Telegraf data pipeline: per-stage flow with diagram, processor ordering and skip_processors settings, output batching, memory vs. disk buffering, and where filtering applies.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
