### PR TITLE
fix(api): clarify trigger arguments in Core and Enterprise

### DIFF
--- a/api-docs/influxdb3/core/influxdb3-core-openapi.yaml
+++ b/api-docs/influxdb3/core/influxdb3-core-openapi.yaml
@@ -2904,8 +2904,15 @@ components:
           example: cron:0 0 6 * * 1-5
         trigger_arguments:
           type: object
-          additionalProperties: true
-          description: Optional arguments passed to the plugin.
+          additionalProperties:
+            type: string
+          description: |
+            Optional, plugin-specific arguments passed to the plugin entry point as its `args` dictionary.
+            Provide string key-value pairs. Omit this field to pass `None` as `args`.
+            Refer to the plugin documentation for supported argument names and values.
+          example:
+            threshold: "90"
+            notify_email: admin@example.com
         disabled:
           type: boolean
           default: false

--- a/api-docs/influxdb3/core/influxdb3-core-openapi.yaml
+++ b/api-docs/influxdb3/core/influxdb3-core-openapi.yaml
@@ -2912,7 +2912,7 @@ components:
             Refer to the plugin documentation for supported argument names and values.
           example:
             threshold: "90"
-            notify_email: admin@example.com
+            target_table: alerts
         disabled:
           type: boolean
           default: false

--- a/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
+++ b/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
@@ -5048,7 +5048,7 @@ components:
             Refer to the plugin documentation for supported argument names and values.
           example:
             threshold: "90"
-            notify_email: admin@example.com
+            target_table: alerts
         disabled:
           type: boolean
           default: false

--- a/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
+++ b/api-docs/influxdb3/enterprise/influxdb3-enterprise-openapi.yaml
@@ -5040,8 +5040,15 @@ components:
           example: cron:0 0 6 * * 1-5
         trigger_arguments:
           type: object
-          additionalProperties: true
-          description: Optional arguments passed to the plugin.
+          additionalProperties:
+            type: string
+          description: |
+            Optional, plugin-specific arguments passed to the plugin entry point as its `args` dictionary.
+            Provide string key-value pairs. Omit this field to pass `None` as `args`.
+            Refer to the plugin documentation for supported argument names and values.
+          example:
+            threshold: "90"
+            notify_email: admin@example.com
         disabled:
           type: boolean
           default: false

--- a/cypress/e2e/content/api-reference.cy.js
+++ b/cypress/e2e/content/api-reference.cy.js
@@ -456,14 +456,14 @@ describe('API lifecycle badges', () => {
   });
 });
 
-// ── Schema rendering: allOf flattening, oneOf variants ──────────────
+// ── Schema rendering: allOf flattening, oneOf variants, object examples ──
 // Covers a regression where `trigger_settings` (wrapped in `allOf`) and
 // `node_spec` (a `oneOf` union via `ApiNodeSpec`) rendered as empty
 // property tables because the schema renderer didn't resolve $ref/allOf
 // before reading `type`/`properties`. See layouts/partials/api/
 // resolve-schema.html and example-value.html.
 
-describe('API schema rendering (allOf / oneOf)', () => {
+describe('API schema rendering', () => {
   beforeEach(() => {
     cy.visit('/influxdb3/enterprise/api/processing-engine/');
   });
@@ -539,6 +539,41 @@ describe('API schema rendering (allOf / oneOf)', () => {
             expect(text).to.match(/"trigger_settings":\s*{/);
             expect(text).to.match(/"run_async":\s*false/);
             expect(text).to.match(/"error_behavior":\s*"log"/);
+          });
+      }
+    );
+  });
+
+  it('object properties render their description, JSON example, and request value', () => {
+    cy.get('[data-operation-id="PostConfigureProcessingEngineTrigger"]').within(
+      () => {
+        cy.contains('.api-schema-property-name', 'trigger_arguments')
+          .closest('.api-schema-property')
+          .as('objectProperty');
+
+        cy.get('@objectProperty')
+          .find('.api-schema-property-type')
+          .should('contain', 'object');
+        cy.get('@objectProperty')
+          .find('.api-schema-property-description')
+          .should('contain', 'Optional, plugin-specific arguments')
+          .and('contain', 'string key-value pairs');
+        cy.get('@objectProperty')
+          .find('.api-example-value')
+          .invoke('text')
+          .then((example) => {
+            expect(JSON.parse(example)).to.deep.equal({
+              target_table: 'alerts',
+              threshold: '90',
+            });
+          });
+
+        cy.get('.api-code-block')
+          .invoke('text')
+          .should((text) => {
+            expect(text).to.match(/"trigger_arguments":\s*{/);
+            expect(text).to.match(/"target_table":\s*"alerts"/);
+            expect(text).to.match(/"threshold":\s*"90"/);
           });
       }
     );


### PR DESCRIPTION
Closes #7727

What changed:
- Define trigger_arguments as an object whose values must be strings in both the Core and Enterprise processing-engine API schemas.
- Explain that it is the plugin-specific args mapping, and that omitting it passes None to the plugin.
- Add threshold and target_table example values so generated request bodies are directly usable.
- Add Cypress coverage for rendering object schema descriptions, JSON examples, and generated request values.

Why:
The server accepts an optional HashMap<String, String> and passes it to the plugin entry point as a Python dict[str, str]. The prior additionalProperties: true schema allowed values the API rejects.

Verification:
- Parsed both YAML specs and asserted the string-map schema and examples.
- Ran sh api-docs/generate-api-docs.sh --no-build.
- Ran npx hugo and inspected both generated processing-engine API pages.
- Ran Redocly lint: Core is valid with 6 existing warnings; Enterprise retains 12 pre-existing errors and 20 warnings, none in the changed schema.
- Ran node cypress/support/run-e2e-specs.js --spec "cypress/e2e/content/api-reference.cy.js" --no-mapping (47 passing).

Note:
Core and Enterprise v3 specs are ported from docs-tooling. Keep the matching source definitions in sync to preserve this correction on future ports.

<img width="722" height="167" alt="test2 docs influxdata com_pr-preview_pr-7728_influxdb3_enterprise_api_processing-engine_" src="https://github.com/user-attachments/assets/0aee9dde-57c7-45b5-8f93-7166b8241733" />