### PR TITLE
docs(influxdb3): add node lifecycle guide and orchestrated upgrade paths

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -225,3 +225,18 @@ to publish the stronger caution plus the log diagnostic, or hold until fixed.
 **Catalog sync interval default of 10 seconds** (page: "Verify node state").
 Carried over from the published `stop node` CLI page. Confirm against current
 config options and name the setting on the page if it is user-tunable.
+
+**Per-engine name for the drain step a graceful stop forces** (pages: shared
+`stop node` CLI "Behavior", `admin/recover-node.md` step 2). Both spots read
+`(Parquet: WAL flush; upgraded engine: WAL snapshot)` on master. Changed to
+`Parquet persistence` on this branch, on the reading that:
+
+- WAL flush is the constant `--wal-flush-interval` operation (default 1s), so
+  it is not something a graceful stop has to force.
+- Data durability says buffered writes stay in the WAL "until the next Parquet
+  persistence captures it" — that is the step that makes the tail durable.
+
+Confirm with engineering, and confirm `WAL snapshot` is the right name for the
+upgraded-engine side. If the original wording was right, revert both spots
+together — they must stay in sync. A `VERIFY (eng/product review)` comment sits
+at each location.

--- a/PLAN.md
+++ b/PLAN.md
@@ -228,8 +228,9 @@ config options and name the setting on the page if it is user-tunable.
 
 **Per-engine name for the drain step a graceful stop forces** (pages: shared
 `stop node` CLI "Behavior", `admin/recover-node.md` step 2). Both spots read
-`(Parquet: WAL flush; upgraded engine: WAL snapshot)` on master. Changed to
-`Parquet persistence` on this branch, on the reading that:
+`(Parquet: WAL flush; upgraded engine: WAL snapshot)` on master. Rewritten on
+this branch as a full sentence naming each engine's step — the shorthand
+parenthetical was unclear to readers — on the reading that:
 
 - WAL flush is the constant `--wal-flush-interval` operation (default 1s), so
   it is not something a graceful stop has to force.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,227 @@
+# Node lifecycle docs — live verification matrix
+
+Working doc for the `claude/influxdb3-node-lifecycle-docs-m9pbew` branch.
+**Remove before merge** (a required PR check blocks `PLAN.md` on the default
+branch).
+
+Every item below corresponds to a `VERIFY (live instance)` comment in
+`content/shared/influxdb3-admin/node-lifecycle.md`.
+Delete each comment as its question is answered, and apply the "if wrong" fix.
+
+The claims not listed here were already validated against the InfluxDB catalog
+source and need no live test: the four state names and their semantics, the
+re-registration matrix, the four removal-refusal conditions and their error
+strings, remove idempotency, and `removing` being terminal for a node ID.
+
+---
+
+## Part 1 — Answerable on Core (no license required)
+
+Start a throwaway node:
+
+```bash
+influxdb3 serve \
+  --node-id test-node-1 \
+  --object-store file \
+  --data-dir /tmp/influxdb3-lifecycle-test
+```
+
+### 1.1 Does a restarting process reuse its instance ID? (HIGHEST PRIORITY)
+
+This one claim carries the page. `can_re_register` accepts a `running` or
+`stopping` node **only when the incoming instance ID matches**. If a restart
+mints a new UUID, then restarting a node still recorded as `running` — the
+post-crash case — is refused, and the re-registration section, the
+crashed-node troubleshooting entry, and the rolling-restart guidance behind
+the whole Helm/Ansible section all fail together.
+
+```bash
+# 1. Record the instance ID while running
+influxdb3 query --database _internal --token $TOKEN \
+  "SELECT node_id, instance_id, state FROM system.nodes"
+
+# 2. Kill ungracefully so the catalog keeps state = running
+kill -9 $(pgrep -f 'influxdb3 serve')
+
+# 3. Confirm the catalog still says running, then restart with the SAME node ID
+influxdb3 serve --node-id test-node-1 --object-store file \
+  --data-dir /tmp/influxdb3-lifecycle-test
+
+# 4. Did it re-register, and did instance_id change?
+influxdb3 query --database _internal --token $TOKEN \
+  "SELECT node_id, instance_id, state FROM system.nodes"
+```
+
+- **Re-registers, instance ID unchanged** → claim holds, delete the comment.
+- **Re-registers, instance ID changed** → the node ID must be re-claimable by
+  some other path; rewrite the explanation, since the current one is wrong even
+  though the outcome is right.
+- **Refused** → the page is materially wrong. Fix the re-registration section,
+  the crashed-node entry, and add recovery guidance for a node wedged in
+  `running`.
+
+### 1.2 Core shutdown sequence and order
+
+The four steps were written from the Enterprise stop cascade plus the
+durability docs, not Core source.
+
+```bash
+# Send SIGTERM, then check the recorded state
+kill -TERM $(pgrep -f 'influxdb3 serve')
+influxdb3 query --database _internal --token $TOKEN \
+  "SELECT node_id, state, updated_at FROM system.nodes"
+```
+
+Confirm (a) writes stop being accepted before the flush rather than in-flight
+writes draining first, and (b) Core marks itself `stopped` at all. If a cleanly
+stopped Core node still reads `running`, say so on the page — it changes what
+"verify node state" means for Core users.
+
+### 1.3 Can a Core node surface `stopping` or `removing`?
+
+The state enum is shared catalog code; `NodeMode::Core` is just another mode.
+The page asserts Core only ever reads `running` or `stopped` because Core lacks
+the commands — not because the states are unreachable.
+
+```bash
+# Does the endpoint exist on Core even without a CLI subcommand?
+curl -i -X POST "http://localhost:8181/api/v3/enterprise/configure/node/stop" \
+  -H "Authorization: Bearer $TOKEN" -d '{"node_id":"test-node-1"}'
+```
+
+A 404/501 supports the current wording. Anything that transitions the node
+means the note needs softening.
+
+### 1.4 `system.nodes` database and columns
+
+Used by two queries on the page.
+
+```bash
+influxdb3 query --database _internal --token $TOKEN \
+  "SELECT * FROM system.nodes"
+```
+
+Confirm `_internal` is right and that `node_id`, `mode`, `state`, and
+`updated_at` exist under those names. If `instance_id` is exposed, add it to
+the page's example — it is what the re-registration rules turn on.
+
+---
+
+## Part 2 — Enterprise only
+
+Needs a multi-node cluster. Use a **throwaway** cluster: 2.6 and 2.7 are
+destructive.
+
+### 2.1 Does reaching `stopped` free licensed cores?
+
+The page and the published `stop node` CLI page both claim it does. Support
+case 00123680 (3.4.1) reported cores were **not** freed by stopping a node, and
+case 00129706 ("Incorrect core count when updating deployment") suggests core
+accounting problems persisted.
+
+```bash
+influxdb3 show nodes                      # record core_count and total in use
+influxdb3 stop node --node-id NODE_ID     # wait for stopped
+influxdb3 show nodes
+# Then: can a new node claim those cores?
+```
+
+If cores are only freed on `remove node` — or not at all — correct **both**
+this page and `content/influxdb3/enterprise/reference/cli/influxdb3/stop/node.md`.
+
+### 2.2 Stopping a node that isn't running: 400 or 200?
+
+Two catalog ops have opposite responses. `StopNodeOp` returns
+`NodeAlreadyStopped` → 400; `RequestStopNodeOp` returns `IdempotentNoOp` → 200
+so controllers can retry safely. The page documents the 400 because that is
+what real users hit (case 00129706 via CLI, case 00130867 via the API).
+
+```bash
+influxdb3 stop node --node-id NODE_ID     # let it reach stopped
+influxdb3 stop node --node-id NODE_ID     # repeat: 400 or 200?
+# Also test against a node that is `stopping`, and one that is `removing`
+```
+
+If the CLI now returns 200, replace the section with idempotent-retry guidance
+for controller authors.
+
+### 2.3 Empty reply from the stop API
+
+EAR #6744: scaling down returned an empty reply (curl exit 52) even when the
+stop succeeded — suspected race where the server tears down before flushing the
+200.
+
+```bash
+curl -i -X POST "http://NODE:8181/api/v3/enterprise/configure/node/stop" \
+  -H "Authorization: Bearer $TOKEN" -d '{"node_id":"NODE_ID"}'
+```
+
+If reproducible, document that an empty reply does not mean failure, and tell
+automation to confirm via `show nodes` rather than retrying.
+
+### 2.4 Stopping a node whose process is dead, via `--host`
+
+Support drove this in case 00130867 and verified it on a test cluster, but it
+is not in the published CLI docs.
+
+```bash
+kill -9 <target node process>
+influxdb3 stop node --node-id DEAD_NODE \
+  --host http://A_RUNNING_NODE:8181 --token $TOKEN
+influxdb3 show nodes
+```
+
+EAR #7030 reports the node moves to `stopping` and **never** reaches `stopped`,
+because no live process completes the handshake. If so, state that explicitly —
+it changes what an operator should expect next.
+
+### 2.5 `system.pt_compaction_nodes` database and columns
+
+The page's stuck-removal diagnostic queries `--database _internal`; internal
+notes describe `db=<any-db>` from any querier.
+
+```bash
+influxdb3 query --database _internal --token $TOKEN \
+  "SELECT * FROM system.pt_compaction_nodes"
+```
+
+Confirm the database, the column names, and that this table is not
+compactor-only (unlike `system.pt_compaction_active_jobs` and
+`system.pt_compaction_deferred_snapshots`, which return
+`400 ... is only available on compactors` through the normal query path).
+If these tables are internal or unstable, drop the example and describe the
+symptom qualitatively.
+
+### 2.6 Compactor replacement — DESTRUCTIVE
+
+Stop the compactor, start a replacement on different hardware with the same
+`--node-id` and `--mode compact`, and confirm it takes the single-writer
+compaction lease cleanly. Determine whether the lease TTL (reported as 30s)
+forces a wait between stopping the old node and starting the replacement.
+
+A dead compactor's catalog record made other nodes crash-loop in case 00130867,
+so the happy path is worth proving.
+
+### 2.7 `--force-finalize` on a zombie node — DESTRUCTIVE, product decision
+
+EAR #7030 (open, seen on 3.11.0) reports this causing a self-perpetuating
+compactor panic loop (`duplicate catalog subscription name:
+pt_compactor_restore`) that kills the node-removal driver so removal never
+completes — escalating in one case to an unresponsive `/health` and a suspected
+deadlock.
+
+```bash
+kubectl logs <compactor-pod> | grep -m1 'duplicate catalog subscription'
+```
+
+If still reproducible, the page's current warning is too mild: force-finalize
+can wedge the cluster, not just lose writes. **Decide with engineering** whether
+to publish the stronger caution plus the log diagnostic, or hold until fixed.
+
+---
+
+## Not testable — needs a product owner
+
+**Catalog sync interval default of 10 seconds** (page: "Verify node state").
+Carried over from the published `stop node` CLI page. Confirm against current
+config options and name the setting on the page if it is user-tunable.

--- a/assets/styles/layouts/article/_diagrams.scss
+++ b/assets/styles/layouts/article/_diagrams.scss
@@ -5,6 +5,16 @@
   transition: opacity .5s;
   font-family: $proxima;
 
+  svg {
+    // Mermaid pins an inline max-width to the diagram's natural pixel size,
+    // so diagrams render small in a wide article column. The svg carries a
+    // viewBox, so lifting the cap scales the whole diagram proportionally.
+    // The svg already carries width="100%", so it never exceeds the column;
+    // this ceiling just stops the scale-up from dwarfing body text.
+    // Avoid CSS min() here -- Sass evaluates it and fails on mixed units.
+    max-width: 680px !important;
+  }
+
   .arrowheadPath, .arrowMarkerPath { fill: $diagram-arrow !important; }
   .edgePath .path, .flowchart-link { stroke: $diagram-arrow !important; }
   .label, .nodeLabel { color: $article-text !important; }
