### PR TITLE
fix(sidebar): hide Feature Board navigation marker

### DIFF
--- a/assets/styles/layouts/_sidebar.scss
+++ b/assets/styles/layouts/_sidebar.scss
@@ -163,6 +163,10 @@
       }
     }
 
+    > li.feature-board-item:before {
+      display: none;
+    }
+
     a {
       text-decoration: none;
       font-weight: $medium;


### PR DESCRIPTION
## What changed

Hide the pseudo-element navigation marker on the Feature Board sidebar item.

## Why

The marker overlaps the Feature Board card in the sidebar.

## Impact

Feature Board cards render without a navigation bullet.

## Verification

- 

## Checklist

- [ ] Signed the InfluxData CLA (if necessary)
- [x] Rebased/mergeable
- [x] Local build passes ()