### PR TITLE
feat(enterprise): InfluxDB Enterprise v1.13.0 release

### DIFF
--- a/content/enterprise_influxdb/v1/about-the-project/release-notes.md
+++ b/content/enterprise_influxdb/v1/about-the-project/release-notes.md
@@ -56,6 +56,12 @@ All OSS v1.13.0 updates, including the
 [adaptive TSI cache sizing](/influxdb/v1/about_the_project/release-notes/#v1130)
 and the TSM file-store lock fix, apply to Enterprise v1.13.0 too.
 
+> [!Important]
+> #### We strongly recommend upgrading to v1.12.4 or later
+>
+> If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
+> recommend [upgrading to 1.12.4 or later](/enterprise_influxdb/v1/administration/upgrading/).
+
 ---
 
 <span id="v1.12.x"></span>
@@ -68,12 +74,24 @@ and the TSM file-store lock fix, apply to Enterprise v1.13.0 too.
   index that could crash InfluxDB during concurrent read and write operations.
   This was a regression introduced in v1.12.3. The fix restores the original locking behavior.
 
+> [!Important]
+> #### We strongly recommend upgrading to v1.12.4 or later
+>
+> If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
+> recommend [upgrading to 1.12.4 or later](/enterprise_influxdb/v1/administration/upgrading/).
+
 ---
 
 ## v1.12.3 {date="2026-03-31"}
 
 InfluxDB Enterprise 1.12.3 delivers substantial efficiency gains in CPU, memory,
 and I/O usage, particularly in high-cardinality and large-scale environments.
+
+> [!Important]
+> #### We strongly recommend upgrading to v1.12.4 or later
+>
+> If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
+> recommend [upgrading to 1.12.4 or later](/enterprise_influxdb/v1/administration/upgrading/).
 
 Highlights include:
 

--- a/content/enterprise_influxdb/v1/about-the-project/release-notes.md
+++ b/content/enterprise_influxdb/v1/about-the-project/release-notes.md
@@ -11,6 +11,59 @@ alt_links:
   v1: /influxdb/v1/about_the_project/release-notes/
 ---
 
+<span id="v1.13.x"></span>
+
+## v1.13.0 {date="2026-08-20"}
+
+> [!Note]
+> #### InfluxDB OSS and Enterprise v1 relationship
+>
+> InfluxDB Enterprise v1 is a superset of InfluxDB OSS v1. All updates in the
+> [OSS v1.13.0 release notes](/influxdb/v1/about_the_project/release-notes/#v1130)
+> are included in this release. This page lists Enterprise-specific updates
+> only.
+
+> [!Important]
+> #### Default replication factor changed to 2
+>
+> Starting in v1.13.0, InfluxDB Enterprise uses a default replication factor
+> of `2` (previously `3`) when you create a database or retention policy
+> without an explicit `REPLICATION` value. This matches InfluxData's
+> recommendation for clusters with two or more data nodes. Existing
+> databases and retention policies aren't affected. To keep the previous
+> default, specify `REPLICATION 3` explicitly when you create a database or
+> retention policy.
+
+### Features
+
+- Add mTLS support to Enterprise data and meta nodes, including certificate
+  reload on `SIGHUP` and TLS configuration integrated into `influxd-ctl` and
+  other CLI commands. For setup steps, see
+  [Enable mTLS](/enterprise_influxdb/v1/administration/configure/security/enable_tls/).
+- Add an `influx-meta cleanup-shards` command that removes shards with no
+  owners and shard groups with no shards from a live cluster.
+- Add a `-timeout <duration>` flag to `influxd-ctl` that applies to any
+  command that uses the control client, including `add-data`.
+- `influxd-ctl backup` now avoids data nodes with no shard data and prefers
+  the most recently written shard copy when selecting a source.
+
+### Bug Fixes
+
+- Fixed deadlocks in the meta store, including one on raft listener close.
+- Fixed read timeouts while waiting for RPC connection reuse.
+
+All OSS v1.13.0 updates, including the
+[adaptive TSI cache sizing](/influxdb/v1/about_the_project/release-notes/#v1130)
+and the TSM file-store lock fix, apply to Enterprise v1.13.0 too.
+
+> [!Important]
+> #### We strongly recommend upgrading to v1.13.0
+>
+> If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
+> recommend [upgrading to 1.13.0](/enterprise_influxdb/v1/administration/upgrading/).
+
+---
+
 <span id="v1.12.x"></span>
 
 ## v1.12.4 {date="2026-04-13"}
@@ -22,10 +75,10 @@ alt_links:
   This was a regression introduced in v1.12.3. The fix restores the original locking behavior.
 
 > [!Important]
-> #### We strongly recommend upgrading to v1.12.4
+> #### We strongly recommend upgrading to v1.13.0
 >
 > If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
-> recommend [upgrading to 1.12.4](/enterprise_influxdb/v1/administration/upgrading/).
+> recommend [upgrading to 1.13.0](/enterprise_influxdb/v1/administration/upgrading/).
 
 ---
 
@@ -35,10 +88,10 @@ InfluxDB Enterprise 1.12.3 delivers substantial efficiency gains in CPU, memory,
 and I/O usage, particularly in high-cardinality and large-scale environments.
 
 > [!Important]
-> #### We strongly recommend upgrading to v1.12.4
+> #### We strongly recommend upgrading to v1.13.0
 >
 > If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
-> recommend [upgrading to 1.12.4](/enterprise_influxdb/v1/administration/upgrading/).
+> recommend [upgrading to 1.13.0](/enterprise_influxdb/v1/administration/upgrading/).
 
 Highlights include:
 
@@ -1198,7 +1251,7 @@ The following summarizes the expected settings for proper configuration of JWT a
 
 > [!Note]
 > To provide encrypted internode communication, you must enable HTTPS. Although
-> the JWT signature is encrypted, the the payload of a JWT token is encoded, but
+> the JWT signature is encrypted, the payload of a JWT token is encoded, but
 > is not encrypted.
 
 ### Bug fixes

--- a/content/enterprise_influxdb/v1/about-the-project/release-notes.md
+++ b/content/enterprise_influxdb/v1/about-the-project/release-notes.md
@@ -56,12 +56,6 @@ All OSS v1.13.0 updates, including the
 [adaptive TSI cache sizing](/influxdb/v1/about_the_project/release-notes/#v1130)
 and the TSM file-store lock fix, apply to Enterprise v1.13.0 too.
 
-> [!Important]
-> #### We strongly recommend upgrading to v1.13.0
->
-> If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
-> recommend [upgrading to 1.13.0](/enterprise_influxdb/v1/administration/upgrading/).
-
 ---
 
 <span id="v1.12.x"></span>
@@ -74,24 +68,12 @@ and the TSM file-store lock fix, apply to Enterprise v1.13.0 too.
   index that could crash InfluxDB during concurrent read and write operations.
   This was a regression introduced in v1.12.3. The fix restores the original locking behavior.
 
-> [!Important]
-> #### We strongly recommend upgrading to v1.13.0
->
-> If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
-> recommend [upgrading to 1.13.0](/enterprise_influxdb/v1/administration/upgrading/).
-
 ---
 
 ## v1.12.3 {date="2026-03-31"}
 
 InfluxDB Enterprise 1.12.3 delivers substantial efficiency gains in CPU, memory,
 and I/O usage, particularly in high-cardinality and large-scale environments.
-
-> [!Important]
-> #### We strongly recommend upgrading to v1.13.0
->
-> If you’re using any previous InfluxDB Enterprise v1.x version, we strongly
-> recommend [upgrading to 1.13.0](/enterprise_influxdb/v1/administration/upgrading/).
 
 Highlights include:
 

--- a/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
@@ -196,6 +196,72 @@ Set to `true` to allow the data node to accept self-signed certificates if [`htt
 
 Environment variable: `INFLUXDB_META_META_INSECURE_TLS`
 
+#### meta-client-certificate {metadata="v1.13.0+"}
+
+Default is `""`.
+
+The client certificate this data node presents to meta nodes when dialing them,
+enabling mutual TLS (mTLS).
+The certificate should be a PEM-encoded bundle of the certificate and key.
+If it is just the certificate, specify a key in
+[`meta-client-private-key`](#meta-client-private-key).
+
+Environment variable: `INFLUXDB_META_META_CLIENT_CERTIFICATE`
+
+#### meta-client-private-key {metadata="v1.13.0+"}
+
+Default is `""`.
+
+Use a separate private key location for the meta client certificate.
+
+Environment variable: `INFLUXDB_META_META_CLIENT_PRIVATE_KEY`
+
+#### meta-insecure-certificate {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Relaxes the local file-permission checks on
+[`meta-client-certificate`](#meta-client-certificate) and
+[`meta-client-private-key`](#meta-client-private-key) when `true`.
+
+Environment variable: `INFLUXDB_META_META_INSECURE_CERTIFICATE`
+
+#### meta-ignore-cert-sanity-checks {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Loads [`meta-client-certificate`](#meta-client-certificate) even when it fails
+the checks for whether a client can use it, such as the certificate not
+permitting client authentication.
+The failed checks are logged instead.
+A missing or unparseable certificate is still an error.
+
+Environment variable: `INFLUXDB_META_META_IGNORE_CERT_SANITY_CHECKS`
+
+#### meta-root-ca {metadata="v1.13.0+"}
+
+Default is unset.
+
+The CA pool used to verify the server certificates of the meta nodes this data
+node dials (mTLS).
+Leaving it unset uses the host's system roots.
+Changes to this pool take effect on configuration reload (`SIGHUP`) and don't
+require a restart.
+
+Specify the CA pool as an inline table with the following keys:
+
+- `paths`: list of PEM files to trust
+- `include-system`: if `true`, also trust the host's system CA pool
+
+```toml
+meta-root-ca = { paths = ["/etc/ssl/cluster-ca.pem"], include-system = false }
+```
+
+Environment variables:
+
+- `INFLUXDB_META_META_ROOT_CA_PATHS`
+- `INFLUXDB_META_META_ROOT_CA_INCLUDE_SYSTEM`
+
 #### meta-auth-enabled
 
 Default is `false`.
@@ -660,6 +726,103 @@ Default is `false`.
 Skips file permission checking for `https-certificate` and `https-private-key` when `true`.
 
 Environment variable: `INFLUXDB_CLUSTER_HTTPS_INSECURE_CERTIFICATE`
+
+#### https-ignore-sanity-checks {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Loads a certificate even when it fails the checks for whether it can be used at
+all, such as a server certificate not permitting server authentication.
+The failed checks are logged instead.
+A missing or unparseable server certificate is still an error.
+
+Environment variable: `INFLUXDB_CLUSTER_HTTPS_IGNORE_SANITY_CHECKS`
+
+#### https-client-certificate {metadata="v1.13.0+"}
+
+Default is `""`.
+
+The certificate this data node presents when it dials a peer data node (mutual
+TLS).
+Leaving it unset presents `https-certificate` and `https-private-key` to peers
+instead.
+This is the opposite direction from `https-client-ca`, which verifies the peers
+that dial this node.
+
+Environment variable: `INFLUXDB_CLUSTER_HTTPS_CLIENT_CERTIFICATE`
+
+#### https-client-private-key {metadata="v1.13.0+"}
+
+Default is `""`.
+
+Use a separate private key location for the `https-client-certificate`.
+
+Environment variable: `INFLUXDB_CLUSTER_HTTPS_CLIENT_PRIVATE_KEY`
+
+#### https-client-auth-type {metadata="v1.13.0+"}
+
+Default is unset (`NoClientCert`).
+
+Enables mutual TLS (mTLS) by requiring and/or verifying a certificate from peer
+data nodes that connect to this node's cluster listener.
+Set to one of the following:
+
+- `NoClientCert`
+- `RequestClientCert`
+- `RequireAnyClientCert`
+- `VerifyClientCertIfGiven`
+- `RequireAndVerifyClientCert`
+
+Leaving it unset disables client-certificate authentication (`NoClientCert`).
+
+Environment variable: `INFLUXDB_CLUSTER_HTTPS_CLIENT_AUTH_TYPE`
+
+#### https-client-ca {metadata="v1.13.0+"}
+
+Default is unset.
+
+The CA pool used to verify certificates presented by peers connecting to this
+node's cluster listener (mTLS).
+Changes to this pool take effect on configuration reload (`SIGHUP`) and don't
+require a restart.
+
+Specify the CA pool as an inline table with the following keys:
+
+- `paths`: list of PEM files to trust
+- `include-system`: if `true`, also trust the host's system CA pool
+
+```toml
+https-client-ca = { paths = ["/etc/ssl/cluster-ca.pem"], include-system = false }
+```
+
+Environment variables:
+
+- `INFLUXDB_CLUSTER_HTTPS_CLIENT_CA_PATHS`
+- `INFLUXDB_CLUSTER_HTTPS_CLIENT_CA_INCLUDE_SYSTEM`
+
+#### https-root-ca {metadata="v1.13.0+"}
+
+Default is unset.
+
+The CA pool used to verify the server certificates of peer data nodes that this
+node dials (mTLS).
+Leaving it unset uses the host's system roots.
+Changes to this pool take effect on configuration reload (`SIGHUP`) and don't
+require a restart.
+
+Specify the CA pool as an inline table with the following keys:
+
+- `paths`: list of PEM files to trust
+- `include-system`: if `true`, also trust the host's system CA pool
+
+```toml
+https-root-ca = { paths = ["/etc/ssl/cluster-ca.pem"], include-system = false }
+```
+
+Environment variables:
+
+- `INFLUXDB_CLUSTER_HTTPS_ROOT_CA_PATHS`
+- `INFLUXDB_CLUSTER_HTTPS_ROOT_CA_INCLUDE_SYSTEM`
 
 #### cluster-tracing
 
@@ -1240,6 +1403,56 @@ Skips file permission checking for `https-certificate` and `https-private-key` w
 
 Environment variable: `INFLUXDB_HTTP_HTTPS_INSECURE_CERTIFICATE`
 
+#### https-ignore-sanity-checks {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Loads `https-certificate` even when it fails the checks for whether a server can
+use it, such as the certificate not permitting server authentication.
+The failed checks are logged instead.
+A missing or unparseable certificate is still an error.
+
+Environment variable: `INFLUXDB_HTTP_HTTPS_IGNORE_SANITY_CHECKS`
+
+#### https-client-auth-type {metadata="v1.13.0+"}
+
+Default is unset (`NoClientCert`).
+
+The type of client certificate authentication (mutual TLS) to require for
+connections to the HTTP API.
+Set to one of the following:
+
+- `NoClientCert`
+- `RequestClientCert`
+- `RequireAnyClientCert`
+- `VerifyClientCertIfGiven`
+- `RequireAndVerifyClientCert`
+
+Leaving it unset disables client authentication (`NoClientCert`).
+
+Environment variable: `INFLUXDB_HTTP_HTTPS_CLIENT_AUTH_TYPE`
+
+#### https-client-ca {metadata="v1.13.0+"}
+
+Default is unset.
+
+CA certificates used to verify client certificates during client authentication
+(mTLS).
+
+Specify the CA pool as an inline table with the following keys:
+
+- `paths`: list of PEM files to trust
+- `include-system`: if `true`, also trust the host's system CA pool
+
+```toml
+https-client-ca = { paths = ["/etc/ssl/client-ca.pem"], include-system = false }
+```
+
+Environment variables:
+
+- `INFLUXDB_HTTP_HTTPS_CLIENT_CA_PATHS`
+- `INFLUXDB_HTTP_HTTPS_CLIENT_CA_INCLUDE_SYSTEM`
+
 #### shared-secret
 
 Default is `""`.
@@ -1403,6 +1616,65 @@ The path to the PEM-encoded CA certs file.
 If the set to the empty string (`""`), the default system certs will used.
 
 Environment variable: `INFLUXDB_SUBSCRIBER_CA_CERTS`
+
+#### root-ca {metadata="v1.13.0+"}
+
+Default is unset.
+
+Additional CA certificates used to verify subscription endpoint server
+certificates, combined with [`ca-certs`](#ca-certs).
+
+Specify the CA pool as an inline table with the following keys:
+
+- `paths`: list of PEM files to trust
+- `include-system`: if `true`, also trust the host's system CA pool
+
+```toml
+root-ca = { paths = ["/etc/ssl/subscriber-ca.pem"], include-system = false }
+```
+
+Environment variables:
+
+- `INFLUXDB_SUBSCRIBER_ROOT_CA_PATHS`
+- `INFLUXDB_SUBSCRIBER_ROOT_CA_INCLUDE_SYSTEM`
+
+#### certificate {metadata="v1.13.0+"}
+
+Default is `""`.
+
+The client certificate the subscriber presents to HTTPS endpoints for mutual TLS
+(mTLS).
+Empty means no client certificate is presented.
+
+Environment variable: `INFLUXDB_SUBSCRIBER_CERTIFICATE`
+
+#### private-key {metadata="v1.13.0+"}
+
+Default is `""`.
+
+The private key for the subscriber client [`certificate`](#certificate).
+
+Environment variable: `INFLUXDB_SUBSCRIBER_PRIVATE_KEY`
+
+#### insecure-certificate {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Allows insecure file permissions on [`certificate`](#certificate) and
+[`private-key`](#private-key) when `true`.
+
+Environment variable: `INFLUXDB_SUBSCRIBER_INSECURE_CERTIFICATE`
+
+#### ignore-cert-sanity-checks {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Loads [`certificate`](#certificate) even when it fails the checks for whether a
+server can use it, such as the certificate not permitting server authentication.
+The failed checks are logged instead.
+A missing or unparseable certificate is still an error.
+
+Environment variable: `INFLUXDB_SUBSCRIBER_IGNORE_CERT_SANITY_CHECKS`
 
 #### write-concurrency
 
@@ -1586,8 +1858,38 @@ For more information, see [OpenTSDB protocol support in InfluxDB](/enterprise_in
 # retention-policy = ""
 # consistency-level = "one"
 # tls-enabled = false
-# certificate= "/etc/ssl/influxdb.pem"
+# certificate = "/etc/ssl/influxdb.pem"
+
+# TLS private key when TLS is enabled.
+# If blank, defaults to assuming the key is in the certificate.
+# private-key = ""                                                 # v1.13.0+
+
+# Allow insecure file permissions on certificate and private-key.
+# insecure-certificate = false                                     # v1.13.0+
+
+# Load the certificate even when it fails the checks for whether a server can
+# use it, such as the certificate not permitting server authentication.
+# The failed checks are logged instead.
+# A missing or unparseable certificate is still an error.
+# ignore-cert-sanity-checks = false                                # v1.13.0+
+
+# The type of client certificate authentication (mutual TLS) to require. One of
+# NoClientCert, RequestClientCert, RequireAnyClientCert,
+# VerifyClientCertIfGiven, or RequireAndVerifyClientCert. Unset disables client
+# authentication.
+# client-auth-type = "RequireAndVerifyClientCert"                  # v1.13.0+
+
+# CA certificates used to verify client certificates during client
+# authentication. "paths" lists PEM files to trust; "include-system" also
+# trusts the host's system CA pool.
+# client-ca = { paths = ["/etc/ssl/client-ca.pem"], include-system = false } # v1.13.0+
 ```
+
+{{% note %}}
+The OpenTSDB TLS mutual-authentication options (`private-key`,
+`insecure-certificate`, `ignore-cert-sanity-checks`, `client-auth-type`, and
+`client-ca`) were added in **v1.13.0**.
+{{% /note %}}
 
 #### log-point-errors
 

--- a/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
@@ -1416,6 +1416,25 @@ Unauthenticated queries are attributed to `(anonymous)`.
 
 Environment variable: `INFLUXDB_HTTP_USER_QUERY_BYTES_ENABLED`
 
+#### user-write-bytes-enabled {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Enables per-user write request byte tracking, the write-path counterpart to
+`user-query-bytes-enabled`.
+When enabled, InfluxDB records the request body bytes for each v1, v2, and
+Prometheus remote write, per user, in the `userwritebytes` measurement,
+available through `SHOW STATS FOR 'userwritebytes'`, the `_internal`
+database, and the `/debug/vars` endpoint.
+
+Unauthenticated writes are attributed to `(anonymous)`.
+
+Byte counts use each endpoint's existing units: `/write` counts
+decompressed (post-gzip) bytes, while the Prometheus remote write endpoint
+counts compressed wire bytes.
+
+Environment variable: `INFLUXDB_HTTP_USER_WRITE_BYTES_ENABLED`
+
 #### https-enabled
 
 Default is `false`.

--- a/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/configure/config-data-nodes.md
@@ -586,6 +586,53 @@ increase in cache size may lead to an increase in heap usage.
 
 Environment variable: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_SIZE`
 
+#### series-id-set-cache-max-size
+
+Default is `0`.
+
+The upper bound, in number of entries, for adaptive growth of the
+`series-id-set-cache-size` cache. Set this together with
+`series-id-set-cache-target-hit-rate` to let the cache grow beyond its fixed
+size when the query hit rate falls below the target. A value of `0` disables
+adaptive sizing.
+
+`series-id-set-cache-max-size` and `series-id-set-cache-target-hit-rate` must
+both be set to enable adaptive sizing, or both left at `0` to disable it.
+Setting only one prevents InfluxDB from starting. When adaptive sizing is
+enabled, `series-id-set-cache-max-size` must be greater than
+`series-id-set-cache-size`.
+
+Environment variable: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_MAX_SIZE`
+
+#### series-id-set-cache-target-hit-rate
+
+Default is `0.0`.
+
+The cache hit rate, as a fraction between `0.0` and `1.0` (exclusive), that
+adaptive sizing tries to reach for the `series-id-set-cache-size` cache.
+While the measured hit rate stays below this target and the cache is
+evicting entries, InfluxDB grows the cache capacity, up to
+`series-id-set-cache-max-size`. A value of `0.0` disables adaptive sizing.
+`1.0` isn't a valid value because that hit rate can never be reached.
+
+Environment variable: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_TARGET_HIT_RATE`
+
+#### series-id-set-cache-shrink-conservatism
+
+Default is `2.5`.
+
+How reluctant the adaptive shrink policy is to release memory from the
+`series-id-set-cache-size` cache, expressed in standard deviations. Higher
+values make the cache hold onto capacity longer and resist rapid
+grow-and-shrink cycles. Lower values reclaim memory sooner after demand
+drops. InfluxDB only uses this setting when adaptive sizing is enabled.
+
+Environment variable: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_SHRINK_CONSERVATISM`
+
+To monitor the series ID set cache, run `SHOW STATS` and check the
+`tsi1_cache` measurement. It reports `hit`, `miss`, `eviction`,
+`shrink_eviction`, `size`, and `capacity` fields.
+
 -----
 
 ## Cluster settings

--- a/content/enterprise_influxdb/v1/administration/configure/config-meta-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/configure/config-meta-nodes.md
@@ -204,6 +204,105 @@ This is useful when testing with self-signed certificates.
 
 Environment variable: `INFLUXDB_META_DATA_INSECURE_TLS`
 
+#### https-ignore-sanity-checks {metadata="v1.13.0+"}
+
+Default is `false`.
+
+Loads a certificate even when it fails the checks for whether it can be used at
+all, such as a server certificate not permitting server authentication.
+The failed checks are logged instead.
+A missing or unparseable server certificate is still an error.
+Applies to both the HTTP API and data/raft listeners.
+
+Environment variable: `INFLUXDB_META_HTTPS_IGNORE_SANITY_CHECKS`
+
+#### https-client-certificate {metadata="v1.13.0+"}
+
+Default is `""`.
+
+The certificate this meta node presents when it dials a peer, such as another
+meta node or a data node (mutual TLS).
+Leaving it unset presents [`https-certificate`](#https-certificate) and
+[`https-private-key`](#https-private-key) to peers instead.
+This is the opposite direction from [`https-client-ca`](#https-client-ca), which
+verifies the peers that dial this node.
+
+Environment variable: `INFLUXDB_META_HTTPS_CLIENT_CERTIFICATE`
+
+#### https-client-private-key {metadata="v1.13.0+"}
+
+Default is `""`.
+
+Use a separate private key location for the
+[`https-client-certificate`](#https-client-certificate).
+
+Environment variable: `INFLUXDB_META_HTTPS_CLIENT_PRIVATE_KEY`
+
+#### https-client-auth-type {metadata="v1.13.0+"}
+
+Default is unset (`NoClientCert`).
+
+Enables mutual TLS (mTLS) by requiring and/or verifying a certificate from peers
+that connect to this meta node's HTTP API and data/raft listeners.
+Set to one of the following:
+
+- `NoClientCert`
+- `RequestClientCert`
+- `RequireAnyClientCert`
+- `VerifyClientCertIfGiven`
+- `RequireAndVerifyClientCert`
+
+Leaving it unset disables client-certificate authentication (`NoClientCert`).
+
+Environment variable: `INFLUXDB_META_HTTPS_CLIENT_AUTH_TYPE`
+
+#### https-client-ca {metadata="v1.13.0+"}
+
+Default is unset.
+
+The CA pool used to verify certificates presented by peers connecting to this
+meta node's listeners (mTLS).
+Changes to this pool take effect on configuration reload (`SIGHUP`) and don't
+require a restart.
+
+Specify the CA pool as an inline table with the following keys:
+
+- `paths`: list of PEM files to trust
+- `include-system`: if `true`, also trust the host's system CA pool
+
+```toml
+https-client-ca = { paths = ["/etc/ssl/cluster-ca.pem"], include-system = false }
+```
+
+Environment variables:
+
+- `INFLUXDB_META_HTTPS_CLIENT_CA_PATHS`
+- `INFLUXDB_META_HTTPS_CLIENT_CA_INCLUDE_SYSTEM`
+
+#### https-root-ca {metadata="v1.13.0+"}
+
+Default is unset.
+
+The CA pool used to verify the server certificates of the peers this meta node
+dials, such as other meta nodes and data nodes (mTLS).
+Leaving it unset uses the host's system roots.
+Changes to this pool take effect on configuration reload (`SIGHUP`) and don't
+require a restart.
+
+Specify the CA pool as an inline table with the following keys:
+
+- `paths`: list of PEM files to trust
+- `include-system`: if `true`, also trust the host's system CA pool
+
+```toml
+https-root-ca = { paths = ["/etc/ssl/cluster-ca.pem"], include-system = false }
+```
+
+Environment variables:
+
+- `INFLUXDB_META_HTTPS_ROOT_CA_PATHS`
+- `INFLUXDB_META_HTTPS_ROOT_CA_INCLUDE_SYSTEM`
+
 #### gossip-frequency
 
 Default is `"5s"`.

--- a/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
+++ b/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
@@ -17,6 +17,7 @@ Enabling HTTPS over TLS encrypts the communication between clients and the Influ
 When configured with a signed certificate, HTTPS over TLS can also verify the authenticity of the InfluxDB Enterprise server to connecting clients.
 
 This pages outlines how to set up HTTPS with InfluxDB Enterprise using either a signed or self-signed certificate.
+It also describes how to enable [mutual TLS (mTLS)](#enable-mutual-tls-mtls) so that both ends of each connection authenticate each other.
 
 {{% warn %}}
 InfluxData **strongly recommends** enabling HTTPS, especially if you plan on sending requests to InfluxDB Enterprise over a network.
@@ -55,7 +56,7 @@ Regardless of your certificate's type, InfluxDB Enterprise supports certificates
 a private key file (`.key`) and a signed certificate file (`.crt`) file pair, as well as certificates
 that combine the private key file and the signed certificate file into a single bundled file (`.pem`).
 
-In general, each node node should have its own certificate, whether signed or unsigned.
+In general, each node should have its own certificate, whether signed or unsigned.
 
 ## Set up HTTPS in an InfluxDB Enterprise cluster
 
@@ -251,6 +252,219 @@ With a self-signed certificate, you must also use the `-k` option to skip certif
     ```
 
     That's it! You've successfully set up HTTPS with InfluxDB Enterprise.
+
+## Enable mutual TLS (mTLS) {metadata="v1.13.0+"}
+
+With standard HTTPS, only the server presents a certificate and the client verifies it.
+**Mutual TLS (mTLS)** additionally requires the _client_ to present a certificate that the _server_ verifies, so both ends of every connection authenticate each other.
+
+In an InfluxDB Enterprise cluster, you can require mTLS on:
+
+- **Inter-node connections**: meta-to-meta, meta-to-data, and data-to-data traffic.
+- **HTTP API connections**: clients such as the [`influx` CLI](/enterprise_influxdb/v1/tools/influx-cli/use-influx/), `influxd-ctl`, and Telegraf connecting to the data node or meta node API.
+
+{{% note %}}
+mTLS options require **InfluxDB Enterprise v1.13.0+** and build on the HTTPS
+configuration described above.
+Complete [Set up HTTPS](#set-up-https-in-an-influxdb-enterprise-cluster) before
+enabling mTLS.
+
+Creating the certificates, private keys, and CA files needed for mTLS is outside
+the scope of this guide.
+The following steps assume you already have a CA certificate (for example,
+`/etc/ssl/cluster-ca.crt`) that signed each node's certificate, plus the server
+certificate and key installed on each node.
+{{% /note %}}
+
+### How mTLS settings map to connections
+
+Each node acts as both a **server** (accepting connections) and a **client**
+(dialing other nodes), so configure mTLS from both perspectives.
+
+| Role              | Purpose                                                        | Settings                                          |
+| :---------------- | :------------------------------------------------------------ | :------------------------------------------------ |
+| Server (listener) | Require and verify certificates from connecting clients       | `*-client-auth-type`, `*-client-ca`               |
+| Client (dialer)   | Present a certificate to the servers this node dials          | `*-client-certificate`, `*-client-private-key`    |
+| Client (dialer)   | Verify the server certificates of the servers this node dials | `*-root-ca` (`meta-root-ca` for meta connections) |
+
+{{% note %}}
+If you don't set a separate client certificate (`*-client-certificate`), the node
+presents its server certificate (`https-certificate`) when dialing peers.
+Set a separate client certificate only if you use distinct certificates for the
+client and server roles.
+{{% /note %}}
+
+Set `*-client-auth-type` to one of the following:
+
+| Value                        | Behavior                                                             |
+| :--------------------------- | :------------------------------------------------------------------ |
+| `NoClientCert`               | Don't request a client certificate (mTLS disabled).                 |
+| `RequestClientCert`          | Request a certificate, but don't require or verify it.              |
+| `RequireAnyClientCert`       | Require a certificate, but don't verify it against a CA.            |
+| `VerifyClientCertIfGiven`    | Verify the certificate against the CA only if one is presented.     |
+| `RequireAndVerifyClientCert` | Require and verify a certificate against the CA (enforced mTLS).    |
+
+The CA settings (`*-client-ca` and `*-root-ca`) are inline tables:
+
+- `paths`: list of PEM files whose certificates are trusted
+- `include-system` _(optional)_: if `true`, also trust the host's system CA pool (default is `false`)
+
+### Configure mTLS on meta nodes
+
+In the `[meta]` section of each meta node configuration file (`influxdb-meta.conf`),
+add the following to the [HTTPS settings you already configured](#set-up-https-in-an-influxdb-enterprise-cluster):
+
+```toml
+[meta]
+
+  [...]
+
+  # Require and verify a certificate from peers that connect to this meta node
+  # (applies to both the HTTP API and raft/data listeners).
+  https-client-auth-type = "RequireAndVerifyClientCert"
+
+  # CA used to verify certificates presented by connecting peers.
+  https-client-ca = { paths = ["/etc/ssl/cluster-ca.crt"] }
+
+  # CA used to verify the server certificates of the peers this meta node dials
+  # (other meta nodes and data nodes).
+  https-root-ca = { paths = ["/etc/ssl/cluster-ca.crt"] }
+
+  # Optional: present a separate client certificate when dialing peers.
+  # If unset, the meta node presents `https-certificate` and `https-private-key`.
+  # https-client-certificate = "/etc/ssl/influxdb-meta-client.crt"
+  # https-client-private-key = "/etc/ssl/influxdb-meta-client.key"
+```
+
+{{% note %}}
+When you verify peer server certificates with `https-root-ca`, you no longer need
+`https-insecure-tls` or `data-insecure-tls` to skip verification.
+Remove those settings (or leave them `false`) to keep server verification enabled.
+{{% /note %}}
+
+### Configure mTLS on data nodes
+
+In the data node configuration file (`influxdb.conf`), configure mTLS for each
+type of connection.
+
+#### Inter-data-node connections `[cluster]`
+
+```toml
+[cluster]
+
+  [...]
+
+  # Require and verify a certificate from peer data nodes that connect to this
+  # node's cluster listener.
+  https-client-auth-type = "RequireAndVerifyClientCert"
+
+  # CA used to verify certificates presented by connecting peer data nodes.
+  https-client-ca = { paths = ["/etc/ssl/cluster-ca.crt"] }
+
+  # CA used to verify the server certificates of peer data nodes this node dials.
+  https-root-ca = { paths = ["/etc/ssl/cluster-ca.crt"] }
+
+  # Optional: present a separate client certificate when dialing peers.
+  # If unset, the data node presents `https-certificate` and `https-private-key`.
+  # https-client-certificate = "/etc/ssl/influxdb-data-client.crt"
+  # https-client-private-key = "/etc/ssl/influxdb-data-client.key"
+```
+
+#### Data-node-to-meta-node connections `[meta]`
+
+```toml
+[meta]
+
+  [...]
+
+  meta-tls-enabled = true
+
+  # Client certificate this data node presents to meta nodes (mTLS).
+  # If unset, no client certificate is presented.
+  meta-client-certificate = "/etc/ssl/influxdb-data.crt"
+  meta-client-private-key  = "/etc/ssl/influxdb-data.key"
+
+  # CA used to verify the server certificates of the meta nodes this data node dials.
+  meta-root-ca = { paths = ["/etc/ssl/cluster-ca.crt"] }
+```
+
+#### HTTP API connections `[http]`
+
+To require client certificates from clients that connect to the data node HTTP API
+(for example, the `influx` CLI and Telegraf), configure the `[http]` section:
+
+```toml
+[http]
+
+  [...]
+
+  # Require and verify a client certificate for HTTP API connections.
+  https-client-auth-type = "RequireAndVerifyClientCert"
+
+  # CA used to verify client certificates.
+  https-client-ca = { paths = ["/etc/ssl/client-ca.crt"] }
+```
+
+{{% warn %}}
+Requiring client certificates on the HTTP API (`[http] https-client-auth-type`)
+means **every** HTTP API client must present a valid certificate.
+Before enabling this setting, ensure all clients&mdash;including the `influx` CLI,
+Telegraf, and your applications&mdash;are configured to present a client certificate.
+{{% /warn %}}
+
+### Apply the configuration
+
+If you're enabling HTTPS and mTLS at the same time, restart each node as described
+in [Set up HTTPS](#set-up-https-in-an-influxdb-enterprise-cluster):
+
+```sh
+sudo systemctl restart influxdb-meta
+sudo systemctl restart influxdb
+```
+
+If HTTPS is already enabled and you're only adding or changing mTLS settings
+(client authentication type, CA pools, or certificates), you can apply the
+changes without a restart by reloading each process with `SIGHUP`:
+
+```sh
+sudo systemctl reload influxdb-meta
+sudo systemctl reload influxdb
+```
+
+{{% note %}}
+Enabling or disabling HTTPS (`https-enabled`) always requires a restart.
+Only certificate, CA pool, and client-authentication changes can be applied with
+`SIGHUP`.
+{{% /note %}}
+
+### Verify mTLS
+
+After you require client certificates on the meta node listeners, `influxd-ctl`
+must present a client certificate to connect:
+
+```sh
+influxd-ctl -bind-tls \
+  -cert /etc/ssl/influxd-ctl-client.crt \
+  -key /etc/ssl/influxd-ctl-client.key \
+  -ca-cert /etc/ssl/cluster-ca.crt \
+  show
+```
+
+- `-cert` and `-key`: the client certificate and private key `influxd-ctl` presents
+  (use `-client-cert` and `-client-key` to present a separate client identity).
+- `-ca-cert`: the CA used to verify the meta node's server certificate.
+
+If you require client certificates on the data node HTTP API, connect with the
+`influx` CLI by passing the client certificate and key:
+
+```sh
+influx -ssl -host <domain_name>.com \
+  -cert /etc/ssl/influx-client.crt \
+  -key /etc/ssl/influx-client.key
+```
+
+You can also set the `INFLUX_CERT` and `INFLUX_KEY` environment variables instead
+of the `-cert` and `-key` flags.
 
 ## Connect Telegraf to a secured InfluxDB Enterprise instance
 

--- a/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
+++ b/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
@@ -403,12 +403,11 @@ To require client certificates from clients that connect to the data node HTTP A
   https-client-ca = { paths = ["/etc/ssl/client-ca.crt"] }
 ```
 
-{{% warn %}}
-Requiring client certificates on the HTTP API (`[http] https-client-auth-type`)
-means **every** HTTP API client must present a valid certificate.
-Before enabling this setting, ensure all clients&mdash;including the `influx` CLI,
-Telegraf, and your applications&mdash;are configured to present a client certificate.
-{{% /warn %}}
+> [!Important]
+> Requiring client certificates on the HTTP API (`[http] https-client-auth-type`)
+> means **every** HTTP API client must present a valid certificate.
+> Before enabling this setting, ensure all clients&mdash;including the `influx` CLI,
+> Telegraf, and your applications&mdash;are configured to present a client certificate.
 
 ### Apply the configuration
 

--- a/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
+++ b/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
@@ -286,12 +286,11 @@ Each node acts as both a **server** (accepting connections) and a **client**
 | Client (dialer)   | Present a certificate to the servers this node dials          | `*-client-certificate`, `*-client-private-key`    |
 | Client (dialer)   | Verify the server certificates of the servers this node dials | `*-root-ca` (`meta-root-ca` for meta connections) |
 
-{{% note %}}
-If you don't set a separate client certificate (`*-client-certificate`), the node
-presents its server certificate (`https-certificate`) when dialing peers.
-Set a separate client certificate only if you use distinct certificates for the
-client and server roles.
-{{% /note %}}
+> [!Note]
+> If you don't set a separate client certificate (`*-client-certificate`), the node
+> presents its server certificate (`https-certificate`) when dialing peers.
+> Set a separate client certificate only if you use distinct certificates for the
+> client and server roles.
 
 Set `*-client-auth-type` to one of the following:
 

--- a/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
+++ b/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
@@ -427,11 +427,10 @@ sudo systemctl reload influxdb-meta
 sudo systemctl reload influxdb
 ```
 
-{{% note %}}
-Enabling or disabling HTTPS (`https-enabled`) always requires a restart.
-Only certificate, CA pool, and client-authentication changes can be applied with
-`SIGHUP`.
-{{% /note %}}
+> [!Note]
+> Enabling or disabling HTTPS (`https-enabled`) always requires a restart.
+> Only certificate, CA pool, and client-authentication changes can be applied with
+> `SIGHUP`.
 
 ### Verify mTLS
 

--- a/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
+++ b/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
@@ -263,18 +263,17 @@ In an InfluxDB Enterprise cluster, you can require mTLS on:
 - **Inter-node connections**: meta-to-meta, meta-to-data, and data-to-data traffic.
 - **HTTP API connections**: clients such as the [`influx` CLI](/enterprise_influxdb/v1/tools/influx-cli/use-influx/), `influxd-ctl`, and Telegraf connecting to the data node or meta node API.
 
-{{% note %}}
-mTLS options require **InfluxDB Enterprise v1.13.0+** and build on the HTTPS
-configuration described above.
-Complete [Set up HTTPS](#set-up-https-in-an-influxdb-enterprise-cluster) before
-enabling mTLS.
-
-Creating the certificates, private keys, and CA files needed for mTLS is outside
-the scope of this guide.
-The following steps assume you already have a CA certificate (for example,
-`/etc/ssl/cluster-ca.crt`) that signed each node's certificate, plus the server
-certificate and key installed on each node.
-{{% /note %}}
+> [!Note]
+> mTLS options require **InfluxDB Enterprise v1.13.0+** and build on the HTTPS
+> configuration described above.
+> Complete [Set up HTTPS](#set-up-https-in-an-influxdb-enterprise-cluster) before
+> enabling mTLS.
+> 
+> Creating the certificates, private keys, and CA files needed for mTLS is outside
+> the scope of this guide.
+> The following steps assume you already have a CA certificate (for example,
+> `/etc/ssl/cluster-ca.crt`) that signed each node's certificate, plus the server
+> certificate and key installed on each node.
 
 ### How mTLS settings map to connections
 

--- a/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
+++ b/content/enterprise_influxdb/v1/administration/configure/security/enable_tls.md
@@ -335,11 +335,10 @@ add the following to the [HTTPS settings you already configured](#set-up-https-i
   # https-client-private-key = "/etc/ssl/influxdb-meta-client.key"
 ```
 
-{{% note %}}
-When you verify peer server certificates with `https-root-ca`, you no longer need
-`https-insecure-tls` or `data-insecure-tls` to skip verification.
-Remove those settings (or leave them `false`) to keep server verification enabled.
-{{% /note %}}
+> [!Note]
+> When you verify peer server certificates with `https-root-ca`, you no longer need
+> `https-insecure-tls` or `data-insecure-tls` to skip verification.
+> Remove those settings (or leave them `false`) to keep server verification enabled.
 
 ### Configure mTLS on data nodes
 

--- a/content/enterprise_influxdb/v1/administration/manage/clusters/replacing-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/manage/clusters/replacing-nodes.md
@@ -61,6 +61,14 @@ influxd-ctl -bind-tls [-k] <command>
 influxd-ctl -bind-tls remove-meta enterprise-meta-02:8091
 ```
 
+{{% note %}}
+If the cluster requires mutual TLS (mTLS), also pass a client certificate and key
+with `-cert` and `-key` (and `-ca-cert` to verify the meta node's certificate).
+For more information, see the
+[`influxd-ctl` global flags](/enterprise_influxdb/v1/tools/influxd-ctl/#influxd-ctl-global-flags)
+and [Enable mutual TLS (mTLS)](/enterprise_influxdb/v1/administration/configure/security/enable_tls/#enable-mutual-tls-mtls). _v1.13.0+_
+{{% /note %}}
+
 #### `curl -k`
 
 `curl` natively supports TLS/SSL connections, but if using a self-signed certificate,

--- a/content/enterprise_influxdb/v1/administration/manage/clusters/replacing-nodes.md
+++ b/content/enterprise_influxdb/v1/administration/manage/clusters/replacing-nodes.md
@@ -61,13 +61,12 @@ influxd-ctl -bind-tls [-k] <command>
 influxd-ctl -bind-tls remove-meta enterprise-meta-02:8091
 ```
 
-{{% note %}}
-If the cluster requires mutual TLS (mTLS), also pass a client certificate and key
-with `-cert` and `-key` (and `-ca-cert` to verify the meta node's certificate).
-For more information, see the
-[`influxd-ctl` global flags](/enterprise_influxdb/v1/tools/influxd-ctl/#influxd-ctl-global-flags)
-and [Enable mutual TLS (mTLS)](/enterprise_influxdb/v1/administration/configure/security/enable_tls/#enable-mutual-tls-mtls). _v1.13.0+_
-{{% /note %}}
+> [!Note]
+> If the cluster requires mutual TLS (mTLS), also pass a client certificate and key
+> with `-cert` and `-key` (and `-ca-cert` to verify the meta node's certificate).
+> For more information, see the
+> [`influxd-ctl` global flags](/enterprise_influxdb/v1/tools/influxd-ctl/#influxd-ctl-global-flags)
+> and [Enable mutual TLS (mTLS)](/enterprise_influxdb/v1/administration/configure/security/enable_tls/#enable-mutual-tls-mtls). _v1.13.0+_
 
 #### `curl -k`
 

--- a/content/enterprise_influxdb/v1/tools/influx-cli/_index.md
+++ b/content/enterprise_influxdb/v1/tools/influx-cli/_index.md
@@ -30,6 +30,11 @@ influx [flags]
 | `-username`       | Username to connect to the server                                                                     |
 | `-ssl`            | Use https for requests                                                                                |
 | `-unsafessl`      | Set this when connecting to the cluster using https                                                   |
+| `-cert`           | Path to the client certificate file (PEM) presented for mutual TLS (mTLS). Also settable via `INFLUX_CERT`. _v1.13.0+_ |
+| `-key`            | Path to the client private key file (PEM) for mutual TLS (mTLS). Also settable via `INFLUX_KEY`. _v1.13.0+_ |
+| `-root-ca`        | Path to the CA bundle (PEM) used to verify the server certificate. Also settable via `INFLUX_ROOT_CA`. _v1.13.0+_ |
+| `-insecure-certificate` | Ignore file permission checks when loading the client certificate and key. Also settable via `INFLUX_INSECURE_CERTIFICATE`. _v1.13.0+_ |
+| `-ignore-cert-sanity-checks` | Load the client certificate even if it fails client-authentication sanity checks. Also settable via `INFLUX_IGNORE_CERT_SANITY_CHECKS`. _v1.13.0+_ |
 | `-execute`        | Execute command and quit                                                                              |
 | `-format`         | Specify the format of the server responses: json, csv, or column                                      |
 | `-precision`      | Specify the format of the timestamp: rfc3339, h, m, s, ms, u or ns                                    |

--- a/content/enterprise_influxdb/v1/tools/influx-cli/use-influx-cli.md
+++ b/content/enterprise_influxdb/v1/tools/influx-cli/use-influx-cli.md
@@ -87,6 +87,10 @@ Arguments specify connection, write, import, and output options for the CLI sess
 `-h`, `-help`
 List `influx` arguments
 
+`-cert 'path'` _(v1.13.0+)_
+Path to the client certificate file (PEM) presented for mutual TLS (mTLS).
+Alternatively, set the certificate with the `INFLUX_CERT` environment variable.
+
 `-compressed`
 Set to true if the import file is compressed.
 Use with `-import`.
@@ -109,9 +113,21 @@ See [-format](#specify-the-format-of-the-server-responses-with--format).
 The host to which `influx` connects.
 By default, InfluxDB runs on localhost.
 
+`-ignore-cert-sanity-checks` _(v1.13.0+)_
+Load the client certificate even if it fails client-authentication sanity checks.
+Alternatively, set this with the `INFLUX_IGNORE_CERT_SANITY_CHECKS` environment variable.
+
 `-import`
 Import new data or [exported data](/enterprise_influxdb/v1/administration/backup-and-restore/#exporting-data) from a file.
 See [-import](#import-data-from-a-file).
+
+`-insecure-certificate` _(v1.13.0+)_
+Ignore file permission checks when loading the client certificate and key.
+Alternatively, set this with the `INFLUX_INSECURE_CERTIFICATE` environment variable.
+
+`-key 'path'` _(v1.13.0+)_
+Path to the client private key file (PEM) for mutual TLS (mTLS).
+Alternatively, set the key with the `INFLUX_KEY` environment variable.
 
 `-password 'password'`
 The password `influx` uses to connect to the server.
@@ -140,6 +156,10 @@ Precision defaults to nanoseconds.
 
 `-pretty`
 Turns on pretty print for the `json` format.
+
+`-root-ca 'path'` _(v1.13.0+)_
+Path to the CA bundle (PEM) used to verify the server certificate.
+Alternatively, set the CA bundle with the `INFLUX_ROOT_CA` environment variable.
 
 `-ssl`
 Use HTTPS for requests.

--- a/content/enterprise_influxdb/v1/tools/influxd-ctl/_index.md
+++ b/content/enterprise_influxdb/v1/tools/influxd-ctl/_index.md
@@ -49,17 +49,24 @@ influxd-ctl [global-flags] <command> [command-flags] [arguments]
 
 ## Global flags {#influxd-ctl-global-flags}
 
-| Flag         | Description                                                              |
-| :----------- | :----------------------------------------------------------------------- |
-| `-auth-type` | Authentication type to use (`none` _default_, `basic`, `jwt`)            |
-| `-bind`      | Meta node HTTP bind address _(default is `localhost:8091`)_              |
-| `-bind-tls`  | Use TLS                                                                  |
-| `-config`    | Configuration file path                                                  |
-| `-k`         | Skip certificate verification _(ignored without `-bind-tls`)_            |
-| `-pwd`       | Password for basic authentication _(ignored without `-auth-type basic`)_ |
-| `-secret`    | JWT shared secret _(ignored without `-auth-type jwt`)_                   |
-| `-timeout`   | Override the default timeout of 10s for operations _(for example, `30s`, `1m`)_. _v1.12.3+_ |
-| `-user`      | Username _(ignored without `-auth-type basic` or `jwt`)_                 |
+| Flag                         | Description                                                                                                           |
+| :--------------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| `-auth-type`                 | Authentication type to use (`none` _default_, `basic`, `jwt`)                                                        |
+| `-bind`                      | Meta node HTTP bind address _(default is `localhost:8091`)_                                                          |
+| `-bind-tls`                  | Use TLS                                                                                                              |
+| `-ca-cert`                   | CA certificate used to verify the meta node's server certificate _(ignored without `-bind-tls`)_. _v1.13.0+_        |
+| `-cert`                      | Client certificate for mutual TLS (mTLS), used unless `-client-cert` is given _(ignored without `-bind-tls`)_. _v1.13.0+_ |
+| `-client-cert`               | Client certificate for mutual TLS (mTLS), overriding `-cert` _(ignored without `-bind-tls`)_. _v1.13.0+_           |
+| `-client-key`                | Client private key for `-client-cert` _(ignored without `-bind-tls`)_. _v1.13.0+_                                   |
+| `-config`                    | Configuration file path                                                                                             |
+| `-ignore-cert-sanity-checks` | Present the client certificate even if it fails the checks for whether a client can use it. _v1.13.0+_             |
+| `-insecure-certificate`      | Skip file-permission checks on the certificate and private key. _v1.13.0+_                                          |
+| `-k`                         | Skip certificate verification _(ignored without `-bind-tls`)_                                                       |
+| `-key`                       | Client private key for `-cert` _(ignored without `-bind-tls`)_. _v1.13.0+_                                          |
+| `-pwd`                       | Password for basic authentication _(ignored without `-auth-type basic`)_                                            |
+| `-secret`                    | JWT shared secret _(ignored without `-auth-type jwt`)_                                                              |
+| `-timeout`                   | Override the default timeout of 10s for operations _(for example, `30s`, `1m`)_. _v1.12.3+_                         |
+| `-user`                      | Username _(ignored without `-auth-type basic` or `jwt`)_                                                            |
 
 ## Examples
 
@@ -67,6 +74,7 @@ influxd-ctl [global-flags] <command> [command-flags] [arguments]
 - [Authenticate with JWT](#authenticate-with-jwt)
 - [Authenticate with basic authentication](#authenticate-with-basic-authentication)
 - [Override the default timeout](#override-the-default-timeout)
+- [Connect with mutual TLS (mTLS)](#connect-with-mutual-tls-mtls)
 
 ### Bind to a remote meta node
 
@@ -91,6 +99,35 @@ influxd-ctl -auth-type basic -user admin -pwd passw0rd
 ```sh
 influxd-ctl -timeout 30s show-shards
 ```
+
+### Connect with mutual TLS (mTLS) {metadata="v1.13.0+"}
+
+When the cluster's meta nodes require a client certificate
+([`https-client-auth-type`](/enterprise_influxdb/v1/administration/configure/config-meta-nodes/#https-client-auth-type)),
+use `-cert` and `-key` to present a client certificate and private key, and use
+`-ca-cert` to verify the meta node's server certificate:
+
+```sh
+influxd-ctl -bind-tls \
+  -cert /etc/ssl/influxd-ctl-client.crt \
+  -key /etc/ssl/influxd-ctl-client.key \
+  -ca-cert /etc/ssl/cluster-ca.crt \
+  show
+```
+
+To present a dedicated client certificate that overrides `-cert`, use
+`-client-cert` and `-client-key`:
+
+```sh
+influxd-ctl -bind-tls \
+  -client-cert /etc/ssl/influxd-ctl-client.crt \
+  -client-key /etc/ssl/influxd-ctl-client.key \
+  -ca-cert /etc/ssl/cluster-ca.crt \
+  show
+```
+
+For more information about configuring mTLS in a cluster, see
+[Enable mutual TLS (mTLS)](/enterprise_influxdb/v1/administration/configure/security/enable_tls/#enable-mutual-tls-mtls).
 
 {{< expand-wrapper >}}
 {{% expand "Troubleshoot `influxd-ctl` authentication" %}}

--- a/content/influxdb/v1/about_the_project/release-notes.md
+++ b/content/influxdb/v1/about_the_project/release-notes.md
@@ -82,6 +82,12 @@ alt_links:
 Other updates include numerous compaction planning, locking, and stability
 improvements.
 
+> [!Important]
+> #### We strongly recommend upgrading to v1.12.4 or later
+>
+> If you’re using any previous InfluxDB v1.x version, we strongly
+> recommend [upgrading to 1.12.4 or later](/influxdb/v1/administration/upgrading/).
+
 ---
 
 ## v1.12.4 {date="2026-04-13"}
@@ -95,6 +101,12 @@ improvements.
   iterated. The fix restores the original locking behavior.
   [#27344](https://github.com/influxdata/influxdb/pull/27344),
   [#27343](https://github.com/influxdata/influxdb/issues/27343)
+
+> [!Important]
+> #### We strongly recommend upgrading to v1.12.4 or later
+>
+> If you’re using any previous InfluxDB v1.x version, we strongly
+> recommend [upgrading to 1.12.4 or later](/influxdb/v1/administration/upgrading/).
 
 ---
 

--- a/content/influxdb/v1/about_the_project/release-notes.md
+++ b/content/influxdb/v1/about_the_project/release-notes.md
@@ -81,12 +81,6 @@ alt_links:
 Other updates include numerous compaction planning, locking, and stability
 improvements.
 
-> [!Important]
-> #### We strongly recommend upgrading to v1.13.0
->
-> If you’re using any previous InfluxDB v1.x version, we strongly
-> recommend [upgrading to 1.13.0](/influxdb/v1/administration/upgrading/).
-
 ---
 
 ## v1.12.4 {date="2026-04-13"}
@@ -100,12 +94,6 @@ improvements.
   iterated. The fix restores the original locking behavior.
   [#27344](https://github.com/influxdata/influxdb/pull/27344),
   [#27343](https://github.com/influxdata/influxdb/issues/27343)
-
-> [!Important]
-> #### We strongly recommend upgrading to v1.13.0
->
-> If you’re using any previous InfluxDB v1.x version, we strongly
-> recommend [upgrading to 1.13.0](/influxdb/v1/administration/upgrading/).
 
 ---
 

--- a/content/influxdb/v1/about_the_project/release-notes.md
+++ b/content/influxdb/v1/about_the_project/release-notes.md
@@ -49,10 +49,11 @@ alt_links:
 - **`SHOW MEASUREMENTS`**: Support partial results when some shards are
   unavailable. ([#27443](https://github.com/influxdata/influxdb/pull/27443))
 - **Operational visibility**: Failed and slow queries, per-user query and
-  write byte statistics (opt-in), the remote host and user in query logs,
-  compaction planning statistics, continuous query diagnostics, and TSM
-  file-store merge metrics are now available through `SHOW STATS`,
-  `/debug/vars`, and `EXPLAIN ANALYZE`.
+  [write byte statistics](/influxdb/v1/administration/config/#user-write-bytes-enabled)
+  (opt-in), the remote host and user in query logs, compaction planning
+  statistics, continuous query diagnostics, and TSM file-store merge
+  metrics are now available through `SHOW STATS`, `/debug/vars`, and
+  `EXPLAIN ANALYZE`.
   ([#27536](https://github.com/influxdata/influxdb/pull/27536),
   [#27547](https://github.com/influxdata/influxdb/pull/27547),
   [#27188](https://github.com/influxdata/influxdb/pull/27188),

--- a/content/influxdb/v1/about_the_project/release-notes.md
+++ b/content/influxdb/v1/about_the_project/release-notes.md
@@ -14,6 +14,81 @@ alt_links:
 ---
 
 
+## v1.13.0 {date="2026-07-23"}
+
+### Features
+
+- **mTLS support**: Add mutual TLS (mTLS) authentication for the HTTP, OpenTSDB,
+  and subscriber services, including certificate reload on `SIGHUP` and
+  separate client and server certificate configuration.
+  ([#27534](https://github.com/influxdata/influxdb/pull/27534),
+  [#27543](https://github.com/influxdata/influxdb/pull/27543))
+- **Adaptive TSI cache sizing**: The
+  [`series-id-set-cache-size`](/influxdb/v1/administration/config/#series-id-set-cache-size)
+  cache can now grow and shrink itself between a configurable floor and
+  ceiling based on the measured query hit rate, instead of staying at one
+  fixed size. Configure it with the new
+  [`series-id-set-cache-max-size`](/influxdb/v1/administration/config/#series-id-set-cache-max-size),
+  [`series-id-set-cache-target-hit-rate`](/influxdb/v1/administration/config/#series-id-set-cache-target-hit-rate),
+  and
+  [`series-id-set-cache-shrink-conservatism`](/influxdb/v1/administration/config/#series-id-set-cache-shrink-conservatism)
+  settings. Monitor it through the new `tsi1_cache` `SHOW STATS` measurement.
+  ([#27480](https://github.com/influxdata/influxdb/pull/27480),
+  [#27552](https://github.com/influxdata/influxdb/pull/27552))
+- **`hardening-enabled`**: Add a `hardening-enabled` configuration option
+  that restricts Flux HTTP requests to public addresses, mitigating
+  server-side request forgery (SSRF). Disabled by default to preserve
+  existing behavior. ([#27488](https://github.com/influxdata/influxdb/pull/27488))
+- **Backup compression**: Add a `-gzipCompressionLevel` flag to `influxd backup`
+  for trading compression ratio against speed.
+  ([#27293](https://github.com/influxdata/influxdb/pull/27293))
+- **Broader config value formats**: Size and duration configuration settings
+  now accept a wider range of human-readable input formats, while remaining
+  compatible with all previously accepted values.
+  ([#27376](https://github.com/influxdata/influxdb/pull/27376))
+- **`SHOW MEASUREMENTS`**: Support partial results when some shards are
+  unavailable. ([#27443](https://github.com/influxdata/influxdb/pull/27443))
+- **Operational visibility**: Failed and slow queries, per-user query and
+  write byte statistics (opt-in), the remote host and user in query logs,
+  compaction planning statistics, continuous query diagnostics, and TSM
+  file-store merge metrics are now available through `SHOW STATS`,
+  `/debug/vars`, and `EXPLAIN ANALYZE`.
+  ([#27536](https://github.com/influxdata/influxdb/pull/27536),
+  [#27547](https://github.com/influxdata/influxdb/pull/27547),
+  [#27188](https://github.com/influxdata/influxdb/pull/27188),
+  [#27528](https://github.com/influxdata/influxdb/pull/27528),
+  [#26981](https://github.com/influxdata/influxdb/pull/26981),
+  [#27523](https://github.com/influxdata/influxdb/pull/27523),
+  [#26874](https://github.com/influxdata/influxdb/pull/26874),
+  [#26615](https://github.com/influxdata/influxdb/pull/26615),
+  [#26624](https://github.com/influxdata/influxdb/pull/26624))
+
+### Bug Fixes
+
+- Fixed a potential deadlock and reduced lock contention between compactions
+  and hot query reads in the TSM file store by splitting its single lock
+  into separate fast and slow paths.
+  ([#27501](https://github.com/influxdata/influxdb/pull/27501))
+- Corrected several TSI compaction-planning and lock-contention issues.
+  ([#27146](https://github.com/influxdata/influxdb/pull/27146),
+  [#27123](https://github.com/influxdata/influxdb/pull/27123),
+  [#26649](https://github.com/influxdata/influxdb/pull/26649),
+  [#26647](https://github.com/influxdata/influxdb/pull/26647),
+  [#26432](https://github.com/influxdata/influxdb/pull/26432))
+- Fixed authorizer leakage in `SHOW` queries.
+  ([#27196](https://github.com/influxdata/influxdb/pull/27196))
+
+Other updates include numerous compaction planning, locking, and stability
+improvements.
+
+> [!Important]
+> #### We strongly recommend upgrading to v1.13.0
+>
+> If you’re using any previous InfluxDB v1.x version, we strongly
+> recommend [upgrading to 1.13.0](/influxdb/v1/administration/upgrading/).
+
+---
+
 ## v1.12.4 {date="2026-04-13"}
 
 ### Bug Fixes
@@ -27,10 +102,10 @@ alt_links:
   [#27343](https://github.com/influxdata/influxdb/issues/27343)
 
 > [!Important]
-> #### We strongly recommend upgrading to v1.12.4
+> #### We strongly recommend upgrading to v1.13.0
 >
 > If you’re using any previous InfluxDB v1.x version, we strongly
-> recommend [upgrading to 1.12.4](/influxdb/v1/administration/upgrading/).
+> recommend [upgrading to 1.13.0](/influxdb/v1/administration/upgrading/).
 
 ---
 

--- a/content/influxdb/v1/administration/config.md
+++ b/content/influxdb/v1/administration/config.md
@@ -534,6 +534,53 @@ An increase in cache size may lead to an increase in heap usage.
 **Default**: `100`  
 **Environment variable**: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_SIZE`
 
+#### series-id-set-cache-max-size
+
+The upper bound, in number of entries, for adaptive growth of the
+[`series-id-set-cache-size`](#series-id-set-cache-size) cache. Set this together
+with `series-id-set-cache-target-hit-rate` to let the cache grow beyond its
+fixed size when the query hit rate falls below the target. A value of `0`
+disables adaptive sizing.
+
+> [!Note]
+> `series-id-set-cache-max-size` and `series-id-set-cache-target-hit-rate` must
+> both be set to enable adaptive sizing, or both left at `0` to disable it.
+> Setting only one prevents InfluxDB from starting. When adaptive sizing is
+> enabled, `series-id-set-cache-max-size` must be greater than
+> `series-id-set-cache-size`.
+
+**Default**: `0`  
+**Environment variable**: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_MAX_SIZE`
+
+#### series-id-set-cache-target-hit-rate
+
+The cache hit rate, as a fraction between `0.0` and `1.0` (exclusive), that
+adaptive sizing tries to reach for the
+[`series-id-set-cache-size`](#series-id-set-cache-size) cache. While the
+measured hit rate stays below this target and the cache is evicting entries,
+InfluxDB grows the cache capacity, up to `series-id-set-cache-max-size`. A
+value of `0.0` disables adaptive sizing. `1.0` isn't a valid value because
+that hit rate can never be reached.
+
+**Default**: `0.0`  
+**Environment variable**: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_TARGET_HIT_RATE`
+
+#### series-id-set-cache-shrink-conservatism
+
+How reluctant the adaptive shrink policy is to release memory from the
+[`series-id-set-cache-size`](#series-id-set-cache-size) cache, expressed in
+standard deviations. Higher values make the cache hold onto capacity longer
+and resist rapid grow-and-shrink cycles. Lower values reclaim memory sooner
+after demand drops. InfluxDB only uses this setting when adaptive sizing is
+enabled.
+
+**Default**: `2.5`  
+**Environment variable**: `INFLUXDB_DATA_SERIES_ID_SET_CACHE_SHRINK_CONSERVATISM`
+
+To monitor the series ID set cache, run `SHOW STATS` and check the
+`tsi1_cache` measurement. It reports `hit`, `miss`, `eviction`,
+`shrink_eviction`, `size`, and `capacity` fields.
+
 ## Query management settings
 
 ### [coordinator]

--- a/content/influxdb/v1/administration/config.md
+++ b/content/influxdb/v1/administration/config.md
@@ -1019,6 +1019,25 @@ Unauthenticated queries are attributed to `(anonymous)`.
 **Default**: `false`
 **Environment variable**: `INFLUXDB_HTTP_USER_QUERY_BYTES_ENABLED`
 
+#### user-write-bytes-enabled {metadata="v1.13.0+"}
+
+Enables per-user write request byte tracking, the write-path counterpart to
+[`user-query-bytes-enabled`](#user-query-bytes-enabled).
+When enabled, InfluxDB records the request body bytes for each v1, v2, and
+Prometheus remote write, per user, in the `userwritebytes` measurement,
+available through `SHOW STATS FOR 'userwritebytes'`, the `_internal`
+database, and the `/debug/vars` endpoint.
+
+Unauthenticated writes are attributed to `(anonymous)`.
+
+> [!Note]
+> Byte counts use each endpoint's existing units: `/write` counts
+> decompressed (post-gzip) bytes, while the Prometheus remote write endpoint
+> counts compressed wire bytes.
+
+**Default**: `false`  
+**Environment variable**: `INFLUXDB_HTTP_USER_WRITE_BYTES_ENABLED`
+
 #### http-headers
 
 User-supplied [HTTP response headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers).

--- a/data/notifications.yaml
+++ b/data/notifications.yaml
@@ -167,6 +167,49 @@
     - [Documentation](/telegraf/enterprise/)
     - [Download and install Telegraf Controller](/telegraf/controller/install/)
 
+- id: influxdb-v1-13-release
+  level: note
+  scope:
+    - /influxdb/v1/
+  title: 'InfluxDB OSS 1.13.0 is now available'
+  slug: |
+    InfluxDB OSS 1.13.0 adds mTLS support, adaptive TSI cache sizing, and
+    a hardening option to mitigate SSRF.
+
+    [View InfluxDB OSS 1.13.0 release notes](/influxdb/v1/about_the_project/release-notes/#v1130)
+  message: |
+    **Key updates in InfluxDB OSS 1.13.0:**
+
+    - **mTLS support** for the HTTP, OpenTSDB, and subscriber services.
+    - **Adaptive TSI cache sizing**—the series ID set cache can grow and
+      shrink based on measured query hit rate.
+    - **`hardening-enabled`** option to mitigate server-side request
+      forgery (SSRF) in Flux HTTP requests.
+
+    For details, see the
+    [InfluxDB OSS 1.13.0 release notes](/influxdb/v1/about_the_project/release-notes/#v1130).
+
+- id: enterprise-influxdb-v1-13-release
+  level: note
+  scope:
+    - /enterprise_influxdb/v1/
+  title: 'InfluxDB Enterprise 1.13.0 is now available'
+  slug: |
+    InfluxDB Enterprise 1.13.0 adds mTLS support and changes the default
+    replication factor from 3 to 2.
+
+    [View InfluxDB Enterprise 1.13.0 release notes](/enterprise_influxdb/v1/about-the-project/release-notes/#v1130)
+  message: |
+    **Key updates in InfluxDB Enterprise 1.13.0:**
+
+    - **Default replication factor changed to 2** (previously 3) for new
+      databases and retention policies. Existing ones aren't affected.
+    - **mTLS support** for Enterprise data and meta nodes.
+    - All InfluxDB OSS 1.13.0 updates apply to Enterprise too.
+
+    For details, see the
+    [InfluxDB Enterprise 1.13.0 release notes](/enterprise_influxdb/v1/about-the-project/release-notes/#v1130).
+
 # - id: influxdb3.8-explorer-1.6
 #   level: note
 #   scope:

--- a/data/products.yml
+++ b/data/products.yml
@@ -305,7 +305,7 @@ influxdb:
   latest: v2.9
   latest_patches:
     v2: 2.9.1
-    v1: 1.12.4
+    v1: 1.13.0
   latest_cli:
     v2: 2.8.0
   detector_config:
@@ -502,9 +502,9 @@ enterprise_influxdb:
   list_order: 5
   versions: [v1]
   supports_flux: true
-  latest: v1.12
+  latest: v1.13
   latest_patches:
-    v1: 1.12.4
+    v1: 1.13.0
   detector_config:
     query_languages:
       InfluxQL:


### PR DESCRIPTION
## Summary

- Enterprise v1.13.0 release documentation. Merge when v1.13.0 is GA in the InfluxData portal.

## Changes

- **mTLS support**: Enable mutual TLS (mTLS) for Enterprise data and meta nodes (`config-data-nodes.md`, `config-meta-nodes.md`, `enable_tls.md`, `replacing-nodes.md`)
- Convert existing admonitions on the touched pages to GitHub-style alert blocks

## Pre-merge gate

- [x] Enterprise v1.13.0 release artifact is GA in the InfluxData portal
- [x] Codeowner sign-off
- [x] #7695 merged into `influxdb-enterprise-1.13.0` first

## Stack

This is the base of the stack (`influxdb-enterprise-1.13.0` -> `master`).

Stacked on top of this branch:
- #7695 (docs-7312-tsi-adaptive-cache — v1.13.0 release notes, TSI adaptive cache config docs). Merges into `influxdb-enterprise-1.13.0` before this PR merges to `master`.

Already merged into this branch:
- #7523 (gw/ent1.x-mtls — Enterprise 1.x mTLS)