### PR TITLE
docs(influxdb3-cloud): add product lineup and version detection

### DIFF
--- a/PLATFORM_REFERENCE.md
+++ b/PLATFORM_REFERENCE.md
@@ -70,7 +70,7 @@ InfluxDB Cloud Dedicated:
 - Query languages: SQL, InfluxQL
 - Host hint: `cluster-id.a.influxdb.io`
 - Characteristics: Paid, Cloud, SQL/InfluxQL, Token, Databases
-- URL contains hints: influxdb.io
+- URL contains hints: a.influxdb.io
 
 InfluxDB Clustered:
 

--- a/assets/js/influxdb-version-detector.ts
+++ b/assets/js/influxdb-version-detector.ts
@@ -12,7 +12,8 @@
  *     |
  *     ├─→ URL matches known cloud patterns?
  *     │   │
- *     │   ├─→ YES: Contains "influxdb.io" → **InfluxDB Cloud Dedicated** ✓
+ *     │   ├─→ YES: Contains ".enterprise.influxdb.io" → **InfluxDB 3 Cloud** ✓
+ *     │   ├─→ YES: Contains ".a.influxdb.io" → **InfluxDB Cloud Dedicated** ✓
  *     │   ├─→ YES: Contains "cloud2.influxdata.com" regions → **InfluxDB Cloud Serverless** ✓
  *     │   ├─→ YES: Contains "influxcloud.net" → **InfluxDB Cloud 1** ✓
  *     │   └─→ YES: Contains other cloud2 regions → **InfluxDB Cloud (TSM)** ✓
