### PR TITLE
test(shortcodes): cover InfluxDB 3 Cloud host URL

### DIFF
--- a/cypress/e2e/content/host-url-shortcode.cy.js
+++ b/cypress/e2e/content/host-url-shortcode.cy.js
@@ -21,6 +21,8 @@ const PAGES = {
   influxdb3_core: '/influxdb3/core/write-data/http-api/v3-write-lp/',
   influxdb3_enterprise:
     '/influxdb3/enterprise/write-data/http-api/v3-write-lp/',
+  influxdb3_cloud:
+    '/influxdb3/cloud/query-data/execute-queries/influxdb-v1-api/',
   influxdb3_cloud_serverless:
     '/influxdb3/cloud-serverless/reference/sample-data/',
   influxdb3_cloud_dedicated:
@@ -55,9 +57,10 @@ describe('influxdb/host-url shortcode', function () {
     });
   });
 
-  it('renders https:// for managed products (Cloud Serverless, Dedicated, Clustered)', function () {
+  it('renders https:// for managed products', function () {
     cy.task('getData', 'products').then((products) => {
       [
+        'influxdb3_cloud',
         'influxdb3_cloud_serverless',
         'influxdb3_cloud_dedicated',
         'influxdb3_clustered',
@@ -80,5 +83,19 @@ describe('influxdb/host-url shortcode', function () {
     cy.get('pre.api-endpoint')
       .should('contain.text', 'https://localhost:8086/query')
       .and('not.contain.text', '{{< influxdb/host-url >}}');
+  });
+
+  it('renders the InfluxDB 3 Cloud host when nested in api-endpoint', function () {
+    cy.task('getData', 'products').then((products) => {
+      const product = products.influxdb3_cloud;
+      const expectedUrl = `${product.scheme}://${product.placeholder_host}`;
+
+      visitClean(PAGES.influxdb3_cloud);
+      cy.get('pre.api-endpoint')
+        .first()
+        .should('contain.text', `${expectedUrl}/query`)
+        .and('not.contain.text', '{{< influxdb/host-url >}}')
+        .and('not.contain.text', products.influxdb_cloud.placeholder_host);
+    });
   });
 });


### PR DESCRIPTION
## What changed

- Add InfluxDB 3 Cloud to the managed-product host URL regression matrix.
- Verify an `influxdb/host-url` nested in `api-endpoint` renders the Cloud 3 scheme and host.
- Verify Cloud 3 does not fall back to the Cloud TSM host.

## Why

The superseded path-derived `productAliases` implementation mapped the `cloud` URL segment to Cloud TSM. Current templates resolve `influxdb3_cloud` from cascade metadata, and this test prevents that regression from returning.

## Impact

No production behavior changes. The PR adds focused end-to-end coverage for the current cascade-backed shortcode behavior.

## Verification

- `node cypress/support/run-e2e-specs.js --spec cypress/e2e/content/host-url-shortcode.cy.js --no-mapping` (4 passing)
- `npx prettier --check cypress/e2e/content/host-url-shortcode.cy.js`
- `git diff --check`