### PR TITLE
fix(influxdb3): add --plugin-repo to serve CLI reference

### DIFF
--- a/content/influxdb3/core/reference/cli/influxdb3/serve.md
+++ b/content/influxdb3/core/reference/cli/influxdb3/serve.md
@@ -113,6 +113,7 @@ influxdb3 serve [OPTIONS]
 |                  | `--file-cache-recency`            | _See [configuration options](/influxdb3/core/reference/config-options/#file-cache-recency)_            |
 |                  | `--file-cache-size`                           | _See [configuration options](/influxdb3/core/reference/config-options/#file-cache-size)_                           |
 |                  | `--plugin-dir`                                       | _See [configuration options](/influxdb3/core/reference/config-options/#plugin-dir)_                                       |
+|                  | `--plugin-repo` | _See [configuration options](/influxdb3/core/reference/config-options/#plugin-repo)_ |
 |                  | `--preemptive-cache-age`                             | _See [configuration options](/influxdb3/core/reference/config-options/#preemptive-cache-age)_                             |
 |                  | `--query-file-limit`                                 | _See [configuration options](/influxdb3/core/reference/config-options/#query-file-limit)_                                 |
 |                  | `--query-log-max-entries`                                   | _See [configuration options](/influxdb3/core/reference/config-options/#query-log-max-entries)_                                   |

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/serve.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/serve.md
@@ -144,6 +144,7 @@ influxdb3 serve [OPTIONS]
 |                  | `--permission-tokens-file`                           | _See [configuration options](/influxdb3/enterprise/reference/config-options/#permission-tokens-file)_                           |
 |                  | `--plugin-dir`                                       | _See [configuration options](/influxdb3/enterprise/reference/config-options/#plugin-dir)_                                       |
 |                  | `--plugin-dir-only` | _See [configuration options](/influxdb3/enterprise/reference/config-options/#plugin-dir-only)_ |
+|                  | `--plugin-repo` | _See [configuration options](/influxdb3/enterprise/reference/config-options/#plugin-repo)_ |
 |                  | `--preemptive-cache-age`                             | _See [configuration options](/influxdb3/enterprise/reference/config-options/#preemptive-cache-age)_                             |
 |                  | `--query-file-limit`                                 | _See [configuration options](/influxdb3/enterprise/reference/config-options/#query-file-limit)_                                 |
 |                  | `--query-log-max-entries`                                   | _See [configuration options](/influxdb3/enterprise/reference/config-options/#query-log-max-entries)_                                   |


### PR DESCRIPTION
## What changed

Added the `--plugin-repo` option to the `influxdb3 serve` CLI reference option tables for InfluxDB 3 Core and InfluxDB 3 Enterprise, linking to the existing entry in the configuration options reference.

## Why

The [configuration options reference](https://docs.influxdata.com/influxdb3/enterprise/reference/config-options/#plugin-repo) documents `plugin-repo`, and the [processing engine plugins page](https://docs.influxdata.com/influxdb3/enterprise/plugins/) references `--plugin-repo` for `gh:`-prefixed plugins, but the `influxdb3 serve` page option tables omit the flag.

## Impact

Users browsing the `influxdb3 serve` reference can now discover `--plugin-repo` alongside the other plugin options.

## Verification

- Verified the flag exists in `influxdb3 serve --help-all` output on Core and Enterprise 3.12.0-nightly.
- Verified the `#plugin-repo` anchor exists on both product configuration options pages (shared source).
- Local build passes (`npx hugo --quiet`).

## Checklist

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)