### PR TITLE
docs(controller): document global constants and rename dynamic values to value substitution

### DIFF
--- a/assets/js/components/tc-substitute-values.js
+++ b/assets/js/components/tc-substitute-values.js
@@ -1,13 +1,14 @@
 /**
- * Highlights Telegraf Controller dynamic values in code blocks.
+ * Highlights Telegraf Controller substituted values in code blocks.
  *
- * Wraps three pattern types in styled <span> elements:
+ * Wraps four pattern types in styled <span> elements:
  *   - Parameters:             &{name}  or  &{name:default}
  *   - Environment variables:  ${VAR_NAME}
  *   - Secrets:                @{store:secret_name}
+ *   - Constants:              ::{constant_name}
  *
- * Applied to code blocks with class="tc-dynamic-values" via
- * the data-component="tc-dynamic-values" attribute set by
+ * Applied to code blocks with class="tc-substitute-values" via
+ * the data-component="tc-substitute-values" attribute set by
  * the render-codeblock hook.
  */
 
@@ -15,13 +16,14 @@ const PATTERNS = [
   { regex: /&\{[^}]+\}/g, className: 'param' },
   { regex: /\$\{[^}]+\}/g, className: 'env' },
   { regex: /@\{[^:]+:[^}]+\}/g, className: 'secret' },
+  { regex: /::\{[^}]+\}/g, className: 'constant' },
 ];
 
 /**
  * Walk all text nodes inside the given element and wrap matches
- * in <span class="tc-dynamic-value {type}"> elements.
+ * in <span class="tc-substitute-value {type}"> elements.
  */
