### PR TITLE
docs(telegraf): convert configuration to a section with topic pages

### DIFF
--- a/DOCS-TESTING.md
+++ b/DOCS-TESTING.md
@@ -147,6 +147,19 @@ SQL, InfluxQL, Go, and other languages are not yet checked.
 - `{ placeholders="TOKEN_NAME|DURATION" }` fence attributes — tokens get language-safe substitutions before parsing
 - Hugo shortcodes inside fences — stripped with a safe replacement
 
+**Skipping a block**: For examples that are *intentionally* invalid (for
+example, demonstrating a syntax error), add the `lint="false"` fence
+attribute:
+
+````markdown
+```toml {lint="false"}
+path = "C:\Program Files\"  # invalid TOML
+```
+````
+
+Skipped blocks still appear in the linter output with the skip reason, so
+exemptions stay visible in review.
+
 ## Link Validation
 
 ### Local setup (macOS)

--- a/PLAN.md
+++ b/PLAN.md
@@ -38,6 +38,14 @@ Remove this file before merging `docs/telegraf-revamp` into `master`.
 5. **Level-based page weights** per `DOCS-FRONTMATTER.md` and newer doc sets (Telegraf Controller, InfluxDB 3 Explorer):
    top level 1–99 (sequential from 1), second level 101–199, third level 201–299.
    `_index.md` files are weighted one level up from other `.md` files in the same directory.
+   Set `weight` at the page level (top-level frontmatter), not on the menu entry; menu items inherit the page weight.
+6. **Settings references use per-setting headings with Type and Default metadata.**
+   Group settings under H2s by purpose; each setting is an H3 (stable anchor) with a short description followed by `**Type:**` and `**Default:**` metadata lines, matching the Telegraf Controller config-options precedent.
+   The Type line ends with a markdown hard break (trailing double space) so Type and Default render as adjacent lines, not separate paragraphs.
+   Type vocabulary: string, boolean, integer, duration, size, table.
+   Defaults use TOML-literal form (`"10s"`, `true`) or "Not set;" plus the unset behavior; inherited options link the agent setting's anchor.
+   Give each repeated option name one canonical heading per page so anchors stay stable.
+   Verify types and defaults against the Telegraf source, not memory.
    The Documentation MCP server sinks to 206 following the Explorer precedent; Release notes leads the reference nav at weight 1.
 
 ## Content sources

