### PR TITLE
fix(version-detector): score shared hosted domain

### DIFF
--- a/assets/js/influxdb-version-detector.ts
+++ b/assets/js/influxdb-version-detector.ts
@@ -1409,6 +1409,16 @@ docker logs &lt;container&gt; 2>&amp;1 | head -20</div>
   private detectContext(urlInput: string): { likelyProduct?: string } {
     const input = urlInput.toLowerCase();
 
+    try {
+      const urlWithScheme = input.includes('://') ? input : `https://${input}`;
+      const hostname = new URL(urlWithScheme).hostname;
+      if (this.isDomainOrSubdomain(hostname, 'influxdb.io')) {
+        return { likelyProduct: 'cloud' };
+      }
+    } catch {
+      // Continue with keyword-based detection.
+    }
+
     // Check for cloud indicators
     if (input.includes('cloud') || input.includes('influxdata.com')) {
       return { likelyProduct: 'cloud' };

--- a/cypress/e2e/content/influxdb-version-detector.cy.js
+++ b/cypress/e2e/content/influxdb-version-detector.cy.js
@@ -65,6 +65,32 @@ describe('InfluxDB Version Detector Component', function () {
       }).should('be.visible');
     });
 
+    it('uses the shared influxdb.io domain as a hosted-product clue', function () {
+      cy.get('#q-url-known .option-button')
+        .contains('Yes, I know the URL')
+        .click();
+
+      cy.get('#url-input').clear().type('influxdb.io');
+      cy.get('#q-url-input .submit-button').click();
+
+      cy.get('#q-paid', { timeout: 5000 }).within(() => {
+        cy.contains('.option-button', 'Paid/Commercial License').click();
+      });
+      cy.get('#q-age').within(() => {
+        cy.contains('.option-button', "I'm not sure").click();
+      });
+      cy.get('#q-language').within(() => {
+        cy.contains('.option-button', 'SQL').click();
+      });
+
+      cy.get('.product-ranking .product-title')
+        .eq(0)
+        .should('contain', 'InfluxDB 3 Cloud');
+      cy.get('.product-ranking .product-title')
+        .eq(1)
+        .should('contain', 'InfluxDB Cloud Dedicated');
+    });
+
     it('should detect products from port 8086 URLs', function () {
       cy.get('#q-url-known .option-button')
         .contains('Yes, I know the URL')


### PR DESCRIPTION
Follow-up to #7669.

## What changed

- Treat influxdb.io and its subdomains as hosted Cloud context when the hostname does not identify a specific product.
- Add end-to-end coverage for the shared domain with Paid and SQL questionnaire answers.

## Why

The shared parent domain previously entered the manual questionnaire with Cloud disabled.
That eliminated InfluxDB 3 Cloud and Cloud Dedicated from the rankings even when the Paid and SQL answers supported them.

## Impact

Users who provide the shared hosted domain now see InfluxDB 3 Cloud and Cloud Dedicated as the leading candidates.
Specific enterprise.influxdb.io and a.influxdb.io hostnames retain their definitive product matches.

## Verification

- yarn build:ts
- Version detector Cypress spec: 19 passing
- Pre-commit hooks
- Pre-push hooks
- git diff --check