### PR TITLE
feat(v1): document InfluxDB OSS and Enterprise v1.13.0 release

### DIFF
--- a/content/enterprise_influxdb/v1/about-the-project/release-notes.md
+++ b/content/enterprise_influxdb/v1/about-the-project/release-notes.md
@@ -56,6 +56,12 @@ All OSS v1.13.0 updates, including the
 [adaptive TSI cache sizing](/influxdb/v1/about_the_project/release-notes/#v1130)
 and the TSM file-store lock fix, apply to Enterprise v1.13.0 too.
 
+> [!Important]
+> #### We strongly recommend upgrading to v1.12.4 or later
+>
+> If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
+> recommend [upgrading to 1.12.4 or later](/enterprise_influxdb/v1/administration/upgrading/).
+
 ---
 
 <span id="v1.12.x"></span>
@@ -68,12 +74,24 @@ and the TSM file-store lock fix, apply to Enterprise v1.13.0 too.
   index that could crash InfluxDB during concurrent read and write operations.
   This was a regression introduced in v1.12.3. The fix restores the original locking behavior.
 
+> [!Important]
+> #### We strongly recommend upgrading to v1.12.4 or later
+>
+> If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
+> recommend [upgrading to 1.12.4 or later](/enterprise_influxdb/v1/administration/upgrading/).
+
 ---
 
 ## v1.12.3 {date="2026-03-31"}
 
 InfluxDB Enterprise 1.12.3 delivers substantial efficiency gains in CPU, memory,
 and I/O usage, particularly in high-cardinality and large-scale environments.
+
+> [!Important]
+> #### We strongly recommend upgrading to v1.12.4 or later
+>
+> If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
+> recommend [upgrading to 1.12.4 or later](/enterprise_influxdb/v1/administration/upgrading/).
 
 Highlights include:
 

--- a/content/enterprise_influxdb/v1/about-the-project/release-notes.md
+++ b/content/enterprise_influxdb/v1/about-the-project/release-notes.md
@@ -11,6 +11,59 @@ alt_links:
   v1: /influxdb/v1/about_the_project/release-notes/
 ---
 
+<span id="v1.13.x"></span>
+
+## v1.13.0 {date="2026-08-20"}
+
+> [!Note]
+> #### InfluxDB OSS and Enterprise v1 relationship
+>
+> InfluxDB Enterprise v1 is a superset of InfluxDB OSS v1. All updates in the
+> [OSS v1.13.0 release notes](/influxdb/v1/about_the_project/release-notes/#v1130)
+> are included in this release. This page lists Enterprise-specific updates
+> only.
+
+> [!Important]
+> #### Default replication factor changed to 2
+>
+> Starting in v1.13.0, InfluxDB Enterprise uses a default replication factor
+> of `2` (previously `3`) when you create a database or retention policy
+> without an explicit `REPLICATION` value. This matches InfluxData's
+> recommendation for clusters with two or more data nodes. Existing
+> databases and retention policies aren't affected. To keep the previous
+> default, specify `REPLICATION 3` explicitly when you create a database or
+> retention policy.
+
+### Features
+
+- Add mTLS support to Enterprise data and meta nodes, including certificate
+  reload on `SIGHUP` and TLS configuration integrated into `influxd-ctl` and
+  other CLI commands. For setup steps, see
+  [Enable mTLS](/enterprise_influxdb/v1/administration/configure/security/enable_tls/).
+- Add an `influx-meta cleanup-shards` command that removes shards with no
+  owners and shard groups with no shards from a live cluster.
+- Add a `-timeout <duration>` flag to `influxd-ctl` that applies to any
+  command that uses the control client, including `add-data`.
+- `influxd-ctl backup` now avoids data nodes with no shard data and prefers
+  the most recently written shard copy when selecting a source.
+
+### Bug Fixes
+
+- Fixed deadlocks in the meta store, including one on raft listener close.
+- Fixed read timeouts while waiting for RPC connection reuse.
+
+All OSS v1.13.0 updates, including the
+[adaptive TSI cache sizing](/influxdb/v1/about_the_project/release-notes/#v1130)
+and the TSM file-store lock fix, apply to Enterprise v1.13.0 too.
+
+> [!Important]
+> #### We strongly recommend upgrading to v1.13.0
+>
+> If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
+> recommend [upgrading to 1.13.0](/enterprise_influxdb/v1/administration/upgrading/).
+
+---
+
 <span id="v1.12.x"></span>
 
 ## v1.12.4 {date="2026-04-13"}
@@ -22,10 +75,10 @@ alt_links:
   This was a regression introduced in v1.12.3. The fix restores the original locking behavior.
 
 > [!Important]
-> #### We strongly recommend upgrading to v1.12.4
+> #### We strongly recommend upgrading to v1.13.0
 >
 > If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
-> recommend [upgrading to 1.12.4](/enterprise_influxdb/v1/administration/upgrading/).
+> recommend [upgrading to 1.13.0](/enterprise_influxdb/v1/administration/upgrading/).
 
 ---
 
@@ -35,10 +88,10 @@ InfluxDB Enterprise 1.12.3 delivers substantial efficiency gains in CPU, memory,
 and I/O usage, particularly in high-cardinality and large-scale environments.
 
 > [!Important]
-> #### We strongly recommend upgrading to v1.12.4
+> #### We strongly recommend upgrading to v1.13.0
 >
 > If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
-> recommend [upgrading to 1.12.4](/enterprise_influxdb/v1/administration/upgrading/).
+> recommend [upgrading to 1.13.0](/enterprise_influxdb/v1/administration/upgrading/).
 
 Highlights include:
 
@@ -1198,7 +1251,7 @@ The following summarizes the expected settings for proper configuration of JWT a
 
 > [!Note]
 > To provide encrypted internode communication, you must enable HTTPS. Although
-> the JWT signature is encrypted, the the payload of a JWT token is encoded, but
+> the JWT signature is encrypted, the payload of a JWT token is encoded, but
 > is not encrypted.
 
 ### Bug fixes

--- a/content/enterprise_influxdb/v1/about-the-project/release-notes.md
+++ b/content/enterprise_influxdb/v1/about-the-project/release-notes.md
@@ -56,12 +56,6 @@ All OSS v1.13.0 updates, including the
 [adaptive TSI cache sizing](/influxdb/v1/about_the_project/release-notes/#v1130)
 and the TSM file-store lock fix, apply to Enterprise v1.13.0 too.
 
-> [!Important]
-> #### We strongly recommend upgrading to v1.13.0
->
-> If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
-> recommend [upgrading to 1.13.0](/enterprise_influxdb/v1/administration/upgrading/).
-
 ---
 
 <span id="v1.12.x"></span>
@@ -74,24 +68,12 @@ and the TSM file-store lock fix, apply to Enterprise v1.13.0 too.
   index that could crash InfluxDB during concurrent read and write operations.
   This was a regression introduced in v1.12.3. The fix restores the original locking behavior.
 
-> [!Important]
-> #### We strongly recommend upgrading to v1.13.0
->
-> If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
-> recommend [upgrading to 1.13.0](/enterprise_influxdb/v1/administration/upgrading/).
-
 ---
 
 ## v1.12.3 {date="2026-03-31"}
 
 InfluxDB Enterprise 1.12.3 delivers substantial efficiency gains in CPU, memory,
 and I/O usage, particularly in high-cardinality and large-scale environments.
-
-> [!Important]
-> #### We strongly recommend upgrading to v1.13.0
->
-> If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
-> recommend [upgrading to 1.13.0](/enterprise_influxdb/v1/administration/upgrading/).
 
 Highlights include:
 

--- a/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
@@ -1416,6 +1416,25 @@ Unauthenticated queries are attributed to `(anonymous)`.
 
 Environment variable: `INFLUXDB_HTTP_USER_QUERY_BYTES_ENABLED`
 
+#### user-write-bytes-enabled {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Enables per-user write request byte tracking, the write-path counterpart to
+`user-query-bytes-enabled`.
+When enabled, InfluxDB records the request body bytes for each v1, v2, and
+Prometheus remote write, per user, in the `userwritebytes` measurement,
+available through `SHOW STATS FOR 'userwritebytes'`, the `_internal`
+database, and the `/debug/vars` endpoint.
+
+Unauthenticated writes are attributed to `(anonymous)`.
+
+Byte counts use each endpoint's existing units: `/write` counts
+decompressed (post-gzip) bytes, while the Prometheus remote write endpoint
+counts compressed wire bytes.
+
+Environment variable: `INFLUXDB_HTTP_USER_WRITE_BYTES_ENABLED`
+
 #### https-enabled
 
 Default is `false`.

--- a/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
@@ -586,6 +586,53 @@ increase in cache size may lead to an increase in heap usage.
 
 Environment variable: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_SIZE`
 
+#### series-id-set-cache-max-size
+
+Default is `0`.
+
+The upper bound, in number of entries, for adaptive growth of the
+`series-id-set-cache-size` cache. Set this together with
+`series-id-set-cache-target-hit-rate` to let the cache grow beyond its fixed
+size when the query hit rate falls below the target. A value of `0` disables
+adaptive sizing.
+
+`series-id-set-cache-max-size` and `series-id-set-cache-target-hit-rate` must
+both be set to enable adaptive sizing, or both left at `0` to disable it.
+Setting only one prevents InfluxDB from starting. When adaptive sizing is
+enabled, `series-id-set-cache-max-size` must be greater than
+`series-id-set-cache-size`.
+
+Environment variable: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_MAX_SIZE`
+
+#### series-id-set-cache-target-hit-rate
+
+Default is `0.0`.
+
+The cache hit rate, as a fraction between `0.0` and `1.0` (exclusive), that
+adaptive sizing tries to reach for the `series-id-set-cache-size` cache.
+While the measured hit rate stays below this target and the cache is
+evicting entries, InfluxDB grows the cache capacity, up to
+`series-id-set-cache-max-size`. A value of `0.0` disables adaptive sizing.
+`1.0` isn't a valid value because that hit rate can never be reached.
+
+Environment variable: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_TARGET_HIT_RATE`
+
+#### series-id-set-cache-shrink-conservatism
+
+Default is `2.5`.
+
+How reluctant the adaptive shrink policy is to release memory from the
+`series-id-set-cache-size` cache, expressed in standard deviations. Higher
+values make the cache hold onto capacity longer and resist rapid
+grow-and-shrink cycles. Lower values reclaim memory sooner after demand
+drops. InfluxDB only uses this setting when adaptive sizing is enabled.
+
+Environment variable: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_SHRINK_CONSERVATISM`
+
+To monitor the series ID set cache, run `SHOW STATS` and check the
+`tsi1_cache` measurement. It reports `hit`, `miss`, `eviction`,
+`shrink_eviction`, `size`, and `capacity` fields.
+
 -----
 
 ## Cluster settings

--- a/content/influxdb/v1/about_the_project/release-notes.md
+++ b/content/influxdb/v1/about_the_project/release-notes.md
@@ -82,6 +82,12 @@ alt_links:
 Other updates include numerous compaction planning, locking, and stability
 improvements.
 
+> [!Important]
+> #### We strongly recommend upgrading to v1.12.4 or later
+>
+> If you’re using any previous InfluxDB v1.x version, we strongly
+> recommend [upgrading to 1.12.4 or later](/influxdb/v1/administration/upgrading/).
+
 ---
 
 ## v1.12.4 {date="2026-04-13"}
@@ -95,6 +101,12 @@ improvements.
   iterated. The fix restores the original locking behavior.
   [#27344](https://github.com/influxdata/influxdb/pull/27344),
   [#27343](https://github.com/influxdata/influxdb/issues/27343)
+
+> [!Important]
+> #### We strongly recommend upgrading to v1.12.4 or later
+>
+> If you’re using any previous InfluxDB v1.x version, we strongly
+> recommend [upgrading to 1.12.4 or later](/influxdb/v1/administration/upgrading/).
 
 ---
 

--- a/content/influxdb/v1/about_the_project/release-notes.md
+++ b/content/influxdb/v1/about_the_project/release-notes.md
@@ -81,12 +81,6 @@ alt_links:
 Other updates include numerous compaction planning, locking, and stability
 improvements.
 
-> [!Important]
-> #### We strongly recommend upgrading to v1.13.0
->
-> If you’re using any previous InfluxDB v1.x version, we strongly
-> recommend [upgrading to 1.13.0](/influxdb/v1/administration/upgrading/).
-
 ---
 
 ## v1.12.4 {date="2026-04-13"}
@@ -100,12 +94,6 @@ improvements.
   iterated. The fix restores the original locking behavior.
   [#27344](https://github.com/influxdata/influxdb/pull/27344),
   [#27343](https://github.com/influxdata/influxdb/issues/27343)
-
-> [!Important]
-> #### We strongly recommend upgrading to v1.13.0
->
-> If you’re using any previous InfluxDB v1.x version, we strongly
-> recommend [upgrading to 1.13.0](/influxdb/v1/administration/upgrading/).
 
 ---
 

--- a/content/influxdb/v1/about_the_project/release-notes.md
+++ b/content/influxdb/v1/about_the_project/release-notes.md
@@ -49,10 +49,11 @@ alt_links:
 - **`SHOW MEASUREMENTS`**: Support partial results when some shards are
   unavailable. ([#27443](https://github.com/influxdata/influxdb/pull/27443))
 - **Operational visibility**: Failed and slow queries, per-user query and
-  write byte statistics (opt-in), the remote host and user in query logs,
-  compaction planning statistics, continuous query diagnostics, and TSM
-  file-store merge metrics are now available through `SHOW STATS`,
-  `/debug/vars`, and `EXPLAIN ANALYZE`.
+  [write byte statistics](/influxdb/v1/administration/config/#user-write-bytes-enabled)
+  (opt-in), the remote host and user in query logs, compaction planning
+  statistics, continuous query diagnostics, and TSM file-store merge
+  metrics are now available through `SHOW STATS`, `/debug/vars`, and
+  `EXPLAIN ANALYZE`.
   ([#27536](https://github.com/influxdata/influxdb/pull/27536),
   [#27547](https://github.com/influxdata/influxdb/pull/27547),
   [#27188](https://github.com/influxdata/influxdb/pull/27188),

--- a/content/influxdb/v1/about_the_project/release-notes.md
+++ b/content/influxdb/v1/about_the_project/release-notes.md
@@ -14,6 +14,81 @@ alt_links:
 ---
 
 
+## v1.13.0 {date="2026-07-23"}
+
+### Features
+
+- **mTLS support**: Add mutual TLS (mTLS) authentication for the HTTP, OpenTSDB,
+  and subscriber services, including certificate reload on `SIGHUP` and
+  separate client and server certificate configuration.
+  ([#27534](https://github.com/influxdata/influxdb/pull/27534),
+  [#27543](https://github.com/influxdata/influxdb/pull/27543))
+- **Adaptive TSI cache sizing**: The
+  [`series-id-set-cache-size`](/influxdb/v1/administration/config/#series-id-set-cache-size)
+  cache can now grow and shrink itself between a configurable floor and
+  ceiling based on the measured query hit rate, instead of staying at one
+  fixed size. Configure it with the new
+  [`series-id-set-cache-max-size`](/influxdb/v1/administration/config/#series-id-set-cache-max-size),
+  [`series-id-set-cache-target-hit-rate`](/influxdb/v1/administration/config/#series-id-set-cache-target-hit-rate),
+  and
+  [`series-id-set-cache-shrink-conservatism`](/influxdb/v1/administration/config/#series-id-set-cache-shrink-conservatism)
+  settings. Monitor it through the new `tsi1_cache` `SHOW STATS` measurement.
+  ([#27480](https://github.com/influxdata/influxdb/pull/27480),
+  [#27552](https://github.com/influxdata/influxdb/pull/27552))
+- **`hardening-enabled`**: Add a `hardening-enabled` configuration option
+  that restricts Flux HTTP requests to public addresses, mitigating
+  server-side request forgery (SSRF). Disabled by default to preserve
+  existing behavior. ([#27488](https://github.com/influxdata/influxdb/pull/27488))
+- **Backup compression**: Add a `-gzipCompressionLevel` flag to `influxd backup`
+  for trading compression ratio against speed.
+  ([#27293](https://github.com/influxdata/influxdb/pull/27293))
+- **Broader config value formats**: Size and duration configuration settings
+  now accept a wider range of human-readable input formats, while remaining
+  compatible with all previously accepted values.
+  ([#27376](https://github.com/influxdata/influxdb/pull/27376))
+- **`SHOW MEASUREMENTS`**: Support partial results when some shards are
+  unavailable. ([#27443](https://github.com/influxdata/influxdb/pull/27443))
+- **Operational visibility**: Failed and slow queries, per-user query and
+  write byte statistics (opt-in), the remote host and user in query logs,
+  compaction planning statistics, continuous query diagnostics, and TSM
+  file-store merge metrics are now available through `SHOW STATS`,
+  `/debug/vars`, and `EXPLAIN ANALYZE`.
+  ([#27536](https://github.com/influxdata/influxdb/pull/27536),
+  [#27547](https://github.com/influxdata/influxdb/pull/27547),
+  [#27188](https://github.com/influxdata/influxdb/pull/27188),
+  [#27528](https://github.com/influxdata/influxdb/pull/27528),
+  [#26981](https://github.com/influxdata/influxdb/pull/26981),
+  [#27523](https://github.com/influxdata/influxdb/pull/27523),
+  [#26874](https://github.com/influxdata/influxdb/pull/26874),
+  [#26615](https://github.com/influxdata/influxdb/pull/26615),
+  [#26624](https://github.com/influxdata/influxdb/pull/26624))
+
+### Bug Fixes
+
+- Fixed a potential deadlock and reduced lock contention between compactions
+  and hot query reads in the TSM file store by splitting its single lock
+  into separate fast and slow paths.
+  ([#27501](https://github.com/influxdata/influxdb/pull/27501))
+- Corrected several TSI compaction-planning and lock-contention issues.
+  ([#27146](https://github.com/influxdata/influxdb/pull/27146),
+  [#27123](https://github.com/influxdata/influxdb/pull/27123),
+  [#26649](https://github.com/influxdata/influxdb/pull/26649),
+  [#26647](https://github.com/influxdata/influxdb/pull/26647),
+  [#26432](https://github.com/influxdata/influxdb/pull/26432))
+- Fixed authorizer leakage in `SHOW` queries.
+  ([#27196](https://github.com/influxdata/influxdb/pull/27196))
+
+Other updates include numerous compaction planning, locking, and stability
+improvements.
+
+> [!Important]
+> #### We strongly recommend upgrading to v1.13.0
+>
+> If you’re using any previous InfluxDB v1.x version, we strongly
+> recommend [upgrading to 1.13.0](/influxdb/v1/administration/upgrading/).
+
+---
+
 ## v1.12.4 {date="2026-04-13"}
 
 ### Bug Fixes
@@ -27,10 +102,10 @@ alt_links:
   [#27343](https://github.com/influxdata/influxdb/issues/27343)
 
 > [!Important]
-> #### We strongly recommend upgrading to v1.12.4
+> #### We strongly recommend upgrading to v1.13.0
 >
 > If you’re using any previous InfluxDB v1.x version, we strongly
-> recommend [upgrading to 1.12.4](/influxdb/v1/administration/upgrading/).
+> recommend [upgrading to 1.13.0](/influxdb/v1/administration/upgrading/).
 
 ---
 

--- a/content/influxdb/v1/administration/config.md
+++ b/content/influxdb/v1/administration/config.md
@@ -534,6 +534,53 @@ An increase in cache size may lead to an increase in heap usage.
 **Default**: `100`  
 **Environment variable**: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_SIZE`
 
+#### series-id-set-cache-max-size
+
+The upper bound, in number of entries, for adaptive growth of the
+[`series-id-set-cache-size`](#series-id-set-cache-size) cache. Set this together
+with `series-id-set-cache-target-hit-rate` to let the cache grow beyond its
+fixed size when the query hit rate falls below the target. A value of `0`
+disables adaptive sizing.
+
+> [!Note]
+> `series-id-set-cache-max-size` and `series-id-set-cache-target-hit-rate` must
+> both be set to enable adaptive sizing, or both left at `0` to disable it.
+> Setting only one prevents InfluxDB from starting. When adaptive sizing is
+> enabled, `series-id-set-cache-max-size` must be greater than
+> `series-id-set-cache-size`.
+
+**Default**: `0`  
+**Environment variable**: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_MAX_SIZE`
+
+#### series-id-set-cache-target-hit-rate
+
+The cache hit rate, as a fraction between `0.0` and `1.0` (exclusive), that
+adaptive sizing tries to reach for the
+[`series-id-set-cache-size`](#series-id-set-cache-size) cache. While the
+measured hit rate stays below this target and the cache is evicting entries,
+InfluxDB grows the cache capacity, up to `series-id-set-cache-max-size`. A
+value of `0.0` disables adaptive sizing. `1.0` isn't a valid value because
+that hit rate can never be reached.
+
+**Default**: `0.0`  
+**Environment variable**: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_TARGET_HIT_RATE`
+
+#### series-id-set-cache-shrink-conservatism
+
+How reluctant the adaptive shrink policy is to release memory from the
+[`series-id-set-cache-size`](#series-id-set-cache-size) cache, expressed in
+standard deviations. Higher values make the cache hold onto capacity longer
+and resist rapid grow-and-shrink cycles. Lower values reclaim memory sooner
+after demand drops. InfluxDB only uses this setting when adaptive sizing is
+enabled.
+
+**Default**: `2.5`  
+**Environment variable**: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_SHRINK_CONSERVATISM`
+
+To monitor the series ID set cache, run `SHOW STATS` and check the
+`tsi1_cache` measurement. It reports `hit`, `miss`, `eviction`,
+`shrink_eviction`, `size`, and `capacity` fields.
+
 ## Query management settings
 
 ### [coordinator]

--- a/content/influxdb/v1/administration/config.md
+++ b/content/influxdb/v1/administration/config.md
@@ -1019,6 +1019,25 @@ Unauthenticated queries are attributed to `(anonymous)`.
 **Default**: `false`
 **Environment variable**: `INFLUXDB_HTTP_USER_QUERY_BYTES_ENABLED`
 
+#### user-write-bytes-enabled {metadata="v1.13.0+"}
+
+Enables per-user write request byte tracking, the write-path counterpart to
+[`user-query-bytes-enabled`](#user-query-bytes-enabled).
+When enabled, InfluxDB records the request body bytes for each v1, v2, and
+Prometheus remote write, per user, in the `userwritebytes` measurement,
+available through `SHOW STATS FOR 'userwritebytes'`, the `_internal`
+database, and the `/debug/vars` endpoint.
+
+Unauthenticated writes are attributed to `(anonymous)`.
+
+> [!Note]
+> Byte counts use each endpoint's existing units: `/write` counts
+> decompressed (post-gzip) bytes, while the Prometheus remote write endpoint
+> counts compressed wire bytes.
+
+**Default**: `false`  
+**Environment variable**: `INFLUXDB_HTTP_USER_WRITE_BYTES_ENABLED`
+
 #### http-headers
 
 User-supplied [HTTP response headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers).

--- a/data/notifications.yaml
+++ b/data/notifications.yaml
@@ -167,6 +167,49 @@
     - [Documentation](/telegraf/enterprise/)
     - [Download and install Telegraf Controller](/telegraf/controller/install/)
 
+- id: influxdb-v1-13-release
+  level: note
+  scope:
+    - /influxdb/v1/
+  title: 'InfluxDB OSS 1.13.0 is now available'
+  slug: |
+    InfluxDB OSS 1.13.0 adds mTLS support, adaptive TSI cache sizing, and
+    a hardening option to mitigate SSRF.
+
+    [View InfluxDB OSS 1.13.0 release notes](/influxdb/v1/about_the_project/release-notes/#v1130)
+  message: |
+    **Key updates in InfluxDB OSS 1.13.0:**
+
+    - **mTLS support** for the HTTP, OpenTSDB, and subscriber services.
+    - **Adaptive TSI cache sizing**—the series ID set cache can grow and
+      shrink based on measured query hit rate.
+    - **`hardening-enabled`** option to mitigate server-side request
+      forgery (SSRF) in Flux HTTP requests.
+
+    For details, see the
+    [InfluxDB OSS 1.13.0 release notes](/influxdb/v1/about_the_project/release-notes/#v1130).
+
+- id: enterprise-influxdb-v1-13-release
+  level: note
+  scope:
+    - /enterprise_influxdb/v1/
+  title: 'InfluxDB Enterprise 1.13.0 is now available'
+  slug: |
+    InfluxDB Enterprise 1.13.0 adds mTLS support and changes the default
+    replication factor from 3 to 2.
+
+    [View InfluxDB Enterprise 1.13.0 release notes](/enterprise_influxdb/v1/about-the-project/release-notes/#v1130)
+  message: |
+    **Key updates in InfluxDB Enterprise 1.13.0:**
+
+    - **Default replication factor changed to 2** (previously 3) for new
+      databases and retention policies. Existing ones aren't affected.
+    - **mTLS support** for Enterprise data and meta nodes.
+    - All InfluxDB OSS 1.13.0 updates apply to Enterprise too.
+
+    For details, see the
+    [InfluxDB Enterprise 1.13.0 release notes](/enterprise_influxdb/v1/about-the-project/release-notes/#v1130).
+
 # - id: influxdb3.8-explorer-1.6
 #   level: note
 #   scope:

--- a/data/products.yml
+++ b/data/products.yml
@@ -305,7 +305,7 @@ influxdb:
   latest: v2.9
   latest_patches:
     v2: 2.9.1
-    v1: 1.12.4
+    v1: 1.13.0
   latest_cli:
     v2: 2.8.0
   detector_config:
@@ -502,9 +502,9 @@ enterprise_influxdb:
   list_order: 5
   versions: [v1]
   supports_flux: true
-  latest: v1.12
+  latest: v1.13
   latest_patches:
-    v1: 1.12.4
+    v1: 1.13.0
   detector_config:
     query_languages:
       InfluxQL:


### PR DESCRIPTION
## What changed
- Added InfluxDB OSS and Enterprise v1.13.0 release notes.
- Documented the three new adaptive TSI series-id-set cache config settings
  (`series-id-set-cache-max-size`, `series-id-set-cache-target-hit-rate`,
  `series-id-set-cache-shrink-conservatism`) on both the OSS and Enterprise
  config reference pages, including the `tsi1_cache` `SHOW STATS` fields.
- Bumped the latest v1 patch version in `data/products.yml` for both
  products.

## Why
InfluxDB OSS and Enterprise v1.13.0 are GA. The adaptive TSI cache config
settings, mTLS support, and other v1.13.0 changes weren't documented yet.

## Impact
Docs-only change. No code or build changes.

## Verification
- Verified the three new config settings, their defaults, validation
  errors, and `SHOW STATS` field names directly against InfluxDB source at
  tag v1.13.0, and against a locally built and running v1.13.0 Enterprise
  instance (config output, a rejected misconfiguration, and observed
  adaptive cache growth under load).
- Verified the Enterprise default replication factor change (3 to 2) and
  other release-note items against their merged PRs.
- Ran Vale on all edited pages: 0 errors, 0 warnings introduced.

## Checklist

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Rebased/mergeable
- [ ] Local build passes (`npx hugo --quiet`)