-function highlightDynamicValues(codeEl) {
+function highlightSubstitutedValues(codeEl) {
   const walker = document.createTreeWalker(codeEl, NodeFilter.SHOW_TEXT);
   const textNodes = [];
 
@@ -73,7 +75,7 @@ function highlightDynamicValues(codeEl) {
       }
 
       const span = document.createElement('span');
-      span.className = `tc-dynamic-value ${matchedPattern.className}`;
+      span.className = `tc-substitute-value ${matchedPattern.className}`;
       span.textContent = earliestMatch[0];
       fragment.appendChild(span);
 
@@ -84,9 +86,9 @@ function highlightDynamicValues(codeEl) {
   }
 }
 
-export default function TcDynamicValues({ component }) {
+export default function TcSubstituteValues({ component }) {
   const codeEl = component.querySelector('code');
   if (codeEl) {
-    highlightDynamicValues(codeEl);
+    highlightSubstitutedValues(codeEl);
   }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -46,7 +46,7 @@ import ReleaseToc from './release-toc.js';
 import { SearchButton } from './search-button.js';
 import SidebarSearch from './components/sidebar-search.js';
 import { SidebarToggle } from './sidebar-toggle.js';
-import TcDynamicValues from './components/tc-dynamic-values.js';
+import TcSubstituteValues from './components/tc-substitute-values.js';
 import Theme from './theme.js';
 import ThemeSwitch from './theme-switch.js';
 import ApiToc from './components/api-toc.ts';
@@ -80,7 +80,7 @@ const componentRegistry = {
   'search-button': SearchButton,
   'sidebar-search': SidebarSearch,
   'sidebar-toggle': SidebarToggle,
-  'tc-dynamic-values': TcDynamicValues,
+  'tc-substitute-values': TcSubstituteValues,
   theme: Theme,
   'theme-switch': ThemeSwitch,
   'api-toc': ApiToc,

--- a/assets/styles/layouts/article/_code.scss
+++ b/assets/styles/layouts/article/_code.scss
@@ -160,9 +160,9 @@ span.code-callout, .code-placeholder {
 }
 .code-placeholder-key code {color: $code-placeholder !important}
 
-////// SPECIAL CODE HIGHLIGHTING FOR TELEGRAF CONTROLLER DYNAMIC VALUES ////////
+///// SPECIAL CODE HIGHLIGHTING FOR TELEGRAF CONTROLLER VALUE SUBSTITUTION /////
 
-pre span.tc-dynamic-value {
+pre span.tc-substitute-value {
   border: 1px solid;
   border-radius: 6px;
   padding: 0 .25rem;
@@ -173,6 +173,8 @@ pre span.tc-dynamic-value {
   --env-bg: #0092b833;
   --secret-color: #9a09ff;
   --secret-bg: #9809ff33;
+  --constant-color: #FFB867;
+  --constant-bg: #ffb86c33;
 
   &.param {
     color: var(--param-color);
@@ -188,6 +190,11 @@ pre span.tc-dynamic-value {
     color: var(--secret-color);
     background: var(--secret-bg);
     border-color: var(--secret-color);
+  }
+  &.constant {
+    color: var(--constant-color);
+    background: var(--constant-bg);
+    border-color: var(--constant-color);
   }
 }
 

--- a/content/telegraf/controller/agents/create.md
+++ b/content/telegraf/controller/agents/create.md
@@ -58,10 +58,10 @@ The following heartbeat plugin configuration options are available:
 ### Example heartbeat output plugin
 
 The following is an example heartbeat output plugin configuration that uses
-an `agent_id` [configuration parameter](/telegraf/controller/configs/dynamic-values/#parameters)
+an `agent_id` [configuration parameter](/telegraf/controller/configs/substitute-values/#parameters)
 to specify the `instance_id`.
 
-```toml { .tc-dynamic-values }
+```toml { .tc-substitute-values }
 [[outputs.heartbeat]]
   url = "http://telegraf_controller.example.com/agents/heartbeat"
   instance_id = "&{agent_id}"

--- a/content/telegraf/controller/agents/status.md
+++ b/content/telegraf/controller/agents/status.md
@@ -60,7 +60,7 @@ heartbeat plugin configuration and define CEL expressions in the
 Report `ok` when metrics are flowing.
 If no metrics arrive, fall back to the `fail` status.
 
-```toml { .tc-dynamic-values }
+```toml { .tc-substitute-values }
 [[outputs.heartbeat]]
   url = "http://telegraf_controller.example.com/agents/heartbeat"
   instance_id = "&{agent_id}"
@@ -77,7 +77,7 @@ If no metrics arrive, fall back to the `fail` status.
 
 Warn when errors are logged, fail when the error count is high.
 
-```toml { .tc-dynamic-values }
+```toml { .tc-substitute-values }
 [[outputs.heartbeat]]
   url = "http://telegraf_controller.example.com/agents/heartbeat"
   instance_id = "&{agent_id}"
@@ -97,7 +97,7 @@ Warn when errors are logged, fail when the error count is high.
 
 Combine error count and buffer pressure signals.
 
-```toml { .tc-dynamic-values }
+```toml { .tc-substitute-values }
 [[outputs.heartbeat]]
   url = "http://telegraf_controller.example.com/agents/heartbeat"
   instance_id = "&{agent_id}"

--- a/content/telegraf/controller/audit-logs/_index.md
+++ b/content/telegraf/controller/audit-logs/_index.md
@@ -39,6 +39,8 @@ and demonstrate compliance with internal or external policies.
 - **Configuration lifecycle**: configuration creation, updates, and deletion,
   and [configuration version](/telegraf/controller/configs/versions/)
   operations (rollbacks, change note updates, and version pruning).
+- **Constants**: [global constant](/telegraf/controller/configs/constants/)
+  creation, value updates, and deletion.
 
 Each entry records:
 

--- a/content/telegraf/controller/configs/constants.md
+++ b/content/telegraf/controller/configs/constants.md
@@ -1,0 +1,135 @@
+---
+title: Manage global constants
+seotitle: Manage global constants with Telegraf Controller
+description: >
+  Define global constants in Telegraf Controller and reference them in
+  Telegraf configurations. Telegraf Controller substitutes constant values
+  server-side when serving configuration TOML.
+menu:
+  telegraf_controller:
+    name: Manage constants
+    parent: Manage configurations
+weight: 106
+related:
+  - /telegraf/controller/configs/substitute-values/
+  - /telegraf/controller/configs/use/
+  - /telegraf/controller/configs/ui/code-editor/
+---
+
+Global constants are name-value pairs defined once in {{% product-name %}}
+and referenced by name in configuration TOML using the `::{constant_name}`
+syntax. {{% product-name %}} substitutes the constant values server-side when
+serving a configuration, so agents receive TOML with the values already in
+place. Use constants for values shared across configurations, for example, a
+common endpoint URL or organization name.
+
+For how constants compare to parameters, environment variables, and secrets,
+see [Substitute values in configurations](/telegraf/controller/configs/substitute-values/).
+
+> [!Important]
+> #### Do not use constants for sensitive information
+>
+> Constant values are stored in plain text and inserted directly into served
+> configurations. Use environment variables or secrets to provide sensitive
+> information to agents.
+
+## Constant naming and value rules
+
+A constant name must:
+
+- start with a letter or underscore.
+- contain only letters, digits, and underscores.
+- be 128 characters or fewer.
+
+Constant names are unique across your {{% product-name %}} instance and
+cannot be changed after the constant is created. To rename a constant, create
+a new constant and update the configurations that reference the old one.
+
+A constant value:
+
+- can be up to 65,536 characters long.
+- cannot contain double quotes or line breaks.
+- is inserted into configuration TOML exactly as written, so the value must be
+  valid in the TOML context where the constant is referenced.
+
+## View constants
+
+1.  In the {{% product-name %}} web interface, select
+    **Configurations** > **Constants** in the navigation bar.
+
+The **Global Constants** page includes the following for each constant:
+
+- **Constant**: the constant name.
+- **Value**: the constant value.
+- **Configs**: the number of configurations that reference the constant.
+  Click the count to view the configurations.
+
+## Add a constant
+
+1.  On the **Global Constants** page, click
+    **{{% lucide "plus" %}} Add Constant**.
+2.  Enter a name that follows the
+    [naming rules](#constant-naming-and-value-rules) and a value.
+3.  Click **Add Constant**.
+
+## Update a constant's value
+
+1.  On the **Global Constants** page, click the
+    **More button ({{% lucide "ellipsis-vertical" %}})** in the constant's
+    row and select **{{% lucide "eye" %}} View/Edit**.
+2.  Enter a new value. The constant name cannot be changed.
+3.  Click **Update Constant**.
+
+Updating a constant value registers a change in every configuration that
+references the constant. Agents that watch for configuration changes with
+`--config-url-watch-interval` reload the affected configurations on their
+next check. For details, see
+[Auto-update agents](/telegraf/controller/configs/use/#auto-update-agents).
+
+## View configurations that use a constant
+
+The **Configs** column on the **Global Constants** page shows how many
+configurations reference each constant. To see which configurations they are,
+click the count, or select **{{% lucide "eye" %}} View/Edit** from the
+constant's actions menu and expand the usage list. Each entry links to the
+configuration.
+
+## Delete a constant
+
+1.  On the **Global Constants** page, click the
+    **More button ({{% lucide "ellipsis-vertical" %}})** in the constant's
+    row and select **{{% lucide "trash-2" %}} Delete**.
+2.  Confirm the deletion.
+
+A constant that is referenced by one or more configurations cannot be
+deleted. {{% product-name %}} returns an error listing the configurations
+that use the constant; remove the references first, then delete the constant.
+
+## Undefined constants
+
+If a configuration references a constant that is not defined:
+
+- The [Code Editor](/telegraf/controller/configs/ui/code-editor/) flags the
+  undefined constant while you edit.
+- When an agent requests the configuration, {{% product-name %}} returns an
+  error listing the undefined constant names instead of serving the TOML.
+
+Define the missing constants, or remove the references, to restore the
+configuration.
+
+## Permissions
+
+Constant operations require permissions on the **Constants** resource:
+
+- **Read**: view constants and their usage.
+- **Write**: add constants and update constant values.
+- **Delete**: delete constants.
+
+For how permissions map to user roles and API tokens, see
+[Authentication and authorization](/telegraf/controller/reference/authentication-authorization/).
+
+## Constants API
+
+Manage constants programmatically using the {{% product-name %}} API.
+Constant endpoints are available under `/api/constants`. For the full API
+reference, see [Telegraf Controller API](/telegraf/controller/reference/api/).

--- a/content/telegraf/controller/configs/create.md
+++ b/content/telegraf/controller/configs/create.md
@@ -11,7 +11,7 @@ menu:
     parent: Manage configurations
 weight: 101
 related:
-  - /telegraf/controller/configs/dynamic-values/
+  - /telegraf/controller/configs/substitute-values/
 ---
 
 Create a configuration to define how Telegraf collects, processes, and writes
@@ -70,7 +70,7 @@ configuration with a [Telegraf heartbeat output plugin](/telegraf/v1/output-plug
 This plugin reports agent information back to the {{% product-name %}} heartbeat
 API and lets you monitor the health of your deployed Telegraf agents.
 
-```toml { .tc-dynamic-values }
+```toml { .tc-substitute-values }
 [[outputs.heartbeat]]
 url = "http://localhost:8000/agents/heartbeat"
 instance_id = "&{agent_id}"
@@ -97,7 +97,7 @@ your Telegraf configurations.
 
 ## Next steps
 
-- Use [dynamic values](/telegraf/controller/configs/dynamic-values/)
+- [Substitute values](/telegraf/controller/configs/substitute-values/)
   to keep configurations portable across environments.
 - [Apply the configuration](/telegraf/controller/configs/use/) to your
   Telegraf agents.

--- a/content/telegraf/controller/configs/delete.md
+++ b/content/telegraf/controller/configs/delete.md
@@ -7,7 +7,7 @@ menu:
   telegraf_controller:
     name: Delete configurations
     parent: Manage configurations
-weight: 107
+weight: 108
 ---
 
 Delete configurations you no longer use to keep {{% product-name %}} organized.

--- a/content/telegraf/controller/configs/substitute-values.md
+++ b/content/telegraf/controller/configs/substitute-values.md
@@ -1,24 +1,41 @@
 ---
-title: Use dynamic values in configurations
-seotitle: Use dynamic values in Telegraf configurations with Telegraf Controller
+title: Substitute values in configurations
+seotitle: Substitute values in Telegraf configurations with Telegraf Controller
 description: >
-  Use parameters, environment variables, and secrets to dynamically set values
-  in your Telegraf configurations.
+  Use parameters, constants, environment variables, and secrets to substitute
+  values in your Telegraf configurations.
 menu:
   telegraf_controller:
-    name: Use dynamic values
+    name: Substitute values
     parent: Manage configurations
 weight: 105
+aliases:
+  - /telegraf/controller/configs/dynamic-values/
 ---
 
-Use dynamic values in your Telegraf configurations and reuse a single
+Substitute values in your Telegraf configurations to reuse a single
 configuration for multiple distinct agents or across environments.
 
-Telegraf Controller supports the following dynamic value types:
+{{% product-name %}} supports the following value substitution types:
 
 - **Parameters** for values you want to set or override per agent.
+- **Constants** for values defined once and shared across configurations.
 - **Environment variables** for values provided by the running Telegraf agent.
 - **Secrets** for sensitive values stored in an external secret store.
+
+Each type is substituted in a different place:
+
+| Type | Syntax | Substituted by | When |
+| :--- | :----- | :------------- | :--- |
+| [Parameter](#parameters) | `&{param_name[:default]}` | {{% product-name %}} | When the configuration is requested |
+| [Constant](#constants) | `::{constant_name}` | {{% product-name %}} | When the configuration is requested |
+| [Environment variable](#environment-variables) | `${VAR_NAME[:-default]}` | Telegraf agent | When the agent starts or reloads |
+| [Secret](#secrets) | `@{store_id:secret_key}` | Telegraf agent | At runtime, through the secret store plugin |
+
+{{% product-name %}} substitutes parameters and constants server-side, so the
+TOML an agent receives already contains the resolved values. Environment
+variables and secrets pass through {{% product-name %}} unchanged and are
+resolved by the Telegraf agent itself.
 
 ## Parameters
 
@@ -26,6 +43,10 @@ Use parameters for values that change between agents, deployments, or environmen
 Define the parameter where the configuration is easy to find, and then
 reference it in plugin settings. _Configuration parameters are a feature of
 {{% product-name %}} and are not part of the Telegraf project._
+
+{{% product-name %}} substitutes parameters server-side when the configuration
+is requested, using values provided as URL query parameters. The agent
+receives TOML with the parameter values already in place.
 
 > [!Important]
 > #### Do not use parameters for sensitive information
@@ -46,7 +67,7 @@ requesting the configuration from {{% product-name %}}.
 
 ### Use parameters in Telegraf configurations
 
-```toml { .tc-dynamic-values }
+```toml { .tc-substitute-values }
 [[outputs.influxdb_v2]]
   # Parameter with a default value
   urls = ["&{db_host:https://localhost:8181}"]
@@ -94,11 +115,56 @@ above, Telegraf would load the following TOML configuration:
   instance_id = "agent123"
 ```
 
-## Environment Variables
+## Constants
+
+Use constants for values that are shared across configurations and do not
+change per agent, for example, a common endpoint URL or organization name.
+Constants are defined once in {{% product-name %}} and referenced by name.
+_Constants are a feature of {{% product-name %}} and are not part of the
+Telegraf project._
+
+{{% product-name %}} substitutes constants server-side when the configuration
+is requested, using the globally defined value. The agent receives TOML with
+the constant values already in place.
+
+> [!Important]
+> #### Do not use constants for sensitive information
+>
+> Constant values are stored in plain text and inserted directly into served
+> configurations. Use environment variables or secrets to provide sensitive
+> information to agents.
+
+Use the following syntax:
+
+```
+::{constant_name}
+```
+
+Constants do not support default values. If a configuration references a
+constant that is not defined, {{% product-name %}} returns an error listing
+the undefined constants when the configuration is requested.
+
+### Use constants in Telegraf configurations
+
+```toml { .tc-substitute-values }
+[[outputs.influxdb_v2]]
+  # Constants shared across configurations
+  urls = ["::{influxdb_url}"]
+  bucket = "::{default_bucket}"
+```
+
+To define and manage constants, see
+[Manage global constants](/telegraf/controller/configs/constants/).
+
+## Environment variables
 
 Use environment variables for values that Telegraf reads from the agent
 environment at runtime.
 Provide a default to keep the configuration portable across environments.
+
+The Telegraf agent substitutes environment variables from its own runtime
+environment when it starts or reloads. {{% product-name %}} serves the
+configuration with environment variable references unchanged.
 
 Use the following syntax:
 
@@ -115,7 +181,7 @@ For more information about Telegraf environment variable syntax, see
 
 ### Use environment variables in Telegraf configurations
 
-```toml { .tc-dynamic-values }
+```toml { .tc-substitute-values }
 [[inputs.http]]
   urls = ["${API_ENDPOINT:-http://localhost:8080}/metrics"]
 
@@ -146,7 +212,11 @@ telegraf \
 Use secrets for credentials or tokens you do not want to store in plain text.
 Secrets require a secret store and its corresponding `secretstores` plugin.
 
-```toml { .tc-dynamic-values }
+The Telegraf agent resolves secrets at runtime through the configured secret
+store plugin. Secret values never pass through {{% product-name %}} and do not
+appear in the served configuration TOML.
+
+```toml { .tc-substitute-values }
 # Configure a secret store plugin
 [[secretstores.vault]]
   id = "my_vault"

--- a/content/telegraf/controller/configs/ui/code-editor.md
+++ b/content/telegraf/controller/configs/ui/code-editor.md
@@ -9,7 +9,8 @@ menu:
     parent: Configuration UI tools
 weight: 201
 related:
-  - /telegraf/controller/configs/dynamic-values/
+  - /telegraf/controller/configs/substitute-values/
+  - /telegraf/controller/configs/constants/
 ---
 
 Use the {{% product-name %}} **Code Editor** to upload, write, or edit raw
@@ -99,11 +100,16 @@ The following bindings come from the reference keymaps.
 - {{< keybind all="⌘⌫" >}} (macOS only): Delete to line start
 - {{< keybind all="⌘ fn⌫" >}} (macOS only): Delete to line end
 
-### Dynamic value syntax highlighting
+### Value substitution syntax highlighting
 
 The {{% product-name %}} Code Editor automatically applies special syntax
-highlighting to dynamic values (parameters, environment variables, and secrets)
-in your configuration TOML to make them more visible.
+highlighting to substituted values (parameters, constants, environment
+variables, and secrets) in your configuration TOML to make them more visible.
 
-For more information about using dynamic values, see
-[Use dynamic values](/telegraf/controller/configs/dynamic-values/).
+For [global constants](/telegraf/controller/configs/constants/), the editor
+also provides autocomplete: type `::{` and the editor suggests defined
+constant names. References to constants that are not defined are flagged
+while you edit.
+
+For more information about substituting values, see
+[Substitute values in configurations](/telegraf/controller/configs/substitute-values/).

--- a/content/telegraf/controller/configs/ui/telegraf-builder.md
+++ b/content/telegraf/controller/configs/ui/telegraf-builder.md
@@ -102,7 +102,7 @@ The **Plugin** tab in a plugin card lets you customize settings specific
 to that plugin.
 
 > [!Note]
-> You can use [dynamic values](/telegraf/controller/configs/dynamic-values/)
+> You can [substitute values](/telegraf/controller/configs/substitute-values/)
 > when defining plugin settings in the Telegraf Builder.
 
 #### Customize

--- a/content/telegraf/controller/configs/use.md
+++ b/content/telegraf/controller/configs/use.md
@@ -8,7 +8,7 @@ menu:
   telegraf_controller:
     name: Use configurations
     parent: Manage configurations
-weight: 106
+weight: 107
 ---
 
 Use Telegraf Controller to centralize management of your Telegraf configurations
@@ -16,7 +16,7 @@ and keep your agents consistent across environments.
 Apply the configuration by pointing your agents to the configuration URL.
 
 - [Apply a configuration to an agent](#apply-a-configuration-to-an-agent)
-- [Set dynamic values](#set-dynamic-values)
+- [Set substitution values](#set-substitution-values)
   - [Set parameter values](#set-parameter-values)
   - [Set environment variables](#set-environment-variables)
 - [Auto-update agents](#auto-update-agents)
@@ -68,25 +68,29 @@ permissions on the **Configs** API.
 > use `INFLUX_TOKEN` instead. For details, see
 > [Use API tokens with Telegraf agents](/telegraf/controller/tokens/use/#with-telegraf-agents).
 
-## Set dynamic values
+## Set substitution values
 
 Telegraf and {{% product-name %}} let you
-[dynamically set values in your configuration files](/telegraf/controller/configs/dynamic-values/)
-using parameters, environment variables, and secrets.
+[substitute values in your configuration files](/telegraf/controller/configs/substitute-values/)
+using parameters, constants, environment variables, and secrets.
 
 - [Set parameter values](#set-parameter-values)
 - [Set environment variables](#set-environment-variables)
 
+[Constants](/telegraf/controller/configs/constants/) require no setup when
+using a configuration; {{% product-name %}} substitutes them automatically
+when serving the TOML.
+
 ### Set parameter values
 
-[Configuration parameters](/telegraf/controller/configs/dynamic-values/#parameters)
+[Configuration parameters](/telegraf/controller/configs/substitute-values/#parameters)
 use the `&{param_name[:default_value]}` syntax in TOML configurations. Use
 URL-encoded query parameters in your configuration URL to define parameter
 values—for example:
 
 ##### Configuration TOML with a parameter
 
-```toml { .tc-dynamic-values }
+```toml { .tc-substitute-values }
 [[outputs.heartbeat]]
   instance_id = "&{agent_id}"
   # ...
@@ -105,14 +109,14 @@ telegraf \
 
 ### Set environment variables
 
-[Telegraf environment variables](/telegraf/controller/configs/dynamic-values/#environment-variables)
+[Telegraf environment variables](/telegraf/controller/configs/substitute-values/#environment-variables)
 use the `${VAR_NAME[:-default_value]}` syntax in TOML configurations. Set
 environment variable values in the Telegraf agent's environment before
 starting Telegraf—for example:
 
 ##### Configuration TOML with an environment variable
 
-```toml { .tc-dynamic-values }
+```toml { .tc-substitute-values }
 [[inputs.http]]
   urls = ["http://localhost:8080/metrics"]
 
@@ -162,7 +166,7 @@ parameters, environment variables, auto-update functionality, and Telegraf
     enable the **Use local configuration file** option.
     See more information [below](#download-a-configuration-to-your-local-filesystem).
 
-5.  Define dynamic values and select options for your command:
+5.  Define substitution values and select options for your command:
 
     - Set environment variable values
     - Set parameter values
@@ -187,7 +191,7 @@ With the **Use local configuration file** option enabled in the command builder,
 {{% product-name %}} lets you configure the directory path and file name to use
 for the configuration.
 
-1.  Define dynamic values and select options for your command:
+1.  Define substitution values and select options for your command:
 
     - Set file details
     - Set environment variable values

--- a/content/telegraf/controller/get-started.md
+++ b/content/telegraf/controller/get-started.md
@@ -79,7 +79,7 @@ stdout and reports agent health back to {{% product-name %}}.
 {{% code-tab-content %}}
 <!----------------------------- BEGIN LINUX/MACOS ----------------------------->
 
-```toml { .tc-dynamic-values }
+```toml { .tc-substitute-values }
 [[inputs.exec]]
   commands = [
     ["echo", "Started with a config from Telegraf Controller"]
@@ -110,7 +110,7 @@ stdout and reports agent health back to {{% product-name %}}.
 {{% code-tab-content %}}
 <!------------------------------- BEGIN WINDOWS ------------------------------->
 
-```toml { .tc-dynamic-values }
+```toml { .tc-substitute-values }
 [[inputs.exec]]
   commands = [
     ["cmd", "/C", "echo Started with a config from Telegraf Controller"]
@@ -151,7 +151,7 @@ stdout and reports agent health back to {{% product-name %}}.
     - Uses the `TELEGRAF_CONTROLLER_TOKEN` (Telegraf 1.39+) or the `INFLUX_TOKEN`
       (Telegraf 1.38.x or earlier) environment variable to authorize with
       {{% product-name %}}.
-    - Uses the `agent_id` [parameter](/telegraf/controller/configs/dynamic-values/#parameters)
+    - Uses the `agent_id` [parameter](/telegraf/controller/configs/substitute-values/#parameters)
       to set the `instance_id` which uniquely identifies the Telegraf agent.
 
     > [!Important]
@@ -328,7 +328,7 @@ new message, confirming that the agent picked up the updated configuration.
 
 - [Create and manage configurations](/telegraf/controller/configs/) to define
   more advanced Telegraf pipelines.
-- [Use dynamic values](/telegraf/controller/configs/dynamic-values/) to keep
+- [Substitute values](/telegraf/controller/configs/substitute-values/) to keep
   configurations portable across environments.
 - [Set up reporting rules](/telegraf/controller/agents/reporting-rules/) to
   define when agents are considered not reporting.

--- a/content/telegraf/controller/reference/glossary.md
+++ b/content/telegraf/controller/reference/glossary.md
@@ -22,7 +22,7 @@ rules, and the heartbeat protocol. Others describe Telegraf concepts that
 For deeper background on Telegraf agent internals, see the
 [Telegraf glossary](/telegraf/v1/glossary/).
 
-[A](#a) | <span style="opacity:.35;font-weight:500">B</span> | [C](#c) | <span style="opacity:.35;font-weight:500">D</span> | [E](#e) | [F](#f) | <span style="opacity:.35;font-weight:500">G</span> | [H](#h) | [I](#i) | <span style="opacity:.35;font-weight:500">J</span> | <span style="opacity:.35;font-weight:500">K</span> | [L](#l) | [M](#m) | <span style="opacity:.35;font-weight:500">N</span> | [O](#o) | [P](#p) | <span style="opacity:.35;font-weight:500">Q</span> | [R](#r) | [S](#s) | [T](#t) | <span style="opacity:.35;font-weight:500">U</span> | <span style="opacity:.35;font-weight:500">V</span> | <span style="opacity:.35;font-weight:500">W</span> | <span style="opacity:.35;font-weight:500">X</span> | <span style="opacity:.35;font-weight:500">Y</span> | <span style="opacity:.35;font-weight:500">Z</span>
+[A](#a) | <span style="opacity:.35;font-weight:500">B</span> | [C](#c) | <span style="opacity:.35;font-weight:500">D</span> | [E](#e) | [F](#f) | [G](#g) | [H](#h) | [I](#i) | <span style="opacity:.35;font-weight:500">J</span> | <span style="opacity:.35;font-weight:500">K</span> | [L](#l) | [M](#m) | <span style="opacity:.35;font-weight:500">N</span> | [O](#o) | [P](#p) | <span style="opacity:.35;font-weight:500">Q</span> | [R](#r) | [S](#s) | [T](#t) | <span style="opacity:.35;font-weight:500">U</span> | [V](#v) | <span style="opacity:.35;font-weight:500">W</span> | <span style="opacity:.35;font-weight:500">X</span> | <span style="opacity:.35;font-weight:500">Y</span> | <span style="opacity:.35;font-weight:500">Z</span>
 
 ## A
 
@@ -109,6 +109,20 @@ configuration and applies globally to all output plugins. It should not be
 smaller than the [collection interval](#collection-interval).
 
 Related entries: [collection interval](#collection-interval), [output plugin](#output-plugin), Telegraf [flush interval](/telegraf/v1/glossary/#flush-interval)
+
+## G
+
+### global constant
+
+A named value defined once in {{% product-name %}} and referenced in
+configuration TOML as `::{constant_name}`. {{% product-name %}} substitutes
+the value server-side when serving the configuration. Constants are shared
+across configurations and cannot vary per agent; use
+[configuration parameters](#configuration-parameter) for per-agent values.
+For details, see
+[Manage global constants](/telegraf/controller/configs/constants/).
+
+Related entries: [configuration parameter](#configuration-parameter), [value substitution](#value-substitution)
 
 ## H
 
@@ -298,3 +312,18 @@ reassigned. For details, see
 [Authorization](/telegraf/controller/reference/authorization/).
 
 Related entries: [agent](#agent), [authorization](/telegraf/controller/reference/authorization/)
+
+## V
+
+### value substitution
+
+The mechanism for replacing references in configuration TOML with values
+outside the TOML text. {{% product-name %}} substitutes
+[configuration parameters](#configuration-parameter) and
+[global constants](#global-constant) server-side when serving a
+configuration; the Telegraf agent substitutes
+[environment variables](#environment-variable) and [secrets](#secret) in its
+own runtime. For details, see
+[Substitute values in configurations](/telegraf/controller/configs/substitute-values/).
+
+Related entries: [configuration parameter](#configuration-parameter), [environment variable](#environment-variable), [global constant](#global-constant), [secret](#secret)

--- a/content/telegraf/controller/reference/release-notes.md
+++ b/content/telegraf/controller/reference/release-notes.md
@@ -281,7 +281,7 @@ telegraf_controller --disable-auth-endpoints=configs,heartbeat
 3.  Use the `INFLUX_TOKEN` environment variable to define the `token` option
     in your heartbeat output plugin configuration:
     
-    ```toml { .tc-dynamic-values }
+    ```toml { .tc-substitute-values }
     [[outputs.heartbeat]]
     # ...
     token = "${INFLUX_TOKEN}"

--- a/content/telegraf/controller/tokens/use.md
+++ b/content/telegraf/controller/tokens/use.md
@@ -68,7 +68,7 @@ Use the `TELEGRAF_CONTROLLER_TOKEN` environment variable to define the `token`
 option in your heartbeat plugin configuration.
 Telegraf uses the environment variable value defined when starting Telegraf.
 
-```toml { .tc-dynamic-values }
+```toml { .tc-substitute-values }
 [[outputs.heartbeat]]
   url = "http://telegraf_controller.example.com/agents/heartbeat"
   instance_id = "&{agent_id}"

--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -13,8 +13,11 @@
   {{- $code | safeHTML -}}
 {{- else -}}
   {{- $wrapped := string $result.Wrapped -}}
-  {{- if in $wrapped "tc-dynamic-values" -}}
-    {{- $wrapped = replace $wrapped "tc-dynamic-values" "tc-dynamic-values\" data-component=\"tc-dynamic-values" -}}
+  {{- if in $wrapped "tc-substitute-values" -}}
+    {{- $wrapped = replace $wrapped "tc-substitute-values" "tc-substitute-values\" data-component=\"tc-substitute-values" -}}
+  {{- else if in $wrapped "tc-dynamic-values" -}}
+    {{- /* Legacy class name; maps to the same component. */ -}}
+    {{- $wrapped = replace $wrapped "tc-dynamic-values" "tc-dynamic-values\" data-component=\"tc-substitute-values" -}}
   {{- end -}}
   {{- $wrapped | safeHTML -}}
 {{- end -}}


### PR DESCRIPTION
Documents global constants and renames the dynamic values concept to value substitution

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
