### PR TITLE
docs(influxdb3): fix cross-references, cloud scope, and delay ambiguity in duplicate-points warnings

### DIFF
--- a/content/shared/v3-line-protocol.md
+++ b/content/shared/v3-line-protocol.md
@@ -286,7 +286,8 @@ A point is uniquely identified by the table name, tag set, and timestamp.
 If you submit line protocol with the same table, tag set, and timestamp,
 but with a different field set, the field set becomes the union of the old
 field set and the new field set, where any conflicts favor the new field set.
-Overwrite behavior is product-specific; see the warning below before relying on overwrites to maintain a last-value view.
+Overwrite behavior is product-specific.
+Read the following warning before relying on overwrites to maintain a last-value view.
 
 {{% show-in "cloud-dedicated,clustered,cloud-serverless" %}}
 > [!Warning]
@@ -294,10 +295,10 @@ Overwrite behavior is product-specific; see the warning below before relying on 
 >
 > Overwriting duplicate points (same table, tag set, and timestamp) is _not a reliable way to maintain a last-value view_.
 > When duplicate points are flushed together, write ordering is not guaranteed—a prior write may "win."
-> See [Anti-patterns to avoid](#anti-patterns-to-avoid) and [Recommended patterns](#recommended-patterns-for-last-value-tracking) below.
+> See [Anti-patterns to avoid](#anti-patterns-to-avoid) and [Recommended patterns](#recommended-patterns-for-last-value-tracking).
 {{% /show-in %}}
 
-{{% show-in "enterprise" %}}
+{{% show-in "enterprise,cloud" %}}
 > [!Warning]
 > #### Overwrites need time between writes
 >
@@ -310,10 +311,10 @@ Overwrite behavior is product-specific; see the warning below before relying on 
 >
 > In clusters with multiple ingest nodes, the ordering of overwrites of the same point
 > written through different nodes is not defined.
-> Route all writes of a given point through the same node, in addition to the overwrite delay above.
+> Route all writes of a given point through the same node, in addition to leaving at least 30 minutes between writes of the same point.
 >
-> For reliable last-value tracking, use the append-only patterns below instead of
-> overwrites.
+> For reliable last-value tracking, use the [append-only patterns](#recommended-patterns-for-last-value-tracking)
+> instead of overwrites.
 {{% /show-in %}}
 
 {{% show-in "core" %}}
@@ -324,11 +325,11 @@ Overwrite behavior is product-specific; see the warning below before relying on 
 > delay between writes: queries may return either version, and either version may
 > be permanently stored.
 >
-> To maintain a last-value view, use the append-only patterns below instead of
-> overwrites.
+> To maintain a last-value view, use the [append-only patterns](#recommended-patterns-for-last-value-tracking)
+> instead of overwrites.
 {{% /show-in %}}
 
-{{% show-in "core,enterprise,cloud-dedicated,clustered,cloud-serverless" %}}
+{{% show-in "core,enterprise,cloud,cloud-dedicated,clustered,cloud-serverless" %}}
 ### Recommended patterns for last-value tracking
 
 To reliably maintain a last-value view of your data, use one of these append-only patterns:
@@ -430,6 +431,14 @@ device_status,device_id=sensor01 status="inactive",temperature=73.1,version=3i 1
 Short delays don't guarantee that duplicate points won't be flushed together.
 The flush interval depends on buffer size, ingestion rate, and system load.
 
+{{% show-in "core" %}}
+In {{% product-name %}}, overwrite timing is never deterministic, regardless of delay length; use the append-only patterns instead.
+{{% /show-in %}}
+
+{{% show-in "enterprise,cloud" %}}
+For {{% product-name %}}, "short" means less than 30 minutes (the recommended delay, assuming a running compactor).
+{{% /show-in %}}
+
 For example, **don't do this**:
 
 ```text
@@ -438,6 +447,15 @@ device_status,device_id=sensor01 status="active" 1700000000000000000
 # Wait 10 seconds...
 device_status,device_id=sensor01 status="inactive" 1700000000000000000
 ```
+
+{{% show-in "core,enterprise,cloud" %}}
+Append-only patterns increase row count.
+See [Create a database](/product/version/admin/databases/create/) to configure shorter retention for last-value data.
+{{% /show-in %}}
+
+{{% show-in "core,enterprise" %}}
+For query and storage guidance, see [Performance tuning](/product/version/admin/performance-tuning/).
+{{% /show-in %}}
 {{% /show-in %}}
 
 {{% show-in "cloud-dedicated" %}}


### PR DESCRIPTION
Follow-up to #7682.

## What changed

- Added anchor links from the Enterprise and Core overwrite warnings to the append-only patterns section (matching the existing distributed-warning convention).
- Removed directional "below"/"above" references in favor of direct links or plain statements.
- Added `cloud` to the Enterprise-scoped warning and to the patterns/anti-patterns `show-in` list — InfluxDB 3 Cloud is documented as the cloud-hosted version of Enterprise.
- Stated that Core overwrite timing is never deterministic regardless of delay length. The "don't rely on short delays" anti-pattern otherwise implies longer delays might work, contradicting Core's own warning.
- Stated the 30-minute threshold inline for Enterprise/Cloud so "short" isn't left undefined or require a lookup elsewhere on the page.
- Collapsed three near-duplicate performance/retention pointers (one per product) into a single `show-in` block, using the shared-content `/product/version/` link placeholder instead of hardcoded per-product paths.

## Why

Follow-up review of #7682 found the new product-scoped warnings:
- Didn't cross-link to the patterns they point readers toward.
- Used directional language ("below"/"above") that silently breaks when a conditional block doesn't render for a given product — which is exactly what happened to Cloud (see below).
- Left Cloud out of scope entirely. Its stub page would render a dangling "see the warning below" with no warning following it. (The page is currently suppressed behind a `request-information` alias pending #7391, so this isn't live-broken today, but it would have broken on launch.)
- Left a wording contradiction between the Core warning ("regardless of delay") and the delay anti-pattern's title ("short" delays, implying longer ones help).
- Left "short" undefined for Enterprise/Cloud readers.

## Impact

`content/shared/v3-line-protocol.md` only.

- Core, Enterprise, and Cloud reference pages now cross-link warnings to patterns and state a concrete delay threshold.
- Core, Enterprise, and Cloud gain a single shared performance/retention pointer (previously would have been three near-duplicate blocks).
- Distributed product pages (Cloud Dedicated, Clustered, Cloud Serverless) are unchanged except for the "below" removed from their existing cross-reference line.

## Verification

- `npx hugo --quiet` builds cleanly.
- Rendered output checked per product: Core and Enterprise render the updated warning with working anchor links to `#recommended-patterns-for-last-value-tracking`; Core-only and Enterprise/Cloud-only delay clarifications render only where scoped, with no stray whitespace from the nested `show-in`; distributed product pages are unaffected apart from the removed "below".
- `link-checker map`/`check` against the affected pages: 0 errors (pre-existing fragment-resolution warnings are unrelated to this change).

## Checklist

- [x] Local build passes (`npx hugo --quiet`)
- [ ] Rebased/mergeable