### PR TITLE
fix(influxdb3): prevent authorization paragraph splitting

### DIFF
--- a/content/shared/influxdb3-get-started/setup.md
+++ b/content/shared/influxdb3-get-started/setup.md
@@ -531,10 +531,15 @@ The command returns a token string for authenticating CLI commands and API reque
 
 ### Set your token for authorization
 
+{{% show-in "enterprise" %}}
 Use your operator token to authenticate server actions in {{% product-name %}},
-such as {{% show-in "enterprise" %}}creating additional tokens, {{% /show-in %}}
-performing administrative tasks{{% show-in "enterprise" %}},{{% /show-in %}}
-and writing and querying data.
+such as creating additional tokens, performing administrative tasks, and
+writing and querying data.
+{{% /show-in %}}
+{{% show-in "core" %}}
+Use your operator token to authenticate server actions in {{% product-name %}},
+such as performing administrative tasks and writing and querying data.
+{{% /show-in %}}
 
 #### Authorize CLI commands
 


### PR DESCRIPTION
## What changed

- Moved the Core and Enterprise authorization introductions into separate block-level `show-in` shortcodes.
- Preserved the product-specific wording while ensuring each introduction renders as one paragraph.

## Why

Inline conditional shortcodes split the authorization sentence into three `<p>` elements, which added paragraph margins after each clause in the rendered documentation.

## Impact

The authorization introduction renders as a single paragraph in both InfluxDB 3 Core and InfluxDB 3 Enterprise documentation.

## Verification

- `git diff --check`
- Pre-push hooks: passed
- Code-block lint and local Hugo build could not run because this worktree is missing required installed dependencies (`p-limit` and the Hugo executable).
