### PR TITLE
test(api): add Cypress coverage for trigger_settings/node_spec schema rendering

### DIFF
--- a/cypress/e2e/content/api-reference.cy.js
+++ b/cypress/e2e/content/api-reference.cy.js
@@ -456,6 +456,93 @@ describe('API lifecycle badges', () => {
   });
 });
 
+// ── Schema rendering: allOf flattening, oneOf variants ──────────────
+// Covers a regression where `trigger_settings` (wrapped in `allOf`) and
+// `node_spec` (a `oneOf` union via `ApiNodeSpec`) rendered as empty
+// property tables because the schema renderer didn't resolve $ref/allOf
+// before reading `type`/`properties`. See layouts/partials/api/
+// resolve-schema.html and example-value.html.
+
+describe('API schema rendering (allOf / oneOf)', () => {
+  beforeEach(() => {
+    cy.visit('/influxdb3/enterprise/api/processing-engine/');
+  });
+
+  it('trigger_settings (allOf-wrapped $ref) renders its nested properties', () => {
+    cy.get('[data-operation-id="PostConfigureProcessingEngineTrigger"]').within(
+      () => {
+        cy.contains('.api-schema-property-name', 'trigger_settings')
+          .closest('.api-schema-property')
+          .as('triggerSettings');
+
+        // allOf flattening: type must resolve to "object", not fall through
+        // to the "string" default resolve-schema.html would leave unresolved.
+        cy.get('@triggerSettings')
+          .find('.api-schema-property-type')
+          .first()
+          .should('contain', 'object');
+
+        // Nested properties from the flattened TriggerSettings schema.
+        cy.get('@triggerSettings')
+          .find('.api-schema-property-name')
+          .should('contain', 'run_async')
+          .and('contain', 'error_behavior');
+
+        // Enum values on the nested error_behavior property.
+        cy.get('@triggerSettings')
+          .find('.api-schema-property-enum .api-enum-value')
+          .should(($vals) => {
+            const values = [...$vals].map((el) => el.textContent);
+            expect(values).to.include.members(['log', 'retry', 'disable']);
+          });
+      }
+    );
+  });
+
+  it('node_spec (oneOf ApiNodeSpec) renders both variants, not required', () => {
+    cy.get('[data-operation-id="PostConfigureProcessingEngineTrigger"]').within(
+      () => {
+        cy.contains('.api-schema-property-name', 'node_spec')
+          .closest('.api-schema-property')
+          .as('nodeSpec');
+
+        // node_spec is optional in CreateTriggerRequest.required.
+        cy.get('@nodeSpec').should(
+          'not.have.class',
+          'api-schema-property--required'
+        );
+
+        // oneOf renders both variants: string "all" and object w/ nodes.
+        cy.get('@nodeSpec')
+          .find('.api-schema-oneof-variant')
+          .should('have.length', 2);
+        cy.get('@nodeSpec')
+          .find('.api-schema-oneof-variant')
+          .first()
+          .find('.api-enum-value')
+          .should('contain', 'all');
+        cy.get('@nodeSpec')
+          .find('.api-schema-oneof-variant')
+          .eq(1)
+          .find('.api-schema-property-name')
+          .should('contain', 'nodes');
+      }
+    );
+  });
+
+  it('example request body includes resolved trigger_settings values', () => {
+    cy.get('[data-operation-id="PostConfigureProcessingEngineTrigger"]').within(
+      () => {
+        cy.get('.api-code-block').invoke('text').should((text) => {
+          expect(text).to.match(/"trigger_settings":\s*{/);
+          expect(text).to.match(/"run_async":\s*false/);
+          expect(text).to.match(/"error_behavior":\s*"log"/);
+        });
+      }
+    );
+  });
+});
+
 // ── Legacy URL redirects ─────────────────────────────────────────────
 // Covers URLs that 404'd on production before Hugo aliases were added
 // via api-docs/<product>/content/page.yml. See

--- a/cypress/e2e/content/api-reference.cy.js
+++ b/cypress/e2e/content/api-reference.cy.js
@@ -506,7 +506,7 @@ describe('API schema rendering (allOf / oneOf)', () => {
           .closest('.api-schema-property')
           .as('nodeSpec');
 
-        // node_spec is optional in CreateTriggerRequest.required.
+        // node_spec is optional in ProcessingEngineTriggerRequest.required.
         cy.get('@nodeSpec').should(
           'not.have.class',
           'api-schema-property--required'

--- a/cypress/e2e/content/api-reference.cy.js
+++ b/cypress/e2e/content/api-reference.cy.js
@@ -533,11 +533,13 @@ describe('API schema rendering (allOf / oneOf)', () => {
   it('example request body includes resolved trigger_settings values', () => {
     cy.get('[data-operation-id="PostConfigureProcessingEngineTrigger"]').within(
       () => {
-        cy.get('.api-code-block').invoke('text').should((text) => {
-          expect(text).to.match(/"trigger_settings":\s*{/);
-          expect(text).to.match(/"run_async":\s*false/);
-          expect(text).to.match(/"error_behavior":\s*"log"/);
-        });
+        cy.get('.api-code-block')
+          .invoke('text')
+          .should((text) => {
+            expect(text).to.match(/"trigger_settings":\s*{/);
+            expect(text).to.match(/"run_async":\s*false/);
+            expect(text).to.match(/"error_behavior":\s*"log"/);
+          });
       }
     );
   });


### PR DESCRIPTION
## What changed
Adds a Cypress `describe` block in `cypress/e2e/content/api-reference.cy.js` covering the schema-rendering fix in #7716: `trigger_settings` (`allOf`-wrapped `$ref`) and `node_spec` (`oneOf` via `ApiNodeSpec`) on `PostConfigureProcessingEngineTrigger`.

## Why
#7716 fixes a regression where `resolve-schema.html` didn't flatten `allOf`/resolve `$ref` before `schema.html` read `type`/`properties`, so `trigger_settings` and `node_spec` rendered as empty property tables. No test guarded that rendering path.

## Impact
Test-only change. No content or layout files touched.

## Verification
- `trigger_settings (allOf-wrapped $ref) renders its nested properties` — asserts resolved `object` type, nested `run_async`/`error_behavior` props, and the `error_behavior` enum values.
- `node_spec (oneOf ApiNodeSpec) renders both variants, not required` — asserts both `oneOf` variants render and the field carries no required badge.
- `example request body includes resolved trigger_settings values` — asserts the generated curl example includes `trigger_settings` with resolved property values.
- Full spec run locally: 46/46 passing (`node cypress/support/run-e2e-specs.js --spec "cypress/e2e/content/api-reference.cy.js" content/influxdb3/enterprise/api/processing-engine/_index.md`), after regenerating stale API content (`yarn build:api-docs` equivalent) — two pre-existing unrelated failures (stale `query-groups` content, missing Deprecated badge) also cleared by that regen and aren't part of this diff.

Base: #7716