### PR TITLE
docs(influxdb3): add Amazon S3, Google Cloud Storage, and Azure guides

### DIFF
--- a/content/influxdb3/core/object-storage/azure.md
+++ b/content/influxdb3/core/object-storage/azure.md
@@ -1,0 +1,19 @@
+---
+title: Use Azure Blob Storage for object storage
+list_title: Azure Blob Storage
+description: |
+  Use [Azure Blob Storage](https://azure.microsoft.com/products/storage/blobs)
+  as the object store for your {{% product-name %}} instance.
+menu:
+  influxdb3_core:
+    name: Azure Blob Storage
+    parent: Configure object storage
+weight: 215
+influxdb3/core/tags: [object storage, Azure]
+related:
+  - https://learn.microsoft.com/azure/storage/blobs/blob-containers-portal, Create a container (Azure docs)
+  - /influxdb3/core/reference/config-options/
+source: /shared/influxdb3-admin/object-storage/azure.md
+---
+
+<!-- //SOURCE content/shared/influxdb3-admin/object-storage/azure.md -->

--- a/content/influxdb3/core/object-storage/gcs.md
+++ b/content/influxdb3/core/object-storage/gcs.md
@@ -1,0 +1,19 @@
+---
+title: Use Google Cloud Storage for object storage
+list_title: Google Cloud Storage
+description: |
+  Use [Google Cloud Storage](https://cloud.google.com/storage) as the object
+  store for your {{% product-name %}} instance.
+menu:
+  influxdb3_core:
+    name: Google Cloud Storage
+    parent: Configure object storage
+weight: 210
+influxdb3/core/tags: [object storage, Google Cloud Storage]
+related:
+  - https://cloud.google.com/storage/docs/creating-buckets, Create a bucket (Google Cloud docs)
+  - /influxdb3/core/reference/config-options/
+source: /shared/influxdb3-admin/object-storage/gcs.md
+---
+
+<!-- //SOURCE content/shared/influxdb3-admin/object-storage/gcs.md -->

--- a/content/influxdb3/core/object-storage/s3.md
+++ b/content/influxdb3/core/object-storage/s3.md
@@ -1,0 +1,19 @@
+---
+title: Use Amazon S3 for object storage
+list_title: Amazon S3
+description: |
+  Use [Amazon S3](https://aws.amazon.com/s3/) as the object store for your
+  {{% product-name %}} instance.
+menu:
+  influxdb3_core:
+    name: Amazon S3
+    parent: Configure object storage
+weight: 201
+influxdb3/core/tags: [object storage, S3]
+related:
+  - https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket.html, Create a bucket (Amazon S3 docs)
+  - /influxdb3/core/reference/config-options/
+source: /shared/influxdb3-admin/object-storage/s3.md
+---
+
+<!-- //SOURCE content/shared/influxdb3-admin/object-storage/s3.md -->

--- a/content/influxdb3/enterprise/admin/object-storage/azure.md
+++ b/content/influxdb3/enterprise/admin/object-storage/azure.md
@@ -1,0 +1,19 @@
+---
+title: Use Azure Blob Storage for object storage
+list_title: Azure Blob Storage
+description: |
+  Use [Azure Blob Storage](https://azure.microsoft.com/products/storage/blobs)
+  as the object store for your {{% product-name %}} instance.
+menu:
+  influxdb3_enterprise:
+    name: Azure Blob Storage
+    parent: Configure object storage
+weight: 215
+influxdb3/enterprise/tags: [object storage, Azure]
+related:
+  - https://learn.microsoft.com/azure/storage/blobs/blob-containers-portal, Create a container (Azure docs)
+  - /influxdb3/enterprise/reference/config-options/
+source: /shared/influxdb3-admin/object-storage/azure.md
+---
+
+<!-- //SOURCE content/shared/influxdb3-admin/object-storage/azure.md -->

--- a/content/influxdb3/enterprise/admin/object-storage/gcs.md
+++ b/content/influxdb3/enterprise/admin/object-storage/gcs.md
@@ -1,0 +1,19 @@
+---
+title: Use Google Cloud Storage for object storage
+list_title: Google Cloud Storage
+description: |
+  Use [Google Cloud Storage](https://cloud.google.com/storage) as the object
+  store for your {{% product-name %}} instance.
+menu:
+  influxdb3_enterprise:
+    name: Google Cloud Storage
+    parent: Configure object storage
+weight: 210
+influxdb3/enterprise/tags: [object storage, Google Cloud Storage]
+related:
+  - https://cloud.google.com/storage/docs/creating-buckets, Create a bucket (Google Cloud docs)
+  - /influxdb3/enterprise/reference/config-options/
+source: /shared/influxdb3-admin/object-storage/gcs.md
+---
+
+<!-- //SOURCE content/shared/influxdb3-admin/object-storage/gcs.md -->

--- a/content/influxdb3/enterprise/admin/object-storage/s3.md
+++ b/content/influxdb3/enterprise/admin/object-storage/s3.md
@@ -1,0 +1,19 @@
+---
+title: Use Amazon S3 for object storage
+list_title: Amazon S3
+description: |
+  Use [Amazon S3](https://aws.amazon.com/s3/) as the object store for your
+  {{% product-name %}} instance.
+menu:
+  influxdb3_enterprise:
+    name: Amazon S3
+    parent: Configure object storage
+weight: 201
+influxdb3/enterprise/tags: [object storage, S3]
+related:
+  - https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket.html, Create a bucket (Amazon S3 docs)
+  - /influxdb3/enterprise/reference/config-options/
+source: /shared/influxdb3-admin/object-storage/s3.md
+---
+
+<!-- //SOURCE content/shared/influxdb3-admin/object-storage/s3.md -->

--- a/content/shared/influxdb3-admin/object-storage/azure.md
+++ b/content/shared/influxdb3-admin/object-storage/azure.md
@@ -1,0 +1,141 @@
+
+Use [Azure Blob Storage](https://azure.microsoft.com/products/storage/blobs)
+as the object store for your {{% product-name %}} instance.
+
+- [Object store requirements](#object-store-requirements)
+- [Create a storage container](#create-a-storage-container)
+- [Get your storage account access key](#get-your-storage-account-access-key)
+- [Configure InfluxDB to connect to Azure Blob Storage](#configure-influxdb-to-connect-to-azure-blob-storage)
+- [Confirm the object store is working](#confirm-the-object-store-is-working)
+
+## Object store requirements
+
+{{% product-name %}} depends on strict object store consistency semantics—
+strong read-after-write and list-after-write consistency, and conditional PUT
+(PUT-if-not-exists) support.
+Your Azure Blob Storage container must provide these semantics.
+See [Object store requirements](../#object-store-requirements) for the full
+list of semantics {{% product-name %}} depends on and how to verify your
+object store meets them.
+
+## Create a storage container
+
+{{% product-name %}} stores data in a container within an existing Azure
+Storage account. If you don't already have a storage account, create one
+first.
+
+1.  Sign in to the [Azure portal](https://portal.azure.com) and go to your
+    storage account.
+2.  Under **Data storage**, click **Containers**, and then click
+    **+ Container**.
+3.  Enter a container name--for example, `influxdb3`--and click **Create**.
+
+Alternatively, use the
+[Azure CLI](https://learn.microsoft.com/cli/azure/storage/container) to
+create a container:
+
+<!-- pytest.mark.skip -->
+
+```bash { placeholders="AZURE_STORAGE_ACCOUNT" }
+az storage container create \
+  --name influxdb3 \
+  --account-name AZURE_STORAGE_ACCOUNT
+```
+
+## Get your storage account access key
+
+{{% product-name %}} authenticates to Azure Blob Storage with your storage
+account name and one of its access keys.
+
+1.  In the Azure portal, go to your storage account.
+2.  Under **Security + networking**, click **Access keys**.
+3.  Copy the storage account **name** and one of the **Key** values--you
+    provide both to configure {{% product-name %}}.
+
+> [!Tip]
+> In production, prefer
+> [Azure Workload Identity](https://learn.microsoft.com/azure/aks/workload-identity-overview)
+> over a static access key where your deployment environment supports it.
+
+## Configure InfluxDB to connect to Azure Blob Storage
+
+To use your Azure container as the object store for your {{% product-name %}}
+instance, provide the following options or environment variables with the
+`influxdb3 serve` command. The `--bucket` option specifies your Azure
+container name.
+
+{{< tabs-wrapper >}}
+{{% tabs "medium" %}}
+[Command options](#)
+[Environment variables](#)
+{{% /tabs %}}
+{{% tab-content %}}
+<!--------------------------- BEGIN COMMAND OPTIONS --------------------------->
+
+{{% show-in "enterprise" %}}- `--cluster-id`: Your {{% product-name %}} cluster ID ({{% code-placeholder-key %}}`INFLUXDB_CLUSTER_ID`{{% /code-placeholder-key %}}){{% /show-in %}}
+- `--node-id`: Your {{% product-name %}} node ID ({{% code-placeholder-key %}}`INFLUXDB_NODE_ID`{{% /code-placeholder-key %}})
+- `--object-store`: `azure`
+- `--bucket`: `influxdb3` (your container name)
+- `--azure-storage-account`: Your storage account name ({{% code-placeholder-key %}}`AZURE_STORAGE_ACCOUNT`{{% /code-placeholder-key %}})
+- `--azure-storage-access-key`: One of your storage account's access keys ({{% code-placeholder-key %}}`AZURE_STORAGE_ACCESS_KEY`{{% /code-placeholder-key %}})
+
+<!-- pytest.mark.skip -->
+
+```bash { placeholders="INFLUXDB_(CLUSTER|NODE)_ID|AZURE_STORAGE_ACCOUNT|AZURE_STORAGE_ACCESS_KEY" }
+influxdb3 serve \
+  {{< show-in "enterprise" >}}--cluster-id INFLUXDB_CLUSTER_ID \
+  {{< /show-in >}}--node-id INFLUXDB_NODE_ID \
+  --object-store azure \
+  --bucket influxdb3 \
+  --azure-storage-account AZURE_STORAGE_ACCOUNT \
+  --azure-storage-access-key AZURE_STORAGE_ACCESS_KEY
+```
+
+<!---------------------------- END COMMAND OPTIONS ---------------------------->
+{{% /tab-content %}}
+{{% tab-content %}}
+<!------------------------ BEGIN ENVIRONMENT VARIABLES ------------------------>
+
+{{% show-in "enterprise" %}}- `INFLUXDB3_CLUSTER_ID`: Your {{% product-name %}} cluster ID ({{% code-placeholder-key %}}`INFLUXDB_CLUSTER_ID`{{% /code-placeholder-key %}}){{% /show-in %}}
+- `INFLUXDB3_NODE_ID`: Your {{% product-name %}} node ID ({{% code-placeholder-key %}}`INFLUXDB_NODE_ID`{{% /code-placeholder-key %}})
+- `INFLUXDB3_OBJECT_STORE`: `azure`
+- `INFLUXDB3_BUCKET`: `influxdb3` (your container name)
+- `AZURE_STORAGE_ACCOUNT`: Your storage account name
+- `AZURE_STORAGE_ACCESS_KEY`: One of your storage account's access keys
+
+<!-- pytest.mark.skip -->
+
+```bash { placeholders="INFLUXDB_(CLUSTER|NODE)_ID|AZURE_STORAGE_ACCOUNT|AZURE_STORAGE_ACCESS_KEY" }
+{{< show-in "enterprise" >}}export INFLUXDB3_CLUSTER_ID=INFLUXDB_CLUSTER_ID
+{{< /show-in >}}export INFLUXDB3_NODE_ID=INFLUXDB_NODE_ID
+export INFLUXDB3_OBJECT_STORE=azure
+export INFLUXDB3_BUCKET=influxdb3
+export AZURE_STORAGE_ACCOUNT=AZURE_STORAGE_ACCOUNT
+export AZURE_STORAGE_ACCESS_KEY=AZURE_STORAGE_ACCESS_KEY
+
+influxdb3 serve
+```
+
+<!------------------------- END ENVIRONMENT VARIABLES ------------------------->
+{{% /tab-content %}}
+{{< /tabs-wrapper >}}
+
+## Confirm the object store is working
+
+When {{% product-name %}} starts, it seeds your Azure container with the
+necessary directory structure and begins storing data there. Confirm the
+object store is functioning properly:
+
+1.  View the `influxdb3 serve` log output to confirm that the server is
+    running correctly.
+2.  Inspect the contents of your container to confirm the necessary
+    directory structure is created--for example, using the Azure CLI:
+
+    <!-- pytest.mark.skip -->
+
+    ```bash { placeholders="AZURE_STORAGE_ACCOUNT" }
+    az storage blob list \
+      --container-name influxdb3 \
+      --account-name AZURE_STORAGE_ACCOUNT \
+      --output table
+    ```

--- a/content/shared/influxdb3-admin/object-storage/gcs.md
+++ b/content/shared/influxdb3-admin/object-storage/gcs.md
@@ -1,0 +1,134 @@
+
+Use [Google Cloud Storage](https://cloud.google.com/storage) as the object
+store for your {{% product-name %}} instance.
+
+- [Object store requirements](#object-store-requirements)
+- [Create a Cloud Storage bucket](#create-a-cloud-storage-bucket)
+- [Create a service account](#create-a-service-account)
+- [Configure InfluxDB to connect to Google Cloud Storage](#configure-influxdb-to-connect-to-google-cloud-storage)
+- [Confirm the object store is working](#confirm-the-object-store-is-working)
+
+## Object store requirements
+
+{{% product-name %}} depends on strict object store consistency semantics—
+strong read-after-write and list-after-write consistency, and conditional PUT
+(PUT-if-not-exists) support.
+Your Google Cloud Storage bucket must provide these semantics.
+See [Object store requirements](../#object-store-requirements) for the full
+list of semantics {{% product-name %}} depends on and how to verify your
+object store meets them.
+
+## Create a Cloud Storage bucket
+
+1.  Sign in to the
+    [Google Cloud Storage console](https://console.cloud.google.com/storage/browser).
+2.  Click **Create bucket**.
+3.  Enter a bucket name--for example, `influxdb3`--and choose a location and
+    storage class.
+4.  Keep the default access control settings unless your organization
+    requires otherwise, and click **Create**.
+
+Alternatively, use the
+[gcloud CLI](https://cloud.google.com/sdk/gcloud/reference/storage/buckets/create)
+to create a bucket:
+
+<!-- pytest.mark.skip -->
+
+```bash { placeholders="GOOGLE_CLOUD_PROJECT" }
+gcloud storage buckets create gs://influxdb3 --project=GOOGLE_CLOUD_PROJECT
+```
+
+## Create a service account
+
+Create a service account with permission to read from and write to your
+bucket, and download a JSON key for it:
+
+1.  In the
+    [IAM & Admin console](https://console.cloud.google.com/iam-admin/serviceaccounts),
+    create a new service account (or use an existing one).
+2.  Grant the service account the **Storage Object Admin**
+    (`roles/storage.objectAdmin`) role on your bucket.
+3.  Under **Keys**, create a new JSON key and download it.
+    Save the JSON key file--you provide its path to configure
+    {{% product-name %}}.
+
+> [!Tip]
+> In production, prefer
+> [workload identity federation](https://cloud.google.com/iam/docs/workload-identity-federation)
+> over a downloaded JSON key where your deployment environment supports it.
+
+## Configure InfluxDB to connect to Google Cloud Storage
+
+To use your Cloud Storage bucket as the object store for your
+{{% product-name %}} instance, provide the following options or environment
+variables with the `influxdb3 serve` command:
+
+{{< tabs-wrapper >}}
+{{% tabs "medium" %}}
+[Command options](#)
+[Environment variables](#)
+{{% /tabs %}}
+{{% tab-content %}}
+<!--------------------------- BEGIN COMMAND OPTIONS --------------------------->
+
+{{% show-in "enterprise" %}}- `--cluster-id`: Your {{% product-name %}} cluster ID ({{% code-placeholder-key %}}`INFLUXDB_CLUSTER_ID`{{% /code-placeholder-key %}}){{% /show-in %}}
+- `--node-id`: Your {{% product-name %}} node ID ({{% code-placeholder-key %}}`INFLUXDB_NODE_ID`{{% /code-placeholder-key %}})
+- `--object-store`: `google`
+- `--bucket`: `influxdb3`
+- `--google-service-account`: Path to your service account JSON key file
+  ({{% code-placeholder-key %}}`/path/to/service-account.json`{{% /code-placeholder-key %}})
+
+<!-- pytest.mark.skip -->
+
+```bash { placeholders="INFLUXDB_(CLUSTER|NODE)_ID|/path/to/service-account\.json" }
+influxdb3 serve \
+  {{< show-in "enterprise" >}}--cluster-id INFLUXDB_CLUSTER_ID \
+  {{< /show-in >}}--node-id INFLUXDB_NODE_ID \
+  --object-store google \
+  --bucket influxdb3 \
+  --google-service-account /path/to/service-account.json
+```
+
+<!---------------------------- END COMMAND OPTIONS ---------------------------->
+{{% /tab-content %}}
+{{% tab-content %}}
+<!------------------------ BEGIN ENVIRONMENT VARIABLES ------------------------>
+
+{{% show-in "enterprise" %}}- `INFLUXDB3_CLUSTER_ID`: Your {{% product-name %}} cluster ID ({{% code-placeholder-key %}}`INFLUXDB_CLUSTER_ID`{{% /code-placeholder-key %}}){{% /show-in %}}
+- `INFLUXDB3_NODE_ID`: Your {{% product-name %}} node ID ({{% code-placeholder-key %}}`INFLUXDB_NODE_ID`{{% /code-placeholder-key %}})
+- `INFLUXDB3_OBJECT_STORE`: `google`
+- `INFLUXDB3_BUCKET`: `influxdb3`
+- `GOOGLE_SERVICE_ACCOUNT`: Path to your service account JSON key file
+
+<!-- pytest.mark.skip -->
+
+```bash { placeholders="INFLUXDB_(CLUSTER|NODE)_ID|/path/to/service-account\.json" }
+{{< show-in "enterprise" >}}export INFLUXDB3_CLUSTER_ID=INFLUXDB_CLUSTER_ID
+{{< /show-in >}}export INFLUXDB3_NODE_ID=INFLUXDB_NODE_ID
+export INFLUXDB3_OBJECT_STORE=google
+export INFLUXDB3_BUCKET=influxdb3
+export GOOGLE_SERVICE_ACCOUNT=/path/to/service-account.json
+
+influxdb3 serve
+```
+
+<!------------------------- END ENVIRONMENT VARIABLES ------------------------->
+{{% /tab-content %}}
+{{< /tabs-wrapper >}}
+
+## Confirm the object store is working
+
+When {{% product-name %}} starts, it seeds your Cloud Storage bucket with the
+necessary directory structure and begins storing data there. Confirm the
+object store is functioning properly:
+
+1.  View the `influxdb3 serve` log output to confirm that the server is
+    running correctly.
+2.  Inspect the contents of your bucket to confirm the necessary directory
+    structure is created--for example, using the gcloud CLI:
+
+    <!-- pytest.mark.skip -->
+
+    ```bash
+    gcloud storage ls gs://influxdb3
+    ```

--- a/content/shared/influxdb3-admin/object-storage/s3.md
+++ b/content/shared/influxdb3-admin/object-storage/s3.md
@@ -1,0 +1,160 @@
+
+Use [Amazon S3](https://aws.amazon.com/s3/) as the object store for your
+{{% product-name %}} instance.
+
+Amazon S3 is the reference object storage implementation {{% product-name %}}
+is built against and tested with.
+
+- [Object store requirements](#object-store-requirements)
+- [Create an S3 bucket](#create-an-s3-bucket)
+- [Create IAM credentials](#create-iam-credentials)
+- [Configure InfluxDB to connect to S3](#configure-influxdb-to-connect-to-s3)
+- [Confirm the object store is working](#confirm-the-object-store-is-working)
+
+## Object store requirements
+
+{{% product-name %}} depends on strict object store consistency semantics—
+strong read-after-write and list-after-write consistency, and conditional PUT
+(PUT-if-not-exists) support.
+Amazon S3 provides these semantics.
+See [Object store requirements](../#object-store-requirements) for the full
+list of semantics {{% product-name %}} depends on and how to verify your
+object store meets them.
+
+## Create an S3 bucket
+
+1.  Sign in to the [Amazon S3 console](https://console.aws.amazon.com/s3/).
+2.  Click **Create bucket**.
+3.  Enter a bucket name--for example, `influxdb3`--and choose an AWS Region.
+4.  Keep the default **Block Public Access** and versioning settings unless
+    your organization requires otherwise, and click **Create bucket**.
+
+Alternatively, use the
+[AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/s3/mb.html) to
+create a bucket:
+
+<!-- pytest.mark.skip -->
+
+```bash { placeholders="AWS_REGION" }
+aws s3 mb s3://influxdb3 --region AWS_REGION
+```
+
+## Create IAM credentials
+
+Create an IAM user or role with permission to read from and write to your
+bucket, and generate an access key for it:
+
+1.  In the [IAM console](https://console.aws.amazon.com/iam/), create a new
+    user (or use an existing one) and attach a policy that grants access to
+    your bucket--for example:
+
+    ```json
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": ["s3:GetBucketLocation", "s3:ListBucket"],
+          "Resource": ["arn:aws:s3:::influxdb3"]
+        },
+        {
+          "Effect": "Allow",
+          "Action": ["s3:PutObject", "s3:GetObject", "s3:DeleteObject"],
+          "Resource": ["arn:aws:s3:::influxdb3/*"]
+        }
+      ]
+    }
+    ```
+
+2.  Generate an access key for the user under **Security credentials**.
+    Save the access key ID and secret access key--you use them to configure
+    {{% product-name %}}.
+
+> [!Tip]
+> In production, prefer an IAM role (for example, an EC2 instance profile or
+> IAM roles for service accounts on EKS) over long-lived access keys where
+> your deployment environment supports it.
+
+## Configure InfluxDB to connect to S3
+
+To use your S3 bucket as the object store for your {{% product-name %}}
+instance, provide the following options or environment variables with the
+`influxdb3 serve` command:
+
+{{< tabs-wrapper >}}
+{{% tabs "medium" %}}
+[Command options](#)
+[Environment variables](#)
+{{% /tabs %}}
+{{% tab-content %}}
+<!--------------------------- BEGIN COMMAND OPTIONS --------------------------->
+
+{{% show-in "enterprise" %}}- `--cluster-id`: Your {{% product-name %}} cluster ID ({{% code-placeholder-key %}}`INFLUXDB_CLUSTER_ID`{{% /code-placeholder-key %}}){{% /show-in %}}
+- `--node-id`: Your {{% product-name %}} node ID ({{% code-placeholder-key %}}`INFLUXDB_NODE_ID`{{% /code-placeholder-key %}})
+- `--object-store`: `s3`
+- `--bucket`: `influxdb3`
+- `--aws-access-key-id`: Your access key ID ({{% code-placeholder-key %}}`AWS_ACCESS_KEY_ID`{{% /code-placeholder-key %}})
+- `--aws-secret-access-key`: Your secret access key ({{% code-placeholder-key %}}`AWS_SECRET_ACCESS_KEY`{{% /code-placeholder-key %}})
+- `--aws-default-region`: _(Optional)_ Your bucket's AWS Region ({{% code-placeholder-key %}}`AWS_REGION`{{% /code-placeholder-key %}}); defaults to `us-east-1`
+
+<!-- pytest.mark.skip -->
+
+```bash { placeholders="INFLUXDB_(CLUSTER|NODE)_ID|AWS_(ACCESS_KEY_ID|SECRET_ACCESS_KEY|REGION)" }
+influxdb3 serve \
+  {{< show-in "enterprise" >}}--cluster-id INFLUXDB_CLUSTER_ID \
+  {{< /show-in >}}--node-id INFLUXDB_NODE_ID \
+  --object-store s3 \
+  --bucket influxdb3 \
+  --aws-access-key-id AWS_ACCESS_KEY_ID \
+  --aws-secret-access-key AWS_SECRET_ACCESS_KEY \
+  --aws-default-region AWS_REGION
+```
+
+<!---------------------------- END COMMAND OPTIONS ---------------------------->
+{{% /tab-content %}}
+{{% tab-content %}}
+<!------------------------ BEGIN ENVIRONMENT VARIABLES ------------------------>
+
+{{% show-in "enterprise" %}}- `INFLUXDB3_CLUSTER_ID`: Your {{% product-name %}} cluster ID ({{% code-placeholder-key %}}`INFLUXDB_CLUSTER_ID`{{% /code-placeholder-key %}}){{% /show-in %}}
+- `INFLUXDB3_NODE_ID`: Your {{% product-name %}} node ID ({{% code-placeholder-key %}}`INFLUXDB_NODE_ID`{{% /code-placeholder-key %}})
+- `INFLUXDB3_OBJECT_STORE`: `s3`
+- `INFLUXDB3_BUCKET`: `influxdb3`
+- `AWS_ACCESS_KEY_ID`: Your access key ID
+- `AWS_SECRET_ACCESS_KEY`: Your secret access key
+- `AWS_DEFAULT_REGION`: _(Optional)_ Your bucket's AWS Region; defaults to
+  `us-east-1`
+
+<!-- pytest.mark.skip -->
+
+```bash { placeholders="INFLUXDB_(CLUSTER|NODE)_ID|AWS_(ACCESS_KEY_ID|SECRET_ACCESS_KEY|REGION)" }
+{{< show-in "enterprise" >}}export INFLUXDB3_CLUSTER_ID=INFLUXDB_CLUSTER_ID
+{{< /show-in >}}export INFLUXDB3_NODE_ID=INFLUXDB_NODE_ID
+export INFLUXDB3_OBJECT_STORE=s3
+export INFLUXDB3_BUCKET=influxdb3
+export AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY
+export AWS_DEFAULT_REGION=AWS_REGION
+
+influxdb3 serve
+```
+
+<!------------------------- END ENVIRONMENT VARIABLES ------------------------->
+{{% /tab-content %}}
+{{< /tabs-wrapper >}}
+
+## Confirm the object store is working
+
+When {{% product-name %}} starts, it seeds your S3 bucket with the necessary
+directory structure and begins storing data there. Confirm the object store
+is functioning properly:
+
+1.  View the `influxdb3 serve` log output to confirm that the server is
+    running correctly.
+2.  Inspect the contents of your bucket to confirm the necessary directory
+    structure is created--for example, using the AWS CLI:
+
+    <!-- pytest.mark.skip -->
+
+    ```bash
+    aws s3 ls s3://influxdb3
+    ```


### PR DESCRIPTION
## Summary
- Adds object-storage provider guides for Amazon S3, Google Cloud Storage, and Azure Blob Storage alongside the existing MinIO guide. Each covers creating a bucket/container, creating credentials, configuring `influxdb3 serve`, and confirming the object store is working.
- Adds Core and Enterprise stub pages for each (weights 201, 210, 215; MinIO stays at 205), so "Configure object storage" lists: S3, MinIO, Google Cloud Storage, Azure.
- Each guide links to the shared "Object store requirements" section from #7444 instead of repeating it.

## Why
Closes #6765. The object-storage guide only documented MinIO, but InfluxDB 3 supports S3, Google Cloud Storage, and Azure Blob Storage (`--object-store` in the CLI reference; "Supported object storage" in the backup/restore guide).

**Stacked on #7710** (base branch is `influxdb3-object-storage-guide`, not `master`) — these guides link to the shared requirements section that PR moves into place. Marking draft until #7710 merges; will retarget to `master` at that point.

## Impact
Core and Enterprise users configuring S3, GCS, or Azure now have a guide instead of only MinIO instructions or the bare CLI reference.

## Test plan
- [x] `npx hugo --quiet` builds clean
- [x] `yarn lint-codeblocks` on the three new shared guides: all blocks pass
- [x] Vale on the six new stub pages: 0 errors (pre-existing unrelated warning only)
- [x] `link-checker` (production config) on the new pages: 0 errors, 0 warnings
- [x] Confirmed rendered output: Enterprise pages include `--cluster-id` options; Core pages don't