@@ -190,6 +191,7 @@ class InfluxDBVersionDetector {
   private static readonly HOST_EXAMPLES: Record<string, string> = {
     influxdb3_core: 'http://localhost:8181',
     influxdb3_enterprise: 'http://localhost:8181',
+    influxdb3_cloud: 'https://instance-id.enterprise.influxdb.io',
     influxdb3_cloud_serverless: 'https://cloud2.influxdata.com',
     influxdb3_cloud_dedicated: 'https://cluster-id.a.influxdb.io',
     influxdb3_clustered: 'https://cluster-host.com',
@@ -245,7 +247,7 @@ class InfluxDBVersionDetector {
     influxdbUrls: Record<string, unknown>;
   } {
     let products: Products = {};
-    let influxdbUrls: Record<string, unknown> = {};
+    let influxdbUrls: Record<string, unknown>;
 
     // Parse products data - Hugo always provides this data
     const productsData = this.container.getAttribute('data-products');
@@ -534,6 +536,7 @@ class InfluxDBVersionDetector {
       serverless: 'InfluxDB Cloud Serverless',
       core: 'InfluxDB 3 Core',
       enterprise: 'InfluxDB 3 Enterprise',
+      cloud3: 'InfluxDB 3 Cloud',
       dedicated: 'InfluxDB Cloud Dedicated',
       clustered: 'InfluxDB Clustered',
       custom: 'Custom URL',
@@ -541,6 +544,7 @@ class InfluxDBVersionDetector {
       // Raw product keys from products.yml (used in scoring)
       influxdb3_core: 'InfluxDB 3 Core',
       influxdb3_enterprise: 'InfluxDB 3 Enterprise',
+      influxdb3_cloud: 'InfluxDB 3 Cloud',
       influxdb3_cloud_serverless: 'InfluxDB Cloud Serverless',
       influxdb3_cloud_dedicated: 'InfluxDB Cloud Dedicated',
       influxdb3_clustered: 'InfluxDB Clustered',
@@ -559,6 +563,7 @@ class InfluxDBVersionDetector {
     const productMapping: Record<string, string> = {
       core: 'influxdb3_core',
       enterprise: 'influxdb3_enterprise',
+      cloud3: 'influxdb3_cloud',
       serverless: 'influxdb3_cloud_serverless',
       dedicated: 'influxdb3_cloud_dedicated',
       clustered: 'influxdb3_clustered',
@@ -733,12 +738,27 @@ class InfluxDBVersionDetector {
     }
 
     const urlLower = url.toLowerCase();
+    let hostname = urlLower;
+
+    try {
+      const urlWithScheme = urlLower.includes('://')
+        ? urlLower
+        : `https://${urlLower}`;
+      hostname = new URL(urlWithScheme).hostname;
+    } catch {
+      // Keep the original input for keyword-based detection below.
+    }
 
     // PRIORITY 1: Check for definitive cloud patterns first (per decision tree)
     // These should be checked before localhost patterns for accuracy
 
-    // InfluxDB Cloud Dedicated: Contains "influxdb.io"
-    if (urlLower.includes('influxdb.io')) {
+    // InfluxDB 3 Cloud: instance hostname ends in enterprise.influxdb.io
+    if (hostname.endsWith('.enterprise.influxdb.io')) {
+      return { likelyProduct: 'cloud3', confidence: 1.0 };
+    }
+
+    // InfluxDB Cloud Dedicated: cluster hostname ends in a.influxdb.io
+    if (hostname.endsWith('.a.influxdb.io')) {
       return { likelyProduct: 'dedicated', confidence: 1.0 };
     }
 
@@ -1527,7 +1547,7 @@ docker logs &lt;container&gt; 2>&amp;1 | head -20</div>
             'InfluxDB OSS 2.x',
             'InfluxDB OSS 1.x',
           ];
-          let freeLinks = '';
+          let freeLinks: string;
           if (this.pageContext === 'grafana') {
             freeLinks = freeProducts
               .map((product) => {
@@ -1560,10 +1580,11 @@ docker logs &lt;container&gt; 2>&amp;1 | head -20</div>
         } else if (answer === 'paid') {
           const paidProducts = [
             'InfluxDB 3 Enterprise',
+            'InfluxDB 3 Cloud',
             'InfluxDB Cloud Dedicated',
             'InfluxDB Cloud Serverless',
           ];
-          let paidLinks = '';
+          let paidLinks: string;
           if (this.pageContext === 'grafana') {
             paidLinks = paidProducts
               .map((product) => {
@@ -1664,6 +1685,7 @@ docker logs &lt;container&gt; 2>&amp;1 | head -20</div>
     const DOC_LINKS: Record<string, string> = {
       'InfluxDB 3 Core': '/influxdb3/core/',
       'InfluxDB 3 Enterprise': '/influxdb3/enterprise/',
+      'InfluxDB 3 Cloud': '/influxdb3/cloud/',
       'InfluxDB Cloud Dedicated': '/influxdb3/cloud-dedicated/',
       'InfluxDB Cloud Serverless': '/influxdb3/cloud-serverless/',
       'InfluxDB OSS 1.x': '/influxdb/v1/',
@@ -1684,6 +1706,7 @@ docker logs &lt;container&gt; 2>&amp;1 | head -20</div>
     const AI_CONTEXTS: Record<string, string> = {
       'InfluxDB 3 Core': 'InfluxDB 3 Core',
       'InfluxDB 3 Enterprise': 'InfluxDB 3 Enterprise',
+      'InfluxDB 3 Cloud': 'InfluxDB 3 Cloud',
       'InfluxDB Cloud Dedicated': 'InfluxDB Cloud Dedicated',
       'InfluxDB Cloud Serverless': 'InfluxDB Cloud Serverless',
       'InfluxDB OSS 1.x': 'InfluxDB OSS v1',
@@ -1706,6 +1729,7 @@ docker logs &lt;container&gt; 2>&amp;1 | head -20</div>
     const PRODUCT_KEY_MAP: Record<string, string> = {
       'InfluxDB 3 Core': 'influxdb3_core',
       'InfluxDB 3 Enterprise': 'influxdb3_enterprise',
+      'InfluxDB 3 Cloud': 'influxdb3_cloud',
       'InfluxDB Cloud Dedicated': 'influxdb3_cloud_dedicated',
       'InfluxDB Cloud Serverless': 'influxdb3_cloud_serverless',
       'InfluxDB OSS 1.x': 'influxdb',
@@ -1842,6 +1866,7 @@ docker logs &lt;container&gt; 2>&amp;1 | head -20</div>
     const KEY_TO_FULL_NAME_MAP: Record<string, string> = {
       core: 'InfluxDB 3 Core',
       enterprise: 'InfluxDB 3 Enterprise',
+      cloud3: 'InfluxDB 3 Cloud',
       serverless: 'InfluxDB Cloud Serverless',
       dedicated: 'InfluxDB Cloud Dedicated',
       clustered: 'InfluxDB Clustered',
@@ -1860,6 +1885,7 @@ docker logs &lt;container&gt; 2>&amp;1 | head -20</div>
     const PRODUCT_RELEASE_DATES: Record<string, Date> = {
       'InfluxDB 3 Core': new Date('2025-01-01'),
       'InfluxDB 3 Enterprise': new Date('2025-01-01'),
+      'InfluxDB 3 Cloud': new Date('2026-01-01'),
       'InfluxDB Cloud Serverless': new Date('2024-01-01'),
       'InfluxDB Cloud Dedicated': new Date('2024-01-01'),
       'InfluxDB Clustered': new Date('2024-01-01'),
@@ -1913,6 +1939,7 @@ docker logs &lt;container&gt; 2>&amp;1 | head -20</div>
       scores['InfluxDB Enterprise'] = -1000;
       scores['InfluxDB Clustered'] = -1000;
     } else if (this.answers.hosted === 'self' || !this.answers.isCloud) {
+      scores['InfluxDB 3 Cloud'] = -1000;
       scores['InfluxDB Cloud Dedicated'] = -1000;
       scores['InfluxDB Cloud Serverless'] = -1000;
       scores['InfluxDB Cloud (TSM)'] = -1000;
@@ -1928,11 +1955,13 @@ docker logs &lt;container&gt; 2>&amp;1 | head -20</div>
       scores['InfluxDB Cloud (TSM)'] += 10;
 
       scores['InfluxDB 3 Enterprise'] = -1000;
+      scores['InfluxDB 3 Cloud'] = -1000;
       scores['InfluxDB Enterprise'] = -1000;
       scores['InfluxDB Clustered'] = -1000;
       scores['InfluxDB Cloud Dedicated'] = -1000;
     } else if (this.answers.paid === 'paid') {
       scores['InfluxDB 3 Enterprise'] += 25;
+      scores['InfluxDB 3 Cloud'] += 20;
       scores['InfluxDB Enterprise'] += 20;
       scores['InfluxDB Clustered'] += 15;
       scores['InfluxDB Cloud Dedicated'] += 20;
@@ -1982,6 +2011,7 @@ docker logs &lt;container&gt; 2>&amp;1 | head -20</div>
     if (this.answers.language === 'sql') {
       scores['InfluxDB 3 Core'] += 40;
       scores['InfluxDB 3 Enterprise'] += 40;
+      scores['InfluxDB 3 Cloud'] += 30;
       scores['InfluxDB Cloud Dedicated'] += 30;
       scores['InfluxDB Cloud Serverless'] += 30;
       scores['InfluxDB Clustered'] += 30;
@@ -2001,6 +2031,7 @@ docker logs &lt;container&gt; 2>&amp;1 | head -20</div>
       scores['InfluxDB OSS 1.x'] = -1000;
       scores['InfluxDB 3 Core'] = -1000;
       scores['InfluxDB 3 Enterprise'] = -1000;
+      scores['InfluxDB 3 Cloud'] = -1000;
       scores['InfluxDB Cloud Dedicated'] = -1000;
       scores['InfluxDB Clustered'] = -1000;
     } else if (this.answers.language === 'influxql') {
@@ -2012,6 +2043,7 @@ docker logs &lt;container&gt; 2>&amp;1 | head -20</div>
       scores['InfluxDB Cloud (TSM)'] += 20;
       scores['InfluxDB 3 Core'] += 25;
       scores['InfluxDB 3 Enterprise'] += 25;
+      scores['InfluxDB 3 Cloud'] += 25;
       scores['InfluxDB Cloud Dedicated'] += 25;
       scores['InfluxDB Cloud Serverless'] += 25;
       scores['InfluxDB Clustered'] += 25;
@@ -2129,6 +2161,14 @@ docker logs &lt;container&gt; 2>&amp;1 | head -20</div>
                 <td>8086</td>
                 <td>No</td>
                 <td>InfluxQL, Flux</td>
+              </tr>
+              <tr>
+                <td class="product-name"><a href="/influxdb3/cloud/">InfluxDB 3 Cloud</a></td>
+                <td>Paid only</td>
+                <td>Cloud</td>
+                <td>N/A</td>
+                <td>No</td>
+                <td>SQL, InfluxQL</td>
               </tr>
               <tr>
                 <td class="product-name"><a href="/influxdb3/cloud-dedicated/">InfluxDB Cloud Dedicated</a></td>

--- a/assets/js/influxdb-version-detector.ts
+++ b/assets/js/influxdb-version-detector.ts
@@ -753,12 +753,12 @@ class InfluxDBVersionDetector {
     // These should be checked before localhost patterns for accuracy
 
     // InfluxDB 3 Cloud: instance hostname ends in enterprise.influxdb.io
-    if (hostname.endsWith('.enterprise.influxdb.io')) {
+    if (this.isDomainOrSubdomain(hostname, 'enterprise.influxdb.io')) {
       return { likelyProduct: 'cloud3', confidence: 1.0 };
     }
 
     // InfluxDB Cloud Dedicated: cluster hostname ends in a.influxdb.io
-    if (hostname.endsWith('.a.influxdb.io')) {
+    if (this.isDomainOrSubdomain(hostname, 'a.influxdb.io')) {
       return { likelyProduct: 'dedicated', confidence: 1.0 };
     }
 
@@ -888,6 +888,10 @@ class InfluxDBVersionDetector {
     }
 
     return { likelyProduct: null, confidence: 0 };
+  }
+
+  private isDomainOrSubdomain(hostname: string, domain: string): boolean {
+    return hostname === domain || hostname.endsWith(`.${domain}`);
   }
 
   private render(): void {

--- a/content/enterprise_influxdb/v1/administration/identify-version.md
+++ b/content/enterprise_influxdb/v1/administration/identify-version.md
@@ -12,6 +12,7 @@ alt_links:
   v1: /influxdb/v1/administration/identify-version/
   v2: /influxdb/v2/admin/identify-version/
   cloud: /influxdb/cloud/admin/identify-version/
+  cloud3: /influxdb3/cloud/admin/identify-version/
   cloud-serverless: /influxdb3/cloud-serverless/admin/identify-version/
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/identify-version/
   clustered: /influxdb3/clustered/admin/identify-version/

--- a/content/influxdb/cloud/admin/identify-version.md
+++ b/content/influxdb/cloud/admin/identify-version.md
@@ -13,6 +13,7 @@ related:
 alt_links:
   v1: /influxdb/v1/administration/identify-version/
   v2: /influxdb/v2/admin/identify-version/
+  cloud3: /influxdb3/cloud/admin/identify-version/
   cloud-serverless: /influxdb3/cloud-serverless/admin/identify-version/
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/identify-version/
   clustered: /influxdb3/clustered/admin/identify-version/

--- a/content/influxdb/v1/administration/identify-version.md
+++ b/content/influxdb/v1/administration/identify-version.md
@@ -11,6 +11,7 @@ related:
 alt_links:
   v2: /influxdb/v2/admin/identify-version/
   cloud: /influxdb/cloud/admin/identify-version/
+  cloud3: /influxdb3/cloud/admin/identify-version/
   cloud-serverless: /influxdb3/cloud-serverless/admin/identify-version/
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/identify-version/
   clustered: /influxdb3/clustered/admin/identify-version/

--- a/content/influxdb/v2/admin/identify-version.md
+++ b/content/influxdb/v2/admin/identify-version.md
@@ -14,6 +14,7 @@ related:
 alt_links:
   v1: /influxdb/v1/administration/identify-version/
   cloud: /influxdb/cloud/admin/identify-version/
+  cloud3: /influxdb3/cloud/admin/identify-version/
   cloud-serverless: /influxdb3/cloud-serverless/admin/identify-version/
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/identify-version/
   clustered: /influxdb3/clustered/admin/identify-version/

--- a/content/influxdb3/cloud-dedicated/admin/identify-version.md
+++ b/content/influxdb3/cloud-dedicated/admin/identify-version.md
@@ -14,6 +14,7 @@ alt_links:
   v1: /influxdb/v1/administration/identify-version/
   v2: /influxdb/v2/admin/identify-version/
   cloud: /influxdb/cloud/admin/identify-version/
+  cloud3: /influxdb3/cloud/admin/identify-version/
   cloud-serverless: /influxdb3/cloud-serverless/admin/identify-version/
   clustered: /influxdb3/clustered/admin/identify-version/
   core: /influxdb3/core/admin/identify-version/

--- a/content/influxdb3/cloud-serverless/admin/identify-version.md
+++ b/content/influxdb3/cloud-serverless/admin/identify-version.md
@@ -14,6 +14,7 @@ alt_links:
   v1: /influxdb/v1/administration/identify-version/
   v2: /influxdb/v2/admin/identify-version/
   cloud: /influxdb/cloud/admin/identify-version/
+  cloud3: /influxdb3/cloud/admin/identify-version/
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/identify-version/
   clustered: /influxdb3/clustered/admin/identify-version/
   core: /influxdb3/core/admin/identify-version/

--- a/content/influxdb3/cloud/admin/identify-version.md
+++ b/content/influxdb3/cloud/admin/identify-version.md
@@ -1,24 +1,27 @@
 ---
-title: Identify InfluxDB Clustered version
-description: Learn how to identify your InfluxDB Clustered version using influxctl CLI and other methods.
+title: Identify InfluxDB 3 Cloud version
+description: Learn how to identify your InfluxDB 3 Cloud instance using command-line tools, HTTP endpoints, and other methods.
 menu:
-  influxdb3_clustered:
+  influxdb3_cloud:
     name: Identify version
-    parent: Administer InfluxDB Clustered
+    parent: Administer InfluxDB
 weight: 10
 source: /shared/identify-version.md
 related:
-  - /influxdb3/clustered/get-started/
-  - /influxdb3/clustered/admin/
-  - /influxdb3/clustered/reference/cli/influxctl/
+  - /influxdb3/cloud/get-started/
+  - /influxdb3/cloud/admin/
+  - /influxdb3/cloud/reference/cli/influxdb3/
 alt_links:
   v1: /influxdb/v1/administration/identify-version/
   v2: /influxdb/v2/admin/identify-version/
   cloud: /influxdb/cloud/admin/identify-version/
-  cloud3: /influxdb3/cloud/admin/identify-version/
   cloud-serverless: /influxdb3/cloud-serverless/admin/identify-version/
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/identify-version/
+  clustered: /influxdb3/clustered/admin/identify-version/
   core: /influxdb3/core/admin/identify-version/
   enterprise: /influxdb3/enterprise/admin/identify-version/
   enterprise_influxdb_v1: /enterprise_influxdb/v1/administration/identify-version/
 ---
+
+<!-- The content for this file is located at
+// SOURCE content/shared/identify-version.md -->

--- a/content/influxdb3/core/admin/identify-version.md
+++ b/content/influxdb3/core/admin/identify-version.md
@@ -15,6 +15,7 @@ alt_links:
   v1: /influxdb/v1/administration/identify-version/
   v2: /influxdb/v2/admin/identify-version/
   cloud: /influxdb/cloud/admin/identify-version/
+  cloud3: /influxdb3/cloud/admin/identify-version/
   cloud-serverless: /influxdb3/cloud-serverless/admin/identify-version/
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/identify-version/
   clustered: /influxdb3/clustered/admin/identify-version/

--- a/content/influxdb3/enterprise/admin/identify-version.md
+++ b/content/influxdb3/enterprise/admin/identify-version.md
@@ -15,6 +15,7 @@ alt_links:
   v1: /influxdb/v1/administration/identify-version/
   v2: /influxdb/v2/admin/identify-version/
   cloud: /influxdb/cloud/admin/identify-version/
+  cloud3: /influxdb3/cloud/admin/identify-version/
   cloud-serverless: /influxdb3/cloud-serverless/admin/identify-version/
   cloud-dedicated: /influxdb3/cloud-dedicated/admin/identify-version/
   clustered: /influxdb3/clustered/admin/identify-version/

--- a/content/platform/_index.md
+++ b/content/platform/_index.md
@@ -47,6 +47,7 @@ The following table compares InfluxDB across the v3, v2, and v1 generations.
 |---------|------------------|---------|------------|-----------------|-------------|-----|
 | **[InfluxDB 3 Core](#influxdb-3)** | v3 (InfluxDB 3) | Open Source (MIT/Apache 2) | Self-managed (single-node) | SQL, InfluxQL | Unlimited | v3, v2, v1 |
 | **[InfluxDB 3 Enterprise](#influxdb-3)** | v3 (InfluxDB 3) | Commercial | Self-managed (cluster or single-node) | SQL, InfluxQL | Unlimited | v3, v2, v1 |
+| **[InfluxDB 3 Cloud](/influxdb3/cloud/)** ([early access](https://www.influxdata.com/products/influxdb3-cloud/)) | v3 (InfluxDB 3) | Commercial | Managed cloud (single-tenant) | SQL, InfluxQL | Unlimited | v3, v2, v1 |
 | **[InfluxDB Clustered](#influxdb-3)** | v3 (InfluxDB 3) | Commercial | Self-managed (Kubernetes) | SQL, InfluxQL | Unlimited | v2, v1 |
 | **[InfluxDB Cloud Serverless](#influxdb-3)** | v3 (InfluxDB 3) | Free & Paid | Managed cloud (multi-tenant) | SQL, InfluxQL | Unlimited | v2, v1 |
 | **[InfluxDB Cloud Dedicated](#influxdb-3)** | v3 (InfluxDB 3) | Paid | Managed cloud (single-tenant) | SQL, InfluxQL | Unlimited | v2, v1 |
@@ -63,12 +64,13 @@ The following table compares InfluxDB across the v3, v2, and v1 generations.
 
 **Product availability:**
 
+- **InfluxDB 3 Cloud**: Early access; [request access](https://www.influxdata.com/products/influxdb3-cloud/)
 - **InfluxDB Cloud (TSM)**: Legacy managed v2 product; new signups are directed to InfluxDB Cloud Serverless (v3)
 - **InfluxDB Cloud 1**: Legacy managed v1 product; new signups are no longer available; existing customers only
 
 **API compatibility:**
 
-- **v3 API**: Latest API in InfluxDB 3 Core and Enterprise (`/api/v3` endpoints) with database-based data model
+- **v3 API**: Latest API in InfluxDB 3 Core, Enterprise, and Cloud (`/api/v3` endpoints) with database-based data model
 - **v2 API**: Used in InfluxDB v2 with token authentication and bucket-based data model; InfluxDB 3 products support `/api/v2/write` compatibility endpoint
 - **v1 HTTP API**: Legacy API with `/write` and `/query` endpoints; InfluxDB 3 products provide v1 compatibility for easier migration from v1 products
 {{% /expand %}}
@@ -90,6 +92,7 @@ The following table compares InfluxDB across the v3, v2, and v1 generations.
 
 ### Hosted
 
+- [InfluxDB 3 Cloud](/influxdb3/cloud/): fully managed, single-tenant InfluxDB 3 Enterprise service in [early access](https://www.influxdata.com/products/influxdb3-cloud/)
 - [InfluxDB Cloud Serverless](/influxdb3/cloud-serverless/): fully managed, multi-tenant InfluxDB 3 instance
 - [InfluxDB Cloud Dedicated](/influxdb3/cloud-dedicated/): fully managed, single-tenant InfluxDB 3 cluster
 

--- a/content/platform/identify-version.md
+++ b/content/platform/identify-version.md
@@ -7,4 +7,7 @@ menu:
     name: Identify version
 weight: 102
 source: /shared/identify-version.md
+related:
+  - /platform/
+  - /influxdb3/cloud/
 ---

--- a/content/shared/identify-version.md
+++ b/content/shared/identify-version.md
@@ -5,7 +5,7 @@ Identifying which InfluxDB product and version you're using is essential for acc
 
 ## Quick detection methods
 
-{{% hide-in "core,enterprise,cloud-serverless,cloud-dedicated,clustered,v2,cloud,v1" %}}
+{{% hide-in "core,enterprise,cloud-serverless,cloud-dedicated,clustered,v2,cloud,v1,influxdb3_cloud" %}}
 
 ### By URL pattern
 
@@ -145,7 +145,7 @@ influxctl cluster list
 
 {{% /show-in %}}
 
-{{% hide-in "v2,cloud,v1" %}}
+{{% hide-in "v2,influxdb_cloud,v1" %}}
 > [!Note]
 >
 > #### SQL version() function
@@ -182,7 +182,7 @@ For more details, see [How can I identify my InfluxDB version?](/influxdb/v2/ref
 
 {{% /show-in %}}
 
-{{% show-in "cloud" %}}
+{{% show-in "influxdb_cloud" %}}
 
 ### InfluxDB Cloud (TSM) detection
 
@@ -200,6 +200,33 @@ For more details, see [How can I identify my InfluxDB version?](/influxdb/v2/ref
 **Account settings**: Check your InfluxDB Cloud account dashboard for product details.
 
 **HTTP headers**: API responses include version information in response headers.
+
+{{% /show-in %}}
+
+{{% show-in "influxdb3_cloud" %}}
+
+### InfluxDB 3 Cloud detection
+
+Check the version using the `influxdb3` command:
+
+```bash
+influxdb3 --version
+```
+
+Send a `GET` request to the `/ping` endpoint to examine HTTP response headers--for example:
+
+```bash
+curl -i http://localhost:8181/ping
+```
+
+The response includes version information in the **headers** and **body**:
+
+- **Headers**:
+  - `x-influxdb-version`: Version number (for example, {{% latest-patch %}})
+  - `x-influxdb-build`: `Enterprise`
+- **JSON body**: Contains `version`, `revision`, and `process_id`
+
+**Account settings**: Check your InfluxDB 3 Cloud account dashboard for cluster and version details.
 
 {{% /show-in %}}
 
@@ -225,7 +252,7 @@ For Enterprise v1, the `x-influxdb-build` header will show `Enterprise`.
 
 {{% /show-in %}}
 
-{{% hide-in "core,enterprise,cloud-serverless,cloud-dedicated,clustered,v2,cloud,v1" %}}
+{{% hide-in "core,enterprise,cloud-serverless,cloud-dedicated,clustered,v2,cloud,v1,influxdb3_cloud" %}}
 
 ## Product-specific methods
 
@@ -381,7 +408,7 @@ Look for the `x-influxdb-version` header (for example, `1.11.7`).
 
 {{% /hide-in %}}
 
-{{% hide-in "core,enterprise,cloud-serverless,cloud-dedicated,clustered,v2,cloud,v1" %}}
+{{% hide-in "core,enterprise,cloud-serverless,cloud-dedicated,clustered,v2,cloud,v1,influxdb3_cloud" %}}
 
 ## Understanding InfluxDB products
 

--- a/content/shared/identify-version.md
+++ b/content/shared/identify-version.md
@@ -13,7 +13,8 @@ If you access InfluxDB via a URL, the hostname often indicates which product you
 
 | URL Pattern                                | Product                                       |
 | ------------------------------------------ | --------------------------------------------- |
-| `*.influxdb.io`                            | InfluxDB Cloud Dedicated                      |
+| `*.enterprise.influxdb.io`                 | InfluxDB 3 Cloud ([early access](https://www.influxdata.com/products/influxdb3-cloud/)) |
+| `*.a.influxdb.io`                          | InfluxDB Cloud Dedicated                      |
 | `us-east-1-1.aws.cloud2.influxdata.com`    | InfluxDB Cloud Serverless                     |
 | `eu-central-1-1.aws.cloud2.influxdata.com` | InfluxDB Cloud Serverless                     |
 | `*.influxcloud.net`                        | [InfluxDB Cloud 1](/platform/#influxdb-cloud-1) (legacy) |
@@ -135,7 +136,7 @@ influxctl cluster list
 
 **InfluxDB Cloud Dedicated** can be identified by:
 
-**URL pattern**: `*.influxdb.io`
+**URL pattern**: `*.a.influxdb.io`
 
 - Example: `cluster-id.a.influxdb.io`
 
@@ -207,26 +208,21 @@ For more details, see [How can I identify my InfluxDB version?](/influxdb/v2/ref
 
 ### InfluxDB 3 Cloud detection
 
-Check the version using the `influxdb3` command:
+**URL pattern**: `*.enterprise.influxdb.io`
+
+- Example: `instance-id.enterprise.influxdb.io`
+
+**Administration interface**: Manage instances through [console.influxdata.com](https://console.influxdata.com).
+
+**CLI**: InfluxDB 3 Cloud workflows use the `influxdb3` CLI rather than `influxctl`.
+The following command reports the installed CLI version:
 
 ```bash
 influxdb3 --version
 ```
 
-Send a `GET` request to the `/ping` endpoint to examine HTTP response headers--for example:
-
-```bash
-curl -i http://localhost:8181/ping
-```
-
-The response includes version information in the **headers** and **body**:
-
-- **Headers**:
-  - `x-influxdb-version`: Version number (for example, {{% latest-patch %}})
-  - `x-influxdb-build`: `Enterprise`
-- **JSON body**: Contains `version`, `revision`, and `process_id`
-
-**Account settings**: Check your InfluxDB 3 Cloud account dashboard for cluster and version details.
+InfluxDB 3 Cloud is in early access.
+[Request access](https://www.influxdata.com/products/influxdb3-cloud/).
 
 {{% /show-in %}}
 
@@ -365,7 +361,7 @@ The InfluxDB UI displays the version:
 
 For more details, see [How can I identify my InfluxDB version?](/influxdb/v2/reference/faq/#administration-1)
 
-### InfluxDB Cloud (Serverless, Dedicated, TSM)
+### InfluxDB Cloud products
 
 For InfluxDB Cloud products, check the version information:
 
@@ -418,6 +414,7 @@ InfluxData offers multiple InfluxDB products to suit different use cases:
 | ----------------------------- | --------- | ------------------------ | ------------------- | ------------ |
 | **InfluxDB 3 Core**           | Free      | Self-hosted              | SQL, InfluxQL       | 8181         |
 | **InfluxDB 3 Enterprise**     | Paid      | Self-hosted              | SQL, InfluxQL       | 8181         |
+| **[InfluxDB 3 Cloud](/influxdb3/cloud/)** ([early access](https://www.influxdata.com/products/influxdb3-cloud/)) | Paid | Cloud | SQL, InfluxQL | N/A |
 | **InfluxDB Cloud Serverless** | Free/Paid | Cloud                    | SQL, InfluxQL, Flux | N/A          |
 | **InfluxDB Cloud Dedicated**  | Paid      | Cloud                    | SQL, InfluxQL       | N/A          |
 | **InfluxDB Clustered**        | Paid      | Self-hosted (Kubernetes) | SQL, InfluxQL       | Custom       |

--- a/cypress/e2e/content/influxdb-version-detector.cy.js
+++ b/cypress/e2e/content/influxdb-version-detector.cy.js
@@ -111,6 +111,44 @@ describe('InfluxDB Version Detector Component', function () {
       cy.get('.result').should('contain', 'InfluxDB 3');
     });
 
+    it('should distinguish InfluxDB 3 Cloud from Cloud Dedicated URLs', function () {
+      cy.get('#q-url-known .option-button')
+        .contains('Yes, I know the URL')
+        .should('be.visible')
+        .click();
+
+      cy.get('#url-input', { timeout: 10000 })
+        .should('be.visible')
+        .clear()
+        .type('https://instance-id.enterprise.influxdb.io');
+      cy.get('#q-url-input .submit-button').click();
+
+      cy.get('.result', { timeout: 10000 })
+        .scrollIntoView()
+        .should('be.visible')
+        .should('contain', 'InfluxDB 3 Cloud')
+        .should('not.contain', 'InfluxDB Cloud Dedicated');
+    });
+
+    it('should detect Cloud Dedicated URLs', function () {
+      cy.get('#q-url-known .option-button')
+        .contains('Yes, I know the URL')
+        .should('be.visible')
+        .click();
+
+      cy.get('#url-input', { timeout: 10000 })
+        .should('be.visible')
+        .clear()
+        .type('https://cluster-id.a.influxdb.io');
+      cy.get('#q-url-input .submit-button').click();
+
+      cy.get('.result', { timeout: 10000 })
+        .scrollIntoView()
+        .should('be.visible')
+        .should('contain', 'InfluxDB Cloud Dedicated')
+        .should('not.contain', 'InfluxDB 3 Cloud');
+    });
+
     it('should handle cloud context keywords', function () {
       cy.get('#q-url-known .option-button')
         .contains('Yes, I know the URL')

--- a/cypress/e2e/content/influxdb-version-detector.cy.js
+++ b/cypress/e2e/content/influxdb-version-detector.cy.js
@@ -130,6 +130,25 @@ describe('InfluxDB Version Detector Component', function () {
         .should('not.contain', 'InfluxDB Cloud Dedicated');
     });
 
+    it('should detect the InfluxDB 3 Cloud hostname suffix', function () {
+      cy.get('#q-url-known .option-button')
+        .contains('Yes, I know the URL')
+        .should('be.visible')
+        .click();
+
+      cy.get('#url-input', { timeout: 10000 })
+        .should('be.visible')
+        .clear()
+        .type('enterprise.influxdb.io');
+      cy.get('#q-url-input .submit-button').click();
+
+      cy.get('.result', { timeout: 10000 })
+        .scrollIntoView()
+        .should('be.visible')
+        .should('contain', 'InfluxDB 3 Cloud')
+        .should('not.contain', 'InfluxDB Cloud Dedicated');
+    });
+
     it('should detect Cloud Dedicated URLs', function () {
       cy.get('#q-url-known .option-button')
         .contains('Yes, I know the URL')
@@ -147,6 +166,41 @@ describe('InfluxDB Version Detector Component', function () {
         .should('be.visible')
         .should('contain', 'InfluxDB Cloud Dedicated')
         .should('not.contain', 'InfluxDB 3 Cloud');
+    });
+
+    it('should detect the Cloud Dedicated hostname suffix', function () {
+      cy.get('#q-url-known .option-button')
+        .contains('Yes, I know the URL')
+        .should('be.visible')
+        .click();
+
+      cy.get('#url-input', { timeout: 10000 })
+        .should('be.visible')
+        .clear()
+        .type('a.influxdb.io');
+      cy.get('#q-url-input .submit-button').click();
+
+      cy.get('.result', { timeout: 10000 })
+        .scrollIntoView()
+        .should('be.visible')
+        .should('contain', 'InfluxDB Cloud Dedicated')
+        .should('not.contain', 'InfluxDB 3 Cloud');
+    });
+
+    it('should not match a hostname without a domain boundary', function () {
+      cy.get('#q-url-known .option-button')
+        .contains('Yes, I know the URL')
+        .should('be.visible')
+        .click();
+
+      cy.get('#url-input', { timeout: 10000 })
+        .should('be.visible')
+        .clear()
+        .type('notenterprise.influxdb.io');
+      cy.get('#q-url-input .submit-button').click();
+
+      cy.get('#q-paid', { timeout: 5000 }).should('be.visible');
+      cy.get('.result').should('not.contain', 'InfluxDB 3 Cloud');
     });
 
     it('should handle cloud context keywords', function () {

--- a/data/products.yml
+++ b/data/products.yml
@@ -108,6 +108,17 @@ influxdb3_cloud:
     database: 100
     table: 10000
     column: 500
+  detector_config:
+    query_languages:
+      SQL:
+        required_params: ['Host', 'Database', 'Token']
+        optional_params: []
+      InfluxQL:
+        required_params: ['Host', 'Database', 'Token']
+        optional_params: []
+    characteristics: ['Paid', 'Cloud', 'SQL/InfluxQL', 'Token', 'Databases']
+    detection:
+      url_contains: ['enterprise.influxdb.io']
   ai_sample_questions:
     - What's my InfluxDB version?
     - How do I get started with InfluxDB 3 Cloud?
@@ -209,7 +220,7 @@ influxdb3_cloud_dedicated:
         optional_params: []
     characteristics: ['Paid', 'Cloud', 'SQL/InfluxQL', 'Token', 'Databases']
     detection:
-      url_contains: ['influxdb.io']
+      url_contains: ['a.influxdb.io']
   ai_sample_questions:
     - What's my InfluxDB version?
     - How do I migrate from InfluxDB v1 to Cloud Dedicated?


### PR DESCRIPTION
Closes #7611
Closes #7626

## What changed

- Add InfluxDB 3 Cloud to the platform comparison and hosted product list.
- Add an InfluxDB 3 Cloud identify-version page and shared detection guidance.
- Add InfluxDB 3 Cloud to the interactive version detector and product metadata.
- Distinguish `*.enterprise.influxdb.io` instance URLs from Cloud Dedicated `*.a.influxdb.io` cluster URLs.
- Add end-to-end regression coverage for both hostname forms.

## Why

Issue #7611 establishes InfluxDB 3 Cloud in the product lineup and version-identification flow.
Issue #7626 depends on that product entry so URL detection can distinguish it from Cloud Dedicated.

The previous detector and shared documentation treated every `influxdb.io` hostname as Cloud Dedicated.

## Impact

Readers can identify InfluxDB 3 Cloud from the platform pages and interactive detector.
Cloud Dedicated readers continue to receive the correct product result.
The documentation marks InfluxDB 3 Cloud as early access and links to the access request page.

## Verification

- `yarn build:ts`
- `npx hugo --quiet`
- Code-block lint on all changed content
- Cypress version detector spec: 15 passing
- Link checker on changed content: 0 errors
- Vale on affected content: 0 errors
- Pre-commit and pre-push hooks

## Checklist

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
