### PR TITLE
docs(api): document Parquet cleanup and upgrade retry endpoints

### DIFF
--- a/content/influxdb3/enterprise/reference/cli/influxdb3/_index.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/_index.md
@@ -32,6 +32,7 @@ influxdb3 [GLOBAL-OPTIONS] [COMMAND]
 | [import](/influxdb3/enterprise/reference/cli/influxdb3/import/)   | Manage bulk Parquet imports         |
 | [install](/influxdb3/enterprise/reference/cli/influxdb3/install/) | Install plugins                     |
 | [loadcap](/influxdb3/enterprise/reference/cli/influxdb3/loadcap/) | Capture and manage workload profiles |
+| [manage](/influxdb3/enterprise/reference/cli/influxdb3/manage/)   | Perform cluster maintenance operations |
 | [query](/influxdb3/enterprise/reference/cli/influxdb3/query/)     | Query {{% product-name %}}          |
 | [remove](/influxdb3/enterprise/reference/cli/influxdb3/remove/)   | Remove stopped nodes                |
 | [serve](/influxdb3/enterprise/reference/cli/influxdb3/serve/)     | Run the {{% product-name %}} server |

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/delete.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/loadcap/delete.md
@@ -14,6 +14,8 @@ related:
 ---
 
 Use `influxdb3 loadcap delete` to delete a workload capture profile.
