### PR TITLE
ci(render-check): run required check on merge_group events

### DIFF
--- a/.github/workflows/pr-render-check.yml
+++ b/.github/workflows/pr-render-check.yml
@@ -19,10 +19,16 @@ name: Render Regression Check
 #      Also runs canonical.cy.js, which verifies the four branches of
 #      layouts/partials/header/canonical.html (incl. shared-source
 #      priority routing) — SEO-critical and editable only via layouts/.
+#
+# check-artifacts is a required status check for the master merge
+# queue, so this workflow must keep the merge_group trigger — without
+# it the check never reports on queue commits and every queued PR is
+# evicted when the queue's check-response timeout expires.
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
 
 jobs:
   check-artifacts:
@@ -61,8 +67,9 @@ jobs:
     # Content-only PRs don't need this layer — the site-wide grep above
     # already catches any page-level impact they could have.
     if: |
-      contains(github.event.pull_request.labels.*.name, 'render-regression') ||
-      github.event.pull_request.draft == false
+      github.event_name == 'pull_request' &&
+      (contains(github.event.pull_request.labels.*.name, 'render-regression') ||
+       github.event.pull_request.draft == false)
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1


### PR DESCRIPTION
## What changed

- Add the `merge_group` trigger to the Render Regression Check workflow (`pr-render-check.yml`).
- Gate the non-required `cypress-render` job to `pull_request` events, since its condition and detect step read `github.event.pull_request` context that `merge_group` events don't provide.
- Document in the workflow header that `check-artifacts` is a required check for the master merge queue and must keep the `merge_group` trigger.

## Why

The master merge queue requires the **Scan built HTML for forbidden render artifacts** check, but no workflow in this repo triggered on `merge_group`. Nothing ran on the queue's temporary merge commits (`statusCheckRollup` was `null`), so every queued PR sat in `AWAITING_CHECKS` until the queue's 60-minute check-response timeout evicted it. PR #7679 was removed from the queue three times this way, each ~63 minutes after enqueue.

The queue was enabled between Aug 19 and Aug 20 (PRs merged on Aug 19 have no merge-queue timeline events), which is why this gap wasn't exposed earlier.

## Impact

- Queued PRs run the required check against the queue's merge commit and can merge.
- `cypress-render` behavior on `pull_request` events is unchanged; it's now explicitly skipped on `merge_group`.
- No chicken-and-egg problem: `merge_group` runs use workflow files from the queue's merge commit, so this PR can merge through the currently-broken queue itself.

## Verification

- Workflow YAML validated with a parser; actionlint reports only pre-existing shellcheck notes in the untouched detect step.
- After this PR is queued: confirm a Render Regression Check run starts on the `gh-readonly-queue/master/...` branch and the PR merges.
- Then re-queue #7679 (no changes needed there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)