@@ -14,7 +24,10 @@
   .edgeLabel {
     color: $article-text !important;
     background: $article-code-bg !important;
-    font-size: .85em;
+    // Mermaid nests .edgeLabel inside .edgeLabel, so an em value compounds
+    // (.85em rendered nested labels at 11.56px). Use rem so the size is
+    // root-relative and applies once, matching the 16px node labels.
+    font-size: 1rem;
     font-weight: $medium;
 
     p {

--- a/content/influxdb3/core/admin/node-lifecycle.md
+++ b/content/influxdb3/core/admin/node-lifecycle.md
@@ -1,0 +1,24 @@
+---
+title: Manage the node lifecycle
+seotitle: Manage the InfluxDB 3 Core node lifecycle
+description: >
+  Understand how an InfluxDB 3 Core node registers in the catalog, how a
+  graceful shutdown flushes the write-ahead log (WAL), and how to keep
+  container and systemd deployments on the graceful shutdown path.
+menu:
+  influxdb3_core:
+    parent: Administer InfluxDB
+    name: Manage the node lifecycle
+weight: 119
+alt_links:
+  enterprise: /influxdb3/enterprise/admin/node-lifecycle/
+related:
+  - /influxdb3/core/admin/upgrade/
+  - /influxdb3/core/admin/backup-restore/
+  - /influxdb3/core/reference/internals/durability/
+  - /influxdb3/core/reference/cli/influxdb3/serve/
+influxdb3/core/tags: [nodes, lifecycle, administration, wal]
+source: /shared/influxdb3-admin/node-lifecycle.md
+---
+
+<!-- //SOURCE - content/shared/influxdb3-admin/node-lifecycle.md -->

--- a/content/influxdb3/enterprise/admin/clustering.md
+++ b/content/influxdb3/enterprise/admin/clustering.md
@@ -10,6 +10,7 @@ menu:
     name: Configure specialized cluster nodes
 weight: 100
 related:
+  - /influxdb3/enterprise/admin/node-lifecycle/
   - /influxdb3/enterprise/admin/performance-tuning/
   - /influxdb3/enterprise/reference/internals/runtime-architecture/
   - /influxdb3/enterprise/reference/config-options/

--- a/content/influxdb3/enterprise/admin/node-lifecycle.md
+++ b/content/influxdb3/enterprise/admin/node-lifecycle.md
@@ -1,0 +1,29 @@
+---
+title: Manage the node lifecycle
+seotitle: Manage the InfluxDB 3 Enterprise node lifecycle
+description: >
+  Understand how an InfluxDB 3 Enterprise node moves through the `running`,
+  `stopping`, `stopped`, and `removing` states—how to restart, stop, and
+  permanently remove nodes, and how to keep Helm, Kubernetes, and Ansible
+  deployments on the graceful shutdown path.
+menu:
+  influxdb3_enterprise:
+    parent: Administer InfluxDB
+    name: Manage the node lifecycle
+weight: 103
+alt_links:
+  core: /influxdb3/core/admin/node-lifecycle/
+related:
+  - /influxdb3/enterprise/admin/recover-node/
+  - /influxdb3/enterprise/admin/clustering/
+  - /influxdb3/enterprise/admin/upgrade/
+  - /influxdb3/enterprise/install/kubernetes/
+  - /influxdb3/enterprise/reference/cli/influxdb3/stop/node/
+  - /influxdb3/enterprise/reference/cli/influxdb3/remove/node/
+  - /influxdb3/enterprise/reference/cli/influxdb3/show/nodes/
+  - /influxdb3/enterprise/reference/cli/influxdb3/serve/
+influxdb3/enterprise/tags: [clustering, nodes, lifecycle, kubernetes, wal]
+source: /shared/influxdb3-admin/node-lifecycle.md
+---
+
+<!-- //SOURCE - content/shared/influxdb3-admin/node-lifecycle.md -->

--- a/content/influxdb3/enterprise/admin/recover-node.md
+++ b/content/influxdb3/enterprise/admin/recover-node.md
@@ -58,6 +58,17 @@ Parquet clusters and clusters still mid-upgrade do **not** have this safeguard.
 On those clusters, completing this recovery procedure before removal is the only
 protection against losing the tail.
 
+To determine which engine your cluster runs, start with how it was created:
+new clusters on {{< product-name >}} 3.11+ default to the upgraded storage
+engine, and clusters that started on 3.10 or earlier keep the Parquet engine
+until you restart them with `--upgrade-pacha-tree`.
+If you started a storage engine upgrade, confirm it finished—query
+`system.upgrade_parquet_node` and check that every node reports `completed`.
+See [Query system data](/influxdb3/enterprise/admin/query-system-data/#query-storage-engine-tables).
+
+For more information about the upgraded storage engine, see
+[Storage engine](/influxdb3/enterprise/reference/internals/storage-engine/).
+
 ## Recover the node
 
 1. **Restart a server process with the same `--node-id`** (environment

--- a/content/influxdb3/enterprise/admin/recover-node.md
+++ b/content/influxdb3/enterprise/admin/recover-node.md
@@ -33,8 +33,9 @@ A node stores recently acknowledged writes in its write-ahead log (WAL) until it
 captures them in a snapshot.
 These buffered writes are the node's [_WAL tail_](/influxdb3/enterprise/reference/internals/durability/#wal-tail).
 Run the [`influxdb3 stop node`](/influxdb3/enterprise/reference/cli/influxdb3/stop/node/)
-command against a running node to save the WAL tail before the node reports a
-`stopped` state.
+command against a running node to save the
+[WAL tail](/influxdb3/enterprise/reference/internals/durability/#wal-tail)
+before the node reports a `stopped` state.
 
 A node that dies without a graceful stop skips that drain:
 
@@ -44,11 +45,15 @@ A node that dies without a graceful stop skips that drain:
   writes not covered by its last snapshot.
 - Sending the process a bare `SIGTERM` (without calling `stop node`) does not
   force a WAL snapshot on the upgraded storage engine, so a plain process
-  shutdown can also leave a WAL tail behind.
+  shutdown can also leave a
+  [WAL tail](/influxdb3/enterprise/reference/internals/durability/#wal-tail)
+  behind.
 
 On clusters that have fully adopted the upgraded storage engine,
 `remove node` refuses (HTTP 409) to remove a `stopped`
-node that still has a WAL tail unless you pass `--force-finalize`.
+node that still has a
+[WAL tail](/influxdb3/enterprise/reference/internals/durability/#wal-tail)
+unless you pass `--force-finalize`.
 Parquet clusters and clusters still mid-upgrade do **not** have this safeguard.
 On those clusters, completing this recovery procedure before removal is the only
 protection against losing the tail.
@@ -70,8 +75,9 @@ protection against losing the tail.
    ```
 
 2. **Stop the node gracefully** and wait for it to reach `stopped`.
-   This drains the WAL tail (Parquet: WAL flush; upgraded engine: WAL
-   snapshot):
+   This drains the
+   [WAL tail](/influxdb3/enterprise/reference/internals/durability/#wal-tail)
+   (Parquet: WAL flush; upgraded engine: WAL snapshot):
 
    <!--pytest.mark.skip-->
 

--- a/content/influxdb3/enterprise/admin/recover-node.md
+++ b/content/influxdb3/enterprise/admin/recover-node.md
@@ -87,13 +87,15 @@ For more information about the upgraded storage engine, see
 
 <!-- VERIFY (eng/product review): Naming of the per-engine drain step.
      See the matching comment in the shared `stop node` CLI page -- both spots
-     must stay in sync. "Parquet: WAL flush" was changed to "Parquet
-     persistence" here on the reading that WAL flush is the constant
+     must stay in sync. "Parquet: WAL flush" was changed to persisting to
+     Parquet files here on the reading that WAL flush is the constant
      --wal-flush-interval operation, not the step a graceful stop forces. -->
 2. **Stop the node gracefully** and wait for it to reach `stopped`.
    This drains the
-   [WAL tail](/influxdb3/enterprise/reference/internals/durability/#wal-tail)
-   (Parquet engine: Parquet persistence; upgraded engine: WAL snapshot):
+   [WAL tail](/influxdb3/enterprise/reference/internals/durability/#wal-tail).
+   How the node drains it depends on the storage engine:
+   on the Parquet engine, the node persists the buffered writes to Parquet
+   files; on the upgraded storage engine, it captures them in a WAL snapshot.
 
    <!--pytest.mark.skip-->
 

--- a/content/influxdb3/enterprise/admin/recover-node.md
+++ b/content/influxdb3/enterprise/admin/recover-node.md
@@ -33,9 +33,8 @@ A node stores recently acknowledged writes in its write-ahead log (WAL) until it
 captures them in a snapshot.
 These buffered writes are the node's [_WAL tail_](/influxdb3/enterprise/reference/internals/durability/#wal-tail).
 Run the [`influxdb3 stop node`](/influxdb3/enterprise/reference/cli/influxdb3/stop/node/)
-command against a running node to save the
-WAL tail
-before the node reports a `stopped` state.
+command against a running node to save the WAL tail before the node reports a
+`stopped` state.
 
 A node that dies without a graceful stop skips that drain:
 
@@ -85,17 +84,19 @@ For more information about the upgraded storage engine, see
      # ...same object store configuration as the original node
    ```
 
-<!-- VERIFY (eng/product review): Naming of the per-engine drain step.
-     See the matching comment in the shared `stop node` CLI page -- both spots
-     must stay in sync. "Parquet: WAL flush" was changed to persisting to
-     Parquet files here on the reading that WAL flush is the constant
-     --wal-flush-interval operation, not the step a graceful stop forces. -->
 2. **Stop the node gracefully** and wait for it to reach `stopped`.
    This drains the
    [WAL tail](/influxdb3/enterprise/reference/internals/durability/#wal-tail).
    How the node drains it depends on the storage engine:
    on the Parquet engine, the node persists the buffered writes to Parquet
    files; on the upgraded storage engine, it captures them in a WAL snapshot.
+
+   <!-- VERIFY (eng/product review): Naming of the per-engine drain step.
+        See the matching comment in the shared `stop node` CLI page -- both
+        spots must stay in sync. "Parquet: WAL flush" was changed to
+        persisting to Parquet files here on the reading that WAL flush is the
+        constant --wal-flush-interval operation, not the step a graceful stop
+        forces. -->
 
    <!--pytest.mark.skip-->
 

--- a/content/influxdb3/enterprise/admin/recover-node.md
+++ b/content/influxdb3/enterprise/admin/recover-node.md
@@ -11,6 +11,7 @@ menu:
     name: Recover a crashed node
 weight: 121
 related:
+  - /influxdb3/enterprise/admin/node-lifecycle/
   - /influxdb3/enterprise/reference/cli/influxdb3/stop/node/
   - /influxdb3/enterprise/reference/cli/influxdb3/remove/node/
   - /influxdb3/enterprise/reference/cli/influxdb3/show/nodes/

--- a/content/influxdb3/enterprise/admin/recover-node.md
+++ b/content/influxdb3/enterprise/admin/recover-node.md
@@ -85,10 +85,15 @@ For more information about the upgraded storage engine, see
      # ...same object store configuration as the original node
    ```
 
+<!-- VERIFY (eng/product review): Naming of the per-engine drain step.
+     See the matching comment in the shared `stop node` CLI page -- both spots
+     must stay in sync. "Parquet: WAL flush" was changed to "Parquet
+     persistence" here on the reading that WAL flush is the constant
+     --wal-flush-interval operation, not the step a graceful stop forces. -->
 2. **Stop the node gracefully** and wait for it to reach `stopped`.
    This drains the
    [WAL tail](/influxdb3/enterprise/reference/internals/durability/#wal-tail)
-   (Parquet: WAL flush; upgraded engine: WAL snapshot):
+   (Parquet engine: Parquet persistence; upgraded engine: WAL snapshot):
 
    <!--pytest.mark.skip-->
 

--- a/content/influxdb3/enterprise/admin/recover-node.md
+++ b/content/influxdb3/enterprise/admin/recover-node.md
@@ -34,7 +34,7 @@ captures them in a snapshot.
 These buffered writes are the node's [_WAL tail_](/influxdb3/enterprise/reference/internals/durability/#wal-tail).
 Run the [`influxdb3 stop node`](/influxdb3/enterprise/reference/cli/influxdb3/stop/node/)
 command against a running node to save the
-[WAL tail](/influxdb3/enterprise/reference/internals/durability/#wal-tail)
+WAL tail
 before the node reports a `stopped` state.
 
 A node that dies without a graceful stop skips that drain:

--- a/content/influxdb3/enterprise/install/kubernetes.md
+++ b/content/influxdb3/enterprise/install/kubernetes.md
@@ -9,6 +9,7 @@ menu:
     parent: Install InfluxDB 3 Enterprise
 weight: 101
 related:
+  - /influxdb3/enterprise/admin/node-lifecycle/
   - /influxdb3/enterprise/get-started/
   - /influxdb3/enterprise/admin/object-storage/
   - /influxdb3/enterprise/get-started/multi-server/

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/remove/node.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/remove/node.md
@@ -10,6 +10,7 @@ menu:
     name: influxdb3 remove node
 weight: 301
 related:
+  - /influxdb3/enterprise/admin/node-lifecycle/
   - /influxdb3/enterprise/reference/cli/influxdb3/stop/node/
   - /influxdb3/enterprise/admin/recover-node/
   - /influxdb3/enterprise/reference/cli/influxdb3/show/nodes/

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/show/nodes.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/show/nodes.md
@@ -8,6 +8,7 @@ menu:
     name: influxdb3 show nodes
 weight: 301
 related:
+  - /influxdb3/enterprise/admin/node-lifecycle/
   - /influxdb3/enterprise/reference/cli/influxdb3/stop/node/
   - /influxdb3/enterprise/reference/cli/influxdb3/serve/
 source: /shared/influxdb3-cli/show/nodes.md

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/stop/node.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/stop/node.md
@@ -10,6 +10,7 @@ menu:
     name: influxdb3 stop node
 weight: 301
 related:
+  - /influxdb3/enterprise/admin/node-lifecycle/
   - /influxdb3/enterprise/reference/cli/influxdb3/remove/node/
   - /influxdb3/enterprise/admin/recover-node/
   - /influxdb3/enterprise/reference/cli/influxdb3/show/nodes/

--- a/content/shared/influxdb3-admin/node-lifecycle.md
+++ b/content/shared/influxdb3-admin/node-lifecycle.md
@@ -442,6 +442,12 @@ cases:
 > clusters, a graceful stop before removal is your only protection against
 > losing the
 > [WAL tail](/influxdb3/version/reference/internals/durability/#wal-tail).
+>
+> Clusters that started on 3.10 or earlier keep the Parquet engine until you
+> restart them with `--upgrade-pacha-tree`.
+> If you started a storage engine upgrade, confirm it finished—query
+> `system.upgrade_parquet_node` and check that every node reports `completed`.
+> See [Query system data](/influxdb3/version/admin/query-system-data/#query-storage-engine-tables).
 
 ### Remove a compactor node
 

--- a/content/shared/influxdb3-admin/node-lifecycle.md
+++ b/content/shared/influxdb3-admin/node-lifecycle.md
@@ -1,0 +1,645 @@
+Every {{% product-name %}} server process registers itself as a _node_ in the
+catalog—the metadata store that tracks databases, tables, and nodes.
+The catalog is the source of truth for a node's identity and state, and it
+persists in object storage—independently of the process, its container, or its
+host.
+Understanding how a node moves through its states helps you restart, upgrade,
+scale, and decommission {{% product-name %}} safely.
+
+{{% show-in "enterprise" %}}
+- [Node states](#node-states)
+- [Lifecycle overview](#lifecycle-overview)
+- [Register a node](#register-a-node)
+- [Stop a node](#stop-a-node)
+- [Remove a node](#remove-a-node)
+- [Re-register a node](#re-register-a-node)
+- [Restart compared to removal](#restart-compared-to-removal)
+- [Deploy with an orchestrator](#deploy-with-an-orchestrator)
+- [Verify node state](#verify-node-state)
+- [Troubleshoot node lifecycle issues](#troubleshoot-node-lifecycle-issues)
+{{% /show-in %}}
+{{% show-in "core" %}}
+- [Node states](#node-states)
+- [Lifecycle overview](#lifecycle-overview)
+- [Register a node](#register-a-node)
+- [Stop a node](#stop-a-node)
+- [Re-register a node](#re-register-a-node)
+- [Deploy with an orchestrator](#deploy-with-an-orchestrator)
+- [Verify node state](#verify-node-state)
+- [Troubleshoot node lifecycle issues](#troubleshoot-node-lifecycle-issues)
+{{% /show-in %}}
+
+## Node states
+
+The catalog records one of the following states for each node:
+
+| State      | Description                                                                 |
+| :--------- | :-------------------------------------------------------------------------- |
+| `running`  | The node started and registered itself in the catalog                       |
+| `stopping` | A graceful stop was requested, but the node hasn't acknowledged it yet      |
+| `stopped`  | The node acknowledged its final snapshot and completed shutdown             |
+| `removing` | The node is marked for permanent removal from the cluster                   |
+
+{{% show-in "core" %}}
+> [!Note]
+> #### Core uses running and stopped
+>
+> {{% product-name %}} runs a single node and doesn't provide node management
+> commands, so a {{% product-name %}} node only ever reads as `running` or
+> `stopped`.
+> The `stopping` and `removing` states apply to
+> [InfluxDB 3 Enterprise](/influxdb3/enterprise/admin/node-lifecycle/) clusters,
+> where an operator can stop and remove individual nodes.
+{{% /show-in %}}
+
+{{% show-in "enterprise" %}}
+Node identity has two parts:
+
+- **Node ID**: The name you assign with
+  [`--node-id`](/influxdb3/version/reference/config-options/#node-id).
+  It identifies the node across restarts and is the value you pass to node
+  management commands.
+- **Instance ID**: A UUID that {{% product-name %}} generates the first time a
+  node ID registers.
+  A node that restarts with the same node ID reuses its existing instance ID.
+{{% /show-in %}}
+{{% show-in "core" %}}
+Node identity has two parts:
+
+- **Node ID**: The name you assign with
+  [`--node-id`](/influxdb3/version/reference/config-options/#node-id).
+  It identifies the node across restarts.
+- **Instance ID**: A UUID that {{% product-name %}} generates the first time a
+  node ID registers.
+  A node that restarts with the same node ID reuses its existing instance ID.
+{{% /show-in %}}
+
+## Lifecycle overview
+
+{{< show-in "enterprise" >}}
+{{< diagram >}}
+stateDiagram-v2
+    [*] --> running: influxdb3 serve
+    running --> stopped: SIGTERM or SIGINT
+    running --> stopping: influxdb3 stop node
+    stopping --> stopped: node acknowledges final snapshot
+    stopped --> running: influxdb3 serve (same node ID)
+    stopped --> removing: influxdb3 remove node
+    removing --> [*]: catalog entry and files purged
+
+{{< /diagram >}}
+{{< /show-in >}}
+
+{{% show-in "enterprise" %}}
+A node reaches `stopped` by one of two paths:
+
+- **Process shutdown** (`SIGTERM`, `SIGINT`, or Ctrl-c) moves the node directly
+  from `running` to `stopped`.
+- **[`influxdb3 stop node`](/influxdb3/version/reference/cli/influxdb3/stop/node/)**
+  moves the node from `running` to `stopping`, and then to `stopped` after the
+  node acknowledges its final snapshot.
+
+Only the second path records a final snapshot sequence, and only the second
+path frees the node's licensed cores for other nodes.
+{{% /show-in %}}
+{{< show-in "core" >}}
+{{< diagram >}}
+stateDiagram-v2
+    [*] --> running: influxdb3 serve
+    running --> stopped: SIGTERM or SIGINT
+    stopped --> running: influxdb3 serve (same node ID)
+
+{{< /diagram >}}
+{{< /show-in >}}
+
+## Register a node
+
+When you start a server with
+[`influxdb3 serve`](/influxdb3/version/reference/cli/influxdb3/serve/), the node
+registers itself in the catalog and enters the `running` state:
+
+{{% show-in "enterprise" %}}
+<!--pytest.mark.skip-->
+
+```bash { placeholders="NODE_ID|CLUSTER_ID|BUCKET_NAME" }
+influxdb3 serve \
+  --node-id NODE_ID \
+  --cluster-id CLUSTER_ID \
+  --object-store s3 \
+  --bucket BUCKET_NAME
+```
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`NODE_ID`{{% /code-placeholder-key %}}:
+  A unique identifier for this node
+- {{% code-placeholder-key %}}`CLUSTER_ID`{{% /code-placeholder-key %}}:
+  The identifier shared by all nodes in the cluster
+- {{% code-placeholder-key %}}`BUCKET_NAME`{{% /code-placeholder-key %}}:
+  The object storage bucket for the cluster
+{{% /show-in %}}
+{{% show-in "core" %}}
+<!--pytest.mark.skip-->
+
+```bash { placeholders="NODE_ID" }
+influxdb3 serve \
+  --node-id NODE_ID \
+  --object-store file \
+  --data-dir ~/.influxdb3
+```
+
+Replace {{% code-placeholder-key %}}`NODE_ID`{{% /code-placeholder-key %}}
+with a unique identifier for the node.
+{{% /show-in %}}
+
+Registration is how a node claims its node ID.
+If the node ID already exists in the catalog, {{% product-name %}} applies the
+[re-registration rules](#re-register-a-node) before accepting the node.
+
+## Stop a node
+
+{{% show-in "core" %}}
+Stop {{% product-name %}} by signaling the process—for example, press Ctrl-c in
+the foreground, run `systemctl stop influxdb3`, or stop the container.
+`SIGTERM` and `SIGINT` both start a graceful shutdown.
+
+During a graceful shutdown, the node does the following:
+
+1. Stops accepting writes.
+2. Flushes the write-ahead log (WAL) buffer to object storage.
+3. Waits for an in-progress snapshot to finish.
+4. Marks itself `stopped` in the catalog.
+
+Because the final flush writes buffered data to the WAL in object storage,
+acknowledged writes survive the shutdown.
+When the node restarts, WAL replay restores any writes that weren't yet
+captured in a snapshot.
+
+> [!Important]
+> #### Give the process time to shut down
+>
+> A graceful shutdown isn't instantaneous.
+> If your init system, container runtime, or orchestrator sends `SIGKILL`
+> before the flush completes, the node can't finish its final flush.
+> For guidance on timeouts, see
+> [Deploy with an orchestrator](#deploy-with-an-orchestrator).
+{{% /show-in %}}
+
+{{% show-in "enterprise" %}}
+How you stop a node depends on whether the node stays in the cluster.
+
+### Stop a node for a restart
+
+To restart a node in place—for a rolling upgrade, a configuration change, or a
+node reschedule—signal the process (`SIGTERM`, `SIGINT`, or Ctrl-c).
+The node stops accepting writes, flushes its write-ahead log (WAL) buffer to
+object storage, waits for an in-progress snapshot to finish, and marks itself
+`stopped` in the catalog.
+
+Because the final flush writes buffered data to the WAL in object storage,
+acknowledged writes survive the shutdown, and WAL replay restores them when the
+node restarts with the same node ID.
+
+### Stop a node before removing it
+
+To take a node out of the cluster permanently, use
+[`influxdb3 stop node`](/influxdb3/version/reference/cli/influxdb3/stop/node/)
+against the **live** node:
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="NODE_ID" }
+influxdb3 stop node --node-id NODE_ID
+```
+
+The stop proceeds in two phases:
+
+1. {{% product-name %}} marks the node `stopping` in the catalog.
+2. The node completes its stop cascade, draining its
+   [WAL tail](/influxdb3/version/reference/internals/durability/#wal-tail)—the
+   writes buffered since the last snapshot.
+3. The node acknowledges the stop, reads as `stopped`, and its licensed cores
+   are freed for other nodes.
+
+By default, the command waits for the node to reach `stopped`
+(up to `--timeout`, default `5m`).
+Use `--no-wait` to return as soon as the cluster accepts the request.
+
+> [!Important]
+> #### Run stop node against the live node—don't kill it first
+>
+> `stop node` is how a node drains its WAL tail and records a final snapshot.
+> If you kill the process first and run `stop node` afterward, the dead process
+> can't drain anything, and
+> [removing the node](/influxdb3/version/reference/cli/influxdb3/remove/node/)
+> can permanently delete the stranded writes.
+> If a node already stopped ungracefully, follow
+> [Recover a crashed node](/influxdb3/version/admin/recover-node/).
+
+> [!Note]
+> #### A flush isn't a snapshot
+>
+> A bare `SIGTERM` flushes the WAL buffer, but it doesn't force a new snapshot.
+> The writes are durable and replay on restart, but they remain part of the WAL
+> tail.
+> That distinction matters only before
+> [removing a node](#remove-a-node), because removal purges the node's WAL
+> files.
+
+### Repeat a stop request safely
+
+Requesting a stop for a node that's already `stopping`, `stopped`, or
+`removing` succeeds without changing the node's state (HTTP `200 OK`).
+Controllers and automation can retry a stop without treating the repeat as a
+conflict.
+{{% /show-in %}}
+
+{{% show-in "enterprise" %}}
+## Remove a node
+
+Removal is permanent.
+After a node reaches `stopped`, remove it with
+[`influxdb3 remove node`](/influxdb3/version/reference/cli/influxdb3/remove/node/):
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="NODE_ID" }
+influxdb3 remove node --node-id NODE_ID
+```
+
+{{% product-name %}} marks the node `removing`, drains its data up to its final
+snapshot, and then purges the node's catalog entry and its object-store file
+paths.
+
+> [!Warning]
+> #### Removal deletes the node's files
+>
+> Removal permanently deletes the node's object-store file paths, including its
+> WAL files.
+> Any acknowledged writes not covered by the node's final snapshot are deleted
+> with them.
+> Complete a graceful [`stop node`](#stop-a-node-before-removing-it) first.
+
+Repeating a remove request for a node that's already `removing` succeeds
+without changing state (HTTP `200 OK`).
+
+### When removal is refused
+
+{{% product-name %}} refuses removal (HTTP `409 Conflict`) in the following
+cases:
+
+| Condition                       | Message                                                                  | Resolution                                                                                          |
+| :------------------------------ | :------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------------------- |
+| Node isn't `stopped`            | `node 'NODE_ID' is not fully stopped (current state: STATE)`             | [Stop the node gracefully](#stop-a-node-before-removing-it) and wait for `stopped`                   |
+| Node runs in `compact` mode     | `node 'NODE_ID' has compact mode and cannot be removed`                  | Compactor nodes can't be removed—see [Remove a compactor node](#remove-a-compactor-node)             |
+| Node belongs to a query group   | `cannot remove node 'NODE_ID' because it is a member of query group ...` | Remove the node from the query group first                                                          |
+| Unsnapshotted WAL remains       | `node 'NODE_ID' has unsnapshotted WAL (wal file N, snapshotted through M)` | Restart the node, stop it gracefully, then remove it—see [Recover a crashed node](/influxdb3/version/admin/recover-node/) |
+
+Trying to stop a node that's already stopped returns HTTP `400 Bad Request`
+with `tried to stop a node (NODE_ID) that is already stopped`.
+
+> [!Note]
+> #### The unsnapshotted WAL safeguard requires the upgraded storage engine
+>
+> The unsnapshotted WAL check applies only to clusters that fully adopted the
+> [upgraded storage engine](/influxdb3/version/reference/internals/storage-engine/)
+> (the default for new clusters in {{% product-name %}} 3.11+).
+> Clusters on the Parquet engine, or still mid-upgrade, aren't guarded—on those
+> clusters, a graceful stop before removal is your only protection against
+> losing the WAL tail.
+
+### Remove a compactor node
+
+A node running in `compact` mode holds the cluster's single-writer compaction
+lease and can't be removed.
+To retire the host running your compactor, start a replacement compactor node
+that reuses the same node ID, as described in
+[Configure specialized cluster nodes](/influxdb3/version/admin/clustering/#from-single-node-to-specialized-cluster).
+{{% /show-in %}}
+
+## Re-register a node
+
+Whether a node ID can be claimed again depends on the current state of the
+node in the catalog:
+
+{{% show-in "enterprise" %}}
+| Current state           | Can register again?                                          |
+| :---------------------- | :------------------------------------------------------------ |
+| `stopped`               | Yes—any instance can take over the node ID                   |
+| `running` or `stopping` | Only the same instance ID (an idempotent retry or a restart) |
+| `removing`              | No—`removing` is terminal for the node ID                    |
+{{% /show-in %}}
+{{% show-in "core" %}}
+| Current state | Can register again?                                          |
+| :------------ | :------------------------------------------------------------ |
+| `stopped`     | Yes—any instance can take over the node ID                   |
+| `running`     | Only the same instance ID (an idempotent retry or a restart) |
+{{% /show-in %}}
+
+Because a node restarting with the same node ID reuses its existing instance
+ID, an ordinary restart always satisfies these rules—even if the node still
+reads as `running` after an ungraceful stop.
+
+{{% show-in "enterprise" %}}
+> [!Warning]
+> #### Don't reuse the node ID of a removed node
+>
+> After removal completes, {{% product-name %}} purges the node's catalog entry
+> and its object-store file paths.
+> While the node is `removing`, registration with that node ID is rejected.
+> Assign a new node ID to a replacement node instead of racing the removal.
+
+## Restart compared to removal
+
+Choosing the wrong operation is the most common way to lose data during routine
+maintenance.
+
+| Goal                                                       | Operation                                                                  |
+| :--------------------------------------------------------- | :-------------------------------------------------------------------------- |
+| Rolling upgrade, config change, pod reschedule, host reboot | Restart the process with the **same** node ID—don't remove the node        |
+| Permanently scale down or decommission hardware             | `stop node`, verify `stopped`, then `remove node`                          |
+| Replace a failed host, keeping its data                     | Start a node with the same node ID and object store configuration          |
+
+Restarting a node is not a removal: the node keeps its catalog entry, its
+instance ID, and its object-store files.
+Removal is the only operation that purges them.
+
+For upgrade-specific sequencing and catalog version constraints, see
+[Troubleshooting cluster upgrades](/influxdb3/version/admin/upgrade/#troubleshooting-cluster-upgrades).
+{{% /show-in %}}
+
+## Deploy with an orchestrator
+
+Helm, Kubernetes, and Ansible deployments drive the node lifecycle on your
+behalf.
+The following guidance keeps orchestrated restarts on the graceful path.
+
+### Kubernetes and Helm
+
+**Give each node a stable node ID.**
+Use a StatefulSet so pod names are stable and ordinal-based, and derive
+`--node-id` from the pod name.
+{{% show-in "enterprise" %}}
+The official
+[{{% product-name %}} Helm chart](https://github.com/influxdata/helm-charts/tree/master/charts/influxdb3-enterprise)
+does this already—it runs a StatefulSet per node mode and sets
+`--node-id=$(POD_NAME)` from `metadata.name`.
+{{% /show-in %}}
+{{% show-in "core" %}}
+The official
+[{{% product-name %}} Helm chart](https://github.com/influxdata/helm-charts/tree/master/charts/influxdb3-core)
+does this already—it runs a StatefulSet and sets `--node-id=$(POD_NAME)` from
+`metadata.name`.
+{{% /show-in %}}
+A Deployment generates a new random pod name on every rollout, which registers a
+new node in the catalog on each restart and leaves the old entries behind.
+
+**Set a termination grace period that fits your WAL.**
+Kubernetes sends `SIGTERM`, waits `terminationGracePeriodSeconds`
+(default `30`), and then sends `SIGKILL`.
+A node that's still flushing when `SIGKILL` arrives stops ungracefully.
+Set `terminationGracePeriodSeconds` well above your observed shutdown time:
+
+```yaml
+spec:
+  template:
+    spec:
+      terminationGracePeriodSeconds: 300
+```
+
+> [!Important]
+> #### The Helm chart doesn't set a grace period
+>
+> The {{% product-name %}} Helm chart doesn't set
+> `terminationGracePeriodSeconds`, so pods inherit the Kubernetes default of
+> 30 seconds.
+> For nodes with a large WAL, raise it in your `values.yaml` overrides and
+> confirm the shutdown completes in the pod logs.
+
+{{% show-in "enterprise" %}}
+**Don't remove nodes during a rolling update.**
+A `helm upgrade` or `kubectl rollout restart` terminates and recreates pods
+with the same names.
+Each node re-registers with its existing node ID, which is exactly what you
+want.
+Never put
+[`influxdb3 remove node`](/influxdb3/version/reference/cli/influxdb3/remove/node/)
+in a `preStop` hook—it turns every rollout into a permanent decommission.
+
+**Sequence rollouts across node modes yourself.**
+The Helm chart runs a separate StatefulSet per node mode, but the image tag is a
+single chart-wide value, so one `helm upgrade` rolls every mode at once.
+Kubernetes doesn't order rollouts across StatefulSets, so a plain upgrade
+doesn't follow the
+[recommended node upgrade order](/influxdb3/version/admin/upgrade/#recommended-node-upgrade-order).
+Freeze the modes you aren't upgrading yet with
+`updateStrategy.rollingUpdate.partition` and release them one at a time—see the
+**Helm** tab in
+[Perform a rolling upgrade](/influxdb3/version/admin/upgrade/#perform-a-rolling-upgrade).
+
+**Protect nodes from concurrent drains.**
+A node drain (`kubectl drain`, cluster autoscaler, or a managed node-pool
+upgrade) evicts pods the same way a rollout does, but nothing stops several
+nodes from draining at once.
+Enable the chart's pod disruption budget so voluntary disruptions take one node
+at a time:
+
+```yaml
+ingester:
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
+```
+
+Set it per node mode (`ingester`, `querier`, `compactor`, and
+`processingEngine`).
+The chart creates a budget for a mode only when that mode runs more than one
+replica, so single-replica modes still drain without protection—make sure their
+termination grace period is long enough to finish the final flush.
+{{% /show-in %}}
+{{% show-in "core" %}}
+**Restarts reuse the same node.**
+A `helm upgrade` or `kubectl rollout restart` terminates and recreates the pod
+with the same name, so the node re-registers with its existing node ID and
+replays its WAL.
+{{% /show-in %}}
+
+{{% show-in "enterprise" %}}
+**Scale down deliberately.**
+Reducing a StatefulSet's replica count stops the pods but leaves the nodes in
+the catalog as `stopped`.
+Removing them is a separate, deliberate step:
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="NODE_ID" }
+# 1. Confirm the node reached the stopped state
+influxdb3 show nodes
+
+# 2. Remove the stopped node from the cluster
+influxdb3 remove node --node-id NODE_ID
+```
+
+**Uninstalling doesn't clean the catalog.**
+`helm uninstall` removes Kubernetes resources, but the catalog and object
+storage persist, and the nodes remain as catalog entries.
+Reinstalling with the same node IDs and object store reattaches those nodes.
+{{% /show-in %}}
+
+### Ansible and systemd
+
+**Let systemd send `SIGTERM`.**
+The systemd default `KillSignal` is `SIGTERM`, which starts a graceful
+shutdown—don't override it with `SIGKILL`.
+
+**Raise `TimeoutStopSec`.**
+If the node doesn't exit within `TimeoutStopSec`, systemd escalates to
+`SIGKILL`.
+Set it above your observed shutdown time:
+
+```ini
+[Service]
+KillSignal=SIGTERM
+TimeoutStopSec=300
+```
+
+{{% show-in "enterprise" %}}
+**Roll one node at a time.**
+Use `serial: 1` in your playbook and confirm each node returns to `running`
+before proceeding.
+Group your inventory by node mode and order the plays to match the
+[recommended node upgrade order](/influxdb3/version/admin/upgrade/#recommended-node-upgrade-order)—for
+a complete playbook, see the **Ansible** tab in
+[Perform a rolling upgrade](/influxdb3/version/admin/upgrade/#perform-a-rolling-upgrade).
+
+**Don't put `remove node` in a playbook.**
+A restart keeps the node's catalog entry and object-store files; removal purges
+them.
+Reserve
+[`influxdb3 remove node`](/influxdb3/version/reference/cli/influxdb3/remove/node/)
+for deliberate decommissioning, never for routine configuration or version
+rollouts.
+{{% /show-in %}}
+{{% show-in "core" %}}
+**Wait for the node to return to `running`.**
+Confirm the node re-registered and finished WAL replay before you send traffic
+to it again.
+{{% /show-in %}}
+
+**Never use `kill -9`.**
+Ad hoc `kill -9`, `docker kill`, and force-stopped containers all skip the
+final flush.
+
+## Verify node state
+
+{{% show-in "enterprise" %}}
+Use [`influxdb3 show nodes`](/influxdb3/version/reference/cli/influxdb3/show/nodes/)
+to check the state of every node in the cluster:
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 show nodes
+```
+
+The output includes a `state` column for each node—abbreviated here to the
+lifecycle-relevant columns:
+
+```
++---------+--------+------------+---------+
+| node_id | mode   | core_count | state   |
++---------+--------+------------+---------+
+| node-1  | ingest | 1          | running |
+| node-2  | ingest | 1          | stopped |
++---------+--------+------------+---------+
+```
+
+Other nodes observe a state change after their catalog sync interval
+(default 10 seconds), so allow for that delay when scripting checks.
+
+You can also query the `system.nodes` table in the `_internal` database:
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="AUTH_TOKEN" }
+influxdb3 query \
+  --database _internal \
+  --token AUTH_TOKEN \
+  "SELECT node_id, mode, state, updated_at FROM system.nodes"
+```
+
+Replace {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}}
+with a token that has permission to query the `_internal` database.
+{{% /show-in %}}
+{{% show-in "core" %}}
+{{% product-name %}} doesn't provide node management commands, but you can query
+the `system.nodes` table in the `_internal` database to see the node's
+registered state:
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="AUTH_TOKEN" }
+influxdb3 query \
+  --database _internal \
+  --token AUTH_TOKEN \
+  "SELECT node_id, mode, state, updated_at FROM system.nodes"
+```
+
+Replace {{% code-placeholder-key %}}`AUTH_TOKEN`{{% /code-placeholder-key %}}
+with a token that has permission to query the `_internal` database.
+{{% /show-in %}}
+
+## Troubleshoot node lifecycle issues
+
+{{% show-in "enterprise" %}}
+### A node is stuck in stopping
+
+The node was marked `stopping` but never acknowledged the stop—usually because
+the process died mid-cascade.
+Follow [Recover a crashed node](/influxdb3/version/admin/recover-node/):
+restart the node with the same node ID, stop it gracefully, and then remove it
+if you still intend to.
+
+### A node still reads as running after it crashed
+
+A node that dies without a graceful shutdown never updates its catalog entry,
+so it keeps its last recorded state.
+Restarting the node with the same node ID re-registers it—the
+[re-registration rules](#re-register-a-node) allow it because the instance ID
+matches.
+
+### Removal fails with a 409 conflict
+
+See [When removal is refused](#when-removal-is-refused) for each condition and
+its resolution.
+Prefer restarting and gracefully stopping the node over
+[`--force-finalize`](/influxdb3/version/reference/cli/influxdb3/remove/node/#force-removal-of-a-node-that-did-not-shut-down-cleanly),
+which can delete unsnapshotted writes.
+
+### Nodes multiply in the catalog after each restart
+
+Each restart registered a new node ID.
+Check that your deployment assigns a stable node ID—see
+[Kubernetes and Helm](#kubernetes-and-helm).
+Stop and remove the stale entries after confirming which nodes are current.
+
+### Writes fail during a rolling upgrade
+
+This is usually a catalog version constraint rather than a lifecycle problem.
+See [Troubleshooting cluster upgrades](/influxdb3/version/admin/upgrade/#troubleshooting-cluster-upgrades).
+{{% /show-in %}}
+{{% show-in "core" %}}
+### The node didn't shut down cleanly
+
+If the process was killed before it finished flushing, restart it with the same
+node ID and object store configuration.
+WAL replay restores acknowledged writes that weren't yet captured in a
+snapshot.
+
+### A new node appears after each restart
+
+Each restart registered a new node ID.
+Check that your deployment assigns a stable
+[`--node-id`](/influxdb3/version/reference/config-options/#node-id)—see
+[Deploy with an orchestrator](#deploy-with-an-orchestrator).
+{{% /show-in %}}

--- a/content/shared/influxdb3-admin/node-lifecycle.md
+++ b/content/shared/influxdb3-admin/node-lifecycle.md
@@ -50,6 +50,14 @@ The catalog records one of the following states for each node:
 > The `stopping` and `removing` states apply to
 > [InfluxDB 3 Enterprise](/influxdb3/enterprise/admin/node-lifecycle/) clusters,
 > where an operator can stop and remove individual nodes.
+
+<!-- VERIFY (live instance): Confirm a Core node never surfaces `stopping` or
+     `removing`. The four-state enum is shared catalog code (NodeMode::Core is
+     just another mode), so the restriction asserted here is about Core lacking
+     the stop/remove commands, not about the states being unreachable. If a
+     Core node can transit `stopping` (for example, via the HTTP endpoint even
+     without a CLI subcommand), soften this note. -->
+
 {{% /show-in %}}
 
 {{% show-in "enterprise" %}}
@@ -169,6 +177,16 @@ During a graceful shutdown, the node does the following:
 2. Flushes the write-ahead log (WAL) buffer to object storage.
 3. Waits for an in-progress snapshot to finish.
 4. Marks itself `stopped` in the catalog.
+
+<!-- VERIFY (live instance): Confirm this four-step shutdown sequence and its
+     ORDER for Core. It was written from the Enterprise stop cascade plus the
+     durability docs, not from Core-specific source. In particular confirm
+     that (a) Core stops accepting writes before flushing rather than draining
+     in-flight writes first, and (b) Core marks itself `stopped` in the catalog
+     at all on SIGTERM -- if a Core node is left `running` after a clean
+     shutdown, say so instead. Test: send SIGTERM to a Core node, then query
+     system.nodes for its state. -->
+
 
 Because the final flush writes buffered data to the WAL in object storage,
 acknowledged writes survive the shutdown.
@@ -428,6 +446,16 @@ lease and can't be removed.
 To retire the host running your compactor, start a replacement compactor node
 that reuses the same node ID, as described in
 [Configure specialized cluster nodes](/influxdb3/version/admin/clustering/#from-single-node-to-specialized-cluster).
+
+<!-- VERIFY (live instance): Confirm the compactor replacement procedure end to
+     end -- stop the compactor, start a new process on different hardware with
+     the SAME --node-id and --mode compact, and confirm it takes over the
+     single-writer compaction lease cleanly. Support case 00130867 shows a dead
+     compactor's catalog record making OTHER nodes crash-loop on restart, so
+     the failure mode here is expensive and the happy path is worth proving.
+     Also determine whether the lease TTL (reported as 30s) forces a wait
+     between stopping the old compactor and starting the replacement. -->
+
 {{% /show-in %}}
 
 ## Re-register a node
@@ -452,6 +480,23 @@ node in the catalog:
 Because a node restarting with the same node ID reuses its existing instance
 ID, an ordinary restart always satisfies these rules—even if the node still
 reads as `running` after an ungraceful stop.
+
+<!-- VERIFY (live instance) -- HIGHEST PRIORITY, this claim carries the page:
+     Does a restarting process actually REUSE its existing instance_id?
+     `can_re_register` only accepts a `running`/`stopping` node when the
+     incoming instance_id MATCHES, and instance_id is described in the catalog
+     source as "a UUID generated when the node is first registered". If the
+     process mints a NEW UUID on each start and reads the old one from
+     somewhere (data dir? object store? catalog lookup by node ID?), that
+     lookup is what makes restart-after-crash work -- and if it does NOT reuse
+     it, then restarting a node still recorded as `running` would be REFUSED,
+     which would invalidate this paragraph, the "still reads as running after
+     it crashed" troubleshooting entry, AND the core promise that a rolling
+     restart is always safe.
+     Test: kill -9 a node (leaving it `running` in the catalog), restart it
+     with the same --node-id, and confirm it re-registers. Then check whether
+     instance_id in `show nodes` changed. -->
+
 
 {{% show-in "enterprise" %}}
 > [!Warning]
@@ -678,6 +723,18 @@ lifecycle-relevant columns:
 
 Other nodes observe a state change after their catalog sync interval
 (default 10 seconds), so allow for that delay when scripting checks.
+
+<!-- VERIFY (live instance): Two things in this section.
+     1. The catalog sync interval default of 10 seconds is carried over from
+        the published `stop node` CLI page -- confirm it against the current
+        config options, and name the setting here if it is user-tunable.
+     2. Confirm `system.nodes` is reachable via `--database _internal` and that
+        the columns node_id, mode, state, and updated_at exist under those
+        names. Real `show nodes` output also includes node_catalog_id,
+        instance_id, core_count, conn_info, and cli_params; if system.nodes
+        exposes the same set, consider selecting instance_id here too, since it
+        is what the re-registration rules turn on. Same check applies to the
+        Core copy of this query below. -->
 
 You can also query the `system.nodes` table in the `_internal` database:
 

--- a/content/shared/influxdb3-admin/node-lifecycle.md
+++ b/content/shared/influxdb3-admin/node-lifecycle.md
@@ -221,6 +221,15 @@ The stop proceeds in two phases:
 3. The node acknowledges the stop, reads as `stopped`, and its licensed cores
    are freed for other nodes.
 
+<!-- VERIFY (live instance): Does reaching `stopped` actually free licensed
+     cores for reuse by other nodes? Support case 00123680 (3.4.1) reported
+     cores were NOT freed by stopping a node, and case 00129706 (April 2026,
+     "Incorrect core count when updating deployment") suggests core accounting
+     issues persisted. This claim currently mirrors the published `stop node`
+     CLI page; if testing shows cores are only freed on `remove node` (or not
+     at all), correct BOTH pages. -->
+
+
 By default, the command waits for the node to reach `stopped`
 (up to `--timeout`, default `5m`).
 Use `--no-wait` to return as soon as the cluster accepts the request.
@@ -246,12 +255,69 @@ Use `--no-wait` to return as soon as the cluster accepts the request.
 > [removing a node](#remove-a-node), because removal purges the node's WAL
 > files.
 
-### Repeat a stop request safely
+### Stop a node that isn't running
 
-Requesting a stop for a node that's already `stopping`, `stopped`, or
-`removing` succeeds without changing the node's state (HTTP `200 OK`).
-Controllers and automation can retry a stop without treating the repeat as a
-conflict.
+Stopping a node that has already stopped returns HTTP `400 Bad Request`:
+
+<!--pytest-codeblocks:expected-output-->
+
+```
+tried to stop a node (NODE_ID) that is already stopped
+```
+
+The error is safe to ignore—it reports that the node reached the state you
+asked for.
+Automation that stops nodes should treat this response as success rather than
+retrying.
+
+<!-- VERIFY (live instance): Two catalog ops exist with OPPOSITE responses for
+     a non-running node. `StopNodeOp` returns NodeAlreadyStopped -> HTTP 400
+     ("tried to stop a node (X) that is already stopped"); `RequestStopNodeOp`
+     returns IdempotentNoOp -> HTTP 200 so controllers can retry safely.
+     The 400 above is what real users hit (case 00129706 via CLI, case 00130867
+     via POST /api/v3/enterprise/configure/node/stop), so it is documented here.
+     Confirm on a current build: (a) which path `influxdb3 stop node` uses now,
+     and (b) the response when the target is `stopping` or `removing` rather
+     than `stopped`. If the CLI now returns 200, replace this section with the
+     idempotent-retry guidance. -->
+
+<!-- VERIFY (live instance): Scaling down via the stop API has returned an
+     EMPTY reply (curl exit 52) even when the stop succeeded -- suspected race
+     where the server tears down before flushing the 200 (EAR #6744).
+     If reproducible, document that an empty reply does not mean the stop
+     failed, and tell automation to confirm via `show nodes` instead of
+     retrying. -->
+
+
+### Stop a node whose process is already gone
+
+`--host` doesn't have to point at the node you're stopping.
+To stop a node whose process is dead, send the request to a **running** node in
+the same cluster:
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="NODE_ID|RUNNING_NODE|ADMIN_TOKEN" }
+influxdb3 stop node \
+  --node-id NODE_ID \
+  --host http://RUNNING_NODE:8181 \
+  --token ADMIN_TOKEN
+```
+
+<!-- VERIFY (live instance): Confirm `stop node --host <other running node>`
+     works for a node whose process is dead. Support drove exactly this in case
+     00130867 (dead compactor blocking restarts) and said they verified the
+     sequence on a test cluster, but it is not covered by the published CLI
+     page. Also confirm the resulting state: EAR #7030 reports the node
+     transitions to `stopping` and NEVER reaches `stopped`, because no live
+     process completes the handshake -- if so, say that explicitly here. -->
+
+This clears a stale `running` entry that would otherwise keep the cluster
+expecting a node that never comes back.
+Remember that a dead process can't drain its WAL tail, so treat the node as
+crashed and follow
+[Recover a crashed node](/influxdb3/version/admin/recover-node/) before you
+remove it.
 {{% /show-in %}}
 
 {{% show-in "enterprise" %}}
@@ -283,6 +349,56 @@ paths.
 Repeating a remove request for a node that's already `removing` succeeds
 without changing state (HTTP `200 OK`).
 
+### Removal completes on the compactor's schedule
+
+`removing` isn't instantaneous, and you can't force it to finish.
+The compactor drives removal: it waits until its per-node compaction floor
+passes the node's recorded final snapshot sequence, and only then deletes the
+node's object-store prefixes and purges the catalog entry.
+Nothing is deleted before it's absorbed.
+
+A node can therefore sit in `removing` for hours if the compactor is backed up,
+under-resourced, or restarting—this is the removal working as designed, waiting
+on compaction.
+Removing several nodes at once multiplies the backlog it has to absorb.
+
+If nodes aren't clearing, check the compactor before the nodes:
+
+<!-- VERIFY (live instance): Confirm the DATABASE for
+     `system.pt_compaction_nodes`. Internal notes describe querying it from any
+     querier with a read token using `db=<any-db>`, NOT specifically `_internal`
+     as written below -- fix the `--database` value if `_internal` is wrong.
+     Also confirm the column names (node_id, node_prefix,
+     last_snapshot_sequence, last_compacted_wal_sequence_number) and that this
+     table is NOT compactor-only (unlike system.pt_compaction_active_jobs and
+     system.pt_compaction_deferred_snapshots, which return
+     "400 ... is only available on compactors" through the normal query path).
+     If these tables are internal/unstable, consider dropping this example and
+     describing the symptom qualitatively instead. -->
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="AUTH_TOKEN" }
+# Compare each node's compaction floor against its snapshots
+influxdb3 query \
+  --database _internal \
+  --token AUTH_TOKEN \
+  "SELECT node_id, node_prefix, last_snapshot_sequence, \
+   last_compacted_wal_sequence_number FROM system.pt_compaction_nodes"
+```
+
+Nodes disappear from `show nodes` as each removal completes.
+
+> [!Warning]
+> #### Removal keeps the cluster expecting the node until it completes
+>
+> While a node is `removing`, its node ID can't be reclaimed—`removing` is
+> terminal.
+> A replacement that reuses the ID (for example, a StatefulSet pod recreated
+> with the same ordinal name) starts but is refused registration.
+> Keep your replica count pinned below the removing ordinals until removal
+> finishes.
+
 ### When removal is refused
 
 {{% product-name %}} refuses removal (HTTP `409 Conflict`) in the following
@@ -294,9 +410,6 @@ cases:
 | Node runs in `compact` mode     | `node 'NODE_ID' has compact mode and cannot be removed`                  | Compactor nodes can't be removed—see [Remove a compactor node](#remove-a-compactor-node)             |
 | Node belongs to a query group   | `cannot remove node 'NODE_ID' because it is a member of query group ...` | Remove the node from the query group first                                                          |
 | Unsnapshotted WAL remains       | `node 'NODE_ID' has unsnapshotted WAL (wal file N, snapshotted through M)` | Restart the node, stop it gracefully, then remove it—see [Recover a crashed node](/influxdb3/version/admin/recover-node/) |
-
-Trying to stop a node that's already stopped returns HTTP `400 Bad Request`
-with `tried to stop a node (NODE_ID) that is already stopped`.
 
 > [!Note]
 > #### The unsnapshotted WAL safeguard requires the upgraded storage engine
@@ -622,8 +735,43 @@ matches.
 See [When removal is refused](#when-removal-is-refused) for each condition and
 its resolution.
 Prefer restarting and gracefully stopping the node over
-[`--force-finalize`](/influxdb3/version/reference/cli/influxdb3/remove/node/#force-removal-of-a-node-that-did-not-shut-down-cleanly),
-which can delete unsnapshotted writes.
+[`--force-finalize`](/influxdb3/version/reference/cli/influxdb3/remove/node/#force-removal-of-a-node-that-did-not-shut-down-cleanly).
+Forcing removal discards the unsnapshotted writes the safeguard was protecting,
+and it starts an object-store cleanup for a node that never recorded a final
+snapshot.
+Restart the node, stop it gracefully, and then remove it.
+
+<!-- VERIFY (live instance) + PRODUCT DECISION: EAR #7030 (open, seen on
+     3.11.0) reports `remove node --force-finalize` against a zombie node
+     causing a SELF-PERPETUATING compactor panic loop
+     ("duplicate catalog subscription name: pt_compactor_restore") that kills
+     the node-removal driver, so removal never completes -- escalating in one
+     case to an unresponsive /health and a suspected deadlock.
+     If this is still reproducible on the current release, this warning is too
+     mild: `--force-finalize` on a node that never shut down cleanly can wedge
+     the cluster, not just lose writes. Decide with engineering whether to
+     document the stronger caution (and the
+     `grep 'duplicate catalog subscription'` compactor-log diagnostic) or wait
+     for the fix. -->
+
+
+### A node stays in removing
+
+Removal waits on the compactor, so a healthy cluster with a compaction backlog
+clears `removing` nodes slowly rather than never.
+See [Removal completes on the compactor's schedule](#removal-completes-on-the-compactors-schedule)
+for how to measure the remaining gap.
+
+Check whether the compactor is making progress at all before assuming the
+removal is stuck:
+
+- Confirm the compactor node is `running` and isn't restarting or being
+  OOM-killed.
+- Watch the compaction floors in `system.pt_compaction_nodes` advance between
+  queries.
+
+Don't scale a replacement node into a removing node's ID while you wait—the
+registration is refused until removal finishes.
 
 ### Nodes multiply in the catalog after each restart
 

--- a/content/shared/influxdb3-admin/node-lifecycle.md
+++ b/content/shared/influxdb3-admin/node-lifecycle.md
@@ -255,7 +255,9 @@ Use `--no-wait` to return as soon as the cluster accepts the request.
 > [!Important]
 > #### Run stop node against the live node—don't kill it first
 >
-> `stop node` is how a node drains its WAL tail and records a final snapshot.
+> `stop node` is how a node drains its
+> [WAL tail](/influxdb3/version/reference/internals/durability/#wal-tail) and
+> records a final snapshot.
 > If you kill the process first and run `stop node` afterward, the dead process
 > can't drain anything, and
 > [removing the node](/influxdb3/version/reference/cli/influxdb3/remove/node/)
@@ -332,8 +334,9 @@ influxdb3 stop node \
 
 This clears a stale `running` entry that would otherwise keep the cluster
 expecting a node that never comes back.
-Remember that a dead process can't drain its WAL tail, so treat the node as
-crashed and follow
+Remember that a dead process can't drain its
+[WAL tail](/influxdb3/version/reference/internals/durability/#wal-tail), so
+treat the node as crashed and follow
 [Recover a crashed node](/influxdb3/version/admin/recover-node/) before you
 remove it.
 {{% /show-in %}}
@@ -437,7 +440,8 @@ cases:
 > (the default for new clusters in {{% product-name %}} 3.11+).
 > Clusters on the Parquet engine, or still mid-upgrade, aren't guarded—on those
 > clusters, a graceful stop before removal is your only protection against
-> losing the WAL tail.
+> losing the
+> [WAL tail](/influxdb3/version/reference/internals/durability/#wal-tail).
 
 ### Remove a compactor node
 
@@ -540,7 +544,8 @@ Use a StatefulSet so pod names are stable and ordinal-based, and derive
 {{% show-in "enterprise" %}}
 The official
 [{{% product-name %}} Helm chart](https://github.com/influxdata/helm-charts/tree/master/charts/influxdb3-enterprise)
-does this already—it runs a StatefulSet per node mode and sets
+does this already—it runs a StatefulSet per
+[node mode](/influxdb3/version/admin/clustering/#configure-node-modes) and sets
 `--node-id=$(POD_NAME)` from `metadata.name`.
 {{% /show-in %}}
 {{% show-in "core" %}}
@@ -585,8 +590,10 @@ Never put
 in a `preStop` hook—it turns every rollout into a permanent decommission.
 
 **Sequence rollouts across node modes yourself.**
-The Helm chart runs a separate StatefulSet per node mode, but the image tag is a
-single chart-wide value, so one `helm upgrade` rolls every mode at once.
+The Helm chart runs a separate StatefulSet per
+[node mode](/influxdb3/version/admin/clustering/#configure-node-modes), but the
+image tag is a single chart-wide value, so one `helm upgrade` rolls every mode
+at once.
 Kubernetes doesn't order rollouts across StatefulSets, so a plain upgrade
 doesn't follow the
 [recommended node upgrade order](/influxdb3/version/admin/upgrade/#recommended-node-upgrade-order).
@@ -609,8 +616,9 @@ ingester:
     maxUnavailable: 1
 ```
 
-Set it per node mode (`ingester`, `querier`, `compactor`, and
-`processingEngine`).
+Set it per
+[node mode](/influxdb3/version/admin/clustering/#configure-node-modes)
+(`ingester`, `querier`, `compactor`, and `processingEngine`).
 The chart creates a budget for a mode only when that mode runs more than one
 replica, so single-replica modes still drain without protection—make sure their
 termination grace period is long enough to finish the final flush.
@@ -638,7 +646,9 @@ influxdb3 show nodes
 influxdb3 remove node --node-id NODE_ID
 ```
 
-**Disabling a node mode leaves its nodes in the catalog.**
+**Disabling a
+[node mode](/influxdb3/version/admin/clustering/#configure-node-modes) leaves
+its nodes in the catalog.**
 Setting a mode's `enabled: false` (for example, `compactor.enabled=false`)
 deletes that StatefulSet, but the nodes it ran keep their catalog entries.
 Stop and remove them deliberately, in that order, the same way you would after
@@ -674,7 +684,9 @@ TimeoutStopSec=300
 **Roll one node at a time.**
 Use `serial: 1` in your playbook and confirm each node returns to `running`
 before proceeding.
-Group your inventory by node mode and order the plays to match the
+Group your inventory by
+[node mode](/influxdb3/version/admin/clustering/#configure-node-modes) and order
+the plays to match the
 [recommended node upgrade order](/influxdb3/version/admin/upgrade/#recommended-node-upgrade-order)—for
 a complete playbook, see the **Ansible** tab in
 [Perform a rolling upgrade](/influxdb3/version/admin/upgrade/#perform-a-rolling-upgrade).

--- a/content/shared/influxdb3-admin/node-lifecycle.md
+++ b/content/shared/influxdb3-admin/node-lifecycle.md
@@ -480,6 +480,15 @@ influxdb3 show nodes
 influxdb3 remove node --node-id NODE_ID
 ```
 
+**Disabling a node mode leaves its nodes in the catalog.**
+Setting a mode's `enabled: false` (for example, `compactor.enabled=false`)
+deletes that StatefulSet, but the nodes it ran keep their catalog entries.
+Stop and remove them deliberately, in that order, the same way you would after
+scaling down.
+A [compactor node can't be removed](#remove-a-compactor-node) at all, so disable
+the compactor only when you're retiring the cluster or replacing it with a node
+that reuses the same node ID.
+
 **Uninstalling doesn't clean the catalog.**
 `helm uninstall` removes Kubernetes resources, but the catalog and object
 storage persist, and the nodes remain as catalog entries.

--- a/content/shared/influxdb3-admin/upgrade.md
+++ b/content/shared/influxdb3-admin/upgrade.md
@@ -335,13 +335,10 @@ count holds every pod in that StatefulSet at its current version.
 A partition lower than the replica count lets the pods at or above that ordinal
 update, so use a ceiling that your replica counts can't reach.
 
-<!-- VERIFY (chart): The identifiers below are written from the chart's
-     documented structure, not from a live release. Confirm against
-     influxdata/helm-charts: the values keys (querier, compactor,
+<!-- Verified against influxdata/helm-charts influxdb3-enterprise 0.9.0
+     (InfluxDB 3.10.5, commit 7a3289b): the values keys (querier, compactor,
      processingEngine) and the app.kubernetes.io/component label values
-     (ingester, querier) used to select each StatefulSet. Step 5 loops over
-     every StatefulSet in the namespace precisely to avoid depending on a
-     component label for the processing engine. -->
+     (ingester, querier) below are current. -->
 
 ```bash { placeholders="RELEASE_NAME|NAMESPACE|VERSION" }
 # 1. Freeze the modes you upgrade later, then apply the new image tag.

--- a/content/shared/influxdb3-admin/upgrade.md
+++ b/content/shared/influxdb3-admin/upgrade.md
@@ -394,6 +394,17 @@ Replace the following:
 > object-store files.
 > See [Restart compared to removal](/influxdb3/version/admin/node-lifecycle/#restart-compared-to-removal).
 
+> [!Caution]
+> #### helm rollback doesn't undo a catalog migration
+>
+> `helm rollback` reverts the image tag, but it can't revert changes the newer
+> version already made to your cluster data.
+> After a node starts {{% product-name %}} 3.10 or later, the on-disk catalog is
+> migrated to v3 and older binaries fail to start against it—so rolling the
+> release back leaves pods crash-looping on a catalog they can't read.
+> Restoring the catalog objects you backed up is the only way back.
+> See [Upgrading to InfluxDB 3.10 is a one-way migration](#upgrading-to-influxdb-310-is-a-one-way-migration).
+
 {{% /tab-content %}}
 {{% tab-content %}}
 

--- a/content/shared/influxdb3-admin/upgrade.md
+++ b/content/shared/influxdb3-admin/upgrade.md
@@ -541,7 +541,7 @@ Verify that your deployment assigns a stable
 [`--node-id`](/influxdb3/version/reference/config-options/#node-id)—a
 Kubernetes Deployment generates a new pod name on every rollout, so use a
 StatefulSet instead.
-See [Node lifecycle](/influxdb3/version/admin/node-lifecycle/#kubernetes-and-helm).
+See [Kubernetes and Helm](/influxdb3/version/admin/node-lifecycle/#kubernetes-and-helm).
 
 #### Version compatibility problems
 

--- a/content/shared/influxdb3-admin/upgrade.md
+++ b/content/shared/influxdb3-admin/upgrade.md
@@ -202,6 +202,8 @@ Follow these steps to upgrade each node in your deployment:
 [systemctl](#)
 [Docker](#)
 [Docker Compose](#)
+[Helm](#)
+[Ansible](#)
 {{% /tabs %}}
 {{% tab-content %}}
 
@@ -316,6 +318,147 @@ Replace the following:
 > The `influxdb:enterprise` tag always points to the latest InfluxDB 3 Enterprise release.
 > Update the `image:` field in your `compose.yaml` to `influxdb:enterprise` to pull the latest version, or specify a version tag directly (for example, `influxdb:{{< latest-patch >}}-enterprise`) to upgrade to a specific version.
 {{% /tab-content %}}
+{{% tab-content %}}
+
+The [{{% product-name %}} Helm chart](https://github.com/influxdata/helm-charts/tree/master/charts/influxdb3-enterprise)
+runs a separate StatefulSet for each node mode, but the image tag
+(`image.tag`) is a single chart-wide value.
+A plain `helm upgrade` therefore rolls _every_ node mode at once, and Kubernetes
+doesn't order rollouts across StatefulSets—so the upgrade doesn't follow the
+[recommended node upgrade order](#recommended-node-upgrade-order) on its own.
+
+To control the order, freeze the modes you aren't upgrading yet with the
+`updateStrategy.rollingUpdate.partition` field, then release them one mode at a
+time.
+Setting `partition` to a StatefulSet's replica count holds every pod in that
+StatefulSet at its current version.
+
+```bash { placeholders="RELEASE_NAME|NAMESPACE|VERSION" }
+# 1. Freeze the modes you upgrade later (partition >= replica count),
+#    then apply the new image tag. Only ingesters roll.
+helm upgrade RELEASE_NAME influxdata/influxdb3-enterprise \
+  --namespace NAMESPACE \
+  --reuse-values \
+  --set image.tag=VERSION-enterprise \
+  --set querier.updateStrategy.rollingUpdate.partition=99 \
+  --set compactor.updateStrategy.rollingUpdate.partition=99 \
+  --set processingEngine.updateStrategy.rollingUpdate.partition=99
+
+# 2. Wait for the ingester pods to roll and become ready
+kubectl rollout status --namespace NAMESPACE \
+  "$(kubectl get statefulset --namespace NAMESPACE \
+    --selector app.kubernetes.io/component=ingester --output name)"
+
+# 3. Release queriers, then compactor, then the processing engine
+helm upgrade RELEASE_NAME influxdata/influxdb3-enterprise \
+  --namespace NAMESPACE --reuse-values \
+  --set querier.updateStrategy.rollingUpdate.partition=0
+kubectl rollout status --namespace NAMESPACE \
+  "$(kubectl get statefulset --namespace NAMESPACE \
+    --selector app.kubernetes.io/component=querier --output name)"
+
+helm upgrade RELEASE_NAME influxdata/influxdb3-enterprise \
+  --namespace NAMESPACE --reuse-values \
+  --set compactor.updateStrategy.rollingUpdate.partition=0 \
+  --set processingEngine.updateStrategy.rollingUpdate.partition=0
+
+# 4. Verify every node re-registered and reports running
+influxdb3 show nodes
+```
+
+Replace the following:
+
+- {{% code-placeholder-key %}}`RELEASE_NAME`{{% /code-placeholder-key %}}: Your Helm release name
+- {{% code-placeholder-key %}}`NAMESPACE`{{% /code-placeholder-key %}}: The namespace of your release
+- {{% code-placeholder-key %}}`VERSION`{{% /code-placeholder-key %}}: The target version (for example, `{{< latest-patch >}}`)
+
+> [!Important]
+> #### Raise the termination grace period before upgrading
+>
+> The chart doesn't set `terminationGracePeriodSeconds`, so pods inherit the
+> Kubernetes default of 30 seconds.
+> If a node is still flushing its write-ahead log when Kubernetes sends
+> `SIGKILL`, it stops ungracefully and has to replay its WAL on restart.
+> Raise the grace period above your observed shutdown time before you roll a
+> cluster—see
+> [Deploy with an orchestrator](/influxdb3/version/admin/node-lifecycle/#kubernetes-and-helm).
+
+> [!Warning]
+> #### A rollout is a restart, not a removal
+>
+> Each pod keeps its StatefulSet-ordinal name, so every node re-registers under
+> its existing node ID.
+> Don't run
+> [`influxdb3 remove node`](/influxdb3/version/reference/cli/influxdb3/remove/node/)
+> as part of an upgrade—removal permanently deletes the node's catalog entry and
+> object-store files.
+> See [Restart compared to removal](/influxdb3/version/admin/node-lifecycle/#restart-compared-to-removal).
+
+{{% /tab-content %}}
+{{% tab-content %}}
+
+Drive the upgrade one node at a time with `serial: 1`, and order your plays by
+node mode to match the
+[recommended node upgrade order](#recommended-node-upgrade-order).
+
+```yaml
+# Upgrade one host at a time, ingest nodes first.
+- hosts: influxdb3_ingest
+  serial: 1
+  vars:
+    # Pin the target version so every host lands on the same build.
+    influxdb3_version: "{{< latest-patch >}}"
+  tasks:
+    - name: Stop influxdb3 gracefully
+      ansible.builtin.systemd_service:
+        name: influxdb3
+        state: stopped
+
+    # Replace this task with the install method you use--for example, a
+    # package from your own repository or the downloaded release archive.
+    # See https://docs.influxdata.com/influxdb3/enterprise/install/
+    - name: Install influxdb3 {{ influxdb3_version }}
+      ansible.builtin.include_role:
+        name: influxdb3_install
+
+    - name: Start influxdb3
+      ansible.builtin.systemd_service:
+        name: influxdb3
+        state: started
+
+    - name: Wait for the node to report healthy
+      ansible.builtin.uri:
+        url: "http://{{ inventory_hostname }}:8181/health"
+        status_code: 200
+      register: health
+      until: health.status == 200
+      retries: 30
+      delay: 10
+
+# Repeat for influxdb3_query, then influxdb3_compact, then influxdb3_process.
+```
+
+Because `systemd` escalates to `SIGKILL` after `TimeoutStopSec`, confirm your
+unit file allows enough time for the final WAL flush before you roll a cluster:
+
+```ini
+[Service]
+KillSignal=SIGTERM
+TimeoutStopSec=300
+```
+
+> [!Important]
+> #### Restart in place—don't remove nodes
+>
+> Each host restarts with the same
+> [`--node-id`](/influxdb3/version/reference/config-options/#node-id), so it
+> re-registers as the same node.
+> Never add
+> [`influxdb3 remove node`](/influxdb3/version/reference/cli/influxdb3/remove/node/)
+> to an upgrade playbook—see
+> [Restart compared to removal](/influxdb3/version/admin/node-lifecycle/#restart-compared-to-removal).
+
+{{% /tab-content %}}
 {{< /tabs-wrapper >}}
 
 **Repeat these steps** for each remaining node in the recommended order.
@@ -361,6 +504,33 @@ If writes fail during a rolling upgrade, verify that you're not attempting to ad
 #### Upgrade order issues
 
 If you upgrade nodes out of the [recommended order](#recommended-node-upgrade-order), you may experience longer periods where catalog modifications are blocked.
+
+#### Nodes upgrade out of order in Helm deployments
+
+The {{% product-name %}} Helm chart uses a single chart-wide `image.tag`, so a
+plain `helm upgrade` rolls every node mode at once instead of following the
+[recommended node upgrade order](#recommended-node-upgrade-order).
+Use `updateStrategy.rollingUpdate.partition` to release one mode at a time, as
+shown in the **Helm** tab of
+[Perform a rolling upgrade](#perform-a-rolling-upgrade).
+
+#### Nodes don't return to running after a rollout
+
+A node that was killed before it finished flushing its write-ahead log stops
+ungracefully and replays its WAL on restart, which can extend startup.
+In Kubernetes, this usually means `terminationGracePeriodSeconds` (default 30)
+is shorter than the node's shutdown time; with `systemd`, it usually means
+`TimeoutStopSec` is too low.
+See [Deploy with an orchestrator](/influxdb3/version/admin/node-lifecycle/#deploy-with-an-orchestrator).
+
+#### Extra nodes appear in the catalog after an upgrade
+
+Each restart registered a new node ID instead of reclaiming the existing one.
+Verify that your deployment assigns a stable
+[`--node-id`](/influxdb3/version/reference/config-options/#node-id)—a
+Kubernetes Deployment generates a new pod name on every rollout, so use a
+StatefulSet instead.
+See [Node lifecycle](/influxdb3/version/admin/node-lifecycle/#kubernetes-and-helm).
 
 #### Version compatibility problems
 

--- a/content/shared/influxdb3-admin/upgrade.md
+++ b/content/shared/influxdb3-admin/upgrade.md
@@ -330,26 +330,37 @@ doesn't order rollouts across StatefulSets—so the upgrade doesn't follow the
 To control the order, freeze the modes you aren't upgrading yet with the
 `updateStrategy.rollingUpdate.partition` field, then release them one mode at a
 time.
-Setting `partition` to a StatefulSet's replica count holds every pod in that
-StatefulSet at its current version.
+Setting `partition` to a value greater than or equal to a StatefulSet's replica
+count holds every pod in that StatefulSet at its current version.
+A partition lower than the replica count lets the pods at or above that ordinal
+update, so use a ceiling that your replica counts can't reach.
+
+<!-- VERIFY (chart): The identifiers below are written from the chart's
+     documented structure, not from a live release. Confirm against
+     influxdata/helm-charts: the values keys (querier, compactor,
+     processingEngine) and the app.kubernetes.io/component label values
+     (ingester, querier) used to select each StatefulSet. Step 5 loops over
+     every StatefulSet in the namespace precisely to avoid depending on a
+     component label for the processing engine. -->
 
 ```bash { placeholders="RELEASE_NAME|NAMESPACE|VERSION" }
-# 1. Freeze the modes you upgrade later (partition >= replica count),
-#    then apply the new image tag. Only ingesters roll.
+# 1. Freeze the modes you upgrade later, then apply the new image tag.
+#    Any partition >= a StatefulSet's replica count holds all of its pods, so
+#    10000 is a ceiling no deployment reaches. Only ingesters roll.
 helm upgrade RELEASE_NAME influxdata/influxdb3-enterprise \
   --namespace NAMESPACE \
   --reuse-values \
   --set image.tag=VERSION-enterprise \
-  --set querier.updateStrategy.rollingUpdate.partition=99 \
-  --set compactor.updateStrategy.rollingUpdate.partition=99 \
-  --set processingEngine.updateStrategy.rollingUpdate.partition=99
+  --set querier.updateStrategy.rollingUpdate.partition=10000 \
+  --set compactor.updateStrategy.rollingUpdate.partition=10000 \
+  --set processingEngine.updateStrategy.rollingUpdate.partition=10000
 
 # 2. Wait for the ingester pods to roll and become ready
 kubectl rollout status --namespace NAMESPACE \
   "$(kubectl get statefulset --namespace NAMESPACE \
     --selector app.kubernetes.io/component=ingester --output name)"
 
-# 3. Release queriers, then compactor, then the processing engine
+# 3. Release queriers and wait for them to roll
 helm upgrade RELEASE_NAME influxdata/influxdb3-enterprise \
   --namespace NAMESPACE --reuse-values \
   --set querier.updateStrategy.rollingUpdate.partition=0
@@ -357,12 +368,19 @@ kubectl rollout status --namespace NAMESPACE \
   "$(kubectl get statefulset --namespace NAMESPACE \
     --selector app.kubernetes.io/component=querier --output name)"
 
+# 4. Release the compactor and the processing engine. Process nodes have no
+#    ordering requirement, so they can roll alongside the compactor.
 helm upgrade RELEASE_NAME influxdata/influxdb3-enterprise \
   --namespace NAMESPACE --reuse-values \
   --set compactor.updateStrategy.rollingUpdate.partition=0 \
   --set processingEngine.updateStrategy.rollingUpdate.partition=0
 
-# 4. Verify every node re-registered and reports running
+# 5. Wait for the remaining StatefulSets to finish rolling before verifying
+for sts in $(kubectl get statefulset --namespace NAMESPACE --output name); do
+  kubectl rollout status --namespace NAMESPACE "$sts"
+done
+
+# 6. Verify every node re-registered and reports running
 influxdb3 show nodes
 ```
 

--- a/content/shared/influxdb3-cli/remove/node.md
+++ b/content/shared/influxdb3-cli/remove/node.md
@@ -9,7 +9,8 @@ catalog entry and the node's object-store file paths are purged.
 > A node must be `stopped` before it can be removed.
 > Use [`influxdb3 stop node`](/influxdb3/version/reference/cli/influxdb3/stop/node/)
 > against the live node and wait for it to reach `stopped`—the graceful stop
-> is what drains the node's write-ahead log (WAL) tail.
+> is what drains the node's
+> [write-ahead log (WAL) tail](/influxdb3/version/reference/internals/durability/#wal-tail).
 > A node stuck in `stopping` (for example, because the process was killed
 > mid-stop or was already dead) cannot be removed normally.
 > To recover such a node safely, follow
@@ -65,7 +66,8 @@ That is why the node must complete a graceful stop first.
 
 On clusters that have fully adopted the upgraded storage engine (the default
 for new clusters), {{% product-name %}} **refuses** (HTTP 409) to remove a
-`stopped` node that still has an unsnapshotted WAL tail:
+`stopped` node that still has an unsnapshotted
+[WAL tail](/influxdb3/version/reference/internals/durability/#wal-tail):
 
 ```text
 node 'NODE_ID' has unsnapshotted WAL (wal file N, snapshotted through M);
@@ -86,7 +88,8 @@ and then remove it.
 > Parquet clusters and clusters still mid-upgrade are **not** guarded.
 > On those clusters, a graceful
 > [`stop node`](/influxdb3/version/reference/cli/influxdb3/stop/node/) before
-> removal is the only protection against losing the WAL tail.
+> removal is the only protection against losing the
+> [WAL tail](/influxdb3/version/reference/internals/durability/#wal-tail).
 
 ## Force removal of a node that did not shut down cleanly {#force-removal-of-a-node-that-did-not-shut-down-cleanly metadata="v3.11+"}
 

--- a/content/shared/influxdb3-cli/remove/node.md
+++ b/content/shared/influxdb3-cli/remove/node.md
@@ -90,6 +90,17 @@ and then remove it.
 > [`stop node`](/influxdb3/version/reference/cli/influxdb3/stop/node/) before
 > removal is the only protection against losing the
 > [WAL tail](/influxdb3/version/reference/internals/durability/#wal-tail).
+>
+> To determine which engine your cluster runs, start with how it was created:
+> new clusters on {{% product-name %}} 3.11+ default to the upgraded storage
+> engine, and clusters that started on 3.10 or earlier keep the Parquet engine
+> until you restart them with `--upgrade-pacha-tree`.
+> If you started a storage engine upgrade, confirm it finished—query
+> `system.upgrade_parquet_node` and check that every node reports `completed`.
+> See [Query system data](/influxdb3/version/admin/query-system-data/#query-storage-engine-tables).
+
+For more information about the upgraded storage engine, see
+[Storage engine](/influxdb3/version/reference/internals/storage-engine/).
 
 ## Force removal of a node that did not shut down cleanly {#force-removal-of-a-node-that-did-not-shut-down-cleanly metadata="v3.11+"}
 

--- a/content/shared/influxdb3-cli/stop/node.md
+++ b/content/shared/influxdb3-cli/stop/node.md
@@ -17,7 +17,8 @@ Use `--no-wait` to return as soon as the stop request is accepted.
 > [!Important]
 > #### Run this command against the live node—do not kill it first
 >
-> `stop node` is how a node drains its WAL tail.
+> `stop node` is how a node drains its
+> [WAL tail](/influxdb3/version/reference/internals/durability/#wal-tail).
 > If you kill the process first (for example, with `kill -9` or by
 > force-stopping a container) and run `stop node` afterward, the dead process
 > cannot drain anything: recently acknowledged writes that were not yet
@@ -69,8 +70,9 @@ You can use the following environment variables to set command options:
 The node lifecycle is two-phase: `stop node` marks the node `stopping`, but
 the node only reads as `stopped` after its own stop cascade completes and it
 confirms the stop.
-That cascade is what drains the node's WAL tail (Parquet: WAL flush;
-upgraded engine: WAL snapshot).
+That cascade is what drains the node's
+[WAL tail](/influxdb3/version/reference/internals/durability/#wal-tail)
+(Parquet: WAL flush; upgraded engine: WAL snapshot).
 
 - By default, the command polls the node state (from `system.nodes`) until it
   reaches `stopped`, up to `--timeout` (default `5m`).
@@ -88,7 +90,8 @@ upgraded engine: WAL snapshot).
 
 Running `stop node` against a node whose process is **already dead** cannot
 drain anything: the catalog still moves the node toward `stopped`, but the
-WAL tail remains at risk until the node is restarted.
+[WAL tail](/influxdb3/version/reference/internals/durability/#wal-tail)
+remains at risk until the node is restarted.
 See [Recover a crashed node](/influxdb3/version/admin/recover-node/).
 
 ## Examples

--- a/content/shared/influxdb3-cli/stop/node.md
+++ b/content/shared/influxdb3-cli/stop/node.md
@@ -70,9 +70,18 @@ You can use the following environment variables to set command options:
 The node lifecycle is two-phase: `stop node` marks the node `stopping`, but
 the node only reads as `stopped` after its own stop cascade completes and it
 confirms the stop.
+<!-- VERIFY (eng/product review): Naming of the per-engine drain step.
+     This said "Parquet: WAL flush" until now, but WAL flush is a different
+     operation -- it writes the WAL buffer to WAL files every
+     --wal-flush-interval (default 1s) and runs constantly, so it isn't what a
+     graceful stop forces. Data durability says buffered writes stay in the WAL
+     "until the next Parquet persistence captures it", so Parquet persistence
+     is the step a stop must force on the Parquet engine. Confirm that reading,
+     and that "WAL snapshot" is right for the upgraded engine. Same
+     parenthetical appears in admin/recover-node.md step 2. -->
 That cascade is what drains the node's
 [WAL tail](/influxdb3/version/reference/internals/durability/#wal-tail)
-(Parquet: WAL flush; upgraded engine: WAL snapshot).
+(Parquet engine: Parquet persistence; upgraded engine: WAL snapshot).
 
 - By default, the command polls the node state (from `system.nodes`) until it
   reaches `stopped`, up to `--timeout` (default `5m`).

--- a/content/shared/influxdb3-cli/stop/node.md
+++ b/content/shared/influxdb3-cli/stop/node.md
@@ -77,11 +77,13 @@ confirms the stop.
      graceful stop forces. Data durability says buffered writes stay in the WAL
      "until the next Parquet persistence captures it", so Parquet persistence
      is the step a stop must force on the Parquet engine. Confirm that reading,
-     and that "WAL snapshot" is right for the upgraded engine. Same
-     parenthetical appears in admin/recover-node.md step 2. -->
+     and that "WAL snapshot" is right for the upgraded engine. The same
+     distinction appears in admin/recover-node.md step 2. -->
 That cascade is what drains the node's
-[WAL tail](/influxdb3/version/reference/internals/durability/#wal-tail)
-(Parquet engine: Parquet persistence; upgraded engine: WAL snapshot).
+[WAL tail](/influxdb3/version/reference/internals/durability/#wal-tail).
+How the node drains it depends on the storage engine:
+on the Parquet engine, the node persists the buffered writes to Parquet
+files; on the upgraded storage engine, it captures them in a WAL snapshot.
 
 - By default, the command polls the node state (from `system.nodes`) until it
   reaches `stopped`, up to `--timeout` (default `5m`).

--- a/measure.mjs
+++ b/measure.mjs
@@ -1,0 +1,25 @@
+import { chromium } from 'playwright';
+const url = process.argv[2], out = process.argv[3];
+const b = await chromium.launch({ executablePath: '/opt/pw-browsers/chromium' });
+const p = await b.newPage({ viewport: { width: 1280, height: 1400 } });
+await p.goto(url, { waitUntil: 'networkidle' });
+await p.waitForSelector('.mermaid[data-processed="true"]', { timeout: 20000 });
+await p.waitForTimeout(800);
+const m = await p.evaluate(() => {
+  const px = el => el ? getComputedStyle(el).fontSize : null;
+  const c = document.querySelector('.mermaid');
+  const svg = c.querySelector('svg');
+  const r = svg.getBoundingClientRect();
+  const edge = [...c.querySelectorAll('.edgeLabel')].filter(e=>e.textContent.trim());
+  const node = [...c.querySelectorAll('.nodeLabel')];
+  return {
+    containerWidth: Math.round(c.getBoundingClientRect().width),
+    svgWidth: Math.round(r.width), svgHeight: Math.round(r.height),
+    svgMaxWidth: svg.style.maxWidth || getComputedStyle(svg).maxWidth,
+    edgeSizes: [...new Set(edge.map(px))],
+    nodeSizes: [...new Set(node.map(px))],
+  };
+});
+console.log(JSON.stringify(m));
+await (await p.$('.mermaid')).screenshot({ path: out });
+await b.close();

--- a/vb.mjs
+++ b/vb.mjs
@@ -1,0 +1,17 @@
+import { chromium } from 'playwright';
+const b = await chromium.launch({ executablePath: '/opt/pw-browsers/chromium' });
+const p = await b.newPage({ viewport: { width: 1280, height: 1400 } });
+await p.goto(process.argv[2], { waitUntil: 'networkidle' });
+await p.waitForSelector('.mermaid[data-processed="true"]');
+await p.waitForTimeout(600);
+console.log(await p.evaluate(() => {
+  const s = document.querySelector('.mermaid svg');
+  return JSON.stringify({
+    viewBox: s.getAttribute('viewBox'),
+    widthAttr: s.getAttribute('width'),
+    heightAttr: s.getAttribute('height'),
+    preserveAR: s.getAttribute('preserveAspectRatio'),
+    foreignObjects: s.querySelectorAll('foreignObject').length,
+  });
+}));
+await b.close();


### PR DESCRIPTION
Add a Node lifecycle page for InfluxDB 3 Core and Enterprise that documents
how a node moves through the catalog states it registers itself in.

Shared content (content/shared/influxdb3-admin/node-lifecycle.md):

- Node states (running, stopping, stopped, removing) and node identity
  (node ID compared to instance ID)
- Lifecycle state diagrams, scoped per product
- Register, stop, remove, and re-register a node, including the two paths to
  stopped and why only a graceful stop node records a final snapshot
- Conditions under which removal is refused (409) and how to resolve each
- Restart compared to removal, the most common way to lose data during
  routine maintenance
- Deploy with an orchestrator: Kubernetes/Helm and Ansible/systemd
- Verify node state and troubleshoot lifecycle issues

Orchestrated upgrades (content/shared/influxdb3-admin/upgrade.md):

- Add Helm and Ansible tabs to the multi-node rolling upgrade procedure.
  The Helm chart uses a single chart-wide image.tag and a StatefulSet per
  node mode, so a plain helm upgrade rolls every mode at once and does not
  follow the recommended node upgrade order. Document sequencing rollouts
  with updateStrategy.rollingUpdate.partition.
- Add troubleshooting entries for out-of-order Helm rollouts, nodes that
  do not return to running after a rollout, and catalog entries that
  multiply when a deployment assigns unstable node IDs.

Cross-link the lifecycle page from clustering, recover-node, the Kubernetes
install page, and the remove/show/stop node CLI references, and link the
lifecycle and upgrade troubleshooting sections to each other.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WUNvDmPaYvcFX5rchCiYhF