### PR TITLE
fix(ui): expand the current section's children in the left nav

### DIFF
--- a/cypress/e2e/content/sidebar-nav.cy.js
+++ b/cypress/e2e/content/sidebar-nav.cy.js
@@ -1,0 +1,31 @@
+/// <reference types="cypress" />
+
+/**
+ * Left nav (sidebar) active-state behavior.
+ *
+ * The inline script in layouts/partials/sidebar.html marks the nav item
+ * matching the current URL as active, opens its ancestor lists, and opens
+ * the active item's own children list when the current page is a section.
+ */
+
+describe('Sidebar nav active state', () => {
+  it('marks the current page active and opens ancestors', () => {
+    cy.visit('/telegraf/v1/configuration/agent/');
+
+    cy.get('#nav-tree li[data-nav-url="/telegraf/v1/configuration/agent/"]')
+      .should('have.class', 'active')
+      .parents('ul.children')
+      .should('have.class', 'open');
+  });
+
+  it('opens the children of the current section page', () => {
+    cy.visit('/telegraf/v1/configuration/');
+
+    cy.get('#nav-tree li[data-nav-url="/telegraf/v1/configuration/"]')
+      .should('have.class', 'active')
+      .within(() => {
+        cy.get('> ul.children').should('have.class', 'open');
+        cy.get('> a.children-toggle').should('have.class', 'open');
+      });
+  });
+});

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -125,6 +125,12 @@
     });
     if (!active) return;
     active.classList.add('active');
+    var ownChildren = active.querySelector(':scope > ul.children');
+    if (ownChildren) {
+      ownChildren.classList.add('open');
+      var ownToggle = active.querySelector(':scope > .children-toggle');
+      if (ownToggle) ownToggle.classList.add('open');
+    }
     var node = active.parentElement;
     while (node && node.id !== 'nav-tree') {
       if (node.tagName === 'UL' && node.classList.contains('children')) {


### PR DESCRIPTION
The sidebar active-state refactor (ae000080a) moved active/open class injection to an inline script that opens the ancestor lists of the active nav item, but dropped the IsMenuCurrent behavior of also opening the active section's own children list. Viewing a section page left its sub-pages collapsed.

Open the active item's direct children list and toggle, and add a Cypress test covering both the ancestor-open and self-open behaviors.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
