### PR TITLE
docs(release-notes): add v3.11.3 release notes

### DIFF
--- a/content/influxdb3/enterprise/reference/storage-engine-config-options.md
+++ b/content/influxdb3/enterprise/reference/storage-engine-config-options.md
@@ -378,7 +378,7 @@ A higher limit increases snapshot lag while recovery runs.
 Discovery lookahead and per-cycle feed limits are unchanged, so recovery can't
 overwhelm the compaction pipeline.
 
-## L1-L2 level tuning
+## L1-L4 level tuning
 
 For what these levels mean and how the time-disjoint compaction model uses
 them, see

--- a/content/influxdb3/enterprise/reference/storage-engine-config-options.md
+++ b/content/influxdb3/enterprise/reference/storage-engine-config-options.md
@@ -345,6 +345,36 @@ influxdb3 serve \
   --final-compaction-age 48h
 ```
 
+### Deferred snapshot recovery
+
+When a snapshot fails to compact, the compactor defers it and records it in
+`system.pt_compaction_deferred_snapshots`.
+`--recover-deferred-snapshots` returns deferred snapshots to compaction, but
+only while every ingest node has fewer snapshots in flight than the recovery
+in-flight limit.
+
+| Option | Description | Default |
+|:-------|:------------|:--------|
+| `--recover-deferred-snapshots-in-flight-limit` | Number of snapshots an ingest node can have in flight before deferred snapshot recovery pauses. Valid values are `1` to `4096`, validated at startup. Applies to recovery only--compaction scheduling keeps the built-in limit of three. | `3` |
+
+If your ingest nodes snapshot faster than compaction completes batches, no node
+drops below the default limit, so recovery never runs and
+`deferred_snapshot_count` in
+[`system.pt_compaction_ingest_nodes`](/influxdb3/enterprise/admin/query-system-data/#query-system-tables)
+doesn't fall.
+Raise the limit to let recovery proceed:
+
+```bash
+influxdb3 serve \
+  # ...
+  --recover-deferred-snapshots \
+  --recover-deferred-snapshots-in-flight-limit 32
+```
+
+A higher limit increases snapshot lag while recovery runs.
+Discovery lookahead and per-cycle feed limits are unchanged, so recovery can't
+overwhelm the compaction pipeline.
+
 ## L1-L2 level tuning
 
 For what these levels mean and how the time-disjoint compaction model uses

--- a/content/influxdb3/enterprise/reference/storage-engine-config-options.md
+++ b/content/influxdb3/enterprise/reference/storage-engine-config-options.md
@@ -357,6 +357,9 @@ in-flight limit.
 |:-------|:------------|:--------|
 | `--recover-deferred-snapshots-in-flight-limit` | Number of snapshots an ingest node can have in flight before deferred snapshot recovery pauses. Valid values are `1` to `4096`, validated at startup. Applies to recovery only--compaction scheduling keeps the built-in limit of three. | `3` |
 
+To set the limit through the environment, use
+`INFLUXDB3_RECOVER_DEFERRED_SNAPSHOTS_IN_FLIGHT_LIMIT`.
+
 If your ingest nodes snapshot faster than compaction completes batches, no node
 drops below the default limit, so recovery never runs and
 `deferred_snapshot_count` in

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -6,6 +6,27 @@
 > All updates to Core are automatically included in Enterprise.
 > The Enterprise sections below only list updates exclusive to Enterprise.
 
+## v3.11.3 {date="2026-08-28"}
+
+### Core
+
+Maintenance release: v3.11.3 Core includes only build and dependency updates, with no user-facing changes.
+
+### Enterprise
+
+All Core updates are included in Enterprise.
+Additional Enterprise-specific updates:
+
+#### Features
+
+- **Run-set indexes written by later releases are readable**: The compactor now reads the v3 run-set index format that later releases write, so a rollback to v3.11.3 from a release that writes v3 leaves no unreadable indexes behind.
+
+#### Bug fixes
+
+- **Missing rows from an `OR` predicate against a [file index](/influxdb3/enterprise/admin/file-index/)**: File pruning now applies to an `OR` only when both sides resolve against the index, and falls back to scanning all files otherwise. Previously, when one side referenced a column the index doesn't cover, the query kept only the files matching the resolved side, so rows that matched solely through the uncovered side were dropped from the result. 
+- **Deferred snapshot recovery makes no progress on a busy cluster**: `--recover-deferred-snapshots` feeds deferred snapshots back into compaction only while every ingest node has fewer than three snapshots in flight. On a cluster which snapshots faster than batches complete, that gate is never met, so the deferred count never falls. The new `--recover-deferred-snapshots-in-flight-limit` option raises the gate for recovery alone.
+- Other bug fixes and performance improvements
+
 ## v3.11.2 {date="2026-08-20"}
 
 ### Core

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -34,26 +34,13 @@ Additional Enterprise-specific updates:
   the query kept only the files that matched the resolved side, so rows that
   matched only through the uncovered side were dropped from the results.
 - **Deferred snapshot recovery makes no progress on a busy cluster**:
-  The new `--recover-deferred-snapshots-in-flight-limit` option
-  (`INFLUXDB3_RECOVER_DEFERRED_SNAPSHOTS_IN_FLIGHT_LIMIT`) sets how many
-  snapshots an ingest node can have in flight before deferred snapshot recovery
-  pauses.
-  `--recover-deferred-snapshots` returns deferred snapshots to compaction only
-  while every ingest node is below this limit.
+  The new
+  [`--recover-deferred-snapshots-in-flight-limit`](/influxdb3/enterprise/reference/storage-engine-config-options/#deferred-snapshot-recovery)
+  option raises the per-node in-flight snapshot limit that gates
+  `--recover-deferred-snapshots`.
   The limit was previously fixed at three, so on a cluster whose ingest nodes
-  snapshot faster than compaction completes batches, no node ever dropped below
-  it, recovery never ran, and the deferred snapshot count never fell.
-  Raise the limit when `--recover-deferred-snapshots` is enabled but
-  `deferred_snapshot_count` in
-  [`system.pt_compaction_ingest_nodes`](/influxdb3/enterprise/admin/query-system-data/#query-system-tables)
-  isn't falling.
-  Valid values are `1` to `4096`.
-  The default is three, so leaving the option unset changes nothing.
-  The option applies to recovery only; compaction scheduling keeps the fixed
-  limit.
-  A higher limit increases snapshot lag while recovery runs, but discovery and
-  per-cycle feed limits are unchanged, so recovery can't overwhelm the
-  compaction pipeline.
+  snapshot faster than compaction completes batches, recovery never ran.
+  The default is unchanged.
 - Other bug fixes and performance improvements
 
 ## v3.11.2 {date="2026-08-20"}

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -10,7 +10,7 @@
 
 ### Core
 
-Maintenance release: v3.11.3 Core includes only build and dependency updates, with no user-facing changes.
+Core remains on v3.11.2 for this cycle. 
 
 ### Enterprise
 

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -34,13 +34,26 @@ Additional Enterprise-specific updates:
   the query kept only the files that matched the resolved side, so rows that
   matched only through the uncovered side were dropped from the results.
 - **Deferred snapshot recovery makes no progress on a busy cluster**:
-  The new `--recover-deferred-snapshots-in-flight-limit` option raises the
-  in-flight snapshot limit that gates recovery alone.
-  By default, `--recover-deferred-snapshots` feeds deferred snapshots back into
-  compaction only while every ingest node has fewer than three snapshots in
-  flight.
-  On a cluster that snapshots faster than batches complete, that gate is never
-  met, so the deferred count never falls.
+  The new `--recover-deferred-snapshots-in-flight-limit` option
+  (`INFLUXDB3_RECOVER_DEFERRED_SNAPSHOTS_IN_FLIGHT_LIMIT`) sets how many
+  snapshots an ingest node can have in flight before deferred snapshot recovery
+  pauses.
+  `--recover-deferred-snapshots` returns deferred snapshots to compaction only
+  while every ingest node is below this limit.
+  The limit was previously fixed at three, so on a cluster whose ingest nodes
+  snapshot faster than compaction completes batches, no node ever dropped below
+  it, recovery never ran, and the deferred snapshot count never fell.
+  Raise the limit when `--recover-deferred-snapshots` is enabled but
+  `deferred_snapshot_count` in
+  [`system.pt_compaction_ingest_nodes`](/influxdb3/enterprise/admin/query-system-data/#query-system-tables)
+  isn't falling.
+  Valid values are `1` to `4096`.
+  The default is three, so leaving the option unset changes nothing.
+  The option applies to recovery only; compaction scheduling keeps the fixed
+  limit.
+  A higher limit increases snapshot lag while recovery runs, but discovery and
+  per-cycle feed limits are unchanged, so recovery can't overwhelm the
+  compaction pipeline.
 - Other bug fixes and performance improvements
 
 ## v3.11.2 {date="2026-08-20"}

--- a/content/shared/v3-core-enterprise-release-notes/_index.md
+++ b/content/shared/v3-core-enterprise-release-notes/_index.md
@@ -10,7 +10,8 @@
 
 ### Core
 
-Core remains on v3.11.2 for this cycle. 
+No adjustments in this release.
+Core remains on v3.11.2.
 
 ### Enterprise
 
@@ -19,12 +20,27 @@ Additional Enterprise-specific updates:
 
 #### Features
 
-- **Run-set indexes written by later releases are readable**: The compactor now reads the v3 run-set index format that later releases write, so a rollback to v3.11.3 from a release that writes v3 leaves no unreadable indexes behind.
+- **Read run-set indexes written by later releases**:
+  The compactor now reads the v3 run-set index format that later releases write,
+  so you can roll back to v3.11.3 from a release that writes v3 indexes without
+  leaving unreadable indexes behind.
 
 #### Bug fixes
 
-- **Missing rows from an `OR` predicate against a [file index](/influxdb3/enterprise/admin/file-index/)**: File pruning now applies to an `OR` only when both sides resolve against the index, and falls back to scanning all files otherwise. Previously, when one side referenced a column the index doesn't cover, the query kept only the files matching the resolved side, so rows that matched solely through the uncovered side were dropped from the result. 
-- **Deferred snapshot recovery makes no progress on a busy cluster**: `--recover-deferred-snapshots` feeds deferred snapshots back into compaction only while every ingest node has fewer than three snapshots in flight. On a cluster which snapshots faster than batches complete, that gate is never met, so the deferred count never falls. The new `--recover-deferred-snapshots-in-flight-limit` option raises the gate for recovery alone.
+- **Missing rows from an `OR` predicate against a [file index](/influxdb3/enterprise/admin/file-index/)**:
+  File pruning now applies to an `OR` only when both sides resolve against the
+  index, and otherwise falls back to scanning all files.
+  Previously, when one side referenced a column that the index doesn't cover,
+  the query kept only the files that matched the resolved side, so rows that
+  matched only through the uncovered side were dropped from the results.
+- **Deferred snapshot recovery makes no progress on a busy cluster**:
+  The new `--recover-deferred-snapshots-in-flight-limit` option raises the
+  in-flight snapshot limit that gates recovery alone.
+  By default, `--recover-deferred-snapshots` feeds deferred snapshots back into
+  compaction only while every ingest node has fewer than three snapshots in
+  flight.
+  On a cluster that snapshots faster than batches complete, that gate is never
+  met, so the deferred count never falls.
 - Other bug fixes and performance improvements
 
 ## v3.11.2 {date="2026-08-20"}

--- a/data/products.yml
+++ b/data/products.yml
@@ -13,7 +13,7 @@ influxdb3_core:
   list_order: 2
   search_includes_resources: false
   latest: core
-  latest_patch: 3.11.3
+  latest_patch: 3.11.2
   placeholder_host: localhost:8181
   scheme: http
   limits:

--- a/data/products.yml
+++ b/data/products.yml
@@ -13,7 +13,7 @@ influxdb3_core:
   list_order: 2
   search_includes_resources: false
   latest: core
-  latest_patch: 3.11.2
+  latest_patch: 3.11.3
   placeholder_host: localhost:8181
   scheme: http
   limits:
@@ -59,7 +59,7 @@ influxdb3_enterprise:
   list_order: 2
   search_includes_resources: false
   latest: enterprise
-  latest_patch: 3.11.2
+  latest_patch: 3.11.3
   placeholder_host: localhost:8181
   scheme: http
   limits:


### PR DESCRIPTION
Adds a v3.11.3 entry (2026-08-28) to the shared Core and Enterprise release
notes, bumps `latest_patch` to 3.11.3 for Enterprise, and documents the
configuration option the release introduces.

## What changed

- `content/shared/v3-core-enterprise-release-notes/_index.md`: adds the
  v3.11.3 entry with one Enterprise feature, two Enterprise bug fixes, and the
  "Other bug fixes and performance improvements" catch-all. The Core section
  records a maintenance release.
- `data/products.yml`: bumps `influxdb3_enterprise.latest_patch` to 3.11.3.
- `content/influxdb3/enterprise/reference/storage-engine-config-options.md`:
  adds a "Deferred snapshot recovery" section under Compactor documenting
  `--recover-deferred-snapshots-in-flight-limit`, and corrects the
  "L1-L2 level tuning" heading to "L1-L4 level tuning" so the page's own
  contents list resolves.

## Why

v3.11.3 is Enterprise-only in substance. The only changes outside `ent/` are
the `oss/Cargo.toml` version bump and its lockfile, so Core stays on 3.11.2 and
`influxdb3_core.latest_patch` is unchanged.

The entries readers act on:

- Rolling back from 3.12 to 3.11 is safe, because the compactor now reads the
  v3 run-set index format that 3.12 writes (influxdb_pro#5417, closes #5414).
- File index pruning no longer drops files under an `OR` whose other operand is
  unindexed, which silently removed matching rows from results
  (influxdb_pro#5479).
- The new `--recover-deferred-snapshots-in-flight-limit` option lets deferred
  snapshot recovery drain on a cluster that never settles below the compiled
  in-flight limit of three (influxdb_pro#5502).

The chacha20 audit bump (influxdb_pro#5484) and the source tarball packaging
fix (influxdb_pro#5374) are release engineering only and fall under the
catch-all entry.

Configuration details for the new option live in the storage engine
configuration reference rather than the release note, so readers find them
where they look when tuning a running cluster.

## Impact

Enterprise readers on 3.11.x get the query correctness fix for file indexes and
the rollback compatibility note. Enterprise download links and version examples
that read `latest_patch` update to 3.11.3.

Readers tuning deferred snapshot recovery find the option in the storage engine
configuration reference alongside the other compactor options.

## Verification

- `npx hugo --quiet` passes.
- Vale check passes.
- Link check reports no errors.

### Expected CI warning

The release version check warns that `influxdb3_core.latest_patch` is 3.11.2
while the release notes document v3.11.3. That's intentional: there is no Core
3.11.3 release, and the Core section says so. This matches the v3.8.4 entry,
where Core stayed on v3.8.3.

### Known gap

`--recover-deferred-snapshots` itself is still undocumented. The new reference
section refers to it because the in-flight limit only has meaning in relation
to it. Tracked in #7738, which needs engineering to confirm the option's
default and behavior.

## Checklist

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/) ([if necessary](https://github.com/influxdata/docs-v2/blob/master/DOCS-CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Rebased/mergeable
- [ ] Local build passes (`npx hugo --quiet`)

***

<b>Suggested reviewers</b> (click to expand)

Based on files changed, consider requesting review from:

### InfluxDB 3

| Content          | Engineering                    | Product                     |
| ---------------- | ------------------------------ | --------------------------- |
| Core, Enterprise | influxdata/monolith-team       | peterbarnett03, garylfowler |
| Clustered        | influxdata/platform-team       | ritwika314, sanderson       |
| Cloud Dedicated  | influxdata/cloud-single-tenant | ritwika314, sanderson       |
| Cloud Serverless | —                              | mavarius, garylfowler       |
| Explorer         | —                              | mavarius, peterbarnett03    |

### InfluxDB v2 / v1 / Enterprise v1

| Content           | Engineering     | Product               |
| ----------------- | --------------- | --------------------- |
| v2, Cloud (TSM)   | influxdata/edge | sanderson, jstirnaman |
| v1, Enterprise v1 | influxdata/edge | sanderson, jstirnaman |

### Other Products

| Content    | Engineering              | Product               |
| ---------- | ------------------------ | --------------------- |
| Telegraf   | influxdata/telegraf-team | sanderson, caterryan  |
| Kapacitor  | influxdata/bonitoo       | sanderson, jstirnaman |
| Chronograf | influxdata/bonitoo       | mavarius, caterryan   |
| Flux       | —                        | sanderson, jstirnaman |

### Shared / Cross-Product

| Content            | Reviewers                   |
| ------------------ | --------------------------- |
| `/content/shared/` | influxdata/product-managers |
| API docs           | Relevant product team above |
