### PR TITLE
docs(influxdb3): document overwrite timing semantics for Core and Enterprise

### DIFF
--- a/content/shared/v3-line-protocol.md
+++ b/content/shared/v3-line-protocol.md
@@ -308,7 +308,7 @@ Overwrites are subject to timing conditions described below; they are not a reli
 >
 > To ensure the last write wins, leave enough time between writes of the same point for
 > the earlier write to be persisted and referenced in a snapshot — with default settings,
-> at least 30 minutes — and ensure the compactor is running.
+> we recommend at least 30 minutes — and ensure the compactor is running.
 > Writes of the same point with insufficient delay yield undefined behavior.
 >
 > In clusters with multiple ingest nodes, the ordering of overwrites of the same point

--- a/content/shared/v3-line-protocol.md
+++ b/content/shared/v3-line-protocol.md
@@ -286,6 +286,7 @@ A point is uniquely identified by the table name, tag set, and timestamp.
 If you submit line protocol with the same table, tag set, and timestamp,
 but with a different field set, the field set becomes the union of the old
 field set and the new field set, where any conflicts favor the new field set.
+Overwrites are subject to timing conditions described below; they are not a reliable way to maintain a last-value view unless those conditions are met.
 
 {{% show-in "cloud-dedicated,clustered,cloud-serverless" %}}
 > [!Warning]
