### PR TITLE
hotfix(notification): fixed tc 1.1 blog link

### DIFF
--- a/data/notifications.yaml
+++ b/data/notifications.yaml
@@ -171,7 +171,7 @@
     so agents can continue pulling configurations and reporting health if an
     instance goes down.
 
-    - [Read the announcement](https://influxdata.com/blog/telegraf-controller-1-1-influxdb/)
+    - [Read the announcement](https://influxdata.com/blog/telegraf-controller-1-1/)
     - [See the release notes](/telegraf/controller/reference/release-notes/#v110)
     - [Download and install Telegraf Controller 1.1](/telegraf/controller/install/)
 


### PR DESCRIPTION
Hotfix for broken Telegraf Controller 1.1 blog link in the announcement notification.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