+You can't delete a profile while it's still capturing.
+Wait for the capture to finish, then retry.
 
 > [!Note]
 > Load capture requires the [upgraded storage engine](/influxdb3/enterprise/reference/internals/storage-engine/)—the default for new clusters.

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/manage/_index.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/manage/_index.md
@@ -1,0 +1,44 @@
+---
+title: influxdb3 manage
+introduced: v3.11.1
+description: >
+  The `influxdb3 manage` command performs maintenance operations on an
+  InfluxDB 3 Enterprise cluster, such as cleaning up Parquet data after a
+  storage engine upgrade.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3
+    name: influxdb3 manage
+weight: 300
+related:
+  - /influxdb3/enterprise/reference/internals/storage-engine/
+---
+
+Use `influxdb3 manage` to perform maintenance operations on an InfluxDB 3 Enterprise cluster.
+
+> [!Note]
+> These commands act on the [upgraded storage engine](/influxdb3/enterprise/reference/internals/storage-engine/) (PachaTree) migration.
+> They have no effect on a cluster that has never run the storage engine upgrade.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 manage <SUBCOMMAND>
+```
+
+## Subcommands
+
+| Subcommand | Description |
+| :--------- | :---------- |
+| [cleanup-parquet](/influxdb3/enterprise/reference/cli/influxdb3/manage/cleanup-parquet/) | Remove pre-upgrade Parquet data after a storage engine upgrade |
+| [retry-upgrade-to-pacha-tree](/influxdb3/enterprise/reference/cli/influxdb3/manage/retry-upgrade-to-pacha-tree/) | Retry a failed storage engine upgrade |
+| help | Print command help or the help of a subcommand |
+
+## Options
+
+| Option |              | Description                     |
+| :----- | :----------- | :------------------------------ |
+| `-h`   | `--help`     | Print help information          |
+|        | `--help-all` | Print detailed help information |

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/manage/cleanup-parquet.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/manage/cleanup-parquet.md
@@ -1,0 +1,85 @@
+---
+title: influxdb3 manage cleanup-parquet
+introduced: v3.11.1
+description: >
+  The `influxdb3 manage cleanup-parquet` command permanently removes
+  pre-upgrade Parquet data left behind by a completed Parquet-to-PachaTree
+  storage engine upgrade in InfluxDB 3 Enterprise.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 manage
+    name: cleanup-parquet
+weight: 301
+related:
+  - /influxdb3/enterprise/reference/internals/storage-engine/
+---
+
+Use `influxdb3 manage cleanup-parquet` to permanently remove Parquet-era data that a completed [storage engine upgrade](/influxdb3/enterprise/reference/internals/storage-engine/) (Parquet-to-PachaTree) left behind.
+Any node in the cluster accepts the request, but the compactor node executes the cleanup.
+
+> [!Important]
+> #### This deletes data permanently
+>
+> - Parquet files superseded by the PachaTree migration are deleted.
+> - The operation is irreversible.
+> - After cleanup, `influxdb3 manage downgrade-to-parquet` is no longer possible.
+>
+> Run with `--dry-run` first to see what a real cleanup would delete.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 manage cleanup-parquet [OPTIONS]
+```
+
+## Options
+
+| Option | | Description | Default | Environment variable |
+| :----- | :-- | :---------- | :------ | :------------------- |
+| | `--dry-run` | Report what would be deleted without deleting anything | | |
+| | `--yes` | Skip the confirmation prompt. Conflicts with `--dry-run` | | |
+| | `--wait` | Poll every 5 seconds until the cleanup completes or fails. Exits non-zero on failure | | |
+| | `--status-only` | Print the status of the current or last cleanup, then exit. Conflicts with `--dry-run`, `--yes`, and `--wait` | | |
+| `-H` | `--host <HOST_URL>` | InfluxDB 3 Enterprise server URL | `http://127.0.0.1:8181` | `INFLUXDB3_HOST_URL` |
+| | `--token <AUTH_TOKEN>` | Authentication token | | `INFLUXDB3_AUTH_TOKEN` |
+| | `--tls-ca <CA_CERT>` | Path to a custom TLS certificate authority | | `INFLUXDB3_TLS_CA` |
+| | `--tls-no-verify` | Disable TLS certificate verification | | `INFLUXDB3_TLS_NO_VERIFY` |
+| `-h` | `--help` | Print help information | | |
+
+## Examples
+
+### Preview what a cleanup would delete
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="AUTH_TOKEN" }
+influxdb3 manage cleanup-parquet \
+  --host http://localhost:8181 \
+  --token AUTH_TOKEN \
+  --dry-run
+```
+
+### Run a cleanup and wait for it to finish
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="AUTH_TOKEN" }
+influxdb3 manage cleanup-parquet \
+  --host http://localhost:8181 \
+  --token AUTH_TOKEN \
+  --yes \
+  --wait
+```
+
+### Check the status of the current or last cleanup
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="AUTH_TOKEN" }
+influxdb3 manage cleanup-parquet \
+  --host http://localhost:8181 \
+  --token AUTH_TOKEN \
+  --status-only
+```

--- a/content/influxdb3/enterprise/reference/cli/influxdb3/manage/retry-upgrade-to-pacha-tree.md
+++ b/content/influxdb3/enterprise/reference/cli/influxdb3/manage/retry-upgrade-to-pacha-tree.md
@@ -1,0 +1,57 @@
+---
+title: influxdb3 manage retry-upgrade-to-pacha-tree
+introduced: v3.11.2
+description: >
+  The `influxdb3 manage retry-upgrade-to-pacha-tree` command resets a
+  Parquet-to-PachaTree storage engine upgrade that latched to a failed state
+  in InfluxDB 3 Enterprise, so it resumes on the next compactor restart.
+menu:
+  influxdb3_enterprise:
+    parent: influxdb3 manage
+    name: retry-upgrade-to-pacha-tree
+weight: 302
+related:
+  - /influxdb3/enterprise/reference/internals/storage-engine/
+  - /influxdb3/enterprise/reference/cli/influxdb3/manage/cleanup-parquet/
+---
+
+Use `influxdb3 manage retry-upgrade-to-pacha-tree` to reset a [storage engine upgrade](/influxdb3/enterprise/reference/internals/storage-engine/) (Parquet-to-PachaTree) that latched to a `failed` state.
+
+The command re-checks every previously failed upgrade source against the catalog and object store:
+
+- Sources that are still readable are requeued.
+- Sources whose table or database was dropped are recorded as skipped.
+- Sources that can't be read back are left unresolved for the next retry.
+
+The reset itself only changes durable state.
+The migration resumes the next time a compactor node starts with `--upgrade-pacha-tree`.
+
+## Usage
+
+<!--pytest.mark.skip-->
+
+```bash
+influxdb3 manage retry-upgrade-to-pacha-tree [OPTIONS]
+```
+
+## Options
+
+| Option | | Description | Default | Environment variable |
+| :----- | :-- | :---------- | :------ | :------------------- |
+| `-H` | `--host <HOST_URL>` | InfluxDB 3 Enterprise server URL | `http://127.0.0.1:8181` | `INFLUXDB3_HOST_URL` |
+| | `--token <AUTH_TOKEN>` | Authentication token | | `INFLUXDB3_AUTH_TOKEN` |
+| | `--tls-ca <CA_CERT>` | Path to a custom TLS certificate authority | | `INFLUXDB3_TLS_CA` |
+| | `--tls-no-verify` | Disable TLS certificate verification | | `INFLUXDB3_TLS_NO_VERIFY` |
+| `-h` | `--help` | Print help information | | |
+
+## Example
+
+<!--pytest.mark.skip-->
+
+```bash { placeholders="AUTH_TOKEN" }
+influxdb3 manage retry-upgrade-to-pacha-tree \
+  --host http://localhost:8181 \
+  --token AUTH_TOKEN
+```
+
+If any sources are left unresolved, run the command again to re-attempt them.


