### PR TITLE
docs(influxdb3): fill in max-concurrent-queries environment variable

### DIFF
--- a/content/shared/influxdb3-cli/config-options.md
+++ b/content/shared/influxdb3-cli/config-options.md
@@ -2437,12 +2437,9 @@ Limits the number of queries that can run concurrently.
 You can also update the limit at runtime with
 `POST /api/v3/configure/query_concurrency_limit`.
 
-<!-- Environment variable not listed in `influxdb3 serve --help-all`
-(verified against 3.10.0-0.rc.2). Confirm before documenting. -->
-
-| influxdb3 serve option     | Environment variable |
-| :------------------------- | :------------------- |
-| `--max-concurrent-queries` |                      |
+| influxdb3 serve option     | Environment variable               |
+| :-------------------------- | :---------------------------------- |
+| `--max-concurrent-queries` | `INFLUXDB3_MAX_CONCURRENT_QUERIES` |
 
 ***
 

--- a/content/shared/influxdb3-cli/config-options.md
+++ b/content/shared/influxdb3-cli/config-options.md
@@ -2437,8 +2437,11 @@ Limits the number of queries that can run concurrently.
 You can also update the limit at runtime with
 `POST /api/v3/configure/query_concurrency_limit`.
 
+<!-- Environment variable confirmed from serve.rs source and verified
+against a live 3.11.2-enterprise instance (2026-08-26). -->
+
 | influxdb3 serve option     | Environment variable               |
-| :-------------------------- | :---------------------------------- |
+| :------------------------- | :--------------------------------- |
 | `--max-concurrent-queries` | `INFLUXDB3_MAX_CONCURRENT_QUERIES` |
 
 ***


### PR DESCRIPTION
## Summary
- Fills the empty environment-variable cell for `max-concurrent-queries` in `content/shared/influxdb3-cli/config-options.md`, and removes the TODO comment that flagged it as unconfirmed.

## Why
The env var was unconfirmed because `--max-concurrent-queries` doesn't appear in `influxdb3 serve --help-all` output. Confirmed directly from `influxdb3/src/commands/serve.rs` source (`env = "INFLUXDB3_MAX_CONCURRENT_QUERIES"`) and verified against a live 3.11.2-enterprise instance during triage — the parser accepts the flag and the env var string is present in the binary.

## Impact
Readers of the Resource Limits config-options reference (Core + Enterprise, shared page) can now see and use the correct environment variable for this setting.

## Verification
- `npx hugo --quiet` — clean build
- `link-checker map/check` on the rendered page — no new warnings/errors (pre-existing fragment-resolution false positives on unrelated release-notes links, per known link-checker limitation)
- `vale content/shared/influxdb3-cli/config-options.md` — 0 errors, 0 warnings

Closes #7707