### PR TITLE
docs(controller): document configuration groups

### DIFF
--- a/content/telegraf/controller/agents/_index.md
+++ b/content/telegraf/controller/agents/_index.md
@@ -7,7 +7,7 @@ description: >
 menu:
   telegraf_controller:
     name: Manage agents
-weight: 4
+weight: 5
 ---
 
 {{% product-name %}} tracks agents that send heartbeats through the Telegraf

--- a/content/telegraf/controller/audit-logs/_index.md
+++ b/content/telegraf/controller/audit-logs/_index.md
@@ -39,6 +39,9 @@ and demonstrate compliance with internal or external policies.
 - **Configuration lifecycle**: configuration creation, updates, and deletion,
   and [configuration version](/telegraf/controller/configs/versions/)
   operations (rollbacks, change note updates, and version pruning).
+- **Configuration group lifecycle**:
+  [configuration group](/telegraf/controller/config-groups/) creation,
+  updates (including membership changes), and deletion.
 - **Constants**: [global constant](/telegraf/controller/configs/constants/)
   creation, value updates, and deletion.
 

--- a/content/telegraf/controller/config-groups/_index.md
+++ b/content/telegraf/controller/config-groups/_index.md
@@ -1,0 +1,59 @@
+---
+title: Manage configuration groups
+seotitle: Manage Telegraf configuration groups with Telegraf Controller
+description: >
+  Group multiple Telegraf configurations into an ordered configuration group
+  that agents retrieve from a single URL. Groups compose by reference, so
+  updating a member configuration updates every group that includes it.
+menu:
+  telegraf_controller:
+    name: Manage configuration groups
+weight: 4
+---
+
+Configuration groups bundle multiple Telegraf configurations into an ordered
+unit that agents retrieve in a single request. Instead of assigning each
+agent its own stack of individual configurations, you assign the group.
+
+Groups compose by reference, not by copy: a configuration can belong to
+multiple groups, and editing a configuration propagates the change to every
+group that includes it. This is what makes groups work as role profiles.
+Build one base configuration with the system inputs every host runs, then
+compose it with the configurations specific to a web server or a database
+host. Tune the base configuration once and every role updates; there is no
+drift between the web profile's copy and the database profile's copy,
+because there are no copies. Groups also work as templates: a group that is
+proven in production becomes the starting point for the next site or
+deployment.
+
+## How group TOML is rendered
+
+When an agent or user requests a group's TOML, {{% product-name %}} renders
+each member configuration in its listed order and concatenates the results
+into a single TOML document. Each member's section begins with a comment
+that identifies the source configuration, so you can trace any plugin in the
+merged output back to the configuration it came from.
+
+Because members are rendered at request time:
+
+- Changes to a member configuration appear in the group's TOML immediately.
+- Deleting a configuration removes it from every group that includes it.
+- An empty group is valid and renders an empty configuration.
+
+Groups cannot contain other groups; members are always individual
+configurations.
+
+{{< children hlevel="h2" >}}
+
+## Permissions
+
+Configuration group operations require permissions on the
+**Config Groups** resource:
+
+- **Read**: view groups and retrieve group TOML.
+- **Write**: create groups, edit group details, and manage members, labels,
+  and aliases.
+- **Delete**: delete groups.
+
+For how permissions map to user roles and API tokens, see
+[Authentication and authorization](/telegraf/controller/reference/authentication-authorization/).

