### PR TITLE
docs(telegraf): add environment variables, secrets, and TLS pages

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -39,6 +39,8 @@ Remove this file before merging `docs/telegraf-revamp` into `master`.
    top level 1–99 (sequential from 1), second level 101–199, third level 201–299.
    `_index.md` files are weighted one level up from other `.md` files in the same directory.
    Set `weight` at the page level (top-level frontmatter), not on the menu entry; menu items inherit the page weight.
+   The Documentation MCP server sinks to 206 following the Explorer precedent.
+   Release notes leads the reference nav at weight 1.
 6. **Settings references use per-setting headings with Type and Default metadata.**
    Group settings under H2s by purpose; each setting is an H3 (stable anchor) with a short description followed by `**Type:**` and `**Default:**` metadata lines, matching the Telegraf Controller config-options precedent.
    The Type line ends with a markdown hard break (trailing double space) so Type and Default render as adjacent lines, not separate paragraphs.
@@ -50,7 +52,6 @@ Remove this file before merging `docs/telegraf-revamp` into `master`.
    Use semicolons and colons sparingly.
    A clause joined by a semicolon or colon should usually be its own sentence.
    Colons that introduce lists, code blocks, or definition-list terms are fine.
-   The Documentation MCP server sinks to 206 following the Explorer precedent; Release notes leads the reference nav at weight 1.
 
 ## Content sources
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -46,6 +46,10 @@ Remove this file before merging `docs/telegraf-revamp` into `master`.
    Defaults use TOML-literal form (`"10s"`, `true`) or "Not set;" plus the unset behavior; inherited options link the agent setting's anchor.
    Give each repeated option name one canonical heading per page so anchors stay stable.
    Verify types and defaults against the Telegraf source, not memory.
+7. **Periods over semicolons and colons in prose.**
+   Use semicolons and colons sparingly.
+   A clause joined by a semicolon or colon should usually be its own sentence.
+   Colons that introduce lists, code blocks, or definition-list terms are fine.
    The Documentation MCP server sinks to 206 following the Explorer precedent; Release notes leads the reference nav at weight 1.
 
 ## Content sources
@@ -268,20 +272,20 @@ High-traffic inbound links to verify in each PR:
 
 All PRs branch from and target `docs/telegraf-revamp`.
 
-| #  | Branch                             | Scope                                                                                                         | Depends on |
-| -- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------- |
-| 0  | (base branch)                      | This plan                                                                                                     | —          |
-| 1  | `docs/telegraf-nav-skeleton`       | Section `_index` pages, menu labels, level-based weights, moves and aliases, landing page revamp              | 0          |
-| 2  | `docs/telegraf-concepts`           | `concepts/` content: metrics rewrite, data-pipeline page                                                      | 1          |
-| 3  | `docs/telegraf-config-core`        | `configuration/` conversion plus file, toml, agent, plugin-options pages                                      | 1          |
-| 4  | `docs/telegraf-config-filtering`   | filtering and labels-selectors pages                                                                          | 3          |
-| 5  | `docs/telegraf-config-secrets-tls` | environment-variables, secrets, TLS pages                                                                     | 3          |
-| 6  | `docs/telegraf-get-started`        | Get started rewrite, install refresh                                                                          | 1          |
-| 7  | `docs/telegraf-plugin-guides`      | Use-plugins guides plus parse-data and serialize-data                                                         | 2          |
-| 8  | `docs/telegraf-data-formats`       | Missing formats plus refresh pass                                                                             | 7          |
-| 9  | `docs/telegraf-examples`           | Examples section (may split per example)                                                                      | 3, 7       |
-| 10 | `docs/telegraf-administer`         | Service, monitor, manage-at-scale, troubleshoot                                                               | 1          |
-| 11 | `docs/telegraf-reference-cleanup`  | Commands, glossary, platforms, release cadence; slim `configuration/_index.md`; light `enterprise.md` refresh | 3, 4, 5    |
+| #  | Branch                             | Scope                                                                                                                                                                                              | Depends on |
+| -- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| 0  | (base branch)                      | This plan                                                                                                                                                                                          | —          |
+| 1  | `docs/telegraf-nav-skeleton`       | Section `_index` pages, menu labels, level-based weights, moves and aliases, landing page revamp                                                                                                   | 0          |
+| 2  | `docs/telegraf-concepts`           | `concepts/` content: metrics rewrite, data-pipeline page                                                                                                                                           | 1          |
+| 3  | `docs/telegraf-config-core`        | `configuration/` conversion plus file, toml, agent, plugin-options pages                                                                                                                           | 1          |
+| 4  | `docs/telegraf-config-filtering`   | filtering and labels-selectors pages                                                                                                                                                               | 3          |
+| 5  | `docs/telegraf-config-secrets-tls` | environment-variables, secrets, TLS pages                                                                                                                                                          | 3          |
+| 6  | `docs/telegraf-get-started`        | Get started rewrite, install refresh                                                                                                                                                               | 1          |
+| 7  | `docs/telegraf-plugin-guides`      | Use-plugins guides plus parse-data and serialize-data                                                                                                                                              | 2          |
+| 8  | `docs/telegraf-data-formats`       | Missing formats plus refresh pass                                                                                                                                                                  | 7          |
+| 9  | `docs/telegraf-examples`           | Examples section (may split per example)                                                                                                                                                           | 3, 7       |
+| 10 | `docs/telegraf-administer`         | Service, monitor, manage-at-scale, troubleshoot                                                                                                                                                    | 1          |
+| 11 | `docs/telegraf-reference-cleanup`  | Commands, glossary, platforms, release cadence; slim `configuration/_index.md`; light `enterprise.md` refresh; sweep earlier parcels for semicolon and colon sentence joins and menu-level weights | 3, 4, 5    |
 
 \| 12 | `docs/telegraf-agent-status-shared` | Extract agent status content to `content/shared/telegraf/`, convert Controller pages to `source:` consumers, add v1 consuming pages | 1 |
 