--- a/content/telegraf/v1/configuration/_index.md
+++ b/content/telegraf/v1/configuration/_index.md
@@ -31,7 +31,7 @@ For the configuration file structure and loading behavior, see
 [Telegraf configuration file](/telegraf/v1/configuration/file/).
 
 - [Create a configuration with default input and output plugins](#create-a-configuration-with-default-input-and-output-plugins)
-- [Create a configuration with specific input and output plugins](#create-a-configuration-with-specific-input-and-output-plugins)
+- [Create a configuration file with specific input and output plugins](#create-a-configuration-file-with-specific-input-and-output-plugins)
 - [Windows PowerShell v5 encoding](#windows-powershell-v5-encoding)
 
 ### Create a configuration with default input and output plugins
@@ -607,7 +607,7 @@ Excluded metrics are passed downstream to the next processor.
 Filters can be configured per input, output, processor, or aggregator.
 
 - [Filters](#filters)
-- [Filtering examples](#filter-examples)
+- [Filtering examples](#filtering-examples)
 
 ### Filters
 

--- a/content/telegraf/v1/configuration/_index.md
+++ b/content/telegraf/v1/configuration/_index.md
@@ -1,14 +1,15 @@
 ---
-title: Configuration options
+title: Configure Telegraf
 description: >
-  Overview of the Telegraf configuration file, enabling plugins, and setting
+  Overview of the Telegraf configuration file: generating and loading
+  configuration, agent settings, plugin options, metric filtering, and
   environment variables.
 aliases:
   - /telegraf/v1/administration/configuration/
 menu:
-  telegraf_v1_ref:
-    name: Configuration options
-    weight: 40
+  telegraf_v1:
+    name: Configure Telegraf
+weight: 5
 ---
 
 Telegraf uses a configuration file to define what plugins to enable and what
@@ -17,11 +18,17 @@ Each Telegraf plugin has its own set of configuration options.
 Telegraf also provides global options for configuring specific Telegraf settings.
 
 > [!Note]
-> See [Get started](/telegraf/v1/get_started/) to quickly get up and running with Telegraf.
+> See [Get started](/telegraf/v1/get-started/) to quickly get up and running with Telegraf.
+
+The following pages cover each configuration topic in depth:
+
+{{< children >}}
 
 ## Generate a configuration file
 
 The `telegraf config` command lets you generate a configuration file using Telegraf's list of plugins.
+For the configuration file structure and loading behavior, see
+[Telegraf configuration file](/telegraf/v1/configuration/file/).
 
 - [Create a configuration with default input and output plugins](#create-a-configuration-with-default-input-and-output-plugins)
 - [Create a configuration with specific input and output plugins](#create-a-configuration-with-specific-input-and-output-plugins)
@@ -406,6 +413,9 @@ Telegraf applies the global tags to all metrics gathered on this host.
 
 ## Agent configuration
 
+For agent settings grouped by what they control, see
+[Agent settings](/telegraf/v1/configuration/agent/).
+
 The `[agent]` section contains the following configuration options:
 
 - **interval**: Default data collection interval for all inputs.
@@ -485,6 +495,9 @@ The `[agent]` section contains the following configuration options:
 
 ## Input configuration
 
+For details and examples, see
+[Common plugin options](/telegraf/v1/configuration/plugin-options/#input-plugin-options).
+
 The following config parameters are available for all inputs:
 
 - **alias**: Name an instance of a plugin.
@@ -504,6 +517,9 @@ The following config parameters are available for all inputs:
 - **tags**: A map of tags to apply to a specific input's measurements.
 
 ## Output configuration
+
+For details and examples, see
+[Common plugin options](/telegraf/v1/configuration/plugin-options/#output-plugin-options).
 
 - **alias**: Name an instance of a plugin.
 - **flush_interval**: Maximum time between flushes. Use this setting to
@@ -541,6 +557,9 @@ For available serializers and configuration options, see
 
 ## Aggregator configuration
 
+For details and examples, see
+[Common plugin options](/telegraf/v1/configuration/plugin-options/#aggregator-plugin-options).
+
 The following config parameters are available for all aggregators:
 
 - **alias**: Name an instance of a plugin.
@@ -569,6 +588,9 @@ get data into Telegraf, see the following video:
 {{< youtube 6XJdZ_kdx14 >}}
 
 ## Processor configuration
+
+For details and examples, see
+[Common plugin options](/telegraf/v1/configuration/plugin-options/#processor-plugin-options).
 
 The following config parameters are available for all processors:
 

--- a/content/telegraf/v1/configuration/agent.md
+++ b/content/telegraf/v1/configuration/agent.md
@@ -1,0 +1,329 @@
+---
+title: Telegraf agent settings
+description: >
+  Reference for every setting in the Telegraf [agent] configuration table,
+  grouped by what it controls: scheduling, batching and buffering, flushing,
+  logging, host identity, pipeline behavior, and state persistence.
+menu:
+  telegraf_v1:
+    name: Agent settings
+    parent: Configure Telegraf
+weight: 103
+related:
+  - /telegraf/v1/concepts/data-pipeline/
+  - /telegraf/v1/configuration/file/
+  - /telegraf/v1/configuration/plugin-options/
+---
+
+The `[agent]` table configures how Telegraf itself runs and sets the defaults
+used across all plugins.
+Define the `[agent]` table only once, in the first configuration file that
+Telegraf reads.
+
+```toml
+[agent]
+  interval = "10s"
+  round_interval = true
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  flush_interval = "10s"
+```
+
+Each setting lists its data type and default value.
+Duration and size values are TOML strings, such as `"10s"`, `"1m"`, or
+`"10MB"`.
+See [Durations](/telegraf/v1/configuration/toml/#durations).
+
+- [Collection scheduling](#collection-scheduling)
+  - [interval](#interval)
+  - [round_interval](#round_interval)
+  - [collection_jitter](#collection_jitter)
+  - [collection_offset](#collection_offset)
+- [Batching and buffering](#batching-and-buffering)
+  - [metric_batch_size](#metric_batch_size)
+  - [metric_buffer_limit](#metric_buffer_limit)
+  - [buffer_strategy](#buffer_strategy)
+  - [buffer_directory](#buffer_directory)
+  - [buffer_disk_sync](#buffer_disk_sync)
+- [Flushing](#flushing)
+  - [flush_interval](#flush_interval)
+  - [flush_jitter](#flush_jitter)
+- [Timestamps](#timestamps)
+  - [precision](#precision)
+- [Logging](#logging)
+  - [debug](#debug)
+  - [quiet](#quiet)
+  - [logformat](#logformat)
+  - [structured_log_message_key](#structured_log_message_key)
+  - [logfile](#logfile)
+  - [logfile_rotation_interval](#logfile_rotation_interval)
+  - [logfile_rotation_max_size](#logfile_rotation_max_size)
+  - [logfile_rotation_max_archives](#logfile_rotation_max_archives)
+  - [log_with_timezone](#log_with_timezone)
+- [Host identity](#host-identity)
+  - [hostname](#hostname)
+  - [omit_hostname](#omit_hostname)
+- [Pipeline behavior](#pipeline-behavior)
+  - [skip_processors_before_aggregators](#skip_processors_before_aggregators)
+  - [skip_processors_after_aggregators](#skip_processors_after_aggregators)
+- [Tag handling](#tag-handling)
+  - [always_include_local_tags](#always_include_local_tags)
+  - [always_include_global_tags](#always_include_global_tags)
+- [State persistence](#state-persistence)
+  - [statefile](#statefile)
+- [SNMP](#snmp)
+  - [snmp_translator](#snmp_translator)
+
+## Collection scheduling
+
+### interval
+
+The default data collection interval for all input plugins.
+
+**Type:** duration  
+**Default:** `"10s"`
+
+### round_interval
+
+Rounds the collection time to the interval.
+For example, with `interval = "10s"`, Telegraf always collects on :00, :10,
+:20, and so on.
+
+**Type:** boolean  
+**Default:** `true`
+
+### collection_jitter
+
+Sleeps each plugin for a random time within the jitter before collecting.
+Use this to keep many plugins from querying resources such as sysfs at the
+same time.
+
+**Type:** duration  
+**Default:** `"0s"`
+
+### collection_offset
+
+Shifts collection by the given interval.
+Use this to schedule plugins at different times when they query constrained
+devices.
+
+**Type:** duration  
+**Default:** `"0s"`
+
+## Batching and buffering
+
+### metric_batch_size
+
+The maximum number of metrics per write.
+Telegraf sends metrics to outputs in batches of at most this size.
+
+**Type:** integer  
+**Default:** `1000`
+
+### metric_buffer_limit
+
+The maximum number of unwritten metrics each output buffers.
+Increasing this value allows longer output downtime without dropping metrics,
+at the cost of more memory.
+When the buffer fills, the oldest metrics are overwritten by new ones.
+
+**Type:** integer  
+**Default:** `10000`
+
+### buffer_strategy
+
+The buffer type for output plugins: `memory` or `disk`, which persists
+pending metrics to disk for durability.
+See
+[Buffering and delivery](/telegraf/v1/concepts/data-pipeline/#buffering-and-delivery).
+
+**Type:** string  
+**Default:** `"memory"`
+
+### buffer_directory
+
+The directory for disk buffer files.
+Each output plugin creates its own subdirectory.
+
+**Type:** string  
+**Default:** Not set; required when using the `disk` buffer strategy.
+
+### buffer_disk_sync
+
+Controls write durability in `disk` buffer mode.
+Disabling sync improves write performance at the risk of losing metrics
+buffered during the last flush interval in a power failure.
+
+**Type:** boolean  
+**Default:** `true`
+
+## Flushing
+
+### flush_interval
+
+The default flush interval for all outputs.
+The maximum time between flushes is `flush_interval + flush_jitter`.
+
+**Type:** duration  
+**Default:** `"10s"`
+
+### flush_jitter
+
+Jitters the flush interval by a random amount.
+Use this to avoid large write spikes when running many Telegraf instances.
+
+**Type:** duration  
+**Default:** `"0s"`
+
+## Timestamps
+
+### precision
+
+Rounds collected metric timestamps to the specified interval.
+Precision is *not* applied to service inputs; each service input sets its own
+timestamp precision.
+
+**Type:** duration  
+**Default:** `"0s"` (no rounding)
+
+## Logging
+
+### debug
+
+Log at debug level.
+
+**Type:** boolean  
+**Default:** `false`
+
+### quiet
+
+Log only error-level messages.
+
+**Type:** boolean  
+**Default:** `false`
+
+### logformat
+
+The log format: `text`, `structured`, or, on Windows, `eventlog`.
+
+**Type:** string  
+**Default:** `"text"`
+
+### structured_log_message_key
+
+Overrides the message key for structured logs.
+
+**Type:** string  
+**Default:** `"msg"`
+
+### logfile
+
+The file to log to.
+Ignored for the `eventlog` format.
+
+**Type:** string  
+**Default:** Not set; Telegraf logs to stderr.
+
+### logfile_rotation_interval
+
+Rotates the log file after the specified interval.
+
+**Type:** duration  
+**Default:** `"0h"` (time-based rotation disabled)
+
+### logfile_rotation_max_size
+
+Rotates the log file when it exceeds the specified size.
+
+**Type:** size  
+**Default:** `"0MB"` (size-based rotation disabled)
+
+### logfile_rotation_max_archives
+
+The maximum number of rotated archives to keep. `-1` keeps all archives.
+
+**Type:** integer  
+**Default:** `5`
+
+### log_with_timezone
+
+The time zone to use when logging, such as `America/Chicago`, or `local` for
+local time.
+
+**Type:** string  
+**Default:** Not set
+
+## Host identity
+
+### hostname
+
+Overrides the hostname used in the `host` tag.
+
+**Type:** string  
+**Default:** Not set; Telegraf uses the operating system's hostname.
+
+### omit_hostname
+
+If `true`, Telegraf doesn't set the `host` tag on metrics.
+
+**Type:** boolean  
+**Default:** `false`
+
+## Pipeline behavior
+
+See
+[Processor ordering](/telegraf/v1/concepts/data-pipeline/#processor-ordering)
+for how these settings change the data pipeline.
+
+### skip_processors_before_aggregators
+
+If `true`, processors run only after aggregators instead of both before and
+after.
+
+**Type:** boolean  
+**Default:** `false`
+
+### skip_processors_after_aggregators
+
+If `true`, processors don't run a second time after aggregators.
+
+**Type:** boolean  
+**Default:** `false`
+
+## Tag handling
+
+### always_include_local_tags
+
+Tags defined directly on a plugin always pass tag filtering (`taginclude`
+and `tagexclude`), so you don't have to list them twice.
+
+**Type:** boolean  
+**Default:** `false`
+
+### always_include_global_tags
+
+Tags defined in `[global_tags]` always pass tag filtering.
+
+**Type:** boolean  
+**Default:** `false`
+
+## State persistence
+
+### statefile
+
+The file used to save the state of stateful plugins when Telegraf stops and
+restore it on start.
+
+**Type:** string  
+**Default:** Not set; plugin state isn't persisted across restarts.
+
+## SNMP
+
+### snmp_translator
+
+The method for translating SNMP objects: `gosmi` (built-in library) or
+`netsnmp` (deprecated; calls the external `snmptranslate` and `snmptable`
+programs).
+
+**Type:** string  
+**Default:** `"netsnmp"`

--- a/content/telegraf/v1/configuration/file.md
+++ b/content/telegraf/v1/configuration/file.md
@@ -1,0 +1,150 @@
+---
+title: Telegraf configuration file
+description: >
+  Learn the structure of the Telegraf configuration file, how to generate one,
+  where Telegraf looks for configuration, and how to load configuration from
+  multiple files or a remote URL.
+menu:
+  telegraf_v1:
+    name: Configuration file
+    parent: Configure Telegraf
+weight: 101
+related:
+  - /telegraf/v1/configuration/toml/
+  - /telegraf/v1/configuration/agent/
+  - /telegraf/v1/commands/
+---
+
+The Telegraf configuration file is written in
+[TOML](/telegraf/v1/configuration/toml/) and is composed of three sections:
+
+- **`[global_tags]`**: tags applied to all metrics that Telegraf gathers.
+- **`[agent]`**: settings that control how Telegraf itself runs.
+  See [Agent settings](/telegraf/v1/configuration/agent/).
+- **Plugin tables**: one table for each plugin instance you enable, such as
+  `[[inputs.cpu]]` or `[[outputs.influxdb_v2]]`.
+  See [Common plugin options](/telegraf/v1/configuration/plugin-options/).
+
+The following example shows the shape of a minimal configuration file:
+
+```toml
+[global_tags]
+  dc = "us-east-1"
+
+[agent]
+  interval = "10s"
+  flush_interval = "10s"
+
+[[inputs.cpu]]
+  percpu = true
+
+[[outputs.influxdb_v2]]
+  urls = ["http://localhost:8086"]
+```
+
+To be valid, **a configuration must enable at least one input plugin and at
+least one output plugin**.
+If either is missing, Telegraf exits at startup with an invalid-configuration
+error.
+The exception is running `telegraf --test`, which prints gathered metrics to
+standard output and doesn't require an output plugin.
+
+## Generate a configuration file
+
+Use the `telegraf config` command to generate a configuration file that
+includes all available plugins with documented defaults:
+
+```sh
+telegraf config > telegraf.conf
+```
+
+To generate a file that enables only specific plugins, use the
+`--input-filter` and `--output-filter` flags with colon-separated plugin
+names:
+
+```sh
+telegraf config --input-filter cpu:mem:net:swap --output-filter influxdb_v2:kafka
+```
+
+For the full list of commands and flags, see
+[Telegraf commands](/telegraf/v1/commands/) or run `telegraf --help`.
+
+> [!Note]
+> #### Windows PowerShell v5 encoding
+>
+> In PowerShell 5, the default encoding is UTF-16LE, but Telegraf expects a
+> UTF-8 configuration file.
+> Specify the output encoding when generating the file:
+>
+> ```powershell
+> telegraf.exe config | Out-File -Encoding utf8 telegraf.conf
+> ```
+>
+> PowerShell 6 and later, the Command Prompt, and Git Bash produce UTF-8 by
+> default.
+
+## Configuration file locations
+
+When starting Telegraf, use the `--config` flag to specify the configuration
+file location:
+
+- A file name and path, for example: `--config /etc/telegraf/telegraf.conf`
+- A remote URL, for example: `--config "http://example.com/telegraf.conf"`
+  (see [Load configuration from a URL](#load-configuration-from-a-url))
+
+Use the `--config-directory` flag to also load every file ending in `.conf`
+in the specified directory.
+
+On most systems, the default locations are `/etc/telegraf/telegraf.conf` for
+the main configuration file and `/etc/telegraf/telegraf.d` for the
+configuration directory.
+On Windows, the defaults are `telegraf.conf` and the `telegraf.d` directory
+in the Telegraf installation directory.
+
+## Use multiple configuration files
+
+Telegraf combines all loaded files into one effective configuration: each
+file is parsed separately, and all settings merge as if they were one file.
+Splitting configuration across files is a common way to manage many plugin
+definitions.
+
+Keep the following in mind:
+
+- Every file must be valid TOML on its own.
+  Telegraf doesn't concatenate files before parsing, so a plugin definition
+  can't be split across files.
+- Define the `[agent]` table only once, in the first file that Telegraf
+  reads.
+- Any plugin can be defined multiple times, across any of the files.
+
+If you need to assemble one plugin definition from fragments, concatenate the
+fragments into a valid configuration file with your own tooling before
+starting Telegraf.
+
+To automatically reload local configuration files when they change, start
+Telegraf with the `--watch-config` flag.
+
+## Load configuration from a URL
+
+Pass an HTTP or HTTPS URL to `--config` to load configuration from a remote
+endpoint, such as a configuration service or an object store.
+
+[Telegraf Controller](/telegraf/controller/) serves managed configurations
+over a URL. Point each agent's `--config` flag at the configuration URL that
+Telegraf Controller provides for it.
+See [Use Telegraf configurations](/telegraf/controller/configs/use/) in the
+Telegraf Controller documentation.
+
+Telegraf controls remote configuration behavior with two flags:
+
+- `--config-url-retry-attempts`: the number of times to attempt to fetch a
+  remote configuration during startup.
+  The default is 3; set to -1 for unlimited attempts.
+- `--config-url-watch-interval`: how often to check the URL for an updated
+  configuration.
+  Disabled by default.
+  At each interval, Telegraf sends an HTTP HEAD request and compares the
+  `Last-Modified` header; if the value changes, Telegraf reloads with the new
+  configuration.
+  If the check fails, Telegraf logs a warning and keeps running the existing
+  configuration.

--- a/content/telegraf/v1/configuration/plugin-options.md
+++ b/content/telegraf/v1/configuration/plugin-options.md
@@ -1,0 +1,327 @@
+---
+title: Common Telegraf plugin options
+description: >
+  Reference for configuration options shared by Telegraf plugins of each
+  type: naming instances, per-plugin intervals, measurement renaming, extra
+  tags, execution order, and startup error behavior.
+menu:
+  telegraf_v1:
+    name: Common plugin options
+    parent: Configure Telegraf
+weight: 104
+related:
+  - /telegraf/v1/configuration/toml/
+  - /telegraf/v1/configuration/agent/
+  - /telegraf/v1/concepts/data-pipeline/
+  - /telegraf/v1/plugins/
+---
+
+Each plugin has its own configuration options, documented on the plugin's
+page in the [Plugin directory](/telegraf/v1/plugins/).
+In addition, Telegraf provides a set of options available to every plugin of
+a given type.
+
+Any plugin can be defined multiple times, and each instance runs
+independently, so you can run the same plugin with different configurations
+in one Telegraf process:
+
+```toml
+[[inputs.cpu]]
+  percpu = false
+  totalcpu = true
+
+[[inputs.cpu]]
+  percpu = true
+  totalcpu = false
+  name_override = "percpu_usage"
+```
+
+You can also attach
+[metric filters](/telegraf/v1/configuration/#metric-filtering) to any plugin
+to control which metrics it handles.
+
+Each option lists its data type and default value.
+Duration values are TOML strings, such as `"10s"`; see
+[Durations](/telegraf/v1/configuration/toml/#durations).
+
+- [Options for all plugin types](#options-for-all-plugin-types)
+  - [alias](#alias)
+  - [log_level](#log_level)
+- [Renaming and tag options](#renaming-and-tag-options)
+  - [name_override](#name_override)
+  - [name_prefix](#name_prefix)
+  - [name_suffix](#name_suffix)
+  - [tags](#tags)
+- [Input plugin options](#input-plugin-options)
+  - [interval](#interval)
+  - [precision](#precision)
+  - [time_source](#time_source)
+  - [collection_jitter](#collection_jitter)
+  - [collection_offset](#collection_offset)
+- [Output plugin options](#output-plugin-options)
+  - [flush_interval](#flush_interval)
+  - [flush_jitter](#flush_jitter)
+  - [metric_batch_size](#metric_batch_size)
+  - [metric_buffer_limit](#metric_buffer_limit)
+- [Processor plugin options](#processor-plugin-options)
+  - [order](#order)
+- [Aggregator plugin options](#aggregator-plugin-options)
+  - [period](#period)
+  - [delay](#delay)
+  - [grace](#grace)
+  - [drop_original](#drop_original)
+- [Startup error behavior](#startup-error-behavior)
+- [Examples](#examples)
+
+## Options for all plugin types
+
+### alias
+
+Names a plugin instance.
+Telegraf uses the alias in log messages, which makes problems easier to trace
+when you run multiple instances of the same plugin.
+
+**Type:** string  
+**Default:** Not set
+
+### log_level
+
+Overrides the log level for this plugin: `error`, `warn`, `info`, `debug`,
+or, for inputs, `trace`.
+
+**Type:** string  
+**Default:** Not set; the plugin logs at the agent log level.
+
+## Renaming and tag options
+
+Input, output, and aggregator plugins support the following options for
+renaming measurements and adding tags.
+
+### name_override
+
+Replaces the measurement name.
+For inputs and aggregators, the default measurement name is the plugin name.
+On outputs, renames measurements before writing.
+
+**Type:** string  
+**Default:** Not set
+
+### name_prefix
+
+A prefix to attach to the measurement name.
+
+**Type:** string  
+**Default:** Not set
+
+### name_suffix
+
+A suffix to attach to the measurement name.
+
+**Type:** string  
+**Default:** Not set
+
+### tags
+
+A map of tags to apply to the plugin's metrics.
+Supported on input and aggregator plugins; on aggregators, behavior varies by
+plugin.
+
+**Type:** table  
+**Default:** Not set
+
+## Input plugin options
+
+### interval
+
+How often to gather metrics from this input.
+
+**Type:** duration  
+**Default:** The value of the agent
+[`interval`](/telegraf/v1/configuration/agent/#interval) setting.
+
+### precision
+
+Rounds collected timestamps to this interval.
+On service inputs, setting precision can cause events with the same timestamp
+to be merged by the output database.
+
+**Type:** duration  
+**Default:** The value of the agent
+[`precision`](/telegraf/v1/configuration/agent/#precision) setting.
+
+### time_source
+
+The source of metric timestamps: `metric` (leaves timestamps unchanged),
+`collection_start`, or `collection_end`.
+Not used by service inputs.
+
+**Type:** string  
+**Default:** `"metric"`
+
+### collection_jitter
+
+Jitters collection for this plugin. Must be non-zero to take effect.
+
+**Type:** duration  
+**Default:** The value of the agent
+[`collection_jitter`](/telegraf/v1/configuration/agent/#collection_jitter)
+setting.
+
+### collection_offset
+
+Shifts collection for this plugin. Must be non-zero to take effect.
+
+**Type:** duration  
+**Default:** The value of the agent
+[`collection_offset`](/telegraf/v1/configuration/agent/#collection_offset)
+setting.
+
+## Output plugin options
+
+### flush_interval
+
+The maximum time between flushes for this output.
+
+**Type:** duration  
+**Default:** The value of the agent
+[`flush_interval`](/telegraf/v1/configuration/agent/#flush_interval) setting.
+
+### flush_jitter
+
+Jitters this output's flush interval. Must be non-zero to take effect.
+
+**Type:** duration  
+**Default:** The value of the agent
+[`flush_jitter`](/telegraf/v1/configuration/agent/#flush_jitter) setting.
+
+### metric_batch_size
+
+The maximum number of metrics per write for this output.
+
+**Type:** integer  
+**Default:** The value of the agent
+[`metric_batch_size`](/telegraf/v1/configuration/agent/#metric_batch_size)
+setting.
+
+### metric_buffer_limit
+
+The maximum number of unsent metrics to buffer for this output.
+
+**Type:** integer  
+**Default:** The value of the agent
+[`metric_buffer_limit`](/telegraf/v1/configuration/agent/#metric_buffer_limit)
+setting.
+
+## Processor plugin options
+
+### order
+
+The order in which processors run, starting with 1.
+Processors without `order` run before those that define it.
+If order matters, set `order` on all processors:
+
+```toml
+[[processors.rename]]
+  order = 1
+  [[processors.rename.replace]]
+    tag = "path"
+    dest = "resource"
+
+[[processors.strings]]
+  order = 2
+  [[processors.strings.trim_prefix]]
+    tag = "resource"
+    prefix = "/api/"
+```
+
+**Type:** integer  
+**Default:** Not set; processors run in the order they appear in the
+configuration.
+
+## Aggregator plugin options
+
+### period
+
+The size of the aggregation window.
+Metrics with timestamps outside the current period are ignored.
+
+**Type:** duration  
+**Default:** `"30s"`
+
+### delay
+
+How long the aggregator waits before flushing, so inputs gathering on the
+same interval have time to deliver metrics.
+
+**Type:** duration  
+**Default:** `"100ms"`
+
+### grace
+
+How long late metrics are still accepted into the next aggregation period.
+
+**Type:** duration  
+**Default:** `"0s"`
+
+### drop_original
+
+If `true`, the aggregator drops the original metrics and emits only the
+aggregates.
+
+**Type:** boolean  
+**Default:** `false`
+
+## Startup error behavior
+
+Plugins that connect to external services support the
+`startup_error_behavior` option, which controls what Telegraf does when the
+plugin fails to start:
+
+- **`error`** (default): Telegraf stops and exits.
+- **`ignore`**: Telegraf disables the plugin and continues processing all
+  other plugins.
+- **`retry`**: Telegraf retries starting the plugin on every gather or write
+  cycle. The plugin is disabled until startup succeeds.
+- **`probe`**: Telegraf probes the plugin's function, if supported, and
+  disables the plugin if probing fails.
+  If the plugin doesn't support probing, this behaves like `ignore`.
+
+## Examples
+
+Use `name_suffix` to emit `cpu` metrics with the measurement name
+`cpu_total`:
+
+```toml
+[[inputs.cpu]]
+  name_suffix = "_total"
+  percpu = false
+  totalcpu = true
+```
+
+Add tags to an input's metrics with an inline table (which can appear
+anywhere in the plugin definition) or a `tags` table (which must come last;
+see [Table ordering](/telegraf/v1/configuration/toml/#table-ordering)):
+
+```toml
+[[inputs.cpu]]
+  tags = {tag1 = "foo", tag2 = "bar"}
+  percpu = false
+  totalcpu = true
+```
+
+Override flush behavior for one output while others use the agent defaults:
+
+```toml
+[agent]
+  flush_interval = "10s"
+  flush_jitter = "5s"
+  metric_batch_size = 1000
+
+[[outputs.influxdb_v2]]
+  urls = ["http://localhost:8086"]
+
+[[outputs.file]]
+  files = ["stdout"]
+  flush_interval = "1s"
+  metric_batch_size = 10
+```

--- a/content/telegraf/v1/configuration/toml.md
+++ b/content/telegraf/v1/configuration/toml.md
@@ -87,7 +87,7 @@ In basic strings (double quotes), backslashes and double quotes must be
 escaped.
 For example, the following Windows path is invalid TOML:
 
-```toml
+```toml {lint="false"}
 path = "C:\Program Files\"  # invalid TOML
 ```
 
@@ -96,6 +96,9 @@ returns exactly what you type:
 
 ```toml
 path = "C:\\Program Files\\"
+```
+
+```toml
 path = 'C:\Program Files\'
 ```
 

--- a/content/telegraf/v1/configuration/toml.md
+++ b/content/telegraf/v1/configuration/toml.md
@@ -1,0 +1,131 @@
+---
+title: TOML syntax for Telegraf
+description: >
+  Learn the TOML configuration language details that matter for Telegraf
+  configurations: table types, ordering pitfalls, string escaping, and
+  duration values.
+menu:
+  telegraf_v1:
+    name: TOML syntax
+    parent: Configure Telegraf
+weight: 102
+related:
+  - /telegraf/v1/configuration/file/
+  - /telegraf/v1/configuration/plugin-options/
+---
+
+Telegraf configuration files use [TOML](https://toml.io/) as the
+configuration language.
+This page covers the TOML details that most often cause confusion in Telegraf
+configurations.
+To validate a configuration file, use a TOML validator or run `telegraf --test`
+to validate the file with Telegraf itself.
+
+## Single tables and arrays of tables
+
+Telegraf uses a single table, `[agent]`, for agent-level settings.
+Define the `[agent]` table only once across all configuration files, in the
+first file Telegraf reads.
+
+Plugins use TOML arrays of tables, written with double brackets, such as
+`[[inputs.file]]`.
+Define an array-of-tables plugin as many times as you need; each definition
+runs as an independent plugin instance.
+
+```toml
+[agent]
+  interval = "10s"
+
+[[inputs.file]]
+  files = ["/var/log/app-a.log"]
+
+[[inputs.file]]
+  files = ["/var/log/app-b.log"]
+```
+
+## Table ordering
+
+Some plugin options are themselves tables, such as the table of arbitrary
+tags to add to an input's metrics:
+
+```toml
+[[inputs.cpu]]
+  percpu = false
+  totalcpu = true
+  [inputs.cpu.tags]
+    tag1 = "foo"
+    tag2 = "bar"
+```
+
+A table like `[inputs.cpu.tags]` must come at the *end* of the plugin
+definition: every key-value pair that follows a table header belongs to that
+table, regardless of indentation.
+The following example shows how this causes problems:
+
+```toml
+[[inputs.cpu]]
+  totalcpu = true
+  [inputs.cpu.tags]
+    tag1 = "foo"
+    tag2 = "bar"
+  percpu = false  # treated as a tag named "percpu", not a plugin option
+```
+
+To avoid the ordering problem entirely, use inline table syntax, which can
+appear anywhere in the plugin definition:
+
+```toml
+[[inputs.cpu]]
+  tags = {tag1 = "foo", tag2 = "bar"}
+  percpu = false
+  totalcpu = true
+```
+
+## Basic strings and literal strings
+
+In basic strings (double quotes), backslashes and double quotes must be
+escaped.
+For example, the following Windows path is invalid TOML:
+
+```toml
+path = "C:\Program Files\"  # invalid TOML
+```
+
+Either escape the backslashes or use a literal string (single quotes), which
+returns exactly what you type:
+
+```toml
+path = "C:\\Program Files\\"
+path = 'C:\Program Files\'
+```
+
+Because literal strings have no escaping, a literal string can't contain a
+single quote.
+
+## Durations
+
+Settings that accept a duration, such as `interval` and `flush_interval`,
+take a string that combines an integer value and a time unit.
+Valid units are:
+
+- `ns`
+- `us` (or `µs`)
+- `ms`
+- `s`
+- `m`
+- `h`
+
+```toml
+[agent]
+  interval = "10s"
+  flush_interval = "1m"
+```
+
+## Multiple files
+
+TOML itself has no concept of multiple files; combining files is a Telegraf
+convenience.
+Telegraf parses each file separately and merges all settings as if they were
+one file.
+See
+[Use multiple configuration files](/telegraf/v1/configuration/file/#use-multiple-configuration-files).

--- a/scripts/ci/__tests__/normalizer.test.mjs
+++ b/scripts/ci/__tests__/normalizer.test.mjs
@@ -9,6 +9,19 @@ test('phase 1 passes valid block without normalization notice', async () => {
   assert.equal(res.notice, undefined);
 });
 
+test('lint="false" fence attribute skips validation with a visible reason', async () => {
+  const block = {
+    lang: 'toml',
+    value: 'path = "C:\\Program Files\\"  # intentionally invalid',
+    meta: '{lint="false"}',
+    placeholders: [],
+  };
+  const res = await validateWithNormalization(block);
+  assert.equal(res.ok, true);
+  assert.equal(res.skipped, true);
+  assert.equal(res.skipReason, 'lint="false"');
+});
+
 test('phase 1 fails are returned unchanged when no normalization is applicable', async () => {
   const block = { lang: 'json', value: '{"a": bad}', placeholders: [] };
   const res = await validateWithNormalization(block);

--- a/scripts/lib/codeblock-normalizer.mjs
+++ b/scripts/lib/codeblock-normalizer.mjs
@@ -163,6 +163,14 @@ function stripElideMarkers(code, lang) {
  * @returns {Promise<{ok: boolean, errors: Array, notice?: string, skipped?: boolean}>}
  */
 export async function validateWithNormalization(block) {
+  // Honor an explicit per-block opt-out for examples that are intentionally
+  // invalid (for example, docs demonstrating a syntax error). Authors set it
+  // as a fence attribute: ```toml {lint="false"}
+  // Skipped blocks are still reported in the output with their skip reason.
+  if (block.meta && /\blint="false"/.test(block.meta)) {
+    return { ok: true, errors: [], skipped: true, skipReason: 'lint="false"' };
+  }
+
   // Detect known non-JS DSLs that are conventionally tagged js/javascript in these docs.
   // Skip them explicitly so real JavaScript blocks still get validated.
   if (block.lang === 'js' || block.lang === 'javascript') {


### PR DESCRIPTION
- Convert configuration.md to configuration/_index.md, preserving the URL and anchors, and move it from the reference nav to the main nav as Configure Telegraf.
- Add topic pages: configuration file (structure, generation, locations, multi-file merging, URL loading including Telegraf Controller as a config source), TOML syntax, agent settings, and common plugin options.
- Settings pages use per-setting headings with Type and Default metadata and in-page tables of contents; types and defaults verified against the Telegraf source.
- Document that a valid config requires at least one input and one output plugin.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
