### PR TITLE
fix(diagrams): add natural-size and center options to the diagram shortcode

### DIFF
--- a/DOCS-SHORTCODES.md
+++ b/DOCS-SHORTCODES.md
@@ -491,6 +491,22 @@ That --> There
 {{< /diagram >}}
 ```
 
+The shortcode accepts optional parameters that adjust how the diagram renders:
+
+- `natural-size`: Render the diagram at Mermaid's natural size.
+  By default, diagrams scale up to fill the article column (up to 680px wide),
+  which can blow up narrow diagrams such as top-down flowcharts.
+- `center`: Center the diagram in the article column.
+  By default, diagrams are left-aligned.
+
+```md
+{{< diagram natural-size center >}}
+graph TD
+This --> That
+That --> There
+{{< /diagram >}}
+```
+
 ### File system diagrams
 
 Use the `{{< filesystem-diagram >}}` shortcode to create a styled file system diagram using a Markdown unordered list.

--- a/assets/styles/layouts/article/_diagrams.scss
+++ b/assets/styles/layouts/article/_diagrams.scss
@@ -5,13 +5,25 @@
   transition: opacity .5s;
   font-family: $proxima;
 
-  svg {
-    // Mermaid pins an inline max-width to the diagram's natural pixel size,
-    // so diagrams render small in a wide article column. The svg carries a
-    // viewBox, so lifting the cap scales the whole diagram proportionally.
-    // The svg already carries width="100%", so it never exceeds the column;
-    // this ceiling just stops the scale-up from dwarfing body text.
-    // Avoid CSS min() here -- Sass evaluates it and fails on mixed units.
+  // Diagrams are left-aligned by default. Pass {{< diagram center >}} to
+  // center one in the article column. svg is inline by default, so it needs
+  // to be a block for auto margins to apply.
+  &.center svg {
+    display: block;
+    margin: 0 auto;
+  }
+
+  // Mermaid pins an inline max-width to the diagram's natural pixel size,
+  // so wide diagrams render small in a wide article column. The svg carries
+  // a viewBox, so lifting the cap scales the whole diagram proportionally.
+  // The svg already carries width="100%", so it never exceeds the column;
+  // this ceiling just stops the scale-up from dwarfing body text.
+  // Narrow diagrams (e.g. a top-down flowchart) scale up far past that
+  // intent -- 236px natural rendered at 680px is a 2.9x blow-up -- so
+  // {{< diagram natural-size >}} opts a diagram out and keeps Mermaid's
+  // natural size.
+  // Avoid CSS min() here -- Sass evaluates it and fails on mixed units.
+  &:not(.natural-size) svg {
     max-width: 680px !important;
   }
 

--- a/content/telegraf/v1/concepts/data-pipeline.md
+++ b/content/telegraf/v1/concepts/data-pipeline.md
@@ -19,7 +19,7 @@ Every metric that Telegraf handles follows the same path: input plugins
 collect it, processor and aggregator plugins transform it, and output plugins
 write it to one or more destinations.
 
-{{< diagram >}}
+{{< diagram natural-size center >}}
 graph TD
   Inputs[<strong>Input plugins</strong> \n <em>Collect and parse</em>]
   P1[<strong>Processor plugins</strong> \n <em>First pass</em>]

--- a/layouts/shortcodes/diagram.html
+++ b/layouts/shortcodes/diagram.html
@@ -1,3 +1,3 @@
-<div class="mermaid" data-component="diagram">
+<div class="mermaid{{ range .Params }} {{ . }}{{ end }}" data-component="diagram">
   {{.Inner}}
 </div>


### PR DESCRIPTION
**What changed:**
The diagram shortcode now passes its parameters through as classes on the .mermaid container, and the diagram styles honor two of them: `natural-size` opts a diagram out of the global 680px column-fill scale-up, and `center`centers a diagram in the article column. The Telegraf data-pipeline diagram uses both, and `DOCS-SHORTCODES.md` documents the options.

**Why:**
The column-fill scale-up added in `7f10cdbf1` lifts Mermaid's natural-size cap unconditionally.
It was measured against the wide node-lifecycle diagram (504px natural, a 1.35x scale-up), but the data-pipeline page's top-down flowchart is only 236px wide, so the same rule blew it up 2.88x to 680x2197px with ~46px effective label text.

**Impact:**
Diagrams that pass no parameters render exactly as before. The data-pipeline diagram returns to its natural 236x763px size with 16px labels, centered in the article column.

**Verification:**
Hugo test server builds with no template errors.
Headless-Chrome measurements: data-pipeline renders 236px wide with equal 298px side gaps; node-lifecycle (no parameters) is unchanged at 680x928px, left-aligned.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