--- a/content/telegraf/v1/configuration/_index.md
+++ b/content/telegraf/v1/configuration/_index.md
@@ -203,6 +203,9 @@ If any file isn't a valid configuration, Telegraf returns an error.
 
 ## Set environment variables
 
+For expansion forms and examples, see
+[Environment variables](/telegraf/v1/configuration/environment-variables/).
+
 Use environment variables anywhere in the configuration file by enclosing them in `${}`.
 For strings, variables must be in quotes (for example, `"test_${STR_VAR}"`).
 For numbers and booleans, variables must be unquoted (for example, `${INT_VAR}`,
@@ -343,6 +346,9 @@ When Telegraf runs, the effective configuration is the following:
 ```
 
 ## Secret stores
+
+For details and examples, see
+[Secrets](/telegraf/v1/configuration/secrets/).
 
 Telegraf also supports secret stores for providing credentials or similar.
 Configure one or more secret store plugins and then reference the secret in
@@ -983,4 +989,4 @@ For details on supported syntax and matching rules, see the labels selectors spe
 ## Transport Layer Security (TLS)
 
 Many Telegraf plugins support TLS configuration for secure communication.
-Reference the detailed TLS documentation for configuration options and examples.
+For all standard TLS settings, see [TLS](/telegraf/v1/configuration/tls/).

--- a/content/telegraf/v1/configuration/environment-variables.md
+++ b/content/telegraf/v1/configuration/environment-variables.md
@@ -1,0 +1,100 @@
+---
+title: Use environment variables in Telegraf configurations
+description: >
+  Substitute environment variables anywhere in the Telegraf configuration
+  file with ${VAR} syntax, including shell parameter expansion forms for
+  defaults and required variables.
+menu:
+  telegraf_v1:
+    name: Environment variables
+    parent: Configure Telegraf
+weight: 106
+related:
+  - /telegraf/v1/configuration/secrets/
+  - /telegraf/v1/configuration/file/
+  - /telegraf/v1/configuration/toml/
+---
+
+Use environment variables anywhere in the configuration file by enclosing
+them in `${}`.
+Telegraf replaces variables before parsing the file, so a variable can supply
+any part of the configuration.
+
+Quoting follows the TOML type of the value:
+
+- For strings, put the variable inside quotes, such as `"${STR_VAR}"`.
+- For numbers and booleans, leave the variable unquoted, such as
+  `${INT_VAR}` or `${BOOL_VAR}`.
+- In double-quoted strings, escape backslashes, such as
+  `"C:\\Program Files"`.
+  For values that contain a single backslash, use a single-quoted literal
+  string, such as `'C:\Program Files'`.
+  See
+  [Basic strings and literal strings](/telegraf/v1/configuration/toml/#basic-strings-and-literal-strings).
+
+> [!Note]
+> For credentials, consider [secret stores](/telegraf/v1/configuration/secrets/)
+> instead of environment variables. Secrets are resolved at runtime and
+> protected in memory.
+
+## Expansion forms
+
+Telegraf supports shell parameter expansion for environment variables:
+
+- **`${VARIABLE}`**: the value of `VARIABLE`.
+- **`${VARIABLE:-default}`**: `default` if `VARIABLE` is unset or empty.
+- **`${VARIABLE-default}`**: `default` only if `VARIABLE` is unset.
+- **`${VARIABLE:?err}`**: exits with an error message containing `err` if
+  `VARIABLE` is unset or empty.
+- **`${VARIABLE?err}`**: exits with an error message containing `err` if
+  `VARIABLE` is unset.
+
+## Where to define variables
+
+Define variables in the environment that starts Telegraf, such as your shell,
+a systemd unit, or a container environment.
+When using the `.deb` or `.rpm` packages, define environment variables in
+`/etc/default/telegraf`.
+The service reads this file at startup.
+
+## Example
+
+Define the variables:
+
+```sh
+# /etc/default/telegraf
+INFLUX_HOST="http://localhost:8086"
+INFLUX_TOKEN="replace_with_your_token"
+INFLUX_ORG="your_org"
+INFLUX_BUCKET="telegraf"
+```
+
+Reference them in the configuration file:
+
+```toml
+[global_tags]
+  user = "${USER}"
+
+[[inputs.mem]]
+
+[[outputs.influxdb_v2]]
+  urls = ["${INFLUX_HOST}"]
+  token = "${INFLUX_TOKEN}"
+  organization = "${INFLUX_ORG}"
+  bucket = "${INFLUX_BUCKET}"
+```
+
+After substitution, Telegraf parses the effective configuration:
+
+```toml
+[global_tags]
+  user = "alice"
+
+[[inputs.mem]]
+
+[[outputs.influxdb_v2]]
+  urls = ["http://localhost:8086"]
+  token = "replace_with_your_token"
+  organization = "your_org"
+  bucket = "telegraf"
+```

--- a/content/telegraf/v1/configuration/secrets.md
+++ b/content/telegraf/v1/configuration/secrets.md
@@ -1,0 +1,93 @@
+---
+title: Use secrets in Telegraf configurations
+description: >
+  Keep credentials out of plain-text Telegraf configuration files: configure
+  secret store plugins and reference secrets with @{store_id:secret_name}
+  syntax.
+menu:
+  telegraf_v1:
+    name: Secrets
+    parent: Configure Telegraf
+weight: 107
+related:
+  - /telegraf/v1/secretstore-plugins/
+  - /telegraf/v1/commands/secrets/
+  - /telegraf/v1/configuration/environment-variables/
+---
+
+Secret stores keep credentials and other sensitive values out of plain-text
+configuration files.
+Configure one or more secret store plugins, then reference secrets in plugin
+configurations. Telegraf resolves them at runtime and protects them in memory.
+
+A secret reference has the form:
+
+```text
+@{<secret_store_id>:<secret_name>}
+```
+
+where `secret_store_id` is the unique `id` you assign to a secret store
+plugin, and `secret_name` is the name of the secret in that store.
+Both can contain only letters, numbers, and underscores.
+
+## Configure a secret store
+
+Each secret store plugin is configured with a required `id` that other
+configuration references. For the available stores, such as the OS keyring,
+Docker secrets, systemd credentials, and encrypted files, see
+[secret store plugins](/telegraf/v1/secretstore-plugins/).
+
+The following example configures two stores and uses a secret from the first
+to unlock the second:
+
+```toml
+[[secretstores.os]]
+  id = "local_secrets"
+
+[[secretstores.jose]]
+  id = "cloud_secrets"
+  path = "/etc/telegraf/secrets"
+  # Optional reference to another secret store to unlock this one
+  password = "@{local_secrets:cloud_store_passwd}"
+```
+
+## Reference secrets in plugins
+
+Use secret references in plugin options that support them:
+
+```toml
+[[inputs.http]]
+  urls = ["http://server.company.org/metrics"]
+  username = "@{local_secrets:company_server_http_metric_user}"
+  password = "@{local_secrets:company_server_http_metric_pass}"
+
+[[outputs.influxdb_v2]]
+  urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
+  token = "@{cloud_secrets:influxdb_token}"
+  organization = "yourname@yourcompany.com"
+  bucket = "your_bucket"
+```
+
+> [!Note]
+> #### Not all configuration options support secrets
+>
+> A plugin option must be implemented as secret-capable to accept a secret
+> reference. Using a secret reference in an unsupported option fails.
+> Options that support secrets are noted in each plugin's documentation.
+
+## Manage secrets from the command line
+
+Use the [`telegraf secrets` command](/telegraf/v1/commands/secrets/) to list,
+read, and store secrets in configured secret stores.
+
+## Memory locking
+
+Telegraf locks the memory pages that contain secrets, so the locked-memory
+limit must be large enough for the number of secrets in use.
+Telegraf checks the limit and the number of secrets at startup and warns if
+the limit is too low.
+Raise the limit with `ulimit -l`.
+
+If Telegraf runs in a FreeBSD jail, the jail must permit locked memory pages.
+Add the `allow.mlock = 1;` jail parameter to the jail's definition
+in `/etc/jail.conf`.

--- a/content/telegraf/v1/configuration/tls.md
+++ b/content/telegraf/v1/configuration/tls.md
@@ -1,0 +1,210 @@
+---
+title: Configure TLS for Telegraf plugins
+description: >
+  Reference for the standard TLS options that Telegraf plugins provide:
+  client and server certificate configuration, mutual TLS, cipher suites,
+  and TLS version constraints.
+menu:
+  telegraf_v1:
+    name: TLS
+    parent: Configure Telegraf
+weight: 108
+related:
+  - /telegraf/v1/configuration/secrets/
+  - /telegraf/v1/plugins/
+---
+
+Telegraf standardizes TLS options across plugins.
+Plugins that support TLS provide the standard settings on this page.
+Each plugin's sample configuration shows which settings apply.
+Client settings appear on plugins that connect out to services, and server
+settings appear on plugins that listen for connections.
+
+Each setting lists its data type and default value.
+
+- [Client configuration](#client-configuration)
+  - [tls_enable](#tls_enable)
+  - [tls_ca](#tls_ca)
+  - [tls_cert](#tls_cert)
+  - [tls_key](#tls_key)
+  - [tls_key_pwd](#tls_key_pwd)
+  - [insecure_skip_verify](#insecure_skip_verify)
+  - [tls_server_name](#tls_server_name)
+- [Server configuration](#server-configuration)
+  - [tls_allowed_cacerts](#tls_allowed_cacerts)
+  - [tls_allowed_dns_names](#tls_allowed_dns_names)
+- [Advanced configuration](#advanced-configuration)
+  - [tls_cipher_suites](#tls_cipher_suites)
+  - [tls_min_version](#tls_min_version)
+  - [tls_max_version](#tls_max_version)
+- [Supported cipher suites](#supported-cipher-suites)
+- [Supported TLS versions](#supported-tls-versions)
+
+## Client configuration
+
+```toml
+[[inputs.http]]
+  urls = ["https://server.company.org/metrics"]
+  tls_ca = "/etc/telegraf/ca.pem"
+  tls_cert = "/etc/telegraf/cert.pem"
+  tls_key = "/etc/telegraf/key.pem"
+```
+
+### tls_enable
+
+Enforces TLS on or off for the connection.
+
+**Type:** boolean  
+**Default:** Not set. TLS is enabled if any other TLS option is set.
+
+### tls_ca
+
+Path to the root certificates used to verify server certificates, encoded in
+PEM format.
+
+**Type:** string  
+**Default:** Not set. The system certificate pool is used.
+
+### tls_cert
+
+Path to the PEM-encoded public certificate.
+On client plugins, this is the client certificate.
+On server plugins, this is the service certificate.
+May contain intermediate certificates.
+
+**Type:** string  
+**Default:** Not set
+
+### tls_key
+
+Path to the PEM-encoded private key that pairs with `tls_cert`.
+
+**Type:** string  
+**Default:** Not set
+
+### tls_key_pwd
+
+Passphrase for an encrypted private key in PKCS#8 format.
+Encrypted PKCS#1 private keys are not supported.
+
+**Type:** string  
+**Default:** Not set
+
+### insecure_skip_verify
+
+Skips verification of the server's certificate chain and host name.
+Use only for testing. Skipping verification makes the connection vulnerable
+to machine-in-the-middle attacks.
+
+**Type:** boolean  
+**Default:** `false`
+
+### tls_server_name
+
+Sends the specified server name via the TLS Server Name Indication (SNI)
+extension instead of the name derived from the connection address.
+
+**Type:** string  
+**Default:** Not set
+
+## Server configuration
+
+Server plugins support TLS mutual authentication in addition to the shared
+[`tls_cert`](#tls_cert), [`tls_key`](#tls_key), and
+[`tls_key_pwd`](#tls_key_pwd) settings:
+
+```toml
+[[inputs.http_listener_v2]]
+  service_address = ":9443"
+  tls_cert = "/etc/telegraf/cert.pem"
+  tls_key = "/etc/telegraf/key.pem"
+  tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]
+```
+
+### tls_allowed_cacerts
+
+Paths to one or more allowed client CA certificate files.
+Setting this enables mutually authenticated TLS. Incoming client
+certificates must be signed by one of these CAs.
+
+**Type:** array of strings  
+**Default:** Not set. Client certificates aren't required.
+
+### tls_allowed_dns_names
+
+Allowed DNS names for verifying incoming client certificates.
+Telegraf checks each subject alternative name (SAN) in the certificate and
+accepts the request if any of them matches.
+
+**Type:** array of strings  
+**Default:** Not set
+
+## Advanced configuration
+
+Plugins that use the standard server configuration also support the
+following settings.
+They aren't included in sample configurations for brevity.
+
+### tls_cipher_suites
+
+The list of allowed cipher suites. See
+[Supported cipher suites](#supported-cipher-suites).
+
+**Type:** array of strings  
+**Default:** Not set. The default ciphers supported by Go are used.
+
+### tls_min_version
+
+The minimum acceptable TLS version. See
+[Supported TLS versions](#supported-tls-versions).
+
+**Type:** string  
+**Default:** `"TLS12"`
+
+### tls_max_version
+
+The maximum acceptable TLS version. See
+[Supported TLS versions](#supported-tls-versions).
+
+**Type:** string  
+**Default:** Not set. The maximum version supported by Go is used.
+
+## Supported cipher suites
+
+Use the following values with [`tls_cipher_suites`](#tls_cipher_suites):
+
+- `TLS_RSA_WITH_RC4_128_SHA`
+- `TLS_RSA_WITH_3DES_EDE_CBC_SHA`
+- `TLS_RSA_WITH_AES_128_CBC_SHA`
+- `TLS_RSA_WITH_AES_256_CBC_SHA`
+- `TLS_RSA_WITH_AES_128_CBC_SHA256`
+- `TLS_RSA_WITH_AES_128_GCM_SHA256`
+- `TLS_RSA_WITH_AES_256_GCM_SHA384`
+- `TLS_ECDHE_ECDSA_WITH_RC4_128_SHA`
+- `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA`
+- `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA`
+- `TLS_ECDHE_RSA_WITH_RC4_128_SHA`
+- `TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA`
+- `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`
+- `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`
+- `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256`
+- `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256`
+- `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
+- `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`
+- `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
+- `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`
+- `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305`
+- `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305`
+- `TLS_AES_128_GCM_SHA256`
+- `TLS_AES_256_GCM_SHA384`
+- `TLS_CHACHA20_POLY1305_SHA256`
+
+## Supported TLS versions
+
+Use the following values with [`tls_min_version`](#tls_min_version) or
+[`tls_max_version`](#tls_max_version):
+
+- `TLS10`
+- `TLS11`
+- `TLS12`
+- `TLS13`


### PR DESCRIPTION
- Environment variables: substitution syntax, quoting by TOML type,
  shell parameter expansion forms, and a before/after example.
- Secrets: the @{store:name} reference syntax, configuring secret
  stores, secret-capable option caveat, the telegraf secrets CLI, and
  memory locking requirements including the FreeBSD jail parameter.
- TLS: client, server, and advanced settings with per-setting anchors;
  the default minimum TLS version documented as TLS12 per the Telegraf
  source.
- Link all three from the corresponding configuration index sections.
- Record the periods-over-semicolons prose principle in PLAN.md and add
  the sweep to the cleanup parcel.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)