### PR TITLE
docs(telegraf): clarify HA supports PostgreSQL-compatible databases

### DIFF
--- a/content/telegraf/controller/high-availability/_index.md
+++ b/content/telegraf/controller/high-availability/_index.md
@@ -1,8 +1,7 @@
 ---
 title: High availability
 description: >
-  Run multiple Telegraf Controller nodes against a shared PostgreSQL or
-  PostgreSQL-compatible database for continuous availability. One node is
+  Run multiple Telegraf Controller nodes against a shared PostgreSQL-compatible database for continuous availability. One node is
   elected leader to run cluster-wide background work while every node serves
   traffic, and a standby takes over if the leader fails.
 menu:

--- a/content/telegraf/controller/high-availability/_index.md
+++ b/content/telegraf/controller/high-availability/_index.md
@@ -1,10 +1,10 @@
 ---
 title: High availability
 description: >
-  Run multiple Telegraf Controller nodes against a shared PostgreSQL database
-  for continuous availability. One node is elected leader to run cluster-wide
-  background work while every node serves traffic, and a standby takes over if
-  the leader fails.
+  Run multiple Telegraf Controller nodes against a shared PostgreSQL or
+  PostgreSQL-compatible database for continuous availability. One node is
+  elected leader to run cluster-wide background work while every node serves
+  traffic, and a standby takes over if the leader fails.
 menu:
   telegraf_controller:
     name: High availability
@@ -19,8 +19,8 @@ related:
 ---
 
 High availability lets you run more than one {{% product-name %}} node against a
-shared PostgreSQL database so that management operations continue if a node
-fails. One node is elected **leader** and performs cluster-wide work; the
+shared PostgreSQL or [PostgreSQL-compatible](#requirements-and-constraints)
+database so that management operations continue if a node fails. One node is elected **leader** and performs cluster-wide work; the
 remaining nodes stand by, ready to take over. Every node keeps accepting agent
 heartbeats, so agent monitoring continues without interruption during a
 failover.

--- a/content/telegraf/controller/high-availability/deploy.md
+++ b/content/telegraf/controller/high-availability/deploy.md
@@ -2,9 +2,9 @@
 title: Deploy a highly available Telegraf Controller cluster
 list_title: Deploy a cluster
 description: >
-  Deploy multiple Telegraf Controller nodes against a shared PostgreSQL
-  database, route traffic with a load balancer using the health endpoints, and
-  tune PostgreSQL for fast failover.
+  Deploy multiple Telegraf Controller nodes against a shared PostgreSQL or
+  PostgreSQL-compatible database, route traffic with a load balancer using the
+  health endpoints, and tune PostgreSQL for fast failover.
 menu:
   telegraf_controller:
     name: Deploy a cluster
@@ -17,9 +17,9 @@ related:
   - /telegraf/controller/install/upgrade/
 ---
 
-Deploy multiple {{% product-name %}} nodes against a shared PostgreSQL database,
-put them behind a load balancer, and let one node lead while the others stand
-by. This guide covers configuring the nodes, routing traffic with the health
+Deploy multiple {{% product-name %}} nodes against a shared PostgreSQL or
+PostgreSQL-compatible database, put them behind a load balancer, and let one
+node lead while the others stand by. This guide covers configuring the nodes, routing traffic with the health
 endpoints, and tuning PostgreSQL for quick failover.
 
 {{< telegraf/enterprise-feature "High availability" >}}
@@ -49,9 +49,10 @@ endpoints, and tuning PostgreSQL for quick failover.
 Every node connects to the same PostgreSQL database and signs sessions with the
 same secret.
 
-1. Provision a PostgreSQL database and note its connection string. Connect nodes
-   directly to PostgreSQL, or use a connection pooler in **session-pooling**
-   mode. Transaction-pooling mode breaks leader election.
+1. Provision a PostgreSQL or PostgreSQL-compatible database and note its
+   connection string. Connect nodes directly to the database, or use a
+   connection pooler in **session-pooling** mode. Transaction-pooling mode
+   breaks leader election.
 
 2. Generate a single `SESSION_SECRET` to share across all nodes. Reuse the same
    value on every node so a session stays valid regardless of which node serves
@@ -222,6 +223,10 @@ ALTER SYSTEM SET tcp_keepalives_interval = 5;
 ALTER SYSTEM SET tcp_keepalives_count = 3;
 SELECT pg_reload_conf();
 ```
+
+If you use a managed or PostgreSQL-compatible service that doesn't support
+`ALTER SYSTEM`, set the equivalent keepalive parameters through your provider's
+configuration interface.
 
 With settings in this range, failover after an abrupt failure completes in well
 under a minute. Adjust the values to match your availability requirements and

--- a/content/telegraf/controller/high-availability/deploy.md
+++ b/content/telegraf/controller/high-availability/deploy.md
@@ -49,10 +49,9 @@ endpoints, and tuning PostgreSQL for quick failover.
 Every node connects to the same PostgreSQL database and signs sessions with the
 same secret.
 
-1. Provision a PostgreSQL or PostgreSQL-compatible database and note its
-   connection string. Connect nodes directly to the database, or use a
-   connection pooler in **session-pooling** mode. Transaction-pooling mode
-   breaks leader election.
+1. Provision a PostgreSQL-compatible database and note its connection string.
+   Connect nodes directly to the database, or use a connection pooler in
+   **session-pooling** mode. Transaction-pooling mode breaks leader election.
 
 2. Generate a single `SESSION_SECRET` to share across all nodes. Reuse the same
    value on every node so a session stays valid regardless of which node serves

--- a/content/telegraf/controller/reference/architecture.md
+++ b/content/telegraf/controller/reference/architecture.md
@@ -51,8 +51,8 @@ responsive even under heavy agent load.
 
 The process model above describes a single node. With
 [Telegraf Enterprise](/telegraf/enterprise/), you can run multiple
-{{% product-name %}} nodes against a shared PostgreSQL database for continuous
-availability. The nodes coordinate through a PostgreSQL advisory lock: one node
+{{% product-name %}} nodes against a shared PostgreSQL or PostgreSQL-compatible
+database for continuous availability. The nodes coordinate through a PostgreSQL advisory lock: one node
 is elected **leader** and runs the background scheduler, while the others stand
 by and take over if the leader fails. Every node accepts agent heartbeats, so
 monitoring continues during a leadership change.


### PR DESCRIPTION
What changed: The high availability landing page, deployment guide, and architecture reference described the shared backend only as "PostgreSQL" in their descriptions, intros, and provisioning steps. These now say "PostgreSQL or PostgreSQL-compatible database", matching the phrasing already used in the install guide and the HA requirements list. The failover-tuning section also notes how to apply keepalive settings on managed services that don't support ALTER SYSTEM.

Why: The backend can be any PostgreSQL-compatible database that supports session-level advisory locks, and the docs should say so consistently.

Impact: Telegraf Controller high availability pages only. No changes to PostgreSQL-specific mechanics (advisory locks, connection URL examples).

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
