### PR TITLE
docs(telegraf): add metric filtering and labels-selectors pages

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -42,7 +42,7 @@ Remove this file before merging `docs/telegraf-revamp` into `master`.
 6. **Settings references use per-setting headings with Type and Default metadata.**
    Group settings under H2s by purpose; each setting is an H3 (stable anchor) with a short description followed by `**Type:**` and `**Default:**` metadata lines, matching the Telegraf Controller config-options precedent.
    The Type line ends with a markdown hard break (trailing double space) so Type and Default render as adjacent lines, not separate paragraphs.
-   Type vocabulary: string, boolean, integer, duration, size, table.
+   Type vocabulary: string, boolean, integer, duration, size, table, array of strings.
    Defaults use TOML-literal form (`"10s"`, `true`) or "Not set;" plus the unset behavior; inherited options link the agent setting's anchor.
    Give each repeated option name one canonical heading per page so anchors stay stable.
    Verify types and defaults against the Telegraf source, not memory.

--- a/content/telegraf/v1/configuration/_index.md
+++ b/content/telegraf/v1/configuration/_index.md
@@ -604,6 +604,9 @@ Excluded metrics are passed downstream to the next processor.
 
 ## Metric filtering
 
+For details and worked examples, see
+[Filter metrics](/telegraf/v1/configuration/filtering/).
+
 Filters can be configured per input, output, processor, or aggregator.
 
 - [Filters](#filters)
@@ -928,6 +931,9 @@ To learn more about configuring the Telegraf agent, watch the following video:
 {{< youtube txUcAxMDBlQ >}}
 
 ## Plugin selection via labels and selectors
+
+For details and matching behavior, see
+[Labels and selectors](/telegraf/v1/configuration/labels-selectors/).
 
 You can control which plugin instances are enabled by adding labels to plugin
 configurations and passing one or more selectors on the command line.

--- a/content/telegraf/v1/configuration/filtering.md
+++ b/content/telegraf/v1/configuration/filtering.md
@@ -1,0 +1,313 @@
+---
+title: Filter Telegraf metrics
+description: >
+  Use metric filters on any Telegraf plugin to select which metrics a plugin
+  handles and which tags and fields remain: namepass, namedrop, tagpass,
+  tagdrop, metricpass, fieldinclude, fieldexclude, taginclude, and tagexclude.
+menu:
+  telegraf_v1:
+    name: Filter metrics
+    parent: Configure Telegraf
+weight: 105
+related:
+  - /telegraf/v1/concepts/data-pipeline/
+  - /telegraf/v1/configuration/plugin-options/
+  - /telegraf/v1/configuration/toml/
+---
+
+Metric filters attach to any input, output, processor, or aggregator plugin
+and control which metrics that plugin handles.
+Filters fall into two categories:
+
+- **Selectors** include or exclude entire metrics.
+  When a selector excludes a metric from an input or output plugin, the
+  metric is dropped.
+  When a selector excludes a metric from a processor or aggregator plugin,
+  the metric skips the plugin and continues downstream unchanged.
+- **Modifiers** remove tags and fields from metrics that pass.
+  If a modifier removes all of a metric's fields, the metric is dropped.
+
+The point at which filters apply depends on the plugin type; see
+[Where filtering happens](/telegraf/v1/concepts/data-pipeline/#where-filtering-happens).
+
+Each filter parameter lists its data type.
+None of the filter parameters are set by default.
+
+- [Selectors](#selectors)
+  - [namepass](#namepass)
+  - [namepass_separator](#namepass_separator)
+  - [namedrop](#namedrop)
+  - [namedrop_separator](#namedrop_separator)
+  - [tagpass](#tagpass)
+  - [tagdrop](#tagdrop)
+  - [metricpass](#metricpass)
+- [Modifiers](#modifiers)
+  - [fieldinclude](#fieldinclude)
+  - [fieldexclude](#fieldexclude)
+  - [taginclude](#taginclude)
+  - [tagexclude](#tagexclude)
+- [Order of operations](#order-of-operations)
+- [Examples](#examples)
+
+## Selectors
+
+Selectors decide *whether* a plugin handles a metric.
+
+### namepass
+
+An array of [glob pattern](https://github.com/gobwas/glob#syntax) strings.
+Only metrics whose measurement name matches a pattern in the list are
+emitted.
+
+**Type:** array of strings
+
+### namepass_separator
+
+A custom list of separator characters excluded from wildcard glob matching
+in `namepass` patterns.
+Useful for dot-delimited measurement names, such as Graphite metrics.
+
+**Type:** string
+
+### namedrop
+
+The inverse of `namepass`: metrics whose measurement name matches a pattern
+are discarded.
+Telegraf tests `namedrop` after metrics pass the `namepass` test.
+
+**Type:** array of strings
+
+### namedrop_separator
+
+A custom list of separator characters excluded from wildcard glob matching
+in `namedrop` patterns.
+
+**Type:** string
+
+### tagpass
+
+A table mapping tag keys to arrays of glob pattern strings.
+Only metrics that contain a matching tag key with a tag value matching one
+of its patterns are emitted.
+Conditions across tag keys are combined with OR: a metric passes if any
+listed tag key matches.
+
+**Type:** table
+
+> [!Important]
+> Because of how TOML parses tables, `tagpass` and `tagdrop` in explicit
+> table syntax (`[inputs.cpu.tagpass]`) must be defined at the *end* of the
+> plugin definition; otherwise subsequent options are read as part of the
+> table.
+> With inline table syntax (`tagpass = {...}`), the table must be in the main
+> plugin definition, not in a sub-table.
+> See [Table ordering](/telegraf/v1/configuration/toml/#table-ordering).
+
+### tagdrop
+
+The inverse of `tagpass`: if a match is found, the metric is discarded.
+Telegraf tests `tagdrop` after metrics pass the `tagpass` test.
+
+**Type:** table
+
+### metricpass
+
+A [Common Expression Language (CEL)](https://github.com/google/cel-go/tree/master)
+expression with a boolean result: `true` passes the metric, anything else
+discards it.
+CEL expressions are more general than the other selectors and support
+time-based filtering.
+For available functions and syntax, see the
+[CEL language definition](https://github.com/google/cel-spec/blob/master/doc/langdef.md)
+and the
+[CEL extension documentation](https://github.com/google/cel-go/tree/master/ext#readme).
+
+Expressions that compile but fail at runtime (for example, reading a field
+that doesn't exist) abort evaluation, log an error, and report `true`, so the
+metric passes.
+
+**Type:** string
+
+> [!Note]
+> CEL is an interpreted language, so `metricpass` filtering is much slower
+> than `namepass`, `tagpass`, and the other selectors.
+> In high-throughput scenarios, prefer the more restricted filter options
+> where possible.
+
+## Modifiers
+
+Modifiers decide *which tags and fields* remain on metrics the plugin
+handles.
+Telegraf applies modifiers before a metric is passed to a processor,
+aggregator, or output plugin; on input plugins, modifiers apply after the
+input runs.
+
+### fieldinclude
+
+An array of glob pattern strings.
+Only fields whose field key matches a pattern in the list are emitted.
+
+**Type:** array of strings
+
+### fieldexclude
+
+The inverse of `fieldinclude`: fields with a matching field key are
+discarded.
+Telegraf tests `fieldexclude` after fields pass the `fieldinclude` test.
+
+**Type:** array of strings
+
+### taginclude
+
+An array of glob pattern strings.
+Only tags with a tag key matching one of the patterns are emitted.
+In contrast to `tagpass`, which passes an entire metric based on its tags,
+`taginclude` removes non-matching tags from the metric.
+Any tag can be removed, including global tags and the agent `host` tag.
+
+**Type:** array of strings
+
+### tagexclude
+
+The inverse of `taginclude`: tags with a matching tag key are discarded from
+the metric.
+
+**Type:** array of strings
+
+## Order of operations
+
+- Selectors run before modifiers: selectors decide whether the plugin
+  handles a metric, then modifiers adjust its tags and fields.
+- `pass` tests run before `drop` tests: Telegraf tests `namedrop` only on
+  metrics that passed `namepass`, and `tagdrop` only on metrics that passed
+  `tagpass`.
+- The stage at which filters apply depends on the plugin type; see
+  [Where filtering happens](/telegraf/v1/concepts/data-pipeline/#where-filtering-happens).
+
+To keep explicitly defined tags from being removed by `taginclude` or
+`tagexclude`, use the agent
+[`always_include_local_tags`](/telegraf/v1/configuration/agent/#always_include_local_tags)
+and
+[`always_include_global_tags`](/telegraf/v1/configuration/agent/#always_include_global_tags)
+settings.
+
+## Examples
+
+### Filter metrics by tag
+
+`tagpass` conditions across tag keys are combined with OR: the disk metric
+passes if the filesystem is ext4 or xfs, *or* the path is `/opt` or under
+`/home`.
+
+```toml
+[[inputs.disk]]
+  [inputs.disk.tagpass]
+    fstype = ["ext4", "xfs"]
+    path = ["/opt", "/home*"]
+```
+
+Drop Windows network metrics for uninteresting interfaces:
+
+```toml
+[[inputs.win_perf_counters]]
+  [[inputs.win_perf_counters.object]]
+    ObjectName = "Network Interface"
+    Instances = ["*"]
+    Counters = ["Bytes Received/sec", "Bytes Sent/sec"]
+    Measurement = "win_net"
+  [inputs.win_perf_counters.tagdrop]
+    instance = ["isatap*", "Local*"]
+```
+
+### Filter fields
+
+```toml
+# Drop guest and steal CPU usage fields
+[[inputs.cpu]]
+  percpu = false
+  totalcpu = true
+  fieldexclude = ["usage_guest", "usage_steal"]
+
+# Only store inode-related disk metrics
+[[inputs.disk]]
+  fieldinclude = ["inodes*"]
+```
+
+### Filter metrics by name
+
+```toml
+# Drop all container metrics from the kubelet
+[[inputs.prometheus]]
+  urls = ["http://kube-node-1:4194/metrics"]
+  namedrop = ["container_*"]
+
+# Only store REST client metrics from the kubelet
+[[inputs.prometheus]]
+  urls = ["http://kube-node-1:4194/metrics"]
+  namepass = ["rest_client_*"]
+```
+
+### Use separators with name filters
+
+With `namepass_separator = "."`, the pattern `A.*.B` matches `A.C.B` but not
+`A.C.D.B`, because the wildcard doesn't cross the separator:
+
+```toml
+[[inputs.socket_listener]]
+  data_format = "graphite"
+  templates = ["measurement*"]
+  namepass = ["A.*.B"]
+  namepass_separator = "."
+```
+
+### Trim tags from metrics
+
+```toml
+# Keep only the "cpu" tag on cpu metrics
+[[inputs.cpu]]
+  percpu = true
+  totalcpu = true
+  taginclude = ["cpu"]
+
+# Remove the "fstype" tag from disk metrics
+[[inputs.disk]]
+  tagexclude = ["fstype"]
+```
+
+### Route metrics to different outputs
+
+Filters on output plugins let each output receive a different subset of
+metrics:
+
+```toml
+[[outputs.influxdb]]
+  urls = ["http://localhost:8086"]
+  database = "telegraf"
+  namedrop = ["aerospike*"]
+
+[[outputs.influxdb]]
+  urls = ["http://localhost:8086"]
+  database = "telegraf-aerospike-data"
+  namepass = ["aerospike*"]
+```
+
+Route metrics with a dedicated tag, then remove the tag before writing:
+
+```toml
+[[inputs.disk]]
+  [inputs.disk.tags]
+    influxdb_database = "other"
+
+[[outputs.influxdb]]
+  urls = ["http://influxdb.example.com"]
+  database = "db_default"
+  [outputs.influxdb.tagdrop]
+    influxdb_database = ["*"]
+
+[[outputs.influxdb]]
+  urls = ["http://influxdb.example.com"]
+  database = "db_other"
+  tagexclude = ["influxdb_database"]
+  [outputs.influxdb.tagpass]
+    influxdb_database = ["other"]
+```

--- a/content/telegraf/v1/configuration/labels-selectors.md
+++ b/content/telegraf/v1/configuration/labels-selectors.md
@@ -1,0 +1,98 @@
+---
+title: Select Telegraf plugins with labels and selectors
+description: >
+  Enable or disable Telegraf plugin instances at startup by adding labels to
+  plugin definitions and passing selectors with the --select flag.
+menu:
+  telegraf_v1:
+    name: Labels and selectors
+    parent: Configure Telegraf
+weight: 109
+related:
+  - /telegraf/v1/configuration/file/
+  - /telegraf/v1/configuration/plugin-options/
+  - /telegraf/controller/configs/use/
+---
+
+Labels and selectors let you enable or disable plugin instances at startup
+without editing the configuration file: add labels to plugins in the
+configuration, then pass selectors on the command line.
+Inspired by Kubernetes labels, this is useful when many Telegraf instances
+share one configuration source, such as a configuration managed with
+[Telegraf Controller](/telegraf/controller/configs/use/), and each instance
+should run only a subset of the configured plugins.
+
+## Add labels to plugins
+
+Add an optional `labels` table to any input, output, processor, or
+aggregator plugin:
+
+```toml
+[[inputs.cpu]]
+  [inputs.cpu.labels]
+    app = "payments"
+    region = "us-east"
+    env = "prod"
+```
+
+Label keys and values are plain strings that can contain alphanumeric
+characters, dots (`.`), dashes (`-`), and underscores (`_`).
+Neither keys nor values can contain wildcard characters.
+
+> [!Important]
+> `labels` is a TOML table, so with explicit table syntax it must come at the
+> *end* of the plugin definition.
+> See [Table ordering](/telegraf/v1/configuration/toml/#table-ordering).
+
+## Select plugins at startup
+
+Pass one or more `--select` flags when starting Telegraf.
+Each `--select` value is a semicolon-separated list of key-value pairs:
+
+```text
+<key>=<value>[;<key>=<value>]
+```
+
+- Pairs within a single `--select` value combine with logical AND: all must
+  match.
+- Multiple `--select` flags combine with logical OR: a plugin is enabled if
+  it matches any selector set.
+- Selector values support glob patterns: `*` matches any number of
+  characters and `?` matches a single character (for example,
+  `region=us-*`).
+  Selector keys don't support wildcards.
+- Repeating the same key within a single `--select` value causes an error at
+  startup; using the same key in *different* `--select` flags is allowed.
+
+<!--pytest.mark.skip-->
+
+```bash
+telegraf --config config.conf --config-directory directory/ \
+  --select="app=payments;region=us-*" \
+  --select="env=prod"
+```
+
+## Matching behavior
+
+Telegraf matches selectors against each plugin's labels to decide whether
+the plugin instance is enabled:
+
+| Telegraf run state | Plugin has labels | Behavior                                                        |
+| :----------------- | :---------------- | :-------------------------------------------------------------- |
+| With `--select`    | Yes               | Enabled only if a selector matches the labels                   |
+| With `--select`    | No                | Enabled (backward compatible)                                   |
+| Without `--select` | Yes               | Enabled (no selector to compare against)                        |
+| Without `--select` | No                | Enabled (default behavior)                                      |
+
+A selector matches when every key-value pair in it matches a label on the
+plugin; labels the selector doesn't mention are ignored.
+
+| `--select` flags               | Plugin labels                | Result   |
+| :----------------------------- | :--------------------------- | :------- |
+| `app=web`                      | `app="web"`                  | Selected |
+| `app=web`                      | `app="api"`                  | Skipped  |
+| `app=web`                      | `app="web", region="us-east"`| Selected |
+| `app=web;region=us-west`       | `app="web", region="us-east"`| Skipped  |
+| `env=prod*`                    | `env="production"`           | Selected |
+| `env=prod`, `env=staging`      | `env="qa"`                   | Skipped  |
+| `app=web;env=prod`, `app=api;env=prod` | `app="api", env="prod"` | Selected |


### PR DESCRIPTION
- Add Filter metrics: selectors (namepass/namedrop with separators, tagpass/tagdrop, metricpass with CEL caveats) and modifiers (fieldinclude/fieldexclude, taginclude/tagexclude) with per-setting anchors, order of operations, and worked examples including output routing.
- Add Labels and selectors: plugin labels, --select matching semantics, behavior matrix, and the Telegraf Controller shared-config use case.
- Link both pages from the corresponding configuration index sections.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
