### PR TITLE
docs(telegraf): reference cleanup and cross-parcel sweeps

### DIFF
--- a/content/telegraf/v1/administer/_index.md
+++ b/content/telegraf/v1/administer/_index.md
@@ -6,7 +6,7 @@ description: >
 menu:
   telegraf_v1:
     name: Administer Telegraf
-    weight: 8
+weight: 8
 ---
 
 Run and manage Telegraf in production.

--- a/content/telegraf/v1/administer/manage-at-scale.md
+++ b/content/telegraf/v1/administer/manage-at-scale.md
@@ -24,12 +24,12 @@ Telegraf Controller provides:
 
 - **Centralized configuration management**: store configurations in one
   place and serve them to agents over a URL.
-  Agents load them with the `--config` flag; see
-  [Load configuration from a URL](/telegraf/v1/configuration/file/#load-configuration-from-a-url).
+  Agents load them with the `--config` flag.
+  See [Load configuration from a URL](/telegraf/v1/configuration/file/#load-configuration-from-a-url).
 - **Agent status and monitoring**: agents running the
   [heartbeat output plugin](/telegraf/v1/output-plugins/heartbeat/) report
-  health and a self-evaluated status back to Telegraf Controller; see
-  [Monitor Telegraf](/telegraf/v1/administer/monitor/).
+  health and a self-evaluated status back to Telegraf Controller.
+  See [Monitor Telegraf](/telegraf/v1/administer/monitor/).
 - **Labels and organization**: group and find agents and configurations
   across environments.
 

--- a/content/telegraf/v1/administer/run-as-service.md
+++ b/content/telegraf/v1/administer/run-as-service.md
@@ -142,8 +142,9 @@ If you do need separate services, install each with unique names:
 By default, the Windows service doesn't restart on failure.
 To enable automatic restarts, install the service with the `--auto-restart`
 flag.
-The default restart delay is 5 minutes; change it with `--restart-delay`
-and a duration, such as `--restart-delay 3m`.
+The default restart delay is 5 minutes.
+Change it with `--restart-delay` and a duration, such as
+`--restart-delay 3m`.
 
 ### Windows service logging
 

--- a/content/telegraf/v1/administer/troubleshoot.md
+++ b/content/telegraf/v1/administer/troubleshoot.md
@@ -93,7 +93,8 @@ For where logs go and how to rotate them, see
 ## Profile Telegraf with pprof
 
 Telegraf serves Go's standard `net/http/pprof` runtime profiling data.
-Profiling is off by default; enable it with the `--pprof-addr` option:
+Profiling is off by default.
+Enable it with the `--pprof-addr` option:
 
 <!--pytest.mark.skip-->
 

--- a/content/telegraf/v1/commands/_index.md
+++ b/content/telegraf/v1/commands/_index.md
@@ -1,13 +1,20 @@
 ---
 title: Telegraf commands and flags
-description: The `telegraf` command starts and runs all the processes necessary for Telegraf to function.
+description: >
+  The `telegraf` command starts and runs all the processes necessary for
+  Telegraf to function. Complete reference for Telegraf commands and global
+  flags.
 menu:
   telegraf_v1_ref:
     name: Telegraf commands
-    weight: 3
+weight: 3
+related:
+  - /telegraf/v1/configuration/
+  - /telegraf/v1/administer/troubleshoot/
 ---
 
-The `telegraf` command starts and runs all the processes necessary for Telegraf to function.
+The `telegraf` command starts and runs all the processes necessary for
+Telegraf to function.
 
 ## Usage
 
@@ -21,41 +28,82 @@ telegraf [flags]
 | Command                                   | Description                                  |
 | :---------------------------------------- | :------------------------------------------- |
 | [config](/telegraf/v1/commands/config/)   | Generate and migrate Telegraf configurations |
-| [secrets](/telegraf/v1/commands/secrets/) | Manage secrets in secret stores              |
 | [plugins](/telegraf/v1/commands/plugins/) | Print available plugins                      |
+| [secrets](/telegraf/v1/commands/secrets/) | Manage secrets in secret stores              |
+| [service](/telegraf/v1/commands/service/) | Manage the Telegraf Windows service (Windows only) |
 | [version](/telegraf/v1/commands/version/) | Print current version to stdout              |
 
 ## Global flags {id="telegraf-global-flags"}
 
-| Flag                             | Description                                                                                                                                       |
-| :------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--config <file>`                | Configuration file to load.                                                                                                                       |
-| `--config-directory <directory>` | Directory containing additional `*.conf` files.                                                                                                   |
-| `--test-wait`                    | Number of seconds to wait for service inputs to complete in test or once mode.                                                                    |
-| `--usage <plugin>`               | Print plugin usage (example: `telegraf --usage mysql`).                                                                                           |
-| `--pprof-addr <address>`         | pprof address to listen on. Disabled by default.                                                                                                  |
-| `--watch-config`                 | Restart Telegraf on local configuration changes. Use either fs notifications (`notify`) or polling (`poll`). Disabled by default.                 |
-| `--pidfile <file>`               | File to write PID to.                                                                                                                             |
-| `--password <password>`          | Password to unlock secret stores.                                                                                                                 |
-| `--old-env-behavior`             | Switch back to pre-v1.27 environment replacement behavior.                                                                                        |
-| `--once`                         | Gather metrics once, write them, and exit.                                                                                                        |
-| `--debug`                        | Enable debug logging.                                                                                                                             |
-| `--quiet`                        | Run in quiet mode.                                                                                                                                |
-| `--unprotected`                  | Do not protect secrets in memory.                                                                                                                 |
-| `--test`                         | Gather metrics once and print them.                                                                                                               |
-| `--deprecation-list`             | Print all deprecated plugins or plugin options.                                                                                                   |
-| `--input-list`                   | Print available input plugins.                                                                                                                    |
-| `--output-list`                  | Print available output plugins.                                                                                                                   |
-| `--version`                      | ({{< req "Deprecated" >}}) Print Telegraf version.                                                                                                |
-| `--sample-config`                | ({{< req "Deprecated" >}}) Print full sample configuration.                                                                                       |
-| `--plugin-directory <directory>` | ({{< req "Deprecated" >}}) Directory containing `*.so` files to search recursively for plugins. Found plugins are loaded, tagged, and identified. |
-| `--section-filter <filter>`      | Filter configuration sections to output (`agent`, `global_tags`, `outputs`, `processors`, `aggregators` and `inputs`). Separator is `:`.          |
-| `--input-filter <filter>`        | Filter input plugins to enable. Separator is `:`.                                                                                                 |
-| `--output-filter`                | Filter output plugins to enable. Separator is `:`.                                                                                                |
-| `--aggregator-filter <filter>`   | Filter aggregators to enable. Separator is `:`.                                                                                                   |
-| `--processor-filter <filter>`    | Filter processor plugins to enable. Separator is `:`.                                                                                             |
-| `--secretstore-filter <filter>`  | Filter secretstore plugins to enable. Separator is `:`.                                                                                           |
+### Load configuration
 
+| Flag                                  | Description                                                                                                                          |
+| :------------------------------------ | :----------------------------------------------------------------------------------------------------------------------------------- |
+| `--config <file>`                     | Configuration file to load. Can be a local path or a URL. Repeat to load multiple files.                                             |
+| `--config-directory <directory>`      | Directory containing additional `*.conf` files. Repeat to load multiple directories.                                                 |
+| `--config-url-retry-attempts <count>` | Number of attempts to obtain a remote configuration from a URL during startup. Set to `-1` for unlimited attempts. Default is `3`.   |
+| `--config-url-watch-interval <duration>` | Time duration to check for updates to URL-based configuration files. Disabled by default.                                         |
+| `--watch-config <method>`             | Restart Telegraf on local configuration changes. Use filesystem notifications (`notify`) on Linux, BSD, and macOS, or polling (`poll`), required on Windows. Disabled by default. |
+| `--watch-interval <duration>`         | Time duration to check for updates to local configuration files. Use with `--watch-config poll`. Disabled by default.                |
+| `--watch-debounce-interval <duration>` | Time duration to wait after a configuration change before reloading.                                                                |
+
+### Run modes
+
+| Flag                   | Description                                                                                                      |
+| :--------------------- | :---------------------------------------------------------------------------------------------------------------- |
+| `--test`               | Gather metrics once, print them, and exit. Test mode runs inputs, processors, and aggregators, but not outputs.  |
+| `--test-wait <seconds>` | Number of seconds to wait for service inputs to complete in test or once mode.                                  |
+| `--once`               | Gather metrics once, write them to the configured outputs, and exit.                                             |
+
+### Select plugins
+
+| Flag                             | Description                                                                                                                              |
+| :------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| `--input-filter <filter>`        | Filter input plugins to enable. Separator is `:`.                                                                                        |
+| `--output-filter <filter>`       | Filter output plugins to enable. Separator is `:`.                                                                                       |
+| `--processor-filter <filter>`    | Filter processor plugins to enable. Separator is `:`.                                                                                    |
+| `--aggregator-filter <filter>`   | Filter aggregator plugins to enable. Separator is `:`.                                                                                   |
+| `--secretstore-filter <filter>`  | Filter secret store plugins to enable. Separator is `:`.                                                                                 |
+| `--section-filter <filter>`      | Filter configuration sections to output (`agent`, `global_tags`, `outputs`, `processors`, `aggregators`, and `inputs`). Separator is `:`. |
+| `--select <selector>`            | Enable only plugins with [labels](/telegraf/v1/configuration/labels-selectors/) matching the given key-value selection. Repeat for OR logic; multiple pairs in one option combine with AND. |
+
+### Print information
+
+| Flag                           | Description                                             |
+| :----------------------------- | :------------------------------------------------------- |
+| `--usage <plugin>`             | Print plugin usage (example: `telegraf --usage mysql`). |
+| `--input-list`                 | Print available input plugins.                          |
+| `--output-list`                | Print available output plugins.                         |
+| `--deprecation-list`           | Print all deprecated plugins or plugin options.         |
+| `--print-plugin-config-source` | Print the source for a given plugin.                    |
+| `--help`, `-h`                 | Print help and exit.                                    |
+
+### Secrets and environment
+
+| Flag                       | Description                                                                                         |
+| :------------------------- | :--------------------------------------------------------------------------------------------------- |
+| `--password <password>`    | Password to unlock secret stores.                                                                   |
+| `--unprotected`            | Do not protect secrets in memory.                                                                   |
+| `--strict-env-handling`    | Enforce strict and secure handling of environment variables. Doesn't work with non-string settings. |
+| `--non-strict-env-handling` | Allow unsafe non-strict handling of environment variables to replace non-string settings.          |
+| `--old-env-behavior`       | Switch back to pre-v1.27 environment replacement behavior.                                          |
+
+### Logging and debugging
+
+| Flag                     | Description                                             |
+| :----------------------- | :------------------------------------------------------- |
+| `--debug`                | Enable debug logging.                                   |
+| `--quiet`                | Run in quiet mode.                                      |
+| `--pprof-addr <address>` | pprof address to listen on. Disabled by default.        |
+| `--pidfile <file>`       | File to write the process ID (PID) to.                  |
+
+### Deprecated flags
+
+| Flag                             | Description                                                             |
+| :------------------------------- | :----------------------------------------------------------------------- |
+| `--version`                      | Print Telegraf version. Use [`telegraf version`](/telegraf/v1/commands/version/) instead. |
+| `--sample-config`                | Print full sample configuration. Use [`telegraf config`](/telegraf/v1/commands/config/) instead. |
+| `--plugin-directory <directory>` | Directory containing `*.so` files to search recursively for plugins. Found plugins are loaded, tagged, and identified. |
 
 ## Examples
 
@@ -77,7 +125,7 @@ telegraf config > telegraf.conf
 ```sh
 telegraf config \
   --input-filter cpu \
-  --output-filter influxdb
+  --output-filter influxdb_v3
 ```
 
 ### Run a single Telegraf configuration and output metrics to stdout
@@ -98,7 +146,7 @@ telegraf --config telegraf.conf
 telegraf \
   --config telegraf.conf \
   --input-filter cpu:mem \
-  --output-filter influxdb
+  --output-filter influxdb_v3
 ```
 
 ### Run Telegraf with pprof

--- a/content/telegraf/v1/commands/service.md
+++ b/content/telegraf/v1/commands/service.md
@@ -1,0 +1,102 @@
+---
+title: telegraf service
+description: >
+  The `telegraf service` command installs, removes, and manages the Telegraf
+  service on Microsoft Windows.
+menu:
+  telegraf_v1_ref:
+    name: telegraf service
+    parent: Telegraf commands
+weight: 201
+related:
+  - /telegraf/v1/administer/run-as-service/
+  - /telegraf/v1/install/
+---
+
+The `telegraf service` command installs, removes, and manages the Telegraf
+service on Microsoft Windows.
+
+> [!Note]
+> #### Windows only
+>
+> The `service` command is available only in Windows builds of Telegraf.
+> On Linux and macOS, manage Telegraf with systemd or launchd.
+> See [Run Telegraf as a service](/telegraf/v1/administer/run-as-service/).
+
+## Usage
+
+```
+telegraf.exe [global flags] service <subcommand> [service flags]
+```
+
+## Subcommands
+
+| Subcommand  | Description                              |
+| :---------- | :---------------------------------------- |
+| `install`   | Install Telegraf as a Windows service    |
+| `uninstall` | Remove the Telegraf service              |
+| `start`     | Start the Telegraf service               |
+| `stop`      | Stop the Telegraf service                |
+| `status`    | Print the current status of the service  |
+
+## Flags
+
+The service to operate on is selected with the global, Windows-only
+`--service-name` flag, placed *before* the `service` command:
+
+| Global flag             | Description                                               |
+| :---------------------- | :--------------------------------------------------------- |
+| `--service-name <name>` | Name of the service to operate on. Default is `telegraf`. |
+
+The `install` subcommand supports the following flags:
+
+| Flag                         | Description                                                              |
+| :--------------------------- | :------------------------------------------------------------------------ |
+| `--display-name <name>`      | Service name as displayed in the service manager. Default is `Telegraf Data Collector Service`. |
+| `--auto-restart`             | Enable automatic service restart on failure.                             |
+| `--restart-delay <duration>` | Duration for delaying the service restart on failure. Default is `5m`.   |
+
+Global flags, such as `--config` and `--config-directory`, are recorded as
+part of the service definition when installing.
+Always use absolute paths.
+
+## Examples
+
+The following examples use PowerShell.
+They also work in Command Prompt if you replace the PowerShell
+line-continuation backtick (`` ` ``) with a caret (`^`) or enter each
+command on a single line.
+
+### Install Telegraf as a Windows service
+
+<!--pytest.mark.skip-->
+
+```powershell
+.\telegraf.exe `
+  --config "C:\Program Files\InfluxData\telegraf\telegraf.conf" `
+  service install
+```
+
+### Install a second service instance with automatic restart
+
+<!--pytest.mark.skip-->
+
+```powershell
+.\telegraf.exe `
+  --config "C:\Program Files\InfluxData\telegraf\telegraf-2.conf" `
+  --service-name telegraf-2 `
+  service install --auto-restart
+```
+
+### Start and check the service
+
+<!--pytest.mark.skip-->
+
+```powershell
+.\telegraf.exe service start
+.\telegraf.exe service status
+```
+
+For running and managing the service, including logging to the Windows
+Event Viewer and troubleshooting startup errors, see
+[Run Telegraf as a service](/telegraf/v1/administer/run-as-service/#windows).

--- a/content/telegraf/v1/concepts/_index.md
+++ b/content/telegraf/v1/concepts/_index.md
@@ -7,7 +7,7 @@ description: >
 menu:
   telegraf_v1:
     name: How Telegraf works
-    weight: 4
+weight: 4
 related:
   - /telegraf/v1/plugins/
   - /telegraf/v1/configure_plugins/

--- a/content/telegraf/v1/concepts/data-pipeline.md
+++ b/content/telegraf/v1/concepts/data-pipeline.md
@@ -7,8 +7,8 @@ description: >
 menu:
   telegraf_v1:
     name: Data pipeline
-    weight: 102
     parent: How Telegraf works
+weight: 102
 related:
   - /telegraf/v1/concepts/metrics/
   - /telegraf/v1/configure_plugins/aggregator_processor/
@@ -131,8 +131,8 @@ The `[agent]` `buffer_strategy` setting controls buffer durability:
 - `disk`: each output persists its buffer to a write-ahead log in
   `buffer_directory`, and Telegraf removes entries as writes succeed.
   After a restart, Telegraf flushes existing log entries before new metrics.
-  Telegraf does not limit the disk space these files use; monitor the buffer
-  directory to keep it from filling the disk.
+  Telegraf does not limit the disk space these files use.
+  Monitor the buffer directory to keep it from filling the disk.
 
 For end-to-end delivery guarantees with queue-based inputs, see
 [tracking metrics](/telegraf/v1/concepts/metrics/#tracking-metrics).

--- a/content/telegraf/v1/concepts/metrics.md
+++ b/content/telegraf/v1/concepts/metrics.md
@@ -7,8 +7,8 @@ description: >
 menu:
   telegraf_v1:
     name: Telegraf metrics
-    weight: 101
     parent: How Telegraf works
+weight: 101
 aliases:
   - /telegraf/v1/metrics/
 related:

--- a/content/telegraf/v1/configuration/_index.md
+++ b/content/telegraf/v1/configuration/_index.md
@@ -10,983 +10,153 @@ menu:
   telegraf_v1:
     name: Configure Telegraf
 weight: 5
+related:
+  - /telegraf/v1/get-started/
+  - /telegraf/v1/concepts/data-pipeline/
 ---
 
-Telegraf uses a configuration file to define what plugins to enable and what
-settings to use when Telegraf starts.
-Each Telegraf plugin has its own set of configuration options.
-Telegraf also provides global options for configuring specific Telegraf settings.
+Telegraf uses a [TOML](/telegraf/v1/configuration/toml/) configuration file
+to define which plugins to enable and which settings to use when Telegraf
+starts.
+To be valid, a configuration must define at least one input plugin and at
+least one output plugin.
 
 > [!Note]
-> See [Get started](/telegraf/v1/get-started/) to quickly get up and running with Telegraf.
+> See [Get started](/telegraf/v1/get-started/) to quickly get up and
+> running with Telegraf.
 
 The following pages cover each configuration topic in depth:
 
 {{< children >}}
 
+The rest of this page is a quick reference that maps the parts of a
+configuration file to the pages that document them.
+
 ## Generate a configuration file
 
-The `telegraf config` command lets you generate a configuration file using Telegraf's list of plugins.
-For the configuration file structure and loading behavior, see
-[Telegraf configuration file](/telegraf/v1/configuration/file/).
+The `telegraf config` command creates a configuration file with plugins you
+select:
 
-- [Create a configuration with default input and output plugins](#create-a-configuration-with-default-input-and-output-plugins)
-- [Create a configuration file with specific input and output plugins](#create-a-configuration-file-with-specific-input-and-output-plugins)
-- [Windows PowerShell v5 encoding](#windows-powershell-v5-encoding)
-
-### Create a configuration with default input and output plugins
-
-To generate a configuration file with default input and output plugins enabled,
-enter the following command in your terminal:
-
-{{< code-tabs-wrapper >}}
-{{% code-tabs %}}
-[Linux and macOS](#)
-[Windows](#)
-{{% /code-tabs %}}
-{{% code-tab-content %}}
-```bash
-telegraf config > telegraf.conf
-```
-{{% /code-tab-content %}}
-{{% code-tab-content %}}
-```powershell
-.\telegraf.exe config > telegraf.conf
-```
-{{% /code-tab-content %}}
-{{< /code-tabs-wrapper >}}
-
-The generated file contains settings for all available plugins--some are enabled and the rest are commented out.
-
-### Create a configuration file with specific input and output plugins
-
-To generate a configuration file that contains settings for only specific plugins,
-use the `--input-filter` and `--output-filter` options to
-specify [input plugins](/telegraf/v1/configure_plugins/input_plugins/)
-and [output plugins](/telegraf/v1/configure_plugins/output_plugins/).
-Use a colon (`:`) to separate plugin names.
-
-#### Syntax
-
-{{< code-tabs-wrapper >}}
-{{% code-tabs %}}
-[Linux and macOS](#)
-[Windows](#)
-{{% /code-tabs %}}
-{{% code-tab-content %}}
-```bash
-telegraf \
---input-filter <INPUT_PLUGIN_NAME>[:<INPUT_PLUGIN_NAME>] \
---output-filter <OUTPUT_PLUGIN_NAME>[:<OUTPUT_PLUGIN_NAME>] \
-config > telegraf.conf
-```
-{{% /code-tab-content %}}
-{{% code-tab-content %}}
-```powershell
-.\telegraf.exe `
---input-filter <INPUT_PLUGIN_NAME>[:<INPUT_PLUGIN_NAME>] `
---output-filter <OUTPUT_PLUGIN_NAME>[:<OUTPUT_PLUGIN_NAME>] `
-config > telegraf.conf
-```
-{{% /code-tab-content %}}
-{{< /code-tabs-wrapper >}}
-
-#### Example
-
-The following example shows how to include configuration sections for the
-[`inputs.cpu`](/telegraf/v1/plugins/#input-cpu),
-[`inputs.http_listener_v2`](/telegraf/v1/plugins/#input-http_listener_v2),
-[`outputs.influxdb_v2`](/telegraf/v1/plugins/#output-influxdb_v2), and
-[`outputs.file`](/telegraf/v1/plugins/#output-file) plugins:
-
-{{< code-tabs-wrapper >}}
-{{% code-tabs %}}
-[Linux and macOS](#)
-[Windows](#)
-{{% /code-tabs %}}
-{{% code-tab-content %}}
-```bash
-telegraf \
---input-filter cpu:http_listener_v2 \
---output-filter influxdb_v2:file \
-config > telegraf.conf
-```
-{{% /code-tab-content %}}
-{{% code-tab-content %}}
-```powershell
-.\telegraf.exe `
---input-filter cpu:http_listener_v2 `
---output-filter influxdb_v2:file `
-config > telegraf.conf
-```
-{{% /code-tab-content %}}
-{{< /code-tabs-wrapper >}}
-
-For more advanced configuration details, see the
-[configuration documentation](/telegraf/v1/administration/configuration/).
-
-### Windows PowerShell v5 encoding
-
-In PowerShell 5, the default encoding is UTF-16LE and not UTF-8.
-Telegraf expects a valid UTF-8 file.
-This is not an issue with PowerShell 6 or newer, as well as the Command Prompt
-or with using the Git Bash shell.
-
-When using PowerShell 5 or earlier, specify the output encoding when generating
-a full configuration file:
-
-```powershell
-telegraf.exe config | Out-File -Encoding utf8 telegraf.conf
+```sh
+telegraf --input-filter cpu:mem --output-filter influxdb_v3 config > telegraf.conf
 ```
 
-This will generate a UTF-8 encoded file with a byte-order mark (BOM).
-However, Telegraf correctly handles the leading BOM.
+See [Generate a configuration file](/telegraf/v1/configuration/file/#generate-a-configuration-file)
+and the [telegraf config command](/telegraf/v1/commands/config/).
 
 ## Configuration file locations
 
-When starting Telegraf, use the `--config` flag to specify the configuration file location:
+Telegraf loads configuration from the path in the `--config` flag, the
+`TELEGRAF_CONFIG_PATH` environment variable, or a default location for your
+operating system.
+Load additional files with `--config-directory`, and load remote
+configuration by passing a URL to `--config`.
 
-- Filename and path, for example: `--config /etc/default/telegraf`
-- Remote URL endpoint, for example: `--config "http://remote-URL-endpoint"`
-
-Use the `--config-directory` flag to include files ending with `.conf` in the
-specified directory in the Telegraf configuration.
-
-On most systems, the default locations are `/etc/telegraf/telegraf.conf` for
-the main configuration file and `/etc/telegraf/telegraf.d` (on Windows, `C:\"Program Files"\Telegraf\telegraf.d`) for the directory of
-configuration files.
-
-Telegraf processes each configuration file separately, and
-the effective configuration is the union of all the files.
-If any file isn't a valid configuration, Telegraf returns an error.
-
-> [!Warning]
-> #### Telegraf doesn't support partial configurations
-> 
-> Telegraf doesn't concatenate configuration files before processing them.
-> Each configuration file that you provide must be a valid configuration.
-> 
-> If you want to use separate files to manage a configuration, you can use your
-> own custom code to concatenate and pre-process the files, and then provide the
-> complete configuration to Telegraf--for example:
-> 
-> 1.  Configure plugin sections and assign partial configs a file extension different
->     from `.conf` to prevent Telegraf loading them--for example:
-> 
->     ```toml
->     # main.opcua: Main configuration file 
->     ...
->     [[inputs.opcua_listener]]
->       name = "PluginSection"
->       endpoint = "opc.tcp://10.0.0.53:4840"
->     ...
->     ```
-> 
->     ```toml
->     # group_1.opcua
->       [[inputs.opcua_listener.group]]
->       name = "SubSection1"
->     ...
->     ```
-> 
->     ```toml
->     # group_2.opcua
->       [[inputs.opcua_listener.group]]
->       name = "SubSection2"
->     ... 
->     ```
-> 
-> 2.  Before you start Telegraf, run your custom script to concatenate
-      `main.opcua`, `group_1.opcua`,
->    `group_2.opcua` into a valid `telegraf.conf`.
-> 3.  Start Telegraf with the complete, valid `telegraf.conf` configuration. 
+See [Configuration file locations](/telegraf/v1/configuration/file/#configuration-file-locations)
+and [Load configuration from a URL](/telegraf/v1/configuration/file/#load-configuration-from-a-url).
 
 ## Set environment variables
 
-For expansion forms and examples, see
-[Environment variables](/telegraf/v1/configuration/environment-variables/).
-
-Use environment variables anywhere in the configuration file by enclosing them in `${}`.
-For strings, variables must be in quotes (for example, `"test_${STR_VAR}"`).
-For numbers and booleans, variables must be unquoted (for example, `${INT_VAR}`,
-`${BOOL_VAR}`).
-
-When using double quotes, escape any backslashes (for example: `"C:\\Program Files"`) or
-other special characters.
-If using an environment variable with a single backslash, enclose the variable
-in single quotes to signify a string literal (for example:
-`'C:\Program Files'`).
-
-Telegraf also supports Shell parameter expansion for environment variables which
-allows the following:
-
-- `${VARIABLE:-default}`: evaluates to `default` if `VARIABLE` is unset or empty
-  in the environment.
-- `${VARIABLE-default}`: evaluates to `default` only if `VARIABLE` is unset in
-  the environment. Similarly, the following syntax allows you to specify
-  mandatory variables:
-- `${VARIABLE:?err}`: exits with an error message containing `err` if `VARIABLE`
-  is unset or empty in the environment.
-- `${VARIABLE?err}`: exits with an error message containing `err` if `VARIABLE`
-  is unset in the environment.
-
-When using the `.deb` or `.rpm` packages, you can define environment variables
-in the `/etc/default/telegraf` file.
-
-You can also set environment variables using the Linux `export` command:
-
-<!--pytest.mark.skip-->
-```bash
-export password=mypassword
-```
-
-> **Note:** Use a secret store or environment variables to store sensitive credentials.
-
-### Example: Telegraf environment variables
-
-Set environment variables in the Telegraf environment variables file
-(`/etc/default/telegraf`).
-
-#### For InfluxDB 1.x:
-
-<!--pytest.mark.skip-->
-
-```sh
-USER="alice"
-INFLUX_URL="http://localhost:8086"
-INFLUX_SKIP_DATABASE_CREATION="true"
-INFLUX_PASSWORD="passw0rd123"
-```
-
-#### For InfluxDB OSS v2:
-
-<!--pytest.mark.skip-->
-
-```sh
-INFLUX_HOST="http://localhost:8086"
-INFLUX_TOKEN="replace_with_your_token"
-INFLUX_ORG="your_username"
-INFLUX_BUCKET="replace_with_your_bucket_name"
-```
-
-#### For InfluxDB Cloud Serverless:
-
-<!--pytest.mark.skip-->
-
-```sh
-# For AWS West (Oregon)
-INFLUX_HOST="https://us-west-2-1.aws.cloud2.influxdata.com"
-# Other Cloud URLs at https://docs.influxdata.com/influxdb/cloud/reference/regions/
-INFLUX_TOKEN="replace_with_your_token"
-INFLUX_ORG="yourname@yourcompany.com"
-INFLUX_BUCKET="replace_with_your_bucket_name"
-```
-
-In the Telegraf configuration file (`/etc/telegraf.conf`), reference the variables--for example:
-
-<!--
-  This example uses Telegraf's `${VAR}` substitution (bare, unquoted)
-  for non-string values like the `skip_database_creation` boolean.
-  That syntax is a Telegraf preprocessor extension, not strict TOML,
-  so the fence is `text` rather than `toml`.
--->
-
-```text
-[global_tags]
-  user = "${USER}"
-
-[[inputs.mem]]
-
-# For InfluxDB 1.x:
-[[outputs.influxdb]]
-  urls = ["${INFLUX_URL}"]
-  skip_database_creation = ${INFLUX_SKIP_DATABASE_CREATION}
-  password = "${INFLUX_PASSWORD}"
-
-# For InfluxDB OSS 2:
-[[outputs.influxdb_v2]]
-  urls = ["${INFLUX_HOST}"]
-  token = "${INFLUX_TOKEN}"
-  organization = "${INFLUX_ORG}"
-  bucket = "${INFLUX_BUCKET}"
-
-# For InfluxDB Cloud:
-[[outputs.influxdb_v2]]
-  urls = ["${INFLUX_HOST}"]
-  token = "${INFLUX_TOKEN}"
-  organization = "${INFLUX_ORG}"
-  bucket = "${INFLUX_BUCKET}"
-```
-
-When Telegraf runs, the effective configuration is the following:
-
-```toml
-[global_tags]
-  user = "alice"
-
-# For InfluxDB 1.x:
-[[outputs.influxdb]]
-  urls = ["http://localhost:8086"]
-  skip_database_creation = true
-  password = "passw0rd123"
-
-# For InfluxDB OSS 2:
-[[outputs.influxdb_v2]]
-  urls = ["http://localhost:8086"]
-  token = "replace_with_your_token"
-  organization = "your_username"
-  bucket = "replace_with_your_bucket_name"
-
-# For InfluxDB Cloud:
-[[outputs.influxdb_v2]]
-  urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
-  token = "replace_with_your_token"
-  organization = "yourname@yourcompany.com"
-  bucket = "replace_with_your_bucket_name"
-```
+Reference environment variables anywhere in the configuration file with
+`${VARIABLE_NAME}` syntax.
+See [Use environment variables](/telegraf/v1/configuration/environment-variables/).
 
 ## Secret stores
 
-For details and examples, see
-[Secrets](/telegraf/v1/configuration/secrets/).
+Keep credentials out of plain-text configuration files with secret store
+plugins, and reference secrets as `@{store_id:secret_key}`.
 
-Telegraf also supports secret stores for providing credentials or similar.
-Configure one or more secret store plugins and then reference the secret in
-your plugin configurations.
+### Secret-store secrets {id="secret-store-secrets"}
 
-Reference secrets using the following syntax:
-
-```txt
-@{<secret_store_id>:<secret_name>}
-```
-
-- `secret_store_id`: the unique ID you define for your secret store plugin.
-- `secret_name`: the name of the secret to use.
-
-> [!Note]
-> Both and `secret_store_id` and `secret_name` only support alphanumeric
-> characters and underscores.
-
-### Example: Use secret stores
-
-This example illustrates the use of secret stores in plugins:
-
-```toml
-[global_tags]
-  user = "alice"
-
-[[secretstores.os]]
-  id = "local_secrets"
-
-[[secretstores.jose]]
-  id = "cloud_secrets"
-  path = "/etc/telegraf/secrets"
-  # Optional reference to another secret store to unlock this one.
-  password = "@{local_secrets:cloud_store_passwd}"
-
-[[inputs.http]]
-  urls = ["http://server.company.org/metrics"]
-  username = "@{local_secrets:company_server_http_metric_user}"
-  password = "@{local_secrets:company_server_http_metric_pass}"
-
-[[outputs.influxdb_v2]]
-  urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
-  token = "@{cloud_secrets:influxdb_token}"
-  organization = "yourname@yourcompany.com"
-  bucket = "replace_with_your_bucket_name"
-```
-
-### Notes on secret stores
-
-Not all plugins support secrets.
-When using plugins that support secrets, Telegraf locks the memory pages
-containing the secrets.
-Therefore, the locked memory limit has to be set to a
-suitable value.
-Telegraf will check the limit and the number of used secrets at
-startup and will warn if your limit is too low.
-In this case, please increase
-the limit via `ulimit -l`.
-
-If you are running Telegraf in a jail you might need to allow locked pages in
-that jail by setting `allow.mlock = 1;` in your config.
+Plugin options that support secrets accept the `@{store_id:secret_key}`
+syntax.
+See [Store secrets](/telegraf/v1/configuration/secrets/) for configuring
+secret stores, referencing secrets, and managing them with the
+[telegraf secrets command](/telegraf/v1/commands/secrets/).
 
 ## Global tags
 
-Global tags can be specified in the `[global_tags]` section of the configuration
-file in `key="value"` format.
-Telegraf applies the global tags to all metrics gathered on this host.
+Define tags in the `[global_tags]` table in `key = "value"` format.
+Telegraf applies global tags to all metrics gathered on the host.
+See the [configuration file anatomy](/telegraf/v1/configuration/file/).
 
 ## Agent configuration
 
-For agent settings grouped by what they control, see
-[Agent settings](/telegraf/v1/configuration/agent/).
+The `[agent]` table controls collection intervals, batching and buffering,
+flushing, logging, and other agent-wide behavior.
+See [Agent settings](/telegraf/v1/configuration/agent/) for every setting
+with types and defaults.
 
-The `[agent]` section contains the following configuration options:
+### Intervals {id="intervals"}
 
-- **interval**: Default data collection interval for all inputs.
-- **round_interval**: Rounds collection interval to `interval`.
-  For example, if `interval` is set to `10s`, then the agent collects on :00, :10, :20, etc.
-- **metric_batch_size**: Telegraf sends metrics to outputs in batches of at
-  most `metric_batch_size` metrics.
-  This controls the size of writes that Telegraf sends to output plugins.
-- **metric_buffer_limit**: Maximum number of unwritten metrics per output.
-  Increasing this value allows for longer periods of output downtime without
-  dropping metrics at the cost of higher maximum memory usage.
-  The oldest metrics are overwritten in favor of new ones when the buffer fills up.
-- **collection_jitter**: Jitter the collection by a random interval.
-  Each plugin sleeps for a random time within the defined jitter before collecting.
-  Use this to avoid many plugins querying things like sysfs at the
-  same time, which can have a measurable effect on the system.
-- **collection_offset**: Shift the collection by the given interval.
-  Use this to avoid many plugins querying constraint devices
-  at the same time by manually scheduling them in time.
-- **flush_interval**: Default flushing interval for all outputs.
-  Maximum `flush_interval` is `flush_interval` + `flush_jitter`.
-- **flush_jitter**: Default flush jitter for all outputs.
-  This jitters the flush interval by a random amount.
-  This is primarily to avoid large write spikes for users
-  running a large number of Telegraf instances.
-  For example, a jitter of `5s` and an interval of `10s` means flushes happen
-  every 10-15 seconds.
-- **precision**: Round collected metrics to the precision specified as an interval.
-  Precision is _not_ used for service inputs.
-  It is up to each individual service input to set the timestamp at the appropriate precision.
-- **debug**: Log at debug level.
-- **quiet**: Log only error level messages.
-- **logformat**: Log format controls the way messages are logged and can be one
-  of `text`, `structured` or, on Windows, `eventlog`.
-  The output file (if any) is determined by the `logfile` setting.
-- **structured_log_message_key**: Message key for structured logs, to override
-  the default of `msg`.
-  Ignored if `logformat` is not `structured`.
-- **logfile**: Name of the file to be logged to or stderr if unset or empty.
-  This setting is ignored for the `eventlog` format.
-- **logfile_rotation_interval**: The logfile rotates after the time interval specified.
-  When set to 0 no time based rotation is performed.
-- **logfile_rotation_max_size**: The logfile rotates when it becomes larger than the specified size.
-  When set to 0 no size based rotation is performed.
-- **logfile_rotation_max_archives**: Maximum number of rotated archives to keep,
-  any older logs are deleted.
-  If set to -1, no archives are removed.
-- **log_with_timezone**: Pick a timezone to use when logging or type 'local' for local time.
-  Example: 'America/Chicago'.
-  [See this page for options/formats.](https://socketloop.com/tutorials/golang-display-list-of-timezones-with-gmt)
-- **hostname**: Override the default hostname, if empty use `os.Hostname()`.
-- **omit_hostname**: If set to true, do no set the "host" tag in the Telegraf agent.
-- **snmp_translator**: Method of translating SNMP objects.
-  Can be "netsnmp" (deprecated) which translates by calling external programs
-  `snmptranslate` and `snmptable`, or "gosmi" which translates using the built-in
-  gosmi library.
-- **statefile**: Name of the file to load the states of plugins from and store the states to.
-  If uncommented and not empty, this file is used to save the state of stateful
-  plugins on termination of Telegraf.
-  If the file exists on start, the state in the file is restored for the plugins.
-- **always_include_local_tags**: Ensure tags explicitly defined in a plugin _always_ pass tag-filtering
-  via `taginclude` or `tagexclude`.
-  This removes the need to specify local tags twice.
-- **always_include_global_tags**: Ensure tags explicitly defined in the `global_tags` section will _always_ pass
-  tag-filtering via `taginclude` or `tagexclude`.
-  This removes the need to specify those tags twice.
-- **skip_processors_after_aggregators**: By default, processors are run a second time after aggregators.
-  Changing this setting to true will skip the second run of processors.
-- **buffer_strategy**: The type of buffer to use for Telegraf output plugins.
-  Supported modes are `memory`, the default and original buffer type, and `disk`,
-  an experimental disk-backed buffer which serializes all metrics to disk as
-  needed to improve data durability and reduce the chance for data loss.
-  This is only supported at the agent level.
-- **buffer_directory**: The directory to use when in `disk` buffer mode.
-  Each output plugin makes another subdirectory in this directory with the
-  output plugin's ID.
+Scheduling settings, including `interval`, `round_interval`,
+`collection_jitter`, `collection_offset`, `flush_interval`, and
+`flush_jitter`, control when Telegraf collects and writes metrics.
+See [Collection scheduling](/telegraf/v1/configuration/agent/#collection-scheduling)
+in the agent settings reference.
 
-## Input configuration
+## Plugins {id="plugins"}
 
-For details and examples, see
-[Common plugin options](/telegraf/v1/configuration/plugin-options/#input-plugin-options).
+Enable a plugin by adding its TOML table to the configuration file, for
+example `[[inputs.cpu]]` or `[[outputs.influxdb_v3]]`.
+You can define multiple instances of any plugin.
+Each plugin's specific options are documented in the
+[Plugin directory](/telegraf/v1/plugins/), and all plugins share a set of
+[common options](/telegraf/v1/configuration/plugin-options/) such as
+`alias`, `interval`, `name_override`, and `tags`.
 
-The following config parameters are available for all inputs:
+### Input configuration
 
-- **alias**: Name an instance of a plugin.
-- **interval**: How often to gather this metric. Normal plugins use a single
-  global interval, but if one particular input should be run less or more often,
-  you can configure that here. `interval` can be increased to reduce data-in rate limits.
-- **precision**: Overrides the `precision` setting of the agent. Collected
-  metrics are rounded to the precision specified as an `interval`. When this value is
-  set on a service input (ex: `statsd`), multiple events occurring at the same
-  timestamp may be merged by the output database.
-- **collection_jitter**: Overrides the `collection_jitter` setting of the agent.  
-  Collection jitter is used to jitter the collection by a random `interval`
-- **name_override**: Override the base name of the measurement.
-  (Default is the name of the input).
-- **name_prefix**: Specifies a prefix to attach to the measurement name.
-- **name_suffix**: Specifies a suffix to attach to the measurement name.
-- **tags**: A map of tags to apply to a specific input's measurements.
+Input plugins collect metrics.
+See [Collect data with input plugins](/telegraf/v1/configure_plugins/input_plugins/)
+and [input plugin options](/telegraf/v1/configuration/plugin-options/#input-plugin-options).
 
-## Output configuration
+### Output configuration
 
-For details and examples, see
-[Common plugin options](/telegraf/v1/configuration/plugin-options/#output-plugin-options).
+Output plugins write metrics to destinations.
+See [Write data with output plugins](/telegraf/v1/configure_plugins/output_plugins/)
+and [output plugin options](/telegraf/v1/configuration/plugin-options/#output-plugin-options).
 
-- **alias**: Name an instance of a plugin.
-- **flush_interval**: Maximum time between flushes. Use this setting to
-  override the agent `flush_interval` on a per plugin basis.
-- **flush_jitter**: Amount of time to jitter the flush interval. Use this
-  setting to override the agent `flush_jitter` on a per plugin basis.
-- **metric_batch_size**: Maximum number of metrics to send at once. Use
-  this setting to override the agent `metric_batch_size` on a per plugin basis.
-- **metric_buffer_limit**: Maximum number of unsent metrics to buffer.
-  Use this setting to override the agent `metric_buffer_limit` on a per plugin basis.
-- **name_override**: Override the base name of the measurement.
-  (Default is the name of the output).
-- **name_prefix**: Specifies a prefix to attach to the measurement name.
-- **name_suffix**: Specifies a suffix to attach to the measurement name.
+### Processor configuration
 
-### Data formats
+Processor plugins transform metrics as they pass through the pipeline.
+See [Processors and aggregators](/telegraf/v1/configure_plugins/aggregator_processor/)
+and [processor plugin options](/telegraf/v1/configuration/plugin-options/#processor-plugin-options).
 
-Some output plugins support the `data_format` option, which specifies a serializer
-to convert metrics before writing.
-Common serializers include `json`, `influx`, `prometheus`, and `csv`.
+### Aggregator configuration
 
-Output plugins that support serializers may also offer `use_batch_format`, which
-controls whether the serializer receives metrics individually or as a batch.
-Batch mode enables more efficient encoding for formats like JSON arrays.
-
-```toml
-[[outputs.file]]
-  files = ["stdout"]
-  data_format = "json"
-  use_batch_format = true
-```
-
-For available serializers and configuration options, see
-[output data formats](/telegraf/v1/data_formats/output/).
-
-## Aggregator configuration
-
-For details and examples, see
-[Common plugin options](/telegraf/v1/configuration/plugin-options/#aggregator-plugin-options).
-
-The following config parameters are available for all aggregators:
-
-- **alias**: Name an instance of a plugin.
-- **period**: The period on which to flush & clear each aggregator. All metrics
-  that are sent with timestamps outside of this period are ignored by the
-  aggregator.
-- **delay**: The delay before each aggregator is flushed. This is to control
-  how long for aggregators to wait before receiving metrics from input plugins,
-  in the case that aggregators are flushing and inputs are gathering on the
-  same interval.
-- **grace**: The duration the metrics are aggregated by the plugin
-  even though they're outside the aggregation period.
-  This setting is needed when the agent is expected to receive late metrics and can
-  be rolled into the next aggregation period.
-- **drop_original**: If true, the original metric is dropped by the
-  aggregator and not sent to the output plugins.
-- **name_override**: Override the base name of the measurement.
-  (Default is the name of the input).
-- **name_prefix**: Specifies a prefix to attach to the measurement name.
-- **name_suffix**: Specifies a suffix to attach to the measurement name.
-- **tags**: A map of tags to apply to a specific input's measurements.
-
-For a demonstration of how to configure SNMP, MQTT, and PostGRE SQL plugins to
-get data into Telegraf, see the following video:
-
-{{< youtube 6XJdZ_kdx14 >}}
-
-## Processor configuration
-
-For details and examples, see
-[Common plugin options](/telegraf/v1/configuration/plugin-options/#processor-plugin-options).
-
-The following config parameters are available for all processors:
-
-- **alias**: Name an instance of a plugin.
-- **order**: This is the order in which processors are executed.
-  If not specified, then order is random.
-
-The [metric filtering](#metric-filtering) parameters can be used to limit what metrics are
-handled by the processor.
-Excluded metrics are passed downstream to the next processor.
+Aggregator plugins produce windowed aggregate metrics.
+See [Processors and aggregators](/telegraf/v1/configure_plugins/aggregator_processor/)
+and [aggregator plugin options](/telegraf/v1/configuration/plugin-options/#aggregator-plugin-options).
 
 ## Metric filtering
 
-For details and worked examples, see
-[Filter metrics](/telegraf/v1/configuration/filtering/).
-
-Filters can be configured per input, output, processor, or aggregator.
-
-- [Filters](#filters)
-- [Filtering examples](#filtering-examples)
+Metric filters attach to any plugin and control which metrics that plugin
+handles.
+See [Filter metrics](/telegraf/v1/configuration/filtering/) for the full
+reference and worked examples.
 
 ### Filters
 
-Filters fall under two categories:
-
-- [Selectors](#selectors)
-- [Modifiers](#modifiers)
-
 #### Selectors
 
-Selector filters include or exclude entire metrics.
-When a metric is excluded from an input or output plugin, the metric is dropped.
-If a metric is excluded from a processor or aggregator plugin, it skips the
-plugin and is sent onwards to the next stage of processing.
-
-- **namepass**: An array of glob pattern strings.
-  Only metrics whose measurement name matches a pattern in this list are emitted.
-  Additionally, custom list of separators can be specified using `namepass_separator`.
-  These separators are excluded from wildcard glob pattern matching.
-- **namedrop**: The inverse of `namepass`.
-  If a match is found the metric is discarded.
-  This is tested on metrics after they have passed the `namepass` test.
-  Additionally, custom list of separators can be specified using `namedrop_separator`.
-  These separators are excluded from wildcard glob pattern matching.
-- **tagpass**: A table mapping tag keys to arrays of glob pattern strings.
-  Only metrics that contain a tag key in the table and a tag value matching one of its
-  patterns is emitted.
-  This can either use the explicit table syntax (for example: a subsection using a `[...]` header)
-  or inline table syntax (e.g like a JSON table with `{...}`).
-  Please see the below notes on specifying the table.
-- **tagdrop**: The inverse of `tagpass`.
-  If a match is found the metric is discarded.
-  This is tested on metrics after they have passed the `tagpass` test.
-- **metricpass**: A Common Expression Language (CEL) expression with boolean result where
-  `true` will allow the metric to pass, otherwise the metric is discarded.
-  This filter expression is more general compared to `namepass` and also
-  supports time-based filtering.
-  Further details, such as available functions and expressions, are provided in the
-  CEL language definition as well as in the extension documentation or the CEL language introduction.
-  
-  > [!Note]
-  > *As CEL is an _interpreted_ language. This type of filtering is much slower
-  > than `namepass`, `namedrop`, and others.
-  > Consider using the more restrictive filter options where possible in case of
-  > high-throughput scenarios.
+Selectors decide whether a plugin handles a metric: `namepass`, `namedrop`,
+`tagpass`, `tagdrop`, and `metricpass`.
+See [Selectors](/telegraf/v1/configuration/filtering/#selectors).
 
 #### Modifiers
 
-Modifier filters remove tags and fields from a metric.
-If all fields are removed, the metric is removed and as a result not passed through
-to the following processors or any output plugin.
-Tags and fields are modified before a metric is passed to a processor,
-aggregator, or output plugin.
-When used with an input plugin the filter applies after the input runs.
+Modifiers decide which tags and fields remain on a metric: `fieldinclude`,
+`fieldexclude`, `taginclude`, and `tagexclude`.
+See [Modifiers](/telegraf/v1/configuration/filtering/#modifiers).
 
-- **fieldinclude**: An array of glob pattern strings.
-  Only fields whose field key matches a pattern in this list are emitted.
-- **fieldexclude**: The inverse of `fieldinclude`.
-  Fields with a field key matching one of the patterns will be discarded from the metric.
-  This is tested on metrics after they have passed the `fieldinclude` test.
-- **taginclude**: An array of glob pattern strings.
-  Only tags with a tag key matching one of the patterns are emitted.
-  In contrast to `tagpass`, which will pass an entire metric based on its tag,
-  `taginclude` removes all non matching tags from the metric.
-  Any tag can be filtered including global tags and the agent `host` tag.
-- **tagexclude**: The inverse of `taginclude`.
-  Tags with a tag key matching one of the patterns will be discarded from the metric.
-  Any tag can be filtered including global tags and the agent `host` tag.
+### Filtering examples
 
-> [!Note]
-> #### Include tagpass and tagdrop at the end of your plugin definition
-> 
-> Due to the way TOML is parsed, `tagpass` and `tagdrop` parameters
-> must be defined at the _end_ of the plugin definition, otherwise subsequent
-> plugin configuration options are interpreted as part of the tagpass and tagdrop
-> tables.
-
-To learn more about metric filtering, watch the following video:
-
-{{< youtube R3DnObs_OKA >}}
-
-## Filtering examples
-
-#### Input configuration examples
-
-The following example configuration collects per-cpu data, drops any
-fields that begin with `time_`, tags measurements with `dc="denver-1"`, and then
-outputs measurements at a 10 second interval to an InfluxDB database named
-`telegraf` at the address `192.168.59.103:8086`.
-
-```toml
-[global_tags]
-  dc = "denver-1"
-
-[agent]
-  interval = "10s"
-
-# OUTPUTS
-[[outputs.influxdb]]
-  url = "http://192.168.59.103:8086" # required.
-  database = "telegraf" # required.
-  precision = "1s"
-
-# INPUTS
-[[inputs.cpu]]
-  percpu = true
-  totalcpu = false
-  # filter all fields beginning with 'time_'
-  fielddrop = ["time_*"]
-```
-
-#### Input Config: `tagpass` and `tagdrop`
-
-**NOTE** `tagpass` and `tagdrop` parameters must be defined at the _end_ of
-the plugin definition, otherwise subsequent plugin configuration options are
-interpreted as part of the tagpass and tagdrop tables.
-
-```toml
-[[inputs.cpu]]
-  percpu = true
-  totalcpu = false
-  fielddrop = ["cpu_time"]
-  # Don't collect CPU data for cpu6 & cpu7
-  [inputs.cpu.tagdrop]
-    cpu = [ "cpu6", "cpu7" ]
-
-[[inputs.disk]]
-  [inputs.disk.tagpass]
-    # tagpass conditions are OR, not AND.
-    # If the (filesystem is ext4 or xfs) OR (the path is /opt or /home)
-    # then the metric passes
-    fstype = [ "ext4", "xfs" ]
-    # Globs can also be used on the tag values
-    path = [ "/opt", "/home*" ]
-```
-
-#### Input Config: `fieldpass` and `fielddrop`
-
-```toml
-# Drop all metrics for guest & steal CPU usage
-[[inputs.cpu]]
-  percpu = false
-  totalcpu = true
-  fielddrop = ["usage_guest", "usage_steal"]
-
-# Only store inode related metrics for disks
-[[inputs.disk]]
-  fieldpass = ["inodes*"]
-```
-
-#### Input Config: `namepass` and `namedrop`
-
-```toml
-# Drop all metrics about containers for kubelet
-[[inputs.prometheus]]
-  urls = ["http://kube-node-1:4194/metrics"]
-  namedrop = ["container_*"]
-
-# Only store rest client related metrics for kubelet
-[[inputs.prometheus]]
-  urls = ["http://kube-node-1:4194/metrics"]
-  namepass = ["rest_client_*"]
-```
-
-#### Input Config: `namepass` and `namedrop` with separators
-
-```toml
-# Pass all metrics of type 'A.C.B' and drop all others like 'A.C.D.B'
-[[inputs.socket_listener]]
-  data_format = "graphite"
-  templates = ["measurement*"]
-
-  namepass = ["A.*.B"]
-  namepass_separator = "."
-
-# Drop all metrics of type 'A.C.B' and pass all others like 'A.C.D.B'
-[[inputs.socket_listener]]
-  data_format = "graphite"
-  templates = ["measurement*"]
-
-  namedrop = ["A.*.B"]
-  namedrop_separator = "."
-```
-
-#### Input Config: `taginclude` and `tagexclude`
-
-```toml
-# Only include the "cpu" tag in the measurements for the cpu plugin.
-[[inputs.cpu]]
-  percpu = true
-  totalcpu = true
-  taginclude = ["cpu"]
-
-# Exclude the `fstype` tag from the measurements for the disk plugin.
-[[inputs.disk]]
-  tagexclude = ["fstype"]
-```
-
-#### Input config: `prefix`, `suffix`, and `override`
-
-The following example emits measurements with the name `cpu_total`:
-
-```toml
-[[inputs.cpu]]
-  name_suffix = "_total"
-  percpu = false
-  totalcpu = true
-```
-
-The following example emits measurements with the name `foobar`:
-
-```toml
-[[inputs.cpu]]
-  name_override = "foobar"
-  percpu = false
-  totalcpu = true
-```
-
-#### Input config: tags
-
-The following example emits measurements with two additional tags: `tag1=foo` and
-`tag2=bar`.
-
-NOTE: Order matters; the `[inputs.cpu.tags]` table must be at the _end_ of the
-plugin definition.
-
-```toml
-[[inputs.cpu]]
-  percpu = false
-  totalcpu = true
-  [inputs.cpu.tags]
-    tag1 = "foo"
-    tag2 = "bar"
-```
-
-#### Multiple inputs of the same type
-
-Additional inputs (or outputs) of the same type can be specified by defining
-these instances in the configuration file. To avoid measurement collisions, use
-the `name_override`, `name_prefix`, or `name_suffix` configuration options:
-
-```toml
-[[inputs.cpu]]
-  percpu = false
-  totalcpu = true
-
-[[inputs.cpu]]
-  percpu = true
-  totalcpu = false
-  name_override = "percpu_usage"
-  fielddrop = ["cpu_time*"]
-```
-
-#### Output configuration examples:
-
-```toml
-[[outputs.influxdb]]
-  urls = [ "http://localhost:8086" ]
-  database = "telegraf"
-  precision = "1s"
-  # Drop all measurements that start with "aerospike"
-  namedrop = ["aerospike*"]
-
-[[outputs.influxdb]]
-  urls = [ "http://localhost:8086" ]
-  database = "telegraf-aerospike-data"
-  precision = "1s"
-  # Only accept aerospike data:
-  namepass = ["aerospike*"]
-
-[[outputs.influxdb]]
-  urls = [ "http://localhost:8086" ]
-  database = "telegraf-cpu0-data"
-  precision = "1s"
-  # Only store measurements where the tag "cpu" matches the value "cpu0"
-  [outputs.influxdb.tagpass]
-    cpu = ["cpu0"]
-```
-
-#### Aggregator Configuration Examples:
-
-This will collect and emit the min/max of the system load1 metric every
-30s, dropping the originals.
-
-```toml
-[[inputs.system]]
-  fieldpass = ["load1"] # collects system load1 metric.
-
-[[aggregators.minmax]]
-  period = "30s"        # send & clear the aggregate every 30s.
-  drop_original = true  # drop the original metrics.
-
-[[outputs.file]]
-  files = ["stdout"]
-```
-
-This will collect and emit the min/max of the swap metrics every
-30s, dropping the originals. The aggregator will not be applied
-to the system load metrics due to the `namepass` parameter.
-
-```toml
-[[inputs.swap]]
-
-[[inputs.system]]
-  fieldpass = ["load1"] # collects system load1 metric.
-
-[[aggregators.minmax]]
-  period = "30s"        # send & clear the aggregate every 30s.
-  drop_original = true  # drop the original metrics.
-  namepass = ["swap"]   # only "pass" swap metrics through the aggregator.
-
-[[outputs.file]]
-  files = ["stdout"]
-```
-
-To learn more about configuring the Telegraf agent, watch the following video:
-
-{{< youtube txUcAxMDBlQ >}}
+For complete worked examples of every filter option, see
+[filtering examples](/telegraf/v1/configuration/filtering/#examples).
 
 ## Plugin selection via labels and selectors
 
-For details and matching behavior, see
-[Labels and selectors](/telegraf/v1/configuration/labels-selectors/).
-
-You can control which plugin instances are enabled by adding labels to plugin
-configurations and passing one or more selectors on the command line.
-
-### Selectors
-
-Provide selectors with one or more `--select` flags when starting Telegraf.
-Each `--select` value is a semicolon-separated list of key=value pairs:
-
-```text
-<key>=<value>[;<key>=<value>]
-```
-
-- Pairs in a single `--select` value are combined with logical AND (all must match).
-- Multiple `--select` flags are combined with logical OR (a plugin is enabled if it matches any selector set).
-
-Selectors support simple glob patterns in values (for example `region=us-*`).
-
-Example:
-
-```console
-telegraf --config config.conf --config-directory directory/ \
-  --select="app=payments;region=us-*" \
-  --select="env=prod" \
-  --watch-config --print-plugin-config-source=true
-```
-
-### Labels
-
-Add an optional `labels` table to a plugin, similar to `tags`.
-Keys and values are plain strings.
-
-Example:
-
-```toml
-[[inputs.cpu]]
-  [inputs.cpu.labels]
-    app = "payments"
-    region = "us-east"
-    env = "prod"
-```
-
-Telegraf matches the command-line selectors against a plugin's labels to decide
-whether that plugin instance should be enabled.
-For details on supported syntax and matching rules, see the labels selectors spec.
-
-## Transport Layer Security (TLS)
-
-Many Telegraf plugins support TLS configuration for secure communication.
-For all standard TLS settings, see [TLS](/telegraf/v1/configuration/tls/).
+Label plugin instances in the configuration file and use the `--select`
+flag to enable only matching plugins at startup.
+See [Labels and selectors](/telegraf/v1/configuration/labels-selectors/).

--- a/content/telegraf/v1/configuration/agent.md
+++ b/content/telegraf/v1/configuration/agent.md
@@ -180,8 +180,8 @@ Use this to avoid large write spikes when running many Telegraf instances.
 ### precision
 
 Rounds collected metric timestamps to the specified interval.
-Precision is *not* applied to service inputs; each service input sets its own
-timestamp precision.
+Precision is *not* applied to service inputs.
+Each service input sets its own timestamp precision.
 
 **Type:** duration  
 **Default:** `"0s"` (no rounding)
@@ -324,8 +324,8 @@ restore it on start.
 ### snmp_translator
 
 The method for translating SNMP objects: `gosmi` (built-in library) or
-`netsnmp` (deprecated; calls the external `snmptranslate` and `snmptable`
-programs).
+`netsnmp` (deprecated), which calls the external `snmptranslate` and
+`snmptable` programs.
 
 **Type:** string  
 **Default:** `"netsnmp"`

--- a/content/telegraf/v1/configuration/environment-variables.md
+++ b/content/telegraf/v1/configuration/environment-variables.md
@@ -63,10 +63,9 @@ Define the variables:
 
 ```sh
 # /etc/default/telegraf
-INFLUX_HOST="http://localhost:8086"
+INFLUX_HOST="http://localhost:8181"
 INFLUX_TOKEN="replace_with_your_token"
-INFLUX_ORG="your_org"
-INFLUX_BUCKET="telegraf"
+INFLUX_DATABASE="telegraf"
 ```
 
 Reference them in the configuration file:
@@ -77,11 +76,10 @@ Reference them in the configuration file:
 
 [[inputs.mem]]
 
-[[outputs.influxdb_v2]]
+[[outputs.influxdb_v3]]
   urls = ["${INFLUX_HOST}"]
   token = "${INFLUX_TOKEN}"
-  organization = "${INFLUX_ORG}"
-  bucket = "${INFLUX_BUCKET}"
+  database = "${INFLUX_DATABASE}"
 ```
 
 After substitution, Telegraf parses the effective configuration:
@@ -92,9 +90,8 @@ After substitution, Telegraf parses the effective configuration:
 
 [[inputs.mem]]
 
-[[outputs.influxdb_v2]]
-  urls = ["http://localhost:8086"]
+[[outputs.influxdb_v3]]
+  urls = ["http://localhost:8181"]
   token = "replace_with_your_token"
-  organization = "your_org"
-  bucket = "telegraf"
+  database = "telegraf"
 ```

--- a/content/telegraf/v1/configuration/file.md
+++ b/content/telegraf/v1/configuration/file.md
@@ -22,7 +22,7 @@ The Telegraf configuration file is written in
 - **`[agent]`**: settings that control how Telegraf itself runs.
   See [Agent settings](/telegraf/v1/configuration/agent/).
 - **Plugin tables**: one table for each plugin instance you enable, such as
-  `[[inputs.cpu]]` or `[[outputs.influxdb_v2]]`.
+  `[[inputs.cpu]]` or `[[outputs.influxdb_v3]]`.
   See [Common plugin options](/telegraf/v1/configuration/plugin-options/).
 
 The following example shows the shape of a minimal configuration file:
@@ -38,8 +38,9 @@ The following example shows the shape of a minimal configuration file:
 [[inputs.cpu]]
   percpu = true
 
-[[outputs.influxdb_v2]]
-  urls = ["http://localhost:8086"]
+[[outputs.influxdb_v3]]
+  urls = ["http://localhost:8181"]
+  database = "your_database"
 ```
 
 To be valid, **a configuration must enable at least one input plugin and at
@@ -63,7 +64,7 @@ To generate a file that enables only specific plugins, use the
 names:
 
 ```sh
-telegraf config --input-filter cpu:mem:net:swap --output-filter influxdb_v2:kafka
+telegraf config --input-filter cpu:mem:net:swap --output-filter influxdb_v3:kafka
 ```
 
 For the full list of commands and flags, see
@@ -139,12 +140,13 @@ Telegraf controls remote configuration behavior with two flags:
 
 - `--config-url-retry-attempts`: the number of times to attempt to fetch a
   remote configuration during startup.
-  The default is 3; set to -1 for unlimited attempts.
+  The default is 3.
+  Set to -1 for unlimited attempts.
 - `--config-url-watch-interval`: how often to check the URL for an updated
   configuration.
   Disabled by default.
   At each interval, Telegraf sends an HTTP HEAD request and compares the
-  `Last-Modified` header; if the value changes, Telegraf reloads with the new
-  configuration.
+  `Last-Modified` header.
+  If the value changes, Telegraf reloads with the new configuration.
   If the check fails, Telegraf logs a warning and keeps running the existing
   configuration.

--- a/content/telegraf/v1/configuration/filtering.md
+++ b/content/telegraf/v1/configuration/filtering.md
@@ -27,8 +27,8 @@ Filters fall into two categories:
 - **Modifiers** remove tags and fields from metrics that pass.
   If a modifier removes all of a metric's fields, the metric is dropped.
 
-The point at which filters apply depends on the plugin type; see
-[Where filtering happens](/telegraf/v1/concepts/data-pipeline/#where-filtering-happens).
+The point at which filters apply depends on the plugin type.
+See [Where filtering happens](/telegraf/v1/concepts/data-pipeline/#where-filtering-happens).
 
 Each filter parameter lists its data type.
 None of the filter parameters are set by default.
@@ -148,8 +148,8 @@ metric passes.
 Modifiers decide *which tags and fields* remain on metrics the plugin
 handles.
 Telegraf applies modifiers before a metric is passed to a processor,
-aggregator, or output plugin; on input plugins, modifiers apply after the
-input runs.
+aggregator, or output plugin.
+On input plugins, modifiers apply after the input runs.
 
 ### fieldinclude
 
@@ -190,8 +190,8 @@ the metric.
 - `pass` tests run before `drop` tests: Telegraf tests `namedrop` only on
   metrics that passed `namepass`, and `tagdrop` only on metrics that passed
   `tagpass`.
-- The stage at which filters apply depends on the plugin type; see
-  [Where filtering happens](/telegraf/v1/concepts/data-pipeline/#where-filtering-happens).
+- The stage at which filters apply depends on the plugin type.
+  See [Where filtering happens](/telegraf/v1/concepts/data-pipeline/#where-filtering-happens).
 
 To keep explicitly defined tags from being removed by `taginclude` or
 `tagexclude`, use the agent

--- a/content/telegraf/v1/configuration/labels-selectors.md
+++ b/content/telegraf/v1/configuration/labels-selectors.md
@@ -62,7 +62,8 @@ Each `--select` value is a semicolon-separated list of key-value pairs:
   `region=us-*`).
   Selector keys don't support wildcards.
 - Repeating the same key within a single `--select` value causes an error at
-  startup; using the same key in *different* `--select` flags is allowed.
+  startup.
+  Using the same key in *different* `--select` flags is allowed.
 
 <!--pytest.mark.skip-->
 
@@ -85,7 +86,8 @@ the plugin instance is enabled:
 | Without `--select` | No                | Enabled (default behavior)                                      |
 
 A selector matches when every key-value pair in it matches a label on the
-plugin; labels the selector doesn't mention are ignored.
+plugin.
+Labels the selector doesn't mention are ignored.
 
 | `--select` flags               | Plugin labels                | Result   |
 | :----------------------------- | :--------------------------- | :------- |

--- a/content/telegraf/v1/configuration/plugin-options.md
+++ b/content/telegraf/v1/configuration/plugin-options.md
@@ -41,8 +41,8 @@ You can also attach
 to control which metrics it handles.
 
 Each option lists its data type and default value.
-Duration values are TOML strings, such as `"10s"`; see
-[Durations](/telegraf/v1/configuration/toml/#durations).
+Duration values are TOML strings, such as `"10s"`.
+See [Durations](/telegraf/v1/configuration/toml/#durations).
 
 - [Options for all plugin types](#options-for-all-plugin-types)
   - [alias](#alias)
@@ -123,8 +123,8 @@ A suffix to attach to the measurement name.
 ### tags
 
 A map of tags to apply to the plugin's metrics.
-Supported on input and aggregator plugins; on aggregators, behavior varies by
-plugin.
+Supported on input and aggregator plugins.
+On aggregators, behavior varies by plugin.
 
 **Type:** table  
 **Default:** Not set
@@ -317,8 +317,8 @@ Override flush behavior for one output while others use the agent defaults:
   flush_jitter = "5s"
   metric_batch_size = 1000
 
-[[outputs.influxdb_v2]]
-  urls = ["http://localhost:8086"]
+[[outputs.influxdb_v3]]
+  urls = ["http://localhost:8181"]
 
 [[outputs.file]]
   files = ["stdout"]

--- a/content/telegraf/v1/configuration/secrets.md
+++ b/content/telegraf/v1/configuration/secrets.md
@@ -61,11 +61,10 @@ Use secret references in plugin options that support them:
   username = "@{local_secrets:company_server_http_metric_user}"
   password = "@{local_secrets:company_server_http_metric_pass}"
 
-[[outputs.influxdb_v2]]
-  urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
+[[outputs.influxdb_v3]]
+  urls = ["http://localhost:8181"]
   token = "@{cloud_secrets:influxdb_token}"
-  organization = "yourname@yourcompany.com"
-  bucket = "your_bucket"
+  database = "your_database"
 ```
 
 > [!Note]

--- a/content/telegraf/v1/configuration/toml.md
+++ b/content/telegraf/v1/configuration/toml.md
@@ -29,8 +29,8 @@ first file Telegraf reads.
 
 Plugins use TOML arrays of tables, written with double brackets, such as
 `[[inputs.file]]`.
-Define an array-of-tables plugin as many times as you need; each definition
-runs as an independent plugin instance.
+Define an array-of-tables plugin as many times as you need.
+Each definition runs as an independent plugin instance.
 
 ```toml
 [agent]
@@ -126,8 +126,8 @@ Valid units are:
 
 ## Multiple files
 
-TOML itself has no concept of multiple files; combining files is a Telegraf
-convenience.
+TOML itself has no concept of multiple files.
+Combining files is a Telegraf convenience.
 Telegraf parses each file separately and merges all settings as if they were
 one file.
 See

--- a/content/telegraf/v1/contribute.md
+++ b/content/telegraf/v1/contribute.md
@@ -4,7 +4,7 @@ description:
 menu:
   telegraf_v1_ref:
     name: Contribute to Telegraf
-    weight: 8
+weight: 8
 ---
 
 There are many ways to contribute to InfluxData open source products.

--- a/content/telegraf/v1/data_formats/input/json_v2.md
+++ b/content/telegraf/v1/data_formats/input/json_v2.md
@@ -159,8 +159,8 @@ share one name and type, from anywhere in the document:
   character), the parser produces one metric per element.
 - If the path returns an **object**, it is ignored.
   Use an [object table](#gather-structures-with-object) instead.
-  `field` and `tag` don't preserve relationships between values; each
-  table is handled as separate data.
+  `field` and `tag` don't preserve relationships between values.
+  Each table is handled as separate data.
 
 Tag values are always strings.
 Field values can be any [line protocol type](#types).
@@ -192,7 +192,7 @@ For example, `device.status.temp` produces the key `temp`.
 
 The type to convert the field value to: `int`, `uint`, `float`, `string`,
 or `bool`.
-Not available on `tag` tables; tag values are always strings.
+Not available on `tag` tables because tag values are always strings.
 
 **Type:** string  
 **Default:** Not set; the JSON type is kept

--- a/content/telegraf/v1/data_formats/input/xpath_json.md
+++ b/content/telegraf/v1/data_formats/input/xpath_json.md
@@ -150,8 +150,8 @@ produces this tree:
     # tag_name_expansion = false
 ```
 
-A configuration can contain multiple `xpath` sections; each section runs
-against the document and produces its own metrics.
+A configuration can contain multiple `xpath` sections.
+Each section runs against the document and produces its own metrics.
 Consider using an XPath tester such as
 [Code Beautify's XPath Tester](https://codebeautify.org/Xpath-Tester) to
 develop and debug your queries.
@@ -163,8 +163,8 @@ develop and debug your queries.
 By default, all fields gathered through `field_selection` are strings.
 Set to `true` to keep the native JSON types (number, boolean, string)
 instead.
-Fields defined in `fields` and `fields_int` are unaffected; their types
-come from the query.
+Fields defined in `fields` and `fields_int` are unaffected.
+Their types come from the query.
 
 **Type:** boolean  
 **Default:** `false`
@@ -262,8 +262,8 @@ The conversion fails if the query result isn't convertible to an integer.
 
 Lists of fields to convert to hex or base64 strings when they contain byte
 arrays.
-Byte arrays don't occur in JSON input; these options apply to binary
-formats such as Protocol Buffers.
+Byte arrays don't occur in JSON input.
+These options apply to binary formats such as Protocol Buffers.
 
 **Type:** array of strings  
 **Default:** `[]`; byte arrays convert to strings
@@ -283,7 +283,8 @@ which are evaluated relative to each selected node.
 Batch-selected field values are strings unless
 [`xpath_native_types = true`](#xpath_native_types).
 Batch selection can be combined with explicit `fields` and `fields_int`
-definitions; explicit definitions take precedence on name collisions.
+definitions.
+Explicit definitions take precedence on name collisions.
 
 ### field_name_expansion
 
@@ -438,8 +439,8 @@ To drop the duplicate field, add
 - Run Telegraf with `--test --debug` and
   [`xpath_print_document = true`](#xpath_print_document) to inspect the
   parsed document.
-- Missing tags or fields usually mean a relative query doesn't match; check
-  that `metric_selection` selects array *elements* (`/sensors/*`), not the
+- Missing tags or fields usually mean a relative query doesn't match.
+  Check that `metric_selection` selects array *elements* (`/sensors/*`), not the
   array container.
 - Missing numeric fields with `could not serialize field ... is NaN` log
   messages mean `number()` received a non-numeric or empty value.

--- a/content/telegraf/v1/data_formats/input/xpath_msgpack.md
+++ b/content/telegraf/v1/data_formats/input/xpath_msgpack.md
@@ -50,6 +50,7 @@ Because MessagePack is a binary format, use
 [`xpath_print_document = true`](/telegraf/v1/data_formats/input/xpath_json/#xpath_print_document)
 with debug logging to inspect the parsed document and work out your
 queries.
-Fields containing byte arrays convert to strings by default; use
+Fields containing byte arrays convert to strings by default.
+Use
 [`fields_bytes_as_hex` or `fields_bytes_as_base64`](/telegraf/v1/data_formats/input/xpath_json/#fields_bytes_as_hex-and-fields_bytes_as_base64)
 to encode them instead.

--- a/content/telegraf/v1/data_formats/input/xpath_protobuf.md
+++ b/content/telegraf/v1/data_formats/input/xpath_protobuf.md
@@ -134,7 +134,8 @@ Known headers and the corresponding values:
 ## Byte-array fields
 
 Protocol-buffer messages often encode data as byte arrays.
-By default, byte-array fields convert to strings; use
+By default, byte-array fields convert to strings.
+Use
 [`fields_bytes_as_hex` or `fields_bytes_as_base64`](/telegraf/v1/data_formats/input/xpath_json/#fields_bytes_as_hex-and-fields_bytes_as_base64)
 to encode them as hex or base64 strings instead.
 

--- a/content/telegraf/v1/data_formats/output/_index.md
+++ b/content/telegraf/v1/data_formats/output/_index.md
@@ -27,7 +27,8 @@ For a task-focused guide with worked examples, see
 
 When you configure `data_format` in an output plugin, Telegraf uses a **serializer**
 to convert metrics into that format before writing.
-The output plugin controls *where* data goes; the serializer controls *how* it's formatted.
+The output plugin controls *where* data goes.
+The serializer controls *how* it's formatted.
 
 Some output plugins support `use_batch_format`, which changes how the serializer
 processes metrics.

--- a/content/telegraf/v1/enterprise.md
+++ b/content/telegraf/v1/enterprise.md
@@ -7,7 +7,6 @@ description: >
 menu:
   telegraf_v1:
     name: Telegraf Enterprise
-    weight: 10
     params:
       state: new
   telegraf_enterprise:
@@ -27,8 +26,8 @@ Telegraf in production. It provides an enterprise support contract from
 InfluxData covering Telegraf, plus higher limits and enterprise security
 features in [Telegraf Controller](/telegraf/controller/).
 
-For the full Telegraf Enterprise overview--what's included, the free-tier
-comparison, and how licensing works--see
+For the full Telegraf Enterprise overview, including what's included, the
+free-tier comparison, and how licensing works, see
 [Telegraf Enterprise](/telegraf/enterprise/).
 
 {{% telegraf/enterprise-upgrade %}}
@@ -48,8 +47,8 @@ For coverage and SLA details,
 
 ## What else is in the package
 
-Telegraf Enterprise also includes Telegraf Controller — the centralized
-application for managing Telegraf deployments at scale — with these
+Telegraf Enterprise also includes Telegraf Controller, the centralized
+application for managing Telegraf deployments at scale, with these
 license-gated enhancements:
 
 - **Higher configuration and agent limits** (defined per contract)

--- a/content/telegraf/v1/examples/_index.md
+++ b/content/telegraf/v1/examples/_index.md
@@ -7,7 +7,7 @@ description: >
 menu:
   telegraf_v1:
     name: Configuration examples
-    weight: 7
+weight: 7
 ---
 
 Use complete, working Telegraf configurations for common scenarios.

--- a/content/telegraf/v1/examples/monitor-docker.md
+++ b/content/telegraf/v1/examples/monitor-docker.md
@@ -90,8 +90,8 @@ Only do this with images you trust.
   metric per CPU core, block device, and interface, which keeps series
   counts low.
 - **`docker_label_include`** limits which container labels become tags.
-  Container labels are often high-cardinality; allowlist only the labels
-  you query by.
+  Container labels are often high-cardinality.
+  Allowlist only the labels you query by.
 - The plugin also produces `docker` and `docker_data` summary metrics for
   the engine itself, such as container counts and storage usage.
 

--- a/content/telegraf/v1/examples/monitor-snmp-devices.md
+++ b/content/telegraf/v1/examples/monitor-snmp-devices.md
@@ -78,7 +78,8 @@ Replace the following:
 
 - **`agents`** lists the devices to poll.
   One plugin instance polls every agent with the same credentials and
-  field definitions; metrics carry a `source` tag identifying the device.
+  field definitions.
+  Metrics carry a `source` tag identifying the device.
 - **`[[inputs.snmp.field]]`** entries read single (scalar) values.
   `sysUpTime` becomes an `uptime` field, and `sysName` becomes a tag on
   every metric from the device.

--- a/content/telegraf/v1/glossary.md
+++ b/content/telegraf/v1/glossary.md
@@ -4,7 +4,7 @@ description: This section includes definitions of important terms for related to
 menu:
   telegraf_v1_ref:
     name: Glossary
-    weight: 7
+weight: 7
 ---
 
 ## agent
@@ -44,6 +44,9 @@ Related entries: [collection interval](/telegraf/v1/glossary/#collection-interva
 ## external plugin
 
 Programs built outside of Telegraf that run through the `execd` plugin. Provides flexibility to add functionality that doesn't exist in internal Telegraf plugins.
+
+Related entries: [input plugin](/telegraf/v1/glossary/#input-plugin), [output plugin](/telegraf/v1/glossary/#output-plugin), [processor plugin](/telegraf/v1/glossary/#processor-plugin)
+
 ## flush interval
 
 The global interval for flushing data from each output plugin to its destination.
@@ -66,6 +69,14 @@ In order to activate an input plugin, it needs to be enabled and configured in T
 
 Related entries: [aggregator plugin](/telegraf/v1/glossary/#aggregator-plugin), [collection interval](/telegraf/v1/glossary/#collection-interval), [output plugin](/telegraf/v1/glossary/#output-plugin), [processor plugin](/telegraf/v1/glossary/#processor-plugin)
 
+## label
+
+A key-value pair attached to a plugin instance in its configuration.
+Use labels with [selectors](/telegraf/v1/glossary/#selector) to enable a subset of configured plugins when starting Telegraf.
+See [Labels and selectors](/telegraf/v1/configuration/labels-selectors/).
+
+Related entries: [selector](/telegraf/v1/glossary/#selector)
+
 ## metric buffer
 
 The metric buffer caches individual metrics when writes are failing for an output plugin.
@@ -80,10 +91,19 @@ Output plugins deliver metrics to their configured destination. In order to acti
 
 Related entries: [aggregator plugin](/telegraf/v1/glossary/#aggregator-plugin), [flush interval](/telegraf/v1/glossary/#flush-interval), [input plugin](/telegraf/v1/glossary/#input-plugin), [processor plugin](/telegraf/v1/glossary/#processor-plugin)
 
+## parser
+
+A parser converts raw input data, such as JSON, CSV, or Prometheus exposition format, into Telegraf metrics.
+Input plugins that read raw data select a parser with the `data_format` option.
+See [input data formats](/telegraf/v1/data_formats/input/) and [Parse incoming data](/telegraf/v1/configure_plugins/input_plugins/parse-data/).
+
+Related entries: [input plugin](/telegraf/v1/glossary/#input-plugin), [serializer](/telegraf/v1/glossary/#serializer)
+
 ## precision
 
 The precision configuration setting determines how much timestamp precision is retained in the points received from input plugins. All incoming timestamps are truncated to the given precision.
-Telegraf then pads the truncated timestamps with zeros to create a nanosecond timestamp; output plugins will emit timestamps in nanoseconds.
+Telegraf then pads the truncated timestamps with zeros to create a nanosecond timestamp.
+Output plugins emit timestamps in nanoseconds.
 Valid precisions are `ns`, `us` or `µs`, `ms`, and `s`.
 
 For example, if the precision is set to `ms`, the nanosecond epoch timestamp `1480000000123456789` would be truncated to `1480000000123` in millisecond precision and then padded with zeroes to make a new, less precise nanosecond timestamp of `1480000000123000000`.
@@ -97,9 +117,41 @@ Processor plugins transform, decorate, and/or filter metrics collected by input 
 
 Related entries: [aggregator plugin](/telegraf/v1/glossary/#aggregator-plugin), [input plugin](/telegraf/v1/glossary/#input-plugin), [output plugin](/telegraf/v1/glossary/#output-plugin)
 
+## secret store
+
+A secret store is a plugin type that keeps credentials, such as passwords and tokens, out of plain-text configuration files.
+Plugin options reference secrets with the `@{store_id:secret_key}` syntax, and Telegraf resolves them at runtime.
+See [Store secrets](/telegraf/v1/configuration/secrets/).
+
+Related entries: [input plugin](/telegraf/v1/glossary/#input-plugin), [output plugin](/telegraf/v1/glossary/#output-plugin)
+
+## selector
+
+A key-value expression that matches plugin [labels](/telegraf/v1/glossary/#label).
+Pass selectors with the `--select` flag to enable only plugins with matching labels.
+See [Labels and selectors](/telegraf/v1/configuration/labels-selectors/).
+
+Related entries: [label](/telegraf/v1/glossary/#label)
+
+## serializer
+
+A serializer converts Telegraf metrics into an output representation, such as InfluxDB line protocol, JSON, or Graphite.
+Output plugins that write generic payloads select a serializer with the `data_format` option.
+See [output data formats](/telegraf/v1/data_formats/output/) and [Serialize outgoing data](/telegraf/v1/configure_plugins/output_plugins/serialize-data/).
+
+Related entries: [output plugin](/telegraf/v1/glossary/#output-plugin), [parser](/telegraf/v1/glossary/#parser)
+
 ## service input plugin
 
 Service input plugins are input plugins that run in a passive collection mode while the Telegraf agent is running.
 They listen on a socket for known protocol inputs, or apply their own logic to ingested metrics before delivering them to the Telegraf agent.
 
 Related entries: [aggregator plugin](/telegraf/v1/glossary/#aggregator-plugin), [input plugin](/telegraf/v1/glossary/#input-plugin), [output plugin](/telegraf/v1/glossary/#output-plugin), [processor plugin](/telegraf/v1/glossary/#processor-plugin)
+
+## tracking metric
+
+A metric whose delivery is tracked through the pipeline.
+Queue-based service inputs, such as Kafka and MQTT consumers, use tracking metrics to acknowledge messages back to the source only after an output writes them, so metrics aren't lost if Telegraf stops.
+See [tracking metrics](/telegraf/v1/concepts/metrics/#tracking-metrics).
+
+Related entries: [service input plugin](/telegraf/v1/glossary/#service-input-plugin), [metric buffer](/telegraf/v1/glossary/#metric-buffer)

--- a/content/telegraf/v1/install.md
+++ b/content/telegraf/v1/install.md
@@ -114,7 +114,8 @@ echo "SHA256_CHECKSUM  telegraf-{{% latest-patch %}}_linux_amd64.tar.gz" \
 | sha256sum -c -
 ```
 
-If the checksums match, the output is the following; otherwise, an error message.
+If the checksums match, the output is the following.
+Otherwise, the command prints an error message.
 
 ```
 telegraf-{{% latest-patch %}}_linux_amd64.tar.gz: OK
@@ -455,8 +456,9 @@ In PowerShell _as an administrator_, do the following:
    For the `--config` option, pass the absolute path of the `telegraf.conf` configuration file.
 
    ```powershell
-   .\telegraf.exe --service install `
-   --config "C:\Program Files\InfluxData\telegraf\telegraf.conf"
+   .\telegraf.exe `
+   --config "C:\Program Files\InfluxData\telegraf\telegraf.conf" `
+   service install
    ```
 
 5. To test that the installation works, enter the following command:
@@ -466,12 +468,12 @@ In PowerShell _as an administrator_, do the following:
    --config C:\"Program Files"\InfluxData\telegraf\telegraf.conf --test
    ```
 
-   When run in test mode (using the `--test` flag), Telegraf runs once, collects metrics, outputs them to the console, and then exits. It doesn't run processors, aggregators, or output plugins.
+   When run in test mode (using the `--test` flag), Telegraf runs once, collects metrics, outputs them to the console, and then exits. Test mode runs inputs, processors, and aggregators, but not outputs, so nothing is written to your destinations.
 
 6. To start collecting data, run:
 
    ```powershell
-   .\telegraf.exe --service start
+   .\telegraf.exe service start
    ```
 
 To manage the Telegraf Windows service and view its logs in the Windows
@@ -664,7 +666,8 @@ to regenerate the Telegraf binary.
 
 Nightly builds are generated from the Telegraf `master` branch at midnight UTC.
 Use them to preview unreleased features and fixes.
-Nightly builds are not stable releases; don't use them in production.
+Nightly builds are not stable releases.
+Don't use them in production.
 
 Common artifacts:
 

--- a/content/telegraf/v1/plugins.md
+++ b/content/telegraf/v1/plugins.md
@@ -7,8 +7,7 @@ description: >
 menu:
   telegraf_v1_ref:
     identifier: plugins_reference
-    weight: 2
-weight: 6
+weight: 2
 aliases:
   - /telegraf/v1/plugins/aggregators/
   - /telegraf/v1/plugins/inputs/

--- a/content/telegraf/v1/release-notes.md
+++ b/content/telegraf/v1/release-notes.md
@@ -8,8 +8,20 @@ aliases:
 menu:
   telegraf_v1_ref:
     name: Release notes
-    weight: 1
+weight: 1
 ---
+
+Telegraf uses [semantic versioning](https://semver.org/) and ships four
+minor releases a year, in March, June, September, and December.
+Between minor releases, bug-fix releases ship about every three weeks.
+Bug fixes go out in the next release, while new features wait for the next
+minor release.
+For upcoming release dates, see the
+[Telegraf release calendar](https://calendar.google.com/calendar/embed?src=c_03d981cefd8d6432894cb162da5c6186e393bc0f970ca6c371201aa05d30d763%40group.calendar.google.com)
+and the [GitHub milestones](https://github.com/influxdata/telegraf/milestones).
+
+To try upcoming features before release, use the
+[nightly builds](/telegraf/v1/install/#nightly-builds).
 
 ## v1.39.3 {date="2026-08-10"}
 

--- a/content/telegraf/v1/supported-platforms.md
+++ b/content/telegraf/v1/supported-platforms.md
@@ -1,0 +1,61 @@
+---
+title: Supported platforms
+description: >
+  Operating systems and versions that Telegraf supports, including Linux,
+  macOS, Microsoft Windows, and FreeBSD support policies.
+menu:
+  telegraf_v1_ref:
+    name: Supported platforms
+weight: 6
+related:
+  - /telegraf/v1/install/
+  - /telegraf/v1/release-notes/
+---
+
+Telegraf supports Linux, macOS, Microsoft Windows, and FreeBSD.
+In general, Telegraf supports operating system versions that are under
+general support from their vendors, not extended or paid support.
+Submit bug reports only for supported platforms under general support.
+
+Telegraf is written in Go, which supports many operating systems.
+Telegraf might work and produce builds for other operating systems, and you
+are welcome to build your own binaries for them.
+See the Go
+[table of valid OS and architecture combinations](https://golang.org/doc/install/source#environment)
+and the Go
+[minimum requirements](https://github.com/golang/go/wiki/MinimumRequirements#operating-systems).
+
+For installation options on each platform, see
+[Install Telegraf](/telegraf/v1/install/).
+
+## Linux
+
+Telegraf supports the latest generally supported versions of major Linux
+distributions.
+This does not include extended support releases.
+
+- [Debian](https://wiki.debian.org/LTS): releases supported by the security
+  and release teams
+- [Fedora](https://fedoraproject.org/wiki/Releases): releases currently
+  supported by the Fedora team
+- [Red Hat Enterprise Linux](https://access.redhat.com/support/policy/updates/errata#Life_Cycle_Dates):
+  releases under full support
+- [Ubuntu](https://ubuntu.com/about/release-cycle): interim and LTS releases
+  in standard support
+
+## macOS
+
+Telegraf supports macOS releases
+[supported by Apple](https://endoflife.date/macos).
+
+## Microsoft Windows
+
+Telegraf supports current versions of
+[Windows](https://learn.microsoft.com/en-us/lifecycle/faq/windows) and
+[Windows Server](https://learn.microsoft.com/en-us/windows-server/get-started/windows-server-release-info)
+under mainstream support, not paid or extended security support.
+
+## FreeBSD
+
+Telegraf supports releases under
+[FreeBSD security support](https://www.freebsd.org/security/#sup).

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -106,7 +106,7 @@
   {{ end }}
 
   <!-- Platform menu for 1.x docs -->
-  {{ $platformWhitelist := (slice "telegraf_v1" "chronograf_v1" "kapacitor_v1" "enterprise_influxdb_v1" "influxdb_v1") }}
+  {{ $platformWhitelist := (slice "chronograf_v1" "kapacitor_v1" "enterprise_influxdb_v1" "influxdb_v1") }}
   {{ if (in $platformWhitelist $menuKey) }}
     <h4 class="platform">InfluxData Platform</h4>
     {{ partialCached "sidebar/nested-menu" (dict "menu" $platformMenu "siteData" .Site.Data) "platform" }}


### PR DESCRIPTION
- Rebuild the commands global-flags reference from telegraf --help (1.39), grouped by purpose, and add the Windows-only service command page with PowerShell examples and a Command Prompt note
- Add the supported platforms reference page
- Add glossary terms: label, parser, secret store, selector, serializer, and tracking metric
- Add a release cadence and versioning intro to the release notes with a nightly-builds pointer
- Slim configuration/_index.md from the full legacy reference to an overview and quick reference; every previously resolving anchor survives, and new plugins, secret-store-secrets, and intervals anchors fix fragment links from the generated plugin pages
- Sweep earlier parcels: convert remaining outputs.influxdb_v2 examples to influxdb_v3, move menu-level weights to page level, and split 31 semicolon clause joins into sentences
- Modernize install.md's Windows service steps to the service subcommand form and correct its --test description
- Fix dash punctuation in enterprise.md
- Remove the legacy InfluxData Platform block from the Telegraf v1 sidebar

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
