### PR TITLE
release: Telegraf Controller 1.1.1

### DIFF
--- a/content/telegraf/controller/config-groups/aliases.md
+++ b/content/telegraf/controller/config-groups/aliases.md
@@ -36,6 +36,12 @@ it. Add an alias with **{{% lucide "plus" %}} Add Alias**, and transfer or
 delete an alias from its row actions, exactly as for
 [configuration aliases](/telegraf/controller/configs/aliases/).
 
+You can also assign aliases while
+[creating a group](/telegraf/controller/config-groups/manage/#create-a-configuration-group).
+As with configurations, if an alias you request at creation is already
+assigned, {{% product-name %}} doesn't create the group. Remove the alias to
+continue, or transfer it after you create the group.
+
 ## Repoint agents from a configuration to a group
 
 Because the alias namespace spans configurations and groups, you can

--- a/content/telegraf/controller/config-groups/manage.md
+++ b/content/telegraf/controller/config-groups/manage.md
@@ -25,11 +25,16 @@ labels, and lifecycle from the group detail page.
     **Configurations > Config Groups** in the navigation bar.
 2.  Click **{{% lucide "plus" %}} Add Config Group**.
 3.  Enter a group name and optional description.
-4.  Click **{{% lucide "plus" %}} Add Configs** and select the
+4.  _(Optional)_ To assign
+    [aliases](/telegraf/controller/config-groups/aliases/) to the group,
+    click **{{% lucide "plus" %}} Add Alias** and enter an alias that
+    follows the
+    [naming rules](/telegraf/controller/configs/aliases/#alias-naming-rules).
+5.  Click **{{% lucide "plus" %}} Add Configs** and select the
     configurations to include.
-5.  Drag members by the **drag handle ({{% lucide "grip-vertical" %}})**
+6.  Drag members by the **drag handle ({{% lucide "grip-vertical" %}})**
     into the order you want them rendered.
-6.  Click **Create Config Group**.
+7.  Click **Create Config Group**.
 
 ## View configuration groups
 

--- a/content/telegraf/controller/configs/aliases.md
+++ b/content/telegraf/controller/configs/aliases.md
@@ -63,6 +63,13 @@ If the alias is already assigned to another configuration,
 agents use it, and offers to [transfer the alias](#transfer-an-alias) to this
 configuration instead.
 
+You can also assign aliases while
+[creating a configuration](/telegraf/controller/configs/create/).
+If an alias you request at creation is already assigned to another
+configuration or configuration group, {{% product-name %}} doesn't create
+the configuration. Remove the alias to continue, or transfer it from the
+**Aliases** tab after you create the configuration.
+
 ## Use an alias
 
 Anywhere the {{% product-name %}} API accepts a configuration ID, you can use

--- a/content/telegraf/controller/configs/create.md
+++ b/content/telegraf/controller/configs/create.md
@@ -26,10 +26,15 @@ plugins.
     navigation bar. 
 2.  Click **{{% lucide "plus" %}} Add Config**.
 3.  Enter a configuration name and optional description.
-4.  Use the {{% product-name %}} [Code Editor](#use-the-code-editor) or
+4.  _(Optional)_ To assign
+    [aliases](/telegraf/controller/configs/aliases/) to the configuration,
+    click **{{% lucide "plus" %}} Add Alias** and enter an alias that
+    follows the
+    [naming rules](/telegraf/controller/configs/aliases/#alias-naming-rules).
+5.  Use the {{% product-name %}} [Code Editor](#use-the-code-editor) or
     [Telegraf Builder](#use-the-telegraf-builder) to provide or build the
     Telegraf configuration TOML.
-5.  Click **Create Configuration**.
+6.  Click **Create Configuration**.
 
 When you create a configuration, {{% product-name %}} records it as the first
 version in the configuration's

--- a/content/telegraf/controller/reference/release-notes.md
+++ b/content/telegraf/controller/reference/release-notes.md
@@ -9,10 +9,63 @@ menu:
 weight: 101
 ---
 
-## v1.1.0 {date="2026-08-25"}
+## v1.1.1 {date="2026-09-07"}
 
 <!-- Update and move the link to the latest version. -->
-[Download Telegraf Controller v1.1.0](/telegraf/controller/install/#download-and-install-telegraf-controller)
+[Download Telegraf Controller v1.1.1](/telegraf/controller/install/#download-and-install-telegraf-controller)
+
+### Features
+
+- Assign [aliases](/telegraf/controller/configs/aliases/) while creating a
+  configuration or a configuration group, in the web interface and through
+  the `POST /api/configs` and `POST /api/config-groups` API endpoints. If a
+  requested alias is already assigned, {{% product-name %}} rejects the
+  request and identifies the alias's current owner.
+- Add TLS client and TLS server settings to 70 plugins in the Telegraf
+  Builder, including plugins that previously had no TLS options.
+- Describe every request, response, and error in the
+  [interactive API reference](/telegraf/controller/reference/api/).
+- Add plugin support to the Telegraf Builder UI:
+  - Nomad (`inputs.nomad`)
+  - NSD (`inputs.nsd`)
+  - NSDP (`inputs.nsdp`)
+  - NSQ (`inputs.nsq`)
+  - NSQ Consumer (`inputs.nsq_consumer`)
+  - Nstat (`inputs.nstat`)
+  - NTPQ (`inputs.ntpq`)
+  - Nvidia SMI (`inputs.nvidia_smi`)
+  - OPC UA (`inputs.opcua`)
+  - OPC UA Listener (`inputs.opcua_listener`)
+  - OpenLDAP (`inputs.openldap`)
+  - OpenNTPD (`inputs.openntpd`)
+  - OpenSearch Query (`inputs.opensearch_query`)
+  - OpenSMTPD (`inputs.opensmtpd`)
+  - OpenStack (`inputs.openstack`)
+  - OpenTelemetry (`inputs.opentelemetry`)
+  - OpenWeatherMap (`inputs.openweathermap`)
+  - P4Runtime (`inputs.p4runtime`)
+  - Passenger (`inputs.passenger`)
+  - PF (`inputs.pf`)
+  - PgBouncer (`inputs.pgbouncer`)
+  - PHP-FPM (`inputs.phpfpm`)
+  - Postfix (`inputs.postfix`)
+  - PostgreSQL (`inputs.postgresql`)
+
+### Bug fixes
+
+- Show configuration groups in the **Managed Configurations** list on agent
+  detail pages.
+- Parse common plugin fields, including `alias`, `interval`, `name_override`,
+  `tags`, and metric filters, when the Telegraf Builder imports the ActiveMQ,
+  Aurora, Beat, Burrow, ClickHouse, Couchbase, DC/OS, and Jenkins input
+  plugins. Previously, the builder dropped these fields.
+- Keep API request and response schemas in the interactive API reference when
+  running {{% product-name %}} as a packaged binary.
+- Align label chips with the plugin count chip on the configurations list.
+
+---
+
+## v1.1.0 {date="2026-08-25"}
 
 ### Features
 

--- a/data/products.yml
+++ b/data/products.yml
@@ -417,7 +417,7 @@ telegraf_controller:
   link: 'https://influxdata.com/contact-sales-telegraf-enterprise/?utm_source=website&utm_medium=direct&utm_campaign=Telegraf-Enterprise'
   versions: [v1]
   latest: 1.1
-  latest_patch: 1.1.0
+  latest_patch: 1.1.1
   schema:
     operating_system: "Docker"
     application_category: "DeveloperApplication"

--- a/data/tc_downloads.yml
+++ b/data/tc_downloads.yml
@@ -1,24 +1,24 @@
-version: "1.1.0"
+version: "1.1.1"
 platforms:
   - name: Linux
     builds:
       - arch: x64
         os: linux
-        sha256: "8690a087d08038fdeedbd3e29aefa457c90be1034171ecd77716fc6879519afd"
+        sha256: "f097a3ee19090005184081caf95ecdb7eda2c1afd34f721301ee0543e24ed2c9"
       - arch: arm64
         os: linux
-        sha256: "9b46829660e9b306ef364cc968f0d888de5c8d6d59cec9457aa0a3c0e8351a21"
+        sha256: "9d43e85705078754ce8ab0b36d188d4451adf12a061053e70465b16279932eeb"
   - name: macOS
     builds:
       - arch: x64
         os: macos
-        sha256: "a91fc5c957175bd836a7b57e911003c27d4ddbdb1eee50bed25e752eaf878c02"
+        sha256: "d8c0d7b10b3e92904e02672f467de214f4cf8dae1955c5976bc39a3fd34f1526"
       - arch: arm64
         os: macos
-        sha256: "0e5da873b0347f7ef772e37860829bbbd2d524537ef81c68d00bc32d0eb334ce"
+        sha256: "c9e3c435fc3ccbe1087f54ab7c8bee21b0736b9542dec41deb198f2e59d940ec"
   - name: Windows
     builds:
       - arch: x64
         os: win
         ext: .exe
-        sha256: "a9ee4fb1b9607281e1a1f63e55d5825edc7fb1fee54ab85c447749f9403522bf"
+        sha256: "efb9079a687fb520de9fc8dcfbe86801217cf7f2cb2d02a13ca0012b52e60fcb"


### PR DESCRIPTION
Add v1.1.1 release notes covering aliases at creation time, 24 new Telegraf Builder input plugins, TLS settings on 70 builder plugins, and bug fixes. Document alias assignment in the configuration and config group creation flows, and update download data with 1.1.1 binary SHAs.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
