### PR TITLE
fix(ci): scope flattened-list regex to a single paragraph

### DIFF
--- a/.ci/scripts/check-render-artifacts.sh
+++ b/.ci/scripts/check-render-artifacts.sh
@@ -103,8 +103,16 @@ done
 #
 # Patterns are intentionally strict (3+ ordered-list markers) to keep
 # false positives near zero on prose that legitimately enumerates.
+#
+# The numbered-list pattern uses [^<]* rather than .* to stay within a
+# single <p>...</p>. List/tag pages render many sibling <p> teasers on
+# one physical output line with no separating newline, so .* let the
+# match span across unrelated paragraphs — three different plugin
+# descriptions each containing "InfluxDB 3." (product name + sentence
+# period, not a list marker) satisfied "3+ 'N.' markers" even though
+# none of them contained a list. See #7764.
 PATTERNS_REGEX=(
-  "<p[^>]*>.*\\s[0-9]+\\.\\s.*\\s[0-9]+\\.\\s.*\\s[0-9]+\\.|Flattened ordered list in prose — three or more 'N.' markers in one paragraph. Likely cause: a template joined multi-line markdown with ' ' before markdownify (see #7122)."
+  "<p[^>]*>[^<]*\\s[0-9]+\\.\\s[^<]*\\s[0-9]+\\.\\s[^<]*\\s[0-9]+\\.|Flattened ordered list in prose — three or more 'N.' markers in one paragraph. Likely cause: a template joined multi-line markdown with ' ' before markdownify (see #7122)."
   "<p[^>]*>[^<]*\`\`\`|Raw markdown code fence inside a prose paragraph. Likely cause: a template passed a description containing code fences to markdownify after flattening newlines."
 )
 


### PR DESCRIPTION
## What changed

`check-render-artifacts.sh`'s flattened-ordered-list pattern now uses
`[^<]*` instead of `.*`, so it stays inside one `<p>...</p>` — matching
the style the code-fence pattern below it already uses.

## Why

List/tag pages render sibling `<p>` teasers on one physical output line
with no newline between them. The unscoped `.*` let three unrelated
plugin descriptions containing "InfluxDB 3." (product version number +
sentence period, not a list marker) satisfy "3+ 'N.' markers" across
separate paragraphs, failing PR #7754's required check with no actual
rendering defect.

## Impact

`check-render-artifacts.sh` no longer false-positives across paragraph
boundaries. Genuine flattened lists within a single paragraph are still
caught.

## Verification

- Rebuilt `sync/influxdb3-plugins@2583d4301` with the CI build flags
  (`--environment production --baseURL
  https://test2.docs.influxdata.com/pr-preview/pr-link-check/`) and
  confirmed the fixed script passes where the old one failed on all 10
  files.
- Synthetic test: a real single-paragraph flattened list
  (`<p>Steps: 1. ... 2. ... 3. ...</p>`) still fails the check; three
  separate paragraphs each containing "InfluxDB 3." no longer does.
- `shellcheck` passes (pre-commit hook).

Fixes #7764.

https://claude.ai/code/session_016nYWq2bEJqm5uyW1To7Ucd