### PR DESCRIPTION
## What changed

- Adds API reference entries for two Enterprise storage-engine-upgrade
  maintenance endpoints: `POST/GET .../upgrade/parquet_cleanup` and
  `POST .../upgrade/retry_parquet_to_pacha_tree`.
- Adds `influxdb3 manage` CLI reference pages: `cleanup-parquet` and
  `retry-upgrade-to-pacha-tree`, plus a section index and a link from
  the top-level `influxdb3` command list.
- Fixes the load capture profile schema: the request-type field is
  `type`, not `capture_type`, and the node identifier is a number, not
  a string.
- Adds the load capture profile detail, preview, and download API
  reference entries.
- Adds a note about the upgraded storage engine requirement to the
  Parquet export endpoints.
- Corrects the resource token endpoint's description of InfluxDB 3
  Cloud support: Cloud has database-scoped read and write tokens, not
  full resource tokens.
- Documents that deleting a load capture profile while it's still
  capturing returns an error (API 409 and the corresponding CLI
  command).

## Why

`cleanup-parquet` and `retry-upgrade-to-pacha-tree` shipped without
CLI or API reference pages. The load capture and export gaps, and the
delete-while-capturing behavior, surfaced while adding and verifying
this content in the same area of the spec.

## Impact

New reference documentation for InfluxDB 3 Enterprise users running
or troubleshooting a storage engine upgrade. Corrects two schema
errors, one product-availability claim, and one undocumented error
response that were live in the published API reference.

## Verification

Tested against a running InfluxDB 3 Enterprise 3.11.2 instance:

- `parquet_cleanup` (GET/POST) and `retry_parquet_to_pacha_tree`
  (POST): confirmed 401 without a token, and the documented 409/404
  responses on a cluster that was never on the pre-upgrade storage
  engine.
- Load capture profile lifecycle: started a real capture, confirmed
  the list/detail/preview responses use `type` (not `capture_type`)
  and an integer `node_id`, downloaded the archive, and deleted the
  profile.
- Deleting a profile while it's still capturing: confirmed 409 from
  both the HTTP API and `influxdb3 loadcap delete` ("a capture is
  already in progress"); confirmed deleting the same profile succeeds
  once the capture finishes.
- `influxdb3 manage cleanup-parquet` and `retry-upgrade-to-pacha-tree`:
  ran `--status-only`, `--dry-run`, the `--dry-run`/`--yes` and
  `--dry-run`/`--status-only` conflicts, and an invalid token, and
  confirmed each against the actual CLI output.
- Frontmatter validated for all new/changed CLI reference pages.
- Cloud token claim checked against
  https://docs.influxdata.com/influxdb3/cloud/admin/tokens/.

Claude-Session: https://claude.ai/code/session_01XqThD3yqz8y64vkaTgQDvR