@@ -294,7 +295,46 @@ field set and the new field set, where any conflicts favor the new field set.
 > Overwriting duplicate points (same table, tag set, and timestamp) is _not a reliable way to maintain a last-value view_.
 > When duplicate points are flushed together, write ordering is not guaranteed—a prior write may "win."
 > See [Anti-patterns to avoid](#anti-patterns-to-avoid) and [Recommended patterns](#recommended-patterns-for-last-value-tracking) below.
+{{% /show-in %}}
 
+{{% show-in "enterprise" %}}
+> [!Warning]
+> #### Overwrites need time between writes
+>
+> Overwriting a point (same table, tag set, and timestamp) resolves non-deterministically
+> if the overwrite arrives before the previous write of that point has been persisted and
+> referenced in a snapshot: queries may return either version, and either version may be
+> permanently stored.
+>
+> To ensure the last write wins, leave enough time between writes of the same point for
+> the earlier write to be persisted and referenced in a snapshot — with default settings,
+> at least 30 minutes — and ensure the compactor is running.
+> Writes of the same point with insufficient delay yield undefined behavior.
+>
+> In clusters with multiple ingest nodes, the ordering of overwrites of the same point
+> written through different nodes is not defined.
+> Route all writes of a given point through the same node, in addition to the overwrite delay above.
+>
+> For reliable last-value tracking, use the append-only patterns below instead of
+> overwrites.
+{{% /show-in %}}
+
+{{% show-in "core" %}}
+> [!Warning]
+> #### Overwrites are not deterministic
+>
+> Overwriting a point (same table, tag set, and timestamp) is not reliable in
+> {{% product-name %}}, regardless of how far apart the writes are — concurrent or
+> spaced: queries may return either version, and either version may be permanently
+> stored.
+> {{% product-name %}} does not include the compaction process that establishes
+> a durable order between data files containing the same point.
+>
+> To maintain a last-value view, use the append-only patterns below instead of
+> overwrites.
+{{% /show-in %}}
+
+{{% show-in "core,enterprise,cloud-dedicated,clustered,cloud-serverless" %}}
 ### Recommended patterns for last-value tracking
 
 To reliably maintain a last-value view of your data, use one of these append-only patterns:

--- a/content/shared/v3-line-protocol.md
+++ b/content/shared/v3-line-protocol.md
@@ -301,15 +301,12 @@ Overwrite behavior is product-specific; see the warning below before relying on 
 > [!Warning]
 > #### Overwrites need time between writes
 >
-> Overwriting a point (same table, tag set, and timestamp) resolves non-deterministically
-> if the overwrite arrives before the previous write of that point has been persisted and
-> referenced in a snapshot: queries may return either version, and either version may be
-> permanently stored.
->
-> To ensure the last write wins, leave enough time between writes of the same point for
-> the earlier write to be persisted and referenced in a snapshot — with default settings,
-> we recommend at least 30 minutes — and ensure the compactor is running.
-> Writes of the same point with insufficient delay yield undefined behavior.
+> To ensure the last write wins when overwriting a point (same table, tag set, and
+> timestamp), leave enough time between writes of the same point for the earlier write
+> to be persisted and referenced in a snapshot — with default settings, we recommend
+> at least 30 minutes (assumes a running compactor).
+> Writes of the same point with insufficient delay resolve non-deterministically:
+> queries may return either version, and either version may be permanently stored.
 >
 > In clusters with multiple ingest nodes, the ordering of overwrites of the same point
 > written through different nodes is not defined.
@@ -323,10 +320,9 @@ Overwrite behavior is product-specific; see the warning below before relying on 
 > [!Warning]
 > #### Overwrites are not deterministic
 >
-> Overwriting a point (same table, tag set, and timestamp) is not reliable in
-> {{% product-name %}}, regardless of how far apart the writes are — concurrent or
-> spaced: queries may return either version, and either version may be permanently
-> stored.
+> Overwriting a point is not reliable in {{% product-name %}}, regardless of the
+> delay between writes: queries may return either version, and either version may
+> be permanently stored.
 >
 > To maintain a last-value view, use the append-only patterns below instead of
 > overwrites.

--- a/content/shared/v3-line-protocol.md
+++ b/content/shared/v3-line-protocol.md
@@ -327,8 +327,6 @@ Overwrites are subject to timing conditions described below; they are not a reli
 > {{% product-name %}}, regardless of how far apart the writes are — concurrent or
 > spaced: queries may return either version, and either version may be permanently
 > stored.
-> {{% product-name %}} does not include the compaction process that establishes
-> a durable order between data files containing the same point.
 >
 > To maintain a last-value view, use the append-only patterns below instead of
 > overwrites.

--- a/content/shared/v3-line-protocol.md
+++ b/content/shared/v3-line-protocol.md
@@ -286,7 +286,7 @@ A point is uniquely identified by the table name, tag set, and timestamp.
 If you submit line protocol with the same table, tag set, and timestamp,
 but with a different field set, the field set becomes the union of the old
 field set and the new field set, where any conflicts favor the new field set.
-Overwrites are subject to timing conditions described below; they are not a reliable way to maintain a last-value view unless those conditions are met.
+Overwrite behavior is product-specific; see the warning below before relying on overwrites to maintain a last-value view.
 
 {{% show-in "cloud-dedicated,clustered,cloud-serverless" %}}
 > [!Warning]
@@ -414,6 +414,7 @@ For example, **don't do this**:
 device_status,device_id=sensor01 status="active",temperature=72.5 1700000000000000000
 device_status,device_id=sensor01 status="active",temperature=73.1 1700000000000000000
 device_status,device_id=sensor01 status="inactive",temperature=73.1 1700000000000000000
+```
 
 #### Don't add a field while overwriting data (time, tags)
 
@@ -426,10 +427,11 @@ Points with the same time and tag set are still considered duplicates--for examp
 device_status,device_id=sensor01 status="active",temperature=72.5,version=1i 1700000000000000000
 device_status,device_id=sensor01 status="active",temperature=73.1,version=2i 1700000000000000000
 device_status,device_id=sensor01 status="inactive",temperature=73.1,version=3i 1700000000000000000
+```
 
-#### Don't rely on write delays to force ordering
+#### Don't rely on short write delays to force ordering
 
-Delays don't guarantee that duplicate points won't be flushed together.
+Short delays don't guarantee that duplicate points won't be flushed together.
 The flush interval depends on buffer size, ingestion rate, and system load.
 
 For example, **don't do this**:
@@ -439,6 +441,7 @@ For example, **don't do this**:
 device_status,device_id=sensor01 status="active" 1700000000000000000
 # Wait 10 seconds...
 device_status,device_id=sensor01 status="inactive" 1700000000000000000
+```
 {{% /show-in %}}
 
 {{% show-in "cloud-dedicated" %}}


### PR DESCRIPTION
## What changed

In `content/shared/v3-line-protocol.md` (Duplicate points section):

- Appended a qualifier to the field-union paragraph (all products): overwrites are subject to timing conditions and are not a reliable last-value mechanism unless those conditions are met.
- Added an Enterprise-scoped warning: overwriting a point resolves non-deterministically if the overwrite arrives before the previous write has been persisted and referenced in a snapshot; guidance to leave enough delay between writes of the same point (at least 30 minutes with default settings), keep the compactor running, and route all writes of a given point through the same node in multi-ingest-node clusters.
- Added a Core-scoped warning: overwrites are not deterministic regardless of write spacing, because Core does not include the compaction process that establishes a durable order between data files containing the same point.
- Widened the `show-in` scope of the existing "Recommended patterns for last-value tracking" and "Anti-patterns to avoid" sections to include `core` and `enterprise`. The influxctl-based retention example remains cloud-dedicated-only and the performance section keeps its existing distributed scoping.
- The existing distributed warning is unchanged.

## Why

The section stated an unqualified last-write-wins behavior for duplicate points. On Core and Enterprise, overwrite resolution depends on persistence and snapshot timing, so the docs now state the conditions and point to the append-only patterns.

## Verification

- `npx hugo --quiet` builds cleanly.
- Rendered output checked per product: Core, Enterprise, Cloud Dedicated, and Clustered each render the base paragraph plus exactly one warning; Core and Enterprise now render the patterns and anti-patterns sections; retention and performance sections unchanged. (Cloud Serverless sources a different shared file and is unaffected.)