### PR TITLE
fix(notifications): remove false compaction claim from Core 3.11 banner

### DIFF
--- a/data/notifications.yaml
+++ b/data/notifications.yaml
@@ -97,12 +97,15 @@
     - /influxdb3/core/
   title: 'InfluxDB 3.11 is now available'
   slug: |
-    InfluxDB 3 Core 3.11 adds compaction and query performance improvements.
+    InfluxDB 3 Core 3.11 improves processing engine trigger reliability and
+    adds a configurable graceful shutdown.
   message: |
     **Key updates in InfluxDB 3 Core 3.11:**
 
-    - **Compaction and query performance improvements**.
-    - **Catalog migration**—back up your catalog before upgrading.
+    - **Processing engine trigger reliability improvements**—capped async
+      trigger concurrency, bounded retries for failed triggers, and WAL
+      triggers that skip empty flushes.
+    - **Configurable graceful shutdown** with the new `--shutdown-timeout` option.
 
     - [Read the announcement](https://www.influxdata.com/blog/influxdb-3-11/)
     - [InfluxDB 3 Core release notes](/influxdb3/core/release-notes/)


### PR DESCRIPTION
The Core release banner reused Enterprise's "Compaction and query
performance improvements" bullet, but 3.11's compaction throughput
work is Enterprise-only (upgraded storage engine; Core remains
Parquet-only). Replace it with Core's actual 3.11 highlights:
processing engine trigger reliability improvements and the new
--shutdown-timeout option.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XgTU1eTmecaCYrKsZ2CvUA