### PR TITLE
docs(style): formalize recommendation voice and page-level weights

### DIFF
--- a/.agents/instructions/content.md
+++ b/.agents/instructions/content.md
@@ -134,6 +134,15 @@ For comprehensive testing workflows, see
   table"), not at the product ("import data into InfluxDB"). The user owns their
   data in their own object storage; InfluxDB reads and writes it but doesn't take
   custody of it.
+- Phrase recommendations in first-person plural: "We recommend...", not
+  third-party attributions such as "The Telegraf project recommends...".
+  Docs speak with InfluxData's voice, even when a recommendation originates
+  in an upstream project's guidance.
+- Set `weight` at the page level (top-level frontmatter), not on the menu
+  entry. Menu items inherit the page weight, and page-level weight keeps
+  sorting consistent outside menu contexts, such as `children` shortcode
+  listings. (Hugo sorts unweighted pages after weighted ones, so mixing the
+  two placements within a section breaks list ordering.)
 
 ## Most Common Shortcodes
 

--- a/.claude/rules/content.md
+++ b/.claude/rules/content.md
@@ -136,6 +136,15 @@ For comprehensive testing workflows, see
   table"), not at the product ("import data into InfluxDB"). The user owns their
   data in their own object storage; InfluxDB reads and writes it but doesn't take
   custody of it.
+- Phrase recommendations in first-person plural: "We recommend...", not
+  third-party attributions such as "The Telegraf project recommends...".
+  Docs speak with InfluxData's voice, even when a recommendation originates
+  in an upstream project's guidance.
+- Set `weight` at the page level (top-level frontmatter), not on the menu
+  entry. Menu items inherit the page weight, and page-level weight keeps
+  sorting consistent outside menu contexts, such as `children` shortcode
+  listings. (Hugo sorts unweighted pages after weighted ones, so mixing the
+  two placements within a section breaks list ordering.)
 
 ## Most Common Shortcodes
 

--- a/.github/instructions/content.instructions.md
+++ b/.github/instructions/content.instructions.md
@@ -135,6 +135,15 @@ For comprehensive testing workflows, see
   table"), not at the product ("import data into InfluxDB"). The user owns their
   data in their own object storage; InfluxDB reads and writes it but doesn't take
   custody of it.
+- Phrase recommendations in first-person plural: "We recommend...", not
+  third-party attributions such as "The Telegraf project recommends...".
+  Docs speak with InfluxData's voice, even when a recommendation originates
+  in an upstream project's guidance.
+- Set `weight` at the page level (top-level frontmatter), not on the menu
+  entry. Menu items inherit the page weight, and page-level weight keeps
+  sorting consistent outside menu contexts, such as `children` shortcode
+  listings. (Hugo sorts unweighted pages after weighted ones, so mixing the
+  two placements within a section breaks list ordering.)
 
 ## Most Common Shortcodes
 

--- a/DOCS-FRONTMATTER.md
+++ b/DOCS-FRONTMATTER.md
@@ -116,6 +116,15 @@ Then 201-299 and so on.
 
 ***Note:** `_index.md` files should be weighted one level up from the other `.md` files in the same directory.*
 
+Set `weight` at the page level (top-level frontmatter), not on the menu
+entry.
+Menu items inherit the page weight, and page-level weight also controls
+sorting outside menu contexts, such as `{{< children >}}` listings.
+Hugo sorts unweighted pages after weighted ones, so mixing menu-level and
+page-level weights within a section breaks list ordering.
+(Menu-level weight is still appropriate when a page appears in multiple
+menus at different positions.)
+
 ### Related Content
 
 Use the `related` frontmatter to include links to specific articles at the bottom of an article.
@@ -244,7 +253,8 @@ cascade:
     > This is just an example note block that gets appended to the article.
 ```
 
-> [!Note]
+> \[!Note]
+>
 > #### Prepended and appended content appears in Markdown twins
 >
 > `prepend` and `append` content renders inside the page article element, so it

--- a/content/AGENTS.md
+++ b/content/AGENTS.md
@@ -135,6 +135,15 @@ For comprehensive testing workflows, see
   table"), not at the product ("import data into InfluxDB"). The user owns their
   data in their own object storage; InfluxDB reads and writes it but doesn't take
   custody of it.
+- Phrase recommendations in first-person plural: "We recommend...", not
+  third-party attributions such as "The Telegraf project recommends...".
+  Docs speak with InfluxData's voice, even when a recommendation originates
+  in an upstream project's guidance.
+- Set `weight` at the page level (top-level frontmatter), not on the menu
+  entry. Menu items inherit the page weight, and page-level weight keeps
+  sorting consistent outside menu contexts, such as `children` shortcode
+  listings. (Hugo sorts unweighted pages after weighted ones, so mixing the
+  two placements within a section breaks list ordering.)
 
 ### Most Common Shortcodes
 


### PR DESCRIPTION
- Recommendations use first-person plural ("We recommend..."), not third-party attributions, matching existing practice across the docs (Google.We and Google.FirstPerson are already disabled in Vale)
- Set weight at the page level rather than on the menu entry: menu items inherit it, and page-level weight keeps children-shortcode and other non-menu listings sorted (Hugo sorts unweighted pages after weighted ones, so mixed placement within a section breaks ordering)

Documented in the canonical agent instructions (adapters regenerated) and DOCS-FRONTMATTER.md.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