--- a/content/telegraf/controller/config-groups/aliases.md
+++ b/content/telegraf/controller/config-groups/aliases.md
@@ -1,0 +1,57 @@
+---
+title: Manage configuration group aliases
+seotitle: Manage Telegraf configuration group aliases in Telegraf Controller
+description: >
+  Assign aliases to Telegraf configuration groups and transfer an alias from
+  a single configuration to a group to migrate agents without changing agent
+  commands.
+menu:
+  telegraf_controller:
+    name: Manage group aliases
+    parent: Manage configuration groups
+weight: 103
+related:
+  - /telegraf/controller/configs/aliases/
+  - /telegraf/controller/config-groups/use/
+---
+
+A configuration group alias is a human-readable name for a group. Use it in
+place of the group ID in the {{% product-name %}} UI and API, including the
+short `/c/` URL agents use to retrieve the group's merged TOML.
+
+Aliases share a single namespace across configurations and configuration
+groups and follow the same naming rules. For the naming rules, conflict and
+transfer semantics, and short URL behavior, see
+[Manage configuration aliases](/telegraf/controller/configs/aliases/).
+
+## Manage a group's aliases
+
+1.  In the {{% product-name %}} web interface, select **Config Groups** in
+    the navigation bar.
+2.  Click the name of the group.
+3.  Select the **Aliases** tab.
+
+The aliases table shows each alias and the number of agents reporting with
+it. Add an alias with **{{% lucide "plus" %}} Add Alias**, and transfer or
+delete an alias from its row actions, exactly as for
+[configuration aliases](/telegraf/controller/configs/aliases/).
+
+## Repoint agents from a configuration to a group
+
+Because the alias namespace spans configurations and groups, you can
+transfer an alias from a single configuration to a group. Agents that
+retrieve TOML by that alias switch from the single configuration to the
+group's merged configuration on their next check, without any agent-side
+changes. Use this to migrate a fleet from one configuration to a composed
+role profile:
+
+1.  Build the group and
+    [review its merged TOML](/telegraf/controller/config-groups/manage/#review-the-merged-toml).
+2.  On the group's **Aliases** tab, add the alias that is currently
+    assigned to the configuration. {{% product-name %}} reports the
+    conflict, shows how many agents use the alias, and offers to transfer
+    it.
+3.  Confirm the transfer. Agents using the alias load the group on their
+    next watch interval.
+
+To roll back, transfer the alias back to the original configuration.

--- a/content/telegraf/controller/config-groups/manage.md
+++ b/content/telegraf/controller/config-groups/manage.md
@@ -1,0 +1,95 @@
+---
+title: Create and manage configuration groups
+seotitle: Create and manage Telegraf configuration groups in Telegraf Controller
+description: >
+  Create Telegraf configuration groups, add and reorder member
+  configurations, and manage group labels and lifecycle in Telegraf
+  Controller.
+menu:
+  telegraf_controller:
+    name: Create and manage groups
+    parent: Manage configuration groups
+weight: 101
+related:
+  - /telegraf/controller/configs/create/
+  - /telegraf/controller/config-groups/use/
+  - /telegraf/controller/labels/
+---
+
+Create a configuration group, then manage its member configurations, order,
+labels, and lifecycle from the group detail page.
+
+## Create a configuration group
+
+1.  In the {{% product-name %}} web interface, select
+    **Configurations > Config Groups** in the navigation bar.
+2.  Click **{{% lucide "plus" %}} Add Config Group**.
+3.  Enter a group name and optional description.
+4.  Click **{{% lucide "plus" %}} Add Configs** and select the
+    configurations to include.
+5.  Drag members by the **drag handle ({{% lucide "grip-vertical" %}})**
+    into the order you want them rendered.
+6.  Click **Create Config Group**.
+
+## View configuration groups
+
+The **Configuration Groups** page lists all groups with their descriptions,
+member counts, labels, and the number of agents using each group. Search by
+name, description, or member configuration name, sort by name or date, and
+filter by label.
+
+Click a group name to open the group detail page. The **More Details**
+section shows the group ID, member count, timestamps, and the API and TOML
+URLs for the group.
+
+## Add or remove member configurations
+
+On the group detail page, under **Configurations**:
+
+- To add members, click **{{% lucide "plus" %}} Add Configs** and select
+  configurations. Configurations already in the group are skipped.
+- To remove a member, click the more icon (**{{% lucide "ellipsis-vertical" %}}**)
+  on the member and select **{{% lucide "x" %}} Remove**.
+  Removing a configuration from a group does not delete the configuration.
+
+## Reorder member configurations
+
+Members render in their listed order, which matters when later plugins
+depend on earlier ones or when you want a predictable merged layout.
+
+1.  Drag members by the **drag handle ({{% lucide "grip-vertical" %}})**
+    into the order you want.
+2.  Click **{{% lucide "save" %}} Save**.
+
+Saving a new order updates the group. Agents that watch the group URL load
+the reordered configuration on their next check. For details, see
+[Auto-update agents](/telegraf/controller/config-groups/use/#auto-update-agents).
+
+## Review the merged TOML
+
+The **Merged TOML Preview** panel on the group detail page shows the
+read-only result of rendering all members in order, including the source
+comments that mark where each member configuration begins. Validation
+issues in the merged output are listed above the preview.
+
+<!-- TODO: screenshot of a configuration group detail page showing the ordered member list and the Merged TOML Preview panel. Save to /static/img/telegraf/controller-config-group-detail.png and replace this comment with: {{< img-hd src="/img/telegraf/controller-config-group-detail.png" alt="Telegraf Controller configuration group detail page with merged TOML preview" />}} -->
+
+## Edit the group name and description
+
+On the group detail page, click the group name or description, enter a new
+value, and confirm.
+
+## Manage group labels
+
+Use the **Labels** box on the group detail page to assign or remove labels.
+Labels on groups work the same way as labels on configurations and agents.
+For details, see [Manage labels](/telegraf/controller/labels/).
+
+## Delete a configuration group
+
+1.  On the group detail page, select the **Manage** tab.
+2.  Click the delete option and confirm.
+
+Deleting a group does not delete its member configurations. Aliases
+assigned to the group are deleted, and agents that retrieve TOML by the
+group's URL can no longer load it.

--- a/content/telegraf/controller/config-groups/use.md
+++ b/content/telegraf/controller/config-groups/use.md
@@ -1,0 +1,90 @@
+---
+title: Use configuration groups
+seotitle: Use Telegraf configuration groups with Telegraf Controller
+description: >
+  Apply a Telegraf configuration group to your agents with a single URL,
+  substitute values across member configurations, and keep agents up to
+  date as the group changes.
+menu:
+  telegraf_controller:
+    name: Use groups
+    parent: Manage configuration groups
+weight: 102
+related:
+  - /telegraf/controller/configs/use/
+  - /telegraf/controller/configs/substitute-values/
+  - /telegraf/controller/config-groups/aliases/
+---
+
+Apply a configuration group by pointing your agents to the group's TOML URL,
+the same way you [apply an individual configuration](/telegraf/controller/configs/use/).
+
+## Apply a configuration group to an agent
+
+When starting a Telegraf agent, use a `--config` flag with the
+{{% product-name %}} configuration group TOML API URL:
+
+```bash
+telegraf \
+  --config "http://localhost:8888/api/config-groups/xxxxxx/toml"
+```
+
+The URL accepts the group ID or a
+[group alias](/telegraf/controller/config-groups/aliases/). If the group has
+an alias, you can use the shorter alias-based URL instead:
+
+```bash
+telegraf \
+  --config "http://localhost:8888/c/my-group-alias"
+```
+
+To have {{% product-name %}} build the command for you, click
+**Use this Config Group** on the group detail page.
+
+If {{% product-name %}} requires authentication on the **Config Groups**
+API, provide an API token with **read** permissions the same way as for
+individual configurations. For details, see
+[Use API tokens](/telegraf/controller/tokens/use/).
+
+## Substitute values in group members
+
+[Value substitution](/telegraf/controller/configs/substitute-values/) is
+carried by the member configurations; a group renders whatever substitution
+references its members contain:
+
+- **Parameters**: query parameters on the group URL apply to all members.
+  If any member has a required parameter without a value, the request
+  returns an error listing the missing parameter names.
+- **Constants**: resolved server-side across all members. Undefined
+  constants cause an error listing the missing names.
+- **Environment variables and secrets**: pass through unchanged and are
+  resolved by the Telegraf agent, as with individual configurations.
+
+For example, to set a parameter used by any member of the group:
+
+```bash
+telegraf \
+  --config "http://localhost:8888/api/config-groups/xxxxxx/toml?agent_id=web-01"
+```
+
+## Auto-update agents
+
+Include `--config-url-watch-interval` to have agents periodically check the
+group URL for changes:
+
+```bash
+telegraf \
+  --config "http://localhost:8888/api/config-groups/xxxxxx/toml" \
+  --config-url-watch-interval 1h
+```
+
+The group's last-modified time reflects the group itself, its member
+configurations, and any constants they reference. Adding, removing, or
+reordering members, editing a member configuration, or updating a
+referenced constant all cause watching agents to reload the merged
+configuration on their next check.
+
+## View agents using a group
+
+On the group detail page, select the **Agents** tab to see the agents
+reporting with this group.

--- a/content/telegraf/controller/configs/aliases.md
+++ b/content/telegraf/controller/configs/aliases.md
@@ -31,10 +31,12 @@ An alias must:
 - contain only lowercase letters, digits, and hyphens.
 - begin and end with a letter or digit.
 
-Aliases are unique across your {{% product-name %}} instance; an alias points
-to exactly one configuration at a time. The names `bulk`, `duplicate`, and
-`many` are reserved, and strings shaped like configuration IDs (36-character
-UUIDs) are not allowed.
+Aliases are unique across your {{% product-name %}} instance, and the
+namespace is shared with
+[configuration group aliases](/telegraf/controller/config-groups/aliases/):
+an alias points to exactly one configuration or configuration group at a
+time. The names `bulk`, `duplicate`, and `many` are reserved, and strings
+shaped like configuration IDs (36-character UUIDs) are not allowed.
 
 ## View aliases
 
@@ -89,6 +91,8 @@ Transferring an alias reassigns it to a different configuration. Agents that
 use an alias-based configuration URL with `--config-url-watch-interval` load
 the newly targeted configuration on their next check, letting you roll out a
 different configuration to a fleet of agents without modifying the agents.
+Transfers can also move an alias between a configuration and a
+[configuration group](/telegraf/controller/config-groups/aliases/#repoint-agents-from-a-configuration-to-a-group).
 For details, see
 [Auto-update agents](/telegraf/controller/configs/use/#auto-update-agents).
 

--- a/content/telegraf/controller/configs/constants.md
+++ b/content/telegraf/controller/configs/constants.md
@@ -25,6 +25,8 @@ common endpoint URL or organization name.
 
 For how constants compare to parameters, environment variables, and secrets,
 see [Substitute values in configurations](/telegraf/controller/configs/substitute-values/).
+When serving a [configuration group](/telegraf/controller/config-groups/),
+{{% product-name %}} substitutes constants across all member configurations.
 
 > [!Important]
 > #### Do not use constants for sensitive information

--- a/content/telegraf/controller/configs/substitute-values.md
+++ b/content/telegraf/controller/configs/substitute-values.md
@@ -35,7 +35,10 @@ Each type is substituted in a different place:
 {{% product-name %}} substitutes parameters and constants server-side, so the
 TOML an agent receives already contains the resolved values. Environment
 variables and secrets pass through {{% product-name %}} unchanged and are
-resolved by the Telegraf agent itself.
+resolved by the Telegraf agent itself. Substitution works the same way when
+{{% product-name %}} serves a
+[configuration group](/telegraf/controller/config-groups/): references in
+every member configuration are resolved in one request.
 
 ## Parameters
 
@@ -113,6 +116,35 @@ above, Telegraf would load the following TOML configuration:
 [[outputs.heartbeat]]
   # Required parameter without a default value
   instance_id = "agent123"
+```
+
+### Provide array values
+
+To provide multiple values for one parameter, repeat the query parameter in
+the configuration URL. {{% product-name %}} joins repeated values with
+`", "`, so a parameter referenced inside a quoted TOML array element renders
+as multiple array elements.
+
+##### Configuration TOML with an array parameter
+
+```toml { .tc-substitute-values }
+[[inputs.http]]
+  urls = ["&{metric_urls}"]
+```
+
+##### Repeat the query parameter to provide multiple values
+
+<!--pytest.mark.skip-->
+```sh
+telegraf \
+  --config "http://localhost:8888/api/configs/xxxxxx/toml?metric_urls=http://host1/metrics&metric_urls=http://host2/metrics"
+```
+
+Telegraf would load the following TOML configuration:
+
+```toml
+[[inputs.http]]
+  urls = ["http://host1/metrics", "http://host2/metrics"]
 ```
 
 ## Constants

--- a/content/telegraf/controller/configs/use.md
+++ b/content/telegraf/controller/configs/use.md
@@ -165,7 +165,8 @@ automatically reload the configuration if the configuration has been updated.
 
 {{% product-name %}} provides a tool for building `telegraf` commands using
 parameters, environment variables, auto-update functionality, and Telegraf
-[label selectors](/telegraf/v1/configuration/#selectors-1). To use this tool:
+[label selectors](/telegraf/v1/configuration/labels-selectors/).
+To use this tool:
 
 1.  In the {{% product-name %}} web interface, select **Configurations** in the 
     navigation bar. 

--- a/content/telegraf/controller/configs/use.md
+++ b/content/telegraf/controller/configs/use.md
@@ -41,6 +41,10 @@ telegraf \
   --config "http://localhost:8888/c/my-config-alias"
 ```
 
+Agents can also retrieve multiple configurations bundled as a
+[configuration group](/telegraf/controller/config-groups/use/) with a
+single `--config` URL.
+
 > [!Note]
 > A single Telegraf agent can use multiple configurations.
 > Provide each with a distinct `--config` flag.

--- a/content/telegraf/controller/labels/_index.md
+++ b/content/telegraf/controller/labels/_index.md
@@ -6,7 +6,7 @@ description: >
 menu:
   telegraf_controller:
     name: Manage labels
-weight: 5
+weight: 6
 cascade:
   draft: true
 ---

--- a/content/telegraf/controller/reference/glossary.md
+++ b/content/telegraf/controller/reference/glossary.md
@@ -65,7 +65,18 @@ each. {{% product-name %}} stores configurations centrally and delivers them
 to agents that request them. The terms _config_ and _configuration_ are used
 interchangeably in the {{% product-name %}} UI and API.
 
-Related entries: [configuration parameter](#configuration-parameter), [environment variable](#environment-variable), [plugin](#plugin), [secret](#secret), [TOML](#toml)
+Related entries: [configuration group](#configuration-group), [configuration parameter](#configuration-parameter), [environment variable](#environment-variable), [plugin](#plugin), [secret](#secret), [TOML](#toml)
+
+### configuration group
+
+An ordered set of Telegraf configurations that {{% product-name %}} serves
+as a single merged TOML document. Groups compose by reference: a
+configuration can belong to multiple groups, and changes to a configuration
+appear in every group that includes it. Agents retrieve a group the same
+way they retrieve an individual configuration. For details, see
+[Manage configuration groups](/telegraf/controller/config-groups/).
+
+Related entries: [configuration](#configuration), [value substitution](#value-substitution)
 
 ### configuration parameter
 


### PR DESCRIPTION
Add a Manage configuration groups section covering the compose-by- reference model, creating and managing groups and member order, applying groups to agents, and group aliases including transferring an alias from a configuration to a group. Document array parameter values on the substitute-values page, cross-link groups from the configs, constants, and aliases pages, and add glossary and audit-log coverage.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
