### PR TITLE
docs(telegraf): update docs for Telegraf 1.40.0

### DIFF
--- a/content/shared/telegraf/agent-status-eval/functions.md
+++ b/content/shared/telegraf/agent-status-eval/functions.md
@@ -26,7 +26,7 @@ now() - last_update > duration('5m')
 ## Math functions
 
 Math functions from the
-[CEL math library](https://github.com/google/cel-go/blob/master/ext/README.md#math)
+[CEL math library](https://github.com/cel-expr/cel-go/blob/master/ext/README.md#math)
 are available for numeric calculations.
 
 ### Commonly used functions
@@ -46,7 +46,7 @@ math.greatest(log_errors, log_warnings) > 5
 ## String functions
 
 String functions from the
-[CEL strings library](https://github.com/google/cel-go/blob/master/ext/README.md#strings)
+[CEL strings library](https://github.com/cel-expr/cel-go/blob/master/ext/README.md#strings)
 are available for string operations.
 These are useful when checking plugin `alias` or `id` fields.
 
@@ -60,7 +60,7 @@ inputs.cpu.exists(i, has(i.alias) && i.alias.contains("critical"))
 ## Encoding functions
 
 Encoding functions from the
-[CEL encoder library](https://github.com/google/cel-go/blob/master/ext/README.md#encoders)
+[CEL encoder library](https://github.com/cel-expr/cel-go/blob/master/ext/README.md#encoders)
 are available for encoding and decoding values.
 
 ## Operators

--- a/content/telegraf/v1/commands/config/migrate.md
+++ b/content/telegraf/v1/commands/config/migrate.md
@@ -20,11 +20,10 @@ location of the source configuration files.
 If migrating remote configurations, the migrated configuration is stored in the
 current directory using the URL as the filename with a `.migrated` suffix.
 
-{{% warn %}}
-#### Test migrated configuration files
-
-We strongly recommend testing migrated configuration files before using them in production.
-{{% /warn %}}
+> [!Warning]
+> #### Test migrated configuration files
+>
+> We strongly recommend testing migrated configuration files before using them in production.
 
 ## Usage
 

--- a/content/telegraf/v1/commands/secrets/_index.md
+++ b/content/telegraf/v1/commands/secrets/_index.md
@@ -23,6 +23,7 @@ telegraf [global-flags] secrets [subcommand] [flags]
 | [list](/telegraf/v1/commands/secrets/list/) | List known secrets and secret stores               |
 | [get](/telegraf/v1/commands/secrets/get/)   | Retrieve the value of a secret from a secret store |
 | [set](/telegraf/v1/commands/secrets/set/)   | Create or modify a secret in a secret store        |
+| [remove](/telegraf/v1/commands/secrets/remove/) | Remove a secret from a secret store            |
 | `help`, `h`                                 | Shows command help                                 |
 
 ## Flags

--- a/content/telegraf/v1/commands/secrets/get.md
+++ b/content/telegraf/v1/commands/secrets/get.md
@@ -12,12 +12,11 @@ weight: 301
 The `telegraf secrets get` command retrieves the value of a secret from the
 specified secret store.
 
-{{% note %}}
-This command requires your configuration file that contains the secret store
-definitions you want to access. If the `--config` or `--config-directory` flags
-are not included in the command, Telegraf checks the
-[default configuration file location](/telegraf/v1/configuration/#configuration-file-locations).
-{{% /note %}}
+> [!Note]
+> This command requires your configuration file that contains the secret store
+> definitions you want to access. If the `--config` or `--config-directory` flags
+> are not included in the command, Telegraf checks the
+> [default configuration file location](/telegraf/v1/configuration/#configuration-file-locations).
 
 Use [`telegraf secrets list`](/telegraf/v1/commands/secrets/list/) to get the
 IDs of available secret stores and the available secret keys.

--- a/content/telegraf/v1/commands/secrets/list.md
+++ b/content/telegraf/v1/commands/secrets/list.md
@@ -10,12 +10,11 @@ weight: 301
 
 The `telegraf secrets list` command lists known secrets and secret stores.
 
-{{% note %}}
-This command requires your configuration file that contains the secret store
-definitions you want to access. If the `--config` or `--config-directory` flags
-are not included in the command, Telegraf checks the
-[default configuration file location](/telegraf/v1/configuration/#configuration-file-locations).
-{{% /note %}}
+> [!Note]
+> This command requires your configuration file that contains the secret store
+> definitions you want to access. If the `--config` or `--config-directory` flags
+> are not included in the command, Telegraf checks the
+> [default configuration file location](/telegraf/v1/configuration/#configuration-file-locations).
 
 If you haven't configured a secret store, use
 [`telegraf plugins secretstores`](/telegraf/v1/commands/plugins/secretstores/)

--- a/content/telegraf/v1/commands/secrets/remove.md
+++ b/content/telegraf/v1/commands/secrets/remove.md
@@ -16,12 +16,11 @@ Removing a key that does not exist in the store results in an error.
 Not all secret stores support modifying secrets.
 Stores backed by a read-only source reject the `set` and `remove` commands.
 
-{{% note %}}
-This command requires your configuration file that contains the secret store
-definitions you want to access. If the `--config` or `--config-directory` flags
-are not included in the command, Telegraf checks the
-[default configuration file location](/telegraf/v1/configuration/#configuration-file-locations).
-{{% /note %}}
+> [!Note]
+> This command requires your configuration file that contains the secret store
+> definitions you want to access. If the `--config` or `--config-directory` flags
+> are not included in the command, Telegraf checks the
+> [default configuration file location](/telegraf/v1/configuration/#configuration-file-locations).
 
 Use [`telegraf secrets list`](/telegraf/v1/commands/secrets/list/) to get the
 IDs of available secret stores and the available secret keys.

--- a/content/telegraf/v1/commands/secrets/remove.md
+++ b/content/telegraf/v1/commands/secrets/remove.md
@@ -1,7 +1,7 @@
 ---
-title: telegraf secrets set
+title: telegraf secrets remove
 description: >
-  The `telegraf secrets set` command creates or modify a secret in a specified
+  The `telegraf secrets remove` command removes a secret from a specified
   secret store.
 menu:
   telegraf_v1_ref:
@@ -9,7 +9,9 @@ menu:
 weight: 301
 ---
 
-The `telegraf secrets set` command creates or modify a secret in a specified secret store.
+The `telegraf secrets remove` command removes a secret from a specified secret
+store.
+Removing a key that does not exist in the store results in an error.
 
 Not all secret stores support modifying secrets.
 Stores backed by a read-only source reject the `set` and `remove` commands.
@@ -33,16 +35,15 @@ View secret store plugin configuration documentation in the
 ## Usage
 
 ```sh
-telegraf [global-flags] secrets set [flags] <SECRET_STORE_ID> <SECRET_KEY> <SECRET_VALUE>
+telegraf [global-flags] secrets remove [flags] <SECRET_STORE_ID> <SECRET_KEY>
 ```
 
 ## Arguments
 
-| Argument            | Description                                 |
-| :------------------ | :------------------------------------------ |
-| **SECRET_STORE_ID** | ID of the secret store to set the secret in |
-| **SECRET_KEY**      | Key of the secret to set                    |
-| **SECRET_VALUE**    | Value of the secret to set                  |
+| Argument            | Description                                      |
+| :------------------ | :----------------------------------------------- |
+| **SECRET_STORE_ID** | ID of the secret store to remove the secret from |
+| **SECRET_KEY**      | Key of the secret to remove                      |
 
 ## Flags
 
@@ -56,37 +57,34 @@ _Also see [Telegraf global flags](/telegraf/v1/commands/#telegraf-global-flags).
 
 ## Examples
 
-- [Set a secret using the default configuration location](#set-a-secret-using-the-default-configuration-location)
-- [Set a secret using a non-default configuration location](#set-a-secret-using-a-non-default-configuration-location)
+- [Remove a secret using the default configuration location](#remove-a-secret-using-the-default-configuration-location)
+- [Remove a secret using a non-default configuration location](#remove-a-secret-using-a-non-default-configuration-location)
 
 In the examples below, replace the following:
 
 - {{% code-placeholder-key %}}`SECRET_STORE_ID`{{% /code-placeholder-key %}}:
-  The ID of the secret store to store the secret in.
+  The ID of the secret store to remove the secret from.
 - {{% code-placeholder-key %}}`SECRET_KEY`{{% /code-placeholder-key %}}:
-  The key of the secret to set.
-- {{% code-placeholder-key %}}`SECRET_VALUE`{{% /code-placeholder-key %}}:
-  The value of the secret to set.
+  The key of the secret to remove.
 - {{% code-placeholder-key %}}`CUSTOM_CONFIG_PATH`{{% /code-placeholder-key %}}:
   The non-default filepath to your Telegraf configuration file containing your
   secret store definitions.
 
-### Set a secret using the default configuration location
+### Remove a secret using the default configuration location
 
 The following example assumes the Telegraf configuration file that contains the
 secret store definition is at the [default location](/telegraf/v1/configuration/#configuration-file-locations).
 
-```sh { placeholders="SECRET_(STORE_ID|KEY|VALUE)" }
-telegraf secrets set SECRET_STORE_ID SECRET_KEY SECRET_VALUE
+```sh { placeholders="SECRET_(STORE_ID|KEY)" }
+telegraf secrets remove SECRET_STORE_ID SECRET_KEY
 ```
 
-### Set a secret using a non-default configuration location
+### Remove a secret using a non-default configuration location
 
-```sh { placeholders="CUSTOM_CONFIG_PATH|SECRET_(STORE_ID|KEY|VALUE)" }
+```sh { placeholders="CUSTOM_CONFIG_PATH|SECRET_(STORE_ID|KEY)" }
 telegraf \
   --config CUSTOM_CONFIG_PATH \
-  secrets set \
+  secrets remove \
   SECRET_STORE_ID \
-  SECRET_KEY \
-  SECRET_VALUE
+  SECRET_KEY
 ```

--- a/content/telegraf/v1/commands/secrets/set.md
+++ b/content/telegraf/v1/commands/secrets/set.md
@@ -1,7 +1,7 @@
 ---
 title: telegraf secrets set
 description: >
-  The `telegraf secrets set` command creates or modify a secret in a specified
+  The `telegraf secrets set` command creates or modifies a secret in a specified
   secret store.
 menu:
   telegraf_v1_ref:
@@ -9,17 +9,17 @@ menu:
 weight: 301
 ---
 
-The `telegraf secrets set` command creates or modify a secret in a specified secret store.
+The `telegraf secrets set` command creates or modifies a secret in a specified
+secret store.
 
 Not all secret stores support modifying secrets.
 Stores backed by a read-only source reject the `set` and `remove` commands.
 
-{{% note %}}
-This command requires your configuration file that contains the secret store
-definitions you want to access. If the `--config` or `--config-directory` flags
-are not included in the command, Telegraf checks the
-[default configuration file location](/telegraf/v1/configuration/#configuration-file-locations).
-{{% /note %}}
+> [!Note]
+> This command requires your configuration file that contains the secret store
+> definitions you want to access. If the `--config` or `--config-directory` flags
+> are not included in the command, Telegraf checks the
+> [default configuration file location](/telegraf/v1/configuration/#configuration-file-locations).
 
 Use [`telegraf secrets list`](/telegraf/v1/commands/secrets/list/) to get the
 IDs of available secret stores and the available secret keys.

--- a/content/telegraf/v1/configuration/agent.md
+++ b/content/telegraf/v1/configuration/agent.md
@@ -286,7 +286,7 @@ after.
 ### skip_processors_after_aggregators
 
 If `true`, processors don't run a second time after aggregators.
-The default is scheduled to change to `true` in Telegraf 1.40, and Telegraf
+The default is scheduled to change to `true` in a future release, and Telegraf
 logs a warning at startup until you set the option explicitly.
 
 **Type:** boolean  

--- a/content/telegraf/v1/configuration/filtering.md
+++ b/content/telegraf/v1/configuration/filtering.md
@@ -292,12 +292,12 @@ metrics:
 [[outputs.influxdb]]
   urls = ["http://localhost:8086"]
   database = "telegraf"
-  namedrop = ["aerospike*"]
+  namedrop = ["redis*"]
 
 [[outputs.influxdb]]
   urls = ["http://localhost:8086"]
-  database = "telegraf-aerospike-data"
-  namepass = ["aerospike*"]
+  database = "telegraf-redis-data"
+  namepass = ["redis*"]
 ```
 
 Route metrics with a dedicated tag, then remove the tag before writing:

--- a/content/telegraf/v1/configuration/filtering.md
+++ b/content/telegraf/v1/configuration/filtering.md
@@ -112,7 +112,7 @@ Telegraf tests `tagdrop` after metrics pass the `tagpass` test.
 
 ### metricpass
 
-A [Common Expression Language (CEL)](https://github.com/google/cel-go/tree/master)
+A [Common Expression Language (CEL)](https://github.com/cel-expr/cel-go)
 expression with a boolean result: `true` passes the metric, anything else
 discards it.
 CEL expressions are more general than the other selectors and support

--- a/content/telegraf/v1/contribute.md
+++ b/content/telegraf/v1/contribute.md
@@ -30,11 +30,10 @@ the following sections will guide you through the process.
     [create a new bug report issue](https://github.com/influxdata/telegraf/issues/new?assignees=&labels=bug&projects=&template=BUG_REPORT.yml).
 3.  Include all the requested details.
 
-{{% note %}}
-Do not open general support requests as GitHub issues.
-Support-related questions should be directed to the [InfluxDB Community Slack](https://influxdata.com/slack)
-or [InfluxData Community forum](https://community.influxdata.com/).
-{{% /note %}}
+> [!Note]
+> Do not open general support requests as GitHub issues.
+> Support-related questions should be directed to the [InfluxDB Community Slack](https://influxdata.com/slack)
+> or [InfluxData Community forum](https://community.influxdata.com/).
 
 ### Open feature requests
 
@@ -78,13 +77,12 @@ or [InfluxData Community forum](https://community.influxdata.com/).
     The pull request title needs to follow the
     [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary).
 
-{{% note %}}
-If you have a pull request with only one commit, the commit message must follow
-the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary),
-otherwise the **Semantic Pull Request** check will fail.
-For single-commit pull requests, GitHub uses the commit message as the default
-pull request title.
-{{% /note %}}
+> [!Note]
+> If you have a pull request with only one commit, the commit message must follow
+> the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary),
+> otherwise the **Semantic Pull Request** check will fail.
+> For single-commit pull requests, GitHub uses the commit message as the default
+> pull request title.
 
 ### Contribute an external plugin
 

--- a/content/telegraf/v1/data_formats/input/csv.md
+++ b/content/telegraf/v1/data_formats/input/csv.md
@@ -237,9 +237,8 @@ If timestamps in the `csv_timestamp_column` contain a time zone offset, the pars
 If `csv_timestamp_format` and your timestamp data contain a time zone abbreviation, then the parser tries to resolve the abbreviation to a location in the [IANA Time Zone Database](https://www.iana.org/time-zones) and return a UTC offset for that location.
 To set the location that the parser should use when resolving time zone abbreviations, specify a value for `csv_timezone`, following the TZ syntax in the [Internet Assigned Numbers Authority time zone database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List).
 
-{{% warn %}}
-Prior to Telegraf v1.27, the Telegraf parser ignored abbreviated time zones (for example, "EST") in parsed time values, and used UTC for the timestamp location.
-{{% /warn %}}
+> [!Warning]
+> Prior to Telegraf v1.27, the Telegraf parser ignored abbreviated time zones (for example, "EST") in parsed time values, and used UTC for the timestamp location.
 
 ## Examples
 

--- a/content/telegraf/v1/output-plugins/heartbeat.md
+++ b/content/telegraf/v1/output-plugins/heartbeat.md
@@ -321,15 +321,15 @@ heartbeat message.
 
 The following functions are available:
 
-- `encoding` functions of the [CEL encoder library](https://github.com/google/cel-go/blob/master/ext/README.md#encoders)
-- `math` functions of the [CEL math library](https://github.com/google/cel-go/blob/master/ext/README.md#math)
-- `string` functions of the [CEL strings library](https://github.com/google/cel-go/blob/master/ext/README.md#strings)
+- `encoding` functions of the [CEL encoder library](https://github.com/cel-expr/cel-go/blob/master/ext/README.md#encoders)
+- `math` functions of the [CEL math library](https://github.com/cel-expr/cel-go/blob/master/ext/README.md#math)
+- `string` functions of the [CEL strings library](https://github.com/cel-expr/cel-go/blob/master/ext/README.md#strings)
 - `now` function for getting the current time
 
 [schema]: /plugins/outputs/heartbeat/schema_v1.json
 [internal_plugin]: /plugins/inputs/internal/README.md
 
 [cel]: https://cel.dev
-[cel_encoder]: https://github.com/google/cel-go/blob/master/ext/README.md#encoders
-[cel_math]: https://github.com/google/cel-go/blob/master/ext/README.md#math
-[cel_strings]: https://github.com/google/cel-go/blob/master/ext/README.md#strings
+[cel_encoder]: https://github.com/cel-expr/cel-go/blob/master/ext/README.md#encoders
+[cel_math]: https://github.com/cel-expr/cel-go/blob/master/ext/README.md#math
+[cel_strings]: https://github.com/cel-expr/cel-go/blob/master/ext/README.md#strings

--- a/content/telegraf/v1/release-notes.md
+++ b/content/telegraf/v1/release-notes.md
@@ -5261,9 +5261,8 @@ Telegraf without having to paste in sample configurations from each plugin's REA
 
 ## v1.21 {date="2021-12-15"}
 
-{{% note %}}
-The signing for RPM digest has changed to use sha256 to improve security. Due to this change, RPM builds might not be compatible with RHEL6 and older releases. (Telegraf only supports releases in RHEL production.)
-{{% /note %}}
+> [!Note]
+> The signing for RPM digest has changed to use sha256 to improve security. Due to this change, RPM builds might not be compatible with RHEL6 and older releases. (Telegraf only supports releases in RHEL production.)
 
 - Restart Telegraf service if it's already running and upgraded via RPM.
 - Print loaded plugins and deprecations for once and test flags.
@@ -6170,9 +6169,8 @@ The signing for RPM digest has changed to use sha256 to improve security. Due to
 
 ## v1.15.0 {date="2020-07-22"}
 
-{{% warn %}}
-Critical bug that impacted non-amd64 packages was introduced in 1.15.0. **Do not install this release.** Instead, install 1.15.1, which includes the features, new plugins, and bug fixes below.
-{{% /warn %}}
+> [!Warning]
+> Critical bug that impacted non-amd64 packages was introduced in 1.15.0. **Do not install this release.** Instead, install 1.15.1, which includes the features, new plugins, and bug fixes below.
 
 ### Breaking changes
 
@@ -6352,10 +6350,9 @@ Breaking changes are updates that may cause Telegraf plugins to fail or function
 - **Microsoft SQL Server** (`sqlserver`) input plugin: Renamed the `sqlserver_azurestats` measurement to `sqlserver_azure_db_resource_stats` to resolve an issue where numeric metrics were previously being reported incorrectly as strings.
 - **Date** (`date`) processor plugin: Now uses the UTC timezone when creating its tag. Previously, the local time was used.
 
-{{% note %}}
-Support for SSL v3.0 is deprecated in this release.
-Telegraf now uses the [Go TLS library](https://golang.org/pkg/crypto/tls/).
-{{% /note %}}
+> [!Note]
+> Support for SSL v3.0 is deprecated in this release.
+> Telegraf now uses the [Go TLS library](https://golang.org/pkg/crypto/tls/).
 
 ### New plugins
 

--- a/content/telegraf/v1/release-notes.md
+++ b/content/telegraf/v1/release-notes.md
@@ -4454,7 +4454,7 @@ Older versions can be manually reverted on a per-plugin basis using the `tls_min
 
 - [AWS CloudWatch Metric Streams](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/cloudwatch_metric_streams) (`cloudwatch_metric_streams`) - Contributed by [@mccabecillian](https://github.com/mccabecillian).
 - [Linux CPU](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/linux_cpu)(`linux_cpu`) - Contributed by [@fabianishere](http://github.com/fabianishere).
-- [NSDP](https://github.com/hdecarne-github/nsdp-telegraf-plugin) (`nsdp`) - Contributed by [@hdecarne](https://github.com/@hdecarne).
+- [NSDP](https://github.com/hdecarne-github/nsdp-telegraf-plugin) (`nsdp`) - Contributed by [@hdecarne](https://github.com/hdecarne).
 - [Supervisor](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/supervisor) (`supervisor`) - Contributed by [@niasar](http://github.com/niasar).
 - [UPSD](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/upsd) (`upsd`) - Contributed by [@Malinskiy](http://github.com/Malinskiy).
 


### PR DESCRIPTION
Document the new `telegraf secrets remove` subcommand and note that read-only secret stores reject set/remove. Correct the skip_processors_after_aggregators default-change claim (the flip did not ship in 1.40.0) and replace the removed aerospike plugin's metrics in the output-routing filter example.

## Checklist

- [x] Rebased/mergeable
- [x] Local build passes (`npx hugo --quiet`)
