### PR TITLE
fix(influxdb3): add missing --cluster-id to Enterprise wal-plugin example

### DIFF
--- a/content/shared/influxdb3-plugins/plugins-library/examples/wal-plugin.md
+++ b/content/shared/influxdb3-plugins/plugins-library/examples/wal-plugin.md
@@ -15,7 +15,8 @@ The plugin can optionally double-count rows for a specified table to demonstrate
 1. Start {{% product-name %}} with the Processing Engine enabled (`--plugin-dir /path/to/plugins`)
    ```bash
    influxdb3 serve \
-     --node-id node0 \
+     {{< show-in "enterprise" >}}--cluster-id cluster0 \
+     {{< /show-in >}}--node-id node0 \
      --object-store file \
      --data-dir ~/.influxdb3 \
      --plugin-dir ~/.plugins


### PR DESCRIPTION
## Summary
- `content/shared/influxdb3-plugins/plugins-library/examples/wal-plugin.md` Installation steps was missing `--cluster-id` for InfluxDB 3 Enterprise (Core has no such flag)
- Added it wrapped in `show-in "enterprise"`, matching the existing pattern in `object-storage/{s3,gcs,minio,azure}.md`

## Why
Closes #6878. Verified during triage that the shared install example omits a required Enterprise flag.

## Verification
- `npx hugo --quiet` build clean
- Confirmed rendered HTML for both Core and Enterprise editions: `--cluster-id` present only on Enterprise, no stray blank lines, matches the merged precedent in the object-storage guides

https://claude.ai/code/session_016VmwhdUNbAdHrykd